### PR TITLE
xcmd: define _GNU_SOURCE

### DIFF
--- a/lxcmd.c
+++ b/lxcmd.c
@@ -44,7 +44,10 @@
 #include <errno.h>
 #include <ctype.h>
 #include <string.h>
-#include <stdlib.h>		/* for WIFEXITED and WEXITSTATUS */
+
+/* for WIFEXITED and WEXITSTATUS */
+#define _GNU_SOURCE
+#include <stdlib.h>
 
 #include "debug.h"
 #include "main.h"


### PR DESCRIPTION
This commit may solve #143.
If _GNU_SOURCE is defined, WEXITSTATUS defined in stdlib.h is
visible.

Signed-off-by: Masatake YAMATO yamato@redhat.com
