### PR TITLE
Units: Print pass/fail message always in the same column

### DIFF
--- a/testing.mak
+++ b/testing.mak
@@ -105,7 +105,7 @@ test.%: DIFF_FILE = $@.diff
 REF_INCLUDE_OPTIONS = $(TEST_OPTIONS) --format=1
 TEST_INCLUDE_OPTIONS = $(TEST_OPTIONS) --format=1
 test.include: $(CTAGS_TEST) $(CTAGS_REF)
-	@ echo -n "Testing tag inclusion..."
+	@ printf '%-60s' "Testing tag inclusion..."
 	@ $(CTAGS_REF) -R $(REF_INCLUDE_OPTIONS) -o tags.ref Test
 	@ $(CTAGS_TEST) -R $(TEST_INCLUDE_OPTIONS) -o tags.test Test
 	@- $(DIFF)
@@ -113,7 +113,7 @@ test.include: $(CTAGS_TEST) $(CTAGS_REF)
 REF_FIELD_OPTIONS = $(TEST_OPTIONS) --fields=+afmikKlnsSz
 TEST_FIELD_OPTIONS = $(TEST_OPTIONS) --fields=+afmikKlnsStz
 FEAtest.fields: $(CTAGS_TEST) $(CTAGS_REF)
-	@ echo -n "Testing extension fields..."
+	@ printf '%-60s' "Testing extension fields..."
 	@ $(CTAGS_REF) -R $(REF_FIELD_OPTIONS) -o tags.ref Test
 	@ $(CTAGS_TEST) -R $(TEST_FIELD_OPTIONS) -o tags.test Test
 	@- $(DIFF)
@@ -121,7 +121,7 @@ FEAtest.fields: $(CTAGS_TEST) $(CTAGS_REF)
 REF_EXTRA_OPTIONS = $(TEST_OPTIONS) --extra=+fq --format=1
 TEST_EXTRA_OPTIONS = $(TEST_OPTIONS) --extra=+fq --format=1
 test.extra: $(CTAGS_TEST) $(CTAGS_REF)
-	@ echo -n "Testing extra tags..."
+	@ printf '%-60s' "Testing extra tags..."
 	@ $(CTAGS_REF) -R $(REF_EXTRA_OPTIONS) -o tags.ref Test
 	@ $(CTAGS_TEST) -R $(TEST_EXTRA_OPTIONS) -o tags.test Test
 	@- $(DIFF)
@@ -129,7 +129,7 @@ test.extra: $(CTAGS_TEST) $(CTAGS_REF)
 REF_LINEDIR_OPTIONS = $(TEST_OPTIONS) --line-directives -n
 TEST_LINEDIR_OPTIONS = $(TEST_OPTIONS) --line-directives -n
 test.linedir: $(CTAGS_TEST) $(CTAGS_REF)
-	@ echo -n "Testing line directives..."
+	@ printf '%-60s' "Testing line directives..."
 	@ $(CTAGS_REF) $(REF_LINEDIR_OPTIONS) -o tags.ref Test/line_directives.c
 	@ $(CTAGS_TEST) $(TEST_LINEDIR_OPTIONS) -o tags.test Test/line_directives.c
 	@- $(DIFF)
@@ -137,7 +137,7 @@ test.linedir: $(CTAGS_TEST) $(CTAGS_REF)
 REF_ETAGS_OPTIONS = -e
 TEST_ETAGS_OPTIONS = -e
 test.etags: $(CTAGS_TEST) $(CTAGS_REF)
-	@ echo -n "Testing TAGS output..."
+	@ printf '%-60s' "Testing TAGS output..."
 	@ $(CTAGS_REF) -R $(REF_ETAGS_OPTIONS) -o tags.ref Test
 	@ $(CTAGS_TEST) -R $(TEST_ETAGS_OPTIONS) -o tags.test Test
 	@- $(DIFF)
@@ -151,7 +151,7 @@ test.eiffel:
 	@ echo "No Eiffel library source found for testing"
 else
 test.eiffel: $(CTAGS_TEST) $(CTAGS_REF)
-	@ echo -n "Testing Eiffel tag inclusion..."
+	@ printf '%-60s' "Testing Eiffel tag inclusion..."
 	@ $(CTAGS_REF) -R $(REF_EIFFEL_OPTIONS) -o tags.ref $(EIFFEL_DIRECTORY)
 	@ $(CTAGS_TEST) -R $(TEST_EIFFEL_OPTIONS) -o tags.test $(EIFFEL_DIRECTORY)
 	@- $(DIFF)
@@ -166,7 +166,7 @@ test.linux:
 	@ echo "No Linux kernel source found for testing"
 else
 test.linux: $(CTAGS_TEST) $(CTAGS_REF)
-	@ echo -n "Testing Linux tag inclusion..."
+	@ printf '%-60s' "Testing Linux tag inclusion..."
 	@ $(CTAGS_REF) -R $(REF_LINUX_OPTIONS) -o tags.ref $(LINUX_DIRECTORY)
 	@ $(CTAGS_TEST) -R $(TEST_LINUX_OPTIONS) -o tags.test $(LINUX_DIRECTORY)
 	@- $(DIFF)
@@ -213,7 +213,7 @@ test.units: $(CTAGS_TEST)
 		features="$$t"/features; \
 		languages="$$t"/languages; \
 		\
-		echo -n "Testing $${name}..."; \
+		printf '%-60s' "Testing $${name}"; \
 		\
 		ext=$${t##*${name}.}; \
 		if test "$${ext}" = "i"; then \


### PR DESCRIPTION
Makes it easier to spot a failure in the log.
