### PR TITLE
verilog: Include define argument with equal sign in tests

### DIFF
--- a/Units/verilog-2001.d/expected.tags
+++ b/Units/verilog-2001.d/expected.tags
@@ -1,5 +1,6 @@
 DEFINE	input.v	/^`define DEFINE$/;"	c
 DEF_VALUE	input.v	/^`define DEF_VALUE   1'd100$/;"	c
+DEF_WITH_EQ	input.v	/^`define DEF_WITH_EQ = 1'd100$/;"	c
 LOCALPARAM	input.v	/^localparam LOCALPARAM = 2**2;$/;"	c	module:mod
 PARAM1	input.v	/^    parameter PARAM1 = 10,$/;"	c	module:mod
 PARAM2	input.v	/^    parameter PARAM2 = 2.0$/;"	c	module:mod

--- a/Units/verilog-2001.d/input.v
+++ b/Units/verilog-2001.d/input.v
@@ -2,6 +2,7 @@
 // module wrong;
 // endmodule
 `define DEFINE
+`define DEF_WITH_EQ = 1'd100
 `define DEF_VALUE   1'd100
 
 module mod#(

--- a/Units/verilog-basic.d/expected.tags
+++ b/Units/verilog-basic.d/expected.tags
@@ -1,5 +1,6 @@
 DEFINE	input.v	/^`define DEFINE$/;"	c
 DEF_VALUE	input.v	/^`define DEF_VALUE   1'd100$/;"	c
+DEF_WITH_EQ	input.v	/^`define DEF_WITH_EQ = 1'd100$/;"	c
 PARAM	input.v	/^parameter PARAM = 1;$/;"	c	module:mod
 STATE1	input.v	/^parameter STATE1 = 4'h0,$/;"	c	module:mod
 STATE2	input.v	/^          STATE2 = 4'h1,$/;"	c	module:mod

--- a/Units/verilog-basic.d/input.v
+++ b/Units/verilog-basic.d/input.v
@@ -2,6 +2,7 @@
 // module wrong;
 // endmodule
 `define DEFINE
+`define DEF_WITH_EQ = 1'd100
 `define DEF_VALUE   1'd100
 
 module mod (


### PR DESCRIPTION
This scenario could make the parser enter an infinite loop in an older version.
Include test to guarantee that the bug is not reintroduced.
