### PR TITLE
verilog: Fix scope for nested constructs

### DIFF
--- a/Units/verilog-scope.d/expected.tags
+++ b/Units/verilog-scope.d/expected.tags
@@ -1,0 +1,4 @@
+f2	Units/verilog-scope.d/input.v	/^function f2()$/;"	f	module:mod
+f2deeper	Units/verilog-scope.d/input.v	/^    function f2deeper()$/;"	f	function:mod.f2.f2sub
+f2sub	Units/verilog-scope.d/input.v	/^  function f2sub()$/;"	f	function:mod.f2
+mod	Units/verilog-scope.d/input.v	/^module mod$/;"	m

--- a/Units/verilog-scope.d/input.v
+++ b/Units/verilog-scope.d/input.v
@@ -1,0 +1,22 @@
+module mod
+
+function f1()
+begin
+end
+endfunction
+
+function f2()
+begin
+  // no idea if this is valid but whatever
+  function f2sub()
+  begin
+    function f2deeper()
+      // here, f2sub used to have scope=function:mod.mod.f2.f2sub
+      // notice the duplicate "mod"
+    endfunction
+  end
+  endfunction
+end
+endfunction
+
+endmodule

--- a/verilog.c
+++ b/verilog.c
@@ -257,24 +257,15 @@ static boolean readIdentifier (vString *const name, int c)
 
 static vString *genContext (void)
 {
-	vString *context, *catNames;
-	tokenInfo *current;
 	if (currentContext)
 	{
-		context = vStringNew ();
-		vStringCopy (context, currentContext->name);
-		current = currentContext->scope;
-		while (current) {
-			catNames = vStringNew ();
-
-			vStringCopy (catNames, current->name);
-			vStringCatS (catNames, ".");
-			vStringCat (catNames, context);
-			vStringCopy (context, catNames);
-
-			current = current->scope;
-			vStringDelete (catNames);
+		vString *context = vStringNew ();
+		if (currentContext->scope)
+		{
+			vStringCat (context, currentContext->scope->name);
+			vStringPut (context, '.');
 		}
+		vStringCat (context, currentContext->name);
 		return context;
 	}
 	else


### PR DESCRIPTION
I don't know if such nesting is valid in Verilog, but the parser would duplicate some scope elements with deep nesting.

This had dramatic implication when parsing invalid input like e.g. _Test/jsFunc_tutorial.js_ as it lead to largely nested scopes getting duplicated, resulting in overly large output and memory usage.

This fix mitigates the issue as the scope is not duplicated anymore and the growth with such invalid input is now linear and not exponential anymore.

Parsing of _Test/jsFunc_tutorial.js_ is now virtually instantaneous, uses about 2M of memory and results in a 7.7K file, where it used to take forever and use several gigabytes of memory and disk space (I don't have numbers because it did not finish in several minutes yet already used more than 2G of memory and 1.1G of disk space).

---

I don't know Verilog so I can't tell whether the test case is correct or not (I doubt it strictly is), but anyway I can't believe the duplicate scope is correct.

In practice, this fixes `make -f testing.mak FUZZ_LANGUAGE=Verilog fuzz`.
