### PR TITLE
 Fix a wrong memory accessing in readLine

### DIFF
--- a/read.c
+++ b/read.c
@@ -527,7 +527,7 @@ extern char *readLine (vString *const vLine, FILE *const fp)
 				eol = vStringValue (vLine) + vStringLength (vLine) - 1;
 				if (*eol == '\r')
 					*eol = '\n';
-				else if (*(eol - 1) == '\r'  &&  *eol == '\n')
+				else if (vStringLength (vLine) != 1 && *(eol - 1) == '\r'  &&  *eol == '\n')
 				{
 					*(eol - 1) = '\n';
 					*eol = '\0';


### PR DESCRIPTION
When reading a line of tags file, ctags assumes that the line of
tags file is longer than one byte or the list contains just one
byte, '\r'. If this assumption is not true, ctags accesses wrong
memory region when cannibalizing new line.

Consider tags file that has a line containing just 'a'.

```
$ valgrind --leak-check=full ./ctags -o tags a.c
...
==9868== Invalid read of size 1
==9868==    at 0x42156C: readLine (read.c:530)
==9868==    by 0x40B2EB: openTagFile (entry.c:328)
==9868==    by 0x402CD9: main (main.c:487)
==9868==  Address 0x4cb09bf is 1 bytes before a block of size 32 alloc'd
==9868==    at 0x4A0645D: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==9868==    by 0x4218A5: eMalloc (routines.c:238)
==9868==    by 0x428D06: vStringNew (vstring.c:82)
==9868==    by 0x40B3AC: openTagFile (entry.c:383)
==9868==    by 0x402CD9: main (main.c:487)
...
```

This patch adds a condition checking line length before entering
code block for cannibalizing new line.

Signed-off-by: Masatake YAMATO yamato@redhat.com
