### PR TITLE
Fix broken compilation under Windows

### DIFF
--- a/lxcmd.c
+++ b/lxcmd.c
@@ -44,8 +44,6 @@
 #include <errno.h>
 #include <ctype.h>
 #include <string.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 
 #include "debug.h"
 #include "main.h"


### PR DESCRIPTION
Commit fb961e95c6e6b31b97c5e3787bbcf36ae4051836 break building on Windows. Two includes were added, but `include <sys/wait.h>` is not available on Windows.
When I look at the diff of that commit, I don't see any need for both those includes. Only "status>0" was added. Therefore I removed them.
