### PR TITLE
xcmd: include stdlib.h instead of sys/wait.h for WEXITSTATUS (#143)

### DIFF
--- a/lxcmd.c
+++ b/lxcmd.c
@@ -44,8 +44,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <string.h>
-#include <sys/types.h>
-#include <sys/wait.h>
+#include <stdlib.h>		/* for WIFEXITED and WEXITSTATUS */
 
 #include "debug.h"
 #include "main.h"


### PR DESCRIPTION
sys/wait.h is not available on Windows.

Signed-off-by: Masatake YAMATO yamato@redhat.com
