### PR TITLE
javascript: Stop using longjmp() and friends

### DIFF
--- a/Units/js-unterminated-leak.d/input.js
+++ b/Units/js-unterminated-leak.d/input.js
@@ -1,0 +1,1 @@
+function f() {


### PR DESCRIPTION
Part of #90.

---

Stop using `longjmp()`, which fixes leaks with malformed inputs (and makes the code more readable).
