### PR TITLE
python: add interpreter names to python parser definition

### DIFF
--- a/TRACKING
+++ b/TRACKING
@@ -95,5 +95,8 @@ patches
 ctags-devel@sourceforge list
 ============================================================
 
-   <MESSAGE-ID> - what we do
-	  commit-id...
+    [Ctags] Shebang with python3 instead of python
+    From: Martin Ueding <dev@ma...> - 2013-01-26 18:36:32
+
+	Added python, python2 and python3 as extensions of
+	python parser.

--- a/Units/nolang-shebang-python3.d/expected.tags
+++ b/Units/nolang-shebang-python3.d/expected.tags
@@ -1,0 +1,1 @@
+foo	Units/nolang-shebang-python3.d/input.nolang	/^def foo():$/;"	f

--- a/Units/nolang-shebang-python3.d/input.nolang
+++ b/Units/nolang-shebang-python3.d/input.nolang
@@ -1,0 +1,5 @@
+#!/usr/bin/python3
+
+def foo():
+    pass
+

--- a/python.c
+++ b/python.c
@@ -854,7 +854,9 @@ static void findPythonTags (void)
 
 extern parserDefinition *PythonParser (void)
 {
-    static const char *const extensions[] = { "py", "pyx", "pxd", "pxi" ,"scons", NULL };
+    static const char *const extensions[] = { "py", "pyx", "pxd", "pxi" ,"scons", 
+					      "python2", "python3", 
+					      NULL };
 	parserDefinition *def = parserNew ("Python");
 	def->kinds = PythonKinds;
 	def->kindCount = KIND_COUNT (PythonKinds);


### PR DESCRIPTION
This achieves the request submitted at ctags-users mailing list:

```
[Ctags] Shebang with python3 instead of python
 From: Martin Ueding <dev@ma...> - 2013-01-26 18:36:32
```

Signed-off-by: Masatake YAMATO yamato@redhat.com
