### PR TITLE
Enable building for Windows with Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,21 @@
 # Derived from
 # https://github.com/steveno/ctags/blob/master/.travis.yml
 #
+
 language: c
+
 compiler:
   - gcc
   - clang
+
+# Only with gcc get the mingw-w64 cross compilers
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y binutils-mingw-w64-i686 gcc-mingw-w64-i686  
+  - if [ $CC = 'gcc' ]; then sudo apt-get update -qq; sudo apt-get install -y binutils-mingw-w64-i686 gcc-mingw-w64-i686; fi
+
+# Build and run tests. Only with gcc cross compile
 script:
   - autoreconf -f -i -v
   - ./configure
   - make -j2
   - make check TRAVIS=1
-  - make distclean
-  - make -f mk_mingw.mak CC=i686-w64-mingw32-gcc
+  - if [ $CC = 'gcc' ]; then make distclean; make -f mk_mingw.mak CC=i686-w64-mingw32-gcc; fi


### PR DESCRIPTION
This PR enables building for Windows with Travis-CI. ctags has always been a multi-platform so building on Windows is important as well. Every now and then the Windows build is broken by Linux specific code and now Travis-CI warns you for that.

First it installs the mingw-w64 cross compiler and after that it it adds the build steps needed to cross compile ctags.

I could not find a way to only let these steps happen with gcc and not with clang. The second time is redundant. If somebody knows a way to fix that, please let know!
