### PR TITLE
javascript: Improve string literals handling

### DIFF
--- a/Units/js-broken-strings.d/expected.tags
+++ b/Units/js-broken-strings.d/expected.tags
@@ -1,0 +1,4 @@
+s1	input.js	/^var s1 = "I'm invalid because not terminated$/;"	v
+s2	input.js	/^var s2 = "I'm valid, I have a line continuation:\\$/;"	v
+s3	input.js	/^var s3 = "I'm invalid because I'm not terminated either \\$/;"	v
+s4	input.js	/^var s4 = 'this is a separate, valid string'$/;"	v

--- a/Units/js-broken-strings.d/input.js
+++ b/Units/js-broken-strings.d/input.js
@@ -1,0 +1,10 @@
+// this file willfully uses CR-LF line endings to check their handling
+
+var s1 = "I'm invalid because not terminated
+
+var s2 = "I'm valid, I have a line continuation:\
+; function bug1(){}";
+
+var s3 = "I'm invalid because I'm not terminated either \
+var bug2 = 'this is inside the s3 string'
+var s4 = 'this is a separate, valid string'

--- a/Units/js-string-continuation.d/expected.tags
+++ b/Units/js-string-continuation.d/expected.tags
@@ -1,0 +1,5 @@
+first	input.js	/^  "first": function(){},$/;"	m	class:o
+fourth	input.js	/^  "fourth": function(){},$/;"	m	class:o
+o	input.js	/^var o = {$/;"	v
+second	input.js	/^ond": function(){},$/;"	m	class:o
+third	input.js	/^": function(){},$/;"	m	class:o

--- a/Units/js-string-continuation.d/input.js
+++ b/Units/js-string-continuation.d/input.js
@@ -1,0 +1,19 @@
+
+var o = {
+  "first": function(){},
+  "sec\
+ond": function(){},
+  "\
+t\
+h\
+i\
+r\
+d\
+": function(){},
+  "fourth": function(){},
+};
+
+o.first();
+o.second();
+o.third();
+o.fourth();


### PR DESCRIPTION
1. Don't include the newline itself in a line continuation construct.
   This fixes generation of e.g. properties with embedded line
   continuations.
2. Don't continue parsing strings past an unescaped newline (as naked
   newlines are invalid inside strings).  This avoids parsing the whole
   remaining file as a string in case of broken input.  It is both
   useful to better support partly written files and to avoid loading a
   whole malformed file in memory while reading it as a string.

See section 7.8.4 "String Literals" of ECMA-262:
http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf
