### PR TITLE
xcmd: define _GNU_SOURCE

### DIFF
--- a/lxcmd.c
+++ b/lxcmd.c
@@ -41,10 +41,11 @@
 */
 #include "general.h"  /* must always come first */
 
+#define _GNU_SOURCE   /* for WIFEXITED and WEXITSTATUS */
 #include <errno.h>
 #include <ctype.h>
+#include <stdlib.h>   /* for WIFEXITED and WEXITSTATUS */
 #include <string.h>
-#include <stdlib.h>		/* for WIFEXITED and WEXITSTATUS */
 
 #include "debug.h"
 #include "main.h"


### PR DESCRIPTION
This commit may solve #143.
If _GNU_SOURCE is defined, WEXITSTATUS defined in stdlib.h is
visible.

Signed-off-by: Masatake YAMATO yamato@redhat.com
