### PR TITLE
verilog: Fix compiler warning

### DIFF
--- a/verilog.c
+++ b/verilog.c
@@ -171,7 +171,7 @@ static tokenInfo *popToken (tokenInfo * const token)
 
 static void pruneTokens (tokenInfo * token)
 {
-	while (token = popToken (token));
+	while ((token = popToken (token)));
 }
 
 static void initialize (const langType language)


### PR DESCRIPTION
verilog.c: In function ‘pruneTokens’:
verilog.c:174:2: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
