### PR TITLE
Travis clanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ language: c
 compiler:
   - gcc
   - clang
-branches:
-  only:
-    - master
 script:
   - autoreconf -f -i -v
   - ./configure


### PR DESCRIPTION
This simplifies a bit the Travis file, and speeds up builds a little.

First, it gets rid of the useless dependencies (ctags actually don't use anything but the basics any Travis C build VM has, so we don't even have anything to install).  Then, run `make` with two jobs as [Travis build VM have 1.5 processors](http://docs.travis-ci.com/user/speeding-up-the-build/#Parallelizing-your-build-on-one-VM), and given how simple building each object is a lot of time is lost between objects, so it almost actually make it twice as fast.
You can see at [my fork's Travis](https://travis-ci.org/b4n/fishman-ctags) that the whole build now takes less a minute (each build take about 22s).

Finally, I removed the part restricting the build to the master branch only, because it looks like something that was just copied from elsewhere, but I think explicitly not building other branches should be something coming from a real decision.  In practice it won't change much as AFAIK we have only one active branch anyway, but it allows to use more branches later and have them checked as well.
However, this might not be so great as it's a personal repo, in case @fishman also pushed "private-ish" branches e.g. for creating PRs himself.  I can remove the last commit if it's the case and so if we really want to only build `master`.
