### PR TITLE
Fix compilation with i686-w64-mingw32-gcc

### DIFF
--- a/general.h
+++ b/general.h
@@ -60,7 +60,11 @@
  *  to prevent warnings about unused variables.
  */
 #if (__GNUC__ > 2  ||  (__GNUC__ == 2  &&  __GNUC_MINOR__ >= 7)) && !defined (__GNUG__)
-# define __unused__  __attribute__((unused))
+# ifdef __MINGW32__
+#  define __unused__
+# else
+#  define __unused__ __attribute__((unused))
+# endif
 # define __printf__(s,f)  __attribute__((format (printf, s, f)))
 #else
 # define __unused__


### PR DESCRIPTION
This patch is required to let the mingw-w64 compiler work. I tested with other Windows-based gcc compilers and Ubuntu. Could someone please test other distos, before I push this.

Based upon https://github.com/vim-jp/ctags
