### PR TITLE
Consolidate regcomp check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -466,9 +466,9 @@ AC_MSG_CHECKING(if regcomp works)
 AC_TRY_RUN([
 #include <sys/types.h>
 #include <regex.h>
-main() {
+int main(void) {
 	regex_t patbuf;
-	exit (regcomp (&patbuf, "/hello/", 0) != 0);
+	return (regcomp (&patbuf, "/hello/", 0) != 0);
 }],regcomp_works=yes,regcomp_works=no,AC_DEFINE(CHECK_REGCOMP))
 AC_MSG_RESULT($regcomp_works)
 if test yes != "$regcomp_works"; then


### PR DESCRIPTION
Use cleaner C in the check for whether `regcomp()` works, in case the
user has strong error flags in his CFLAGS:
- Use a proper signature for `main()`
- Don't use undeclared functions.

---

BTW, now I have push rights here, do you want me to push these kind of stuff right away or still use PR as a review process?
