### PR TITLE
vim: define default filename patterns for vimrc etc

### DIFF
--- a/vim.c
+++ b/vim.c
@@ -746,10 +746,13 @@ static void findVimTags (void)
 extern parserDefinition* VimParser (void)
 {
 	static const char *const extensions [] = { "vim", "vba", NULL };
+	static const char *const patterns [] = { "vimrc", "[._]vimrc", "gvimrc",
+		"[._]gvimrc", NULL };
 	parserDefinition* def = parserNew ("Vim");
 	def->kinds		= VimKinds;
 	def->kindCount	= KIND_COUNT (VimKinds);
 	def->extensions = extensions;
+	def->patterns   = patterns;
 	def->parser		= findVimTags;
 	return def;
 }


### PR DESCRIPTION
This is meant to match:
- vimrc, gvimrc (typically used in dotfiles repos or system-wide config)
- .vimrc, _vimrc (config file name for unix/windows)
- .gvimrc, _gvimrc (GUI config file name unix/windows)
