### PR TITLE
Include Anjuta in "Interesting Repositories List"

### DIFF
--- a/TRACKING
+++ b/TRACKING
@@ -319,3 +319,12 @@ Repo:
 https://github.com/vim-jp/ctags/
 
 VIM-Japan added better multi-byte support, if I understand correctly.
+
+Anjuta
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Repo:
+https://git.gnome.org/browse/anjuta/tree/plugins/symbol-db/anjuta-tags
+
+Anjuta is a Gnome IDE. They did not fork Exuberant ctags, but they did natively include it 
+in Anjuta. They have made several additions to thier version of it including fairly extensive
+Vala langauge support.


### PR DESCRIPTION
Anjuta is Gnome's native IDE. They didn't really fork ctags, and they require all new patches also be submitted Exuberant ctags, but they do have a lot in there not in Exuberant ctags.
