### PR TITLE
New option "--config-filename"

### DIFF
--- a/options.h
+++ b/options.h
@@ -97,6 +97,7 @@ typedef struct sOptionValues {
 	char *fileList;         /* -L  name of file containing names of files */
 	char *tagFileName;      /* -o  name of tags file */
 	stringList* headerExt;  /* -h  header extensions */
+	char* configFilename;   /* --config-filename  use instead of 'ctags' in option file names */
 	stringList* etagsInclude;/* --etags-include  list of TAGS files to include*/
 	unsigned int tagFileFormat;/* --format  tag file format (level) */
 	boolean if0;            /* --if0  examine code within "#if 0" branch */


### PR DESCRIPTION
- The new --config-filename=someFileName changes the 'ctags' component
  in the various configuration file names to 'someFileName'
