### PR TITLE
Escape control control characters when writing tag files

### DIFF
--- a/entry.c
+++ b/entry.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <ctype.h>        /* to define isspace () */
 #include <errno.h>
+#include <stdarg.h>
 
 #if defined (HAVE_SYS_TYPES_H)
 # include <sys/types.h>	  /* to declare off_t on some hosts */
@@ -115,6 +116,157 @@ extern const char *tagFileName (void)
 	return TagFile.name;
 }
 
+static char valueToXDigit (int v)
+{
+	Assert (v >= 0 && v <= 0xF);
+
+	if (v >= 0xA)
+		return 'A' + (v - 0xA);
+	else
+		return '0' + v;
+}
+
+static int printEscapedString (FILE *const fp, const char *s)
+{
+	int length = 0;
+
+	for (; *s; s++)
+	{
+		int c = *s;
+
+		/* escape control characters (incl. \t) */
+		if ((c >= 0x00 && c <= 0x1F) || c == 0x7F)
+		{
+			putc ('\\', fp);
+			length++;
+
+			switch (c)
+			{
+				/* use a short form for known escapes */
+				case '\0': c = '0'; break;
+				case '\a': c = 'a'; break;
+				case '\b': c = 'b'; break;
+				case '\t': c = 't'; break;
+				case '\n': c = 'n'; break;
+				case '\v': c = 'v'; break;
+				case '\f': c = 'f'; break;
+				case '\r': c = 'r'; break;
+
+				default:
+				{
+					putc ('x', fp);
+					putc (valueToXDigit ((c & 0xF0) >> 4), fp);
+					putc (valueToXDigit (c & 0x0F), fp);
+					length += 3;
+					continue; /* skip printing c */
+				}
+			}
+		}
+
+		putc (c, fp);
+		length ++;
+	}
+
+	return length;
+}
+
+/* escapes each %s argument.  Only supports basic formats (%c, %s, %ld, %lu,
+ * %d, %u) and escapes (\a, \b, \t, \n, \v, \f, \r and \NNN) */
+__printf__(2, 3)
+static int fprintfEscaped (FILE *fp, const char *fmt, ...)
+{
+	int length = 0;
+	va_list ap;
+	va_start (ap, fmt);
+
+	for (; *fmt; fmt++)
+	{
+		if (*fmt == '%')
+		{
+			++fmt;
+			switch (*fmt)
+			{
+				case 'c':
+					putc (va_arg (ap, int /* char is promoted through '...' */), fp);
+					length++;
+					break;
+				case 's':
+					length += printEscapedString (fp, va_arg (ap, const char *));
+					break;
+				case 'l':
+					switch (fmt[1])
+					{
+						case 'd':
+							++fmt;
+							length += fprintf (fp, "%ld", va_arg (ap, long int));
+							break;
+						case 'u':
+							++fmt;
+							length += fprintf (fp, "%lu", va_arg (ap, unsigned long int));
+							break;
+						default:
+							putc (*fmt, fp);
+							length++;
+							break;
+					}
+					break;
+				case 'd':
+					length += fprintf (fp, "%d", va_arg (ap, int));
+					break;
+				case 'u':
+					length += fprintf (fp, "%u", va_arg (ap, unsigned int));
+					break;
+
+				default:
+					Assert ("Unknown format" == NULL);
+				case '%':
+					putc (*fmt, fp);
+					length++;
+					break;
+			}
+		}
+		else if (*fmt == '\\')
+		{
+			int c;
+			++fmt;
+			switch (*fmt)
+			{
+				case 'a': c = '\a'; break;
+				case 'b': c = '\b'; break;
+				case 't': c = '\t'; break;
+				case 'n': c = '\n'; break;
+				case 'v': c = '\v'; break;
+				case 'f': c = '\f'; break;
+				case 'r': c = '\r'; break;
+
+				/* octal escape from \0 to \377 */
+				case '0': case '1': case '2': case '3':
+					c = (*fmt - '0');
+					if (fmt[1] >= '0' && fmt[1] <= '7')
+						c = (c << 3) | (*++fmt - '0');
+					if (fmt[1] >= '0' && fmt[1] <= '7')
+						c = (c << 3) | (*++fmt - '0');
+				break;
+
+				default:
+					Assert ("Unknown escape sequence" == NULL);
+					c = *fmt;
+					break;
+			}
+			putc (c, fp);
+			length++;
+		}
+		else
+		{
+			putc (*fmt, fp);
+			length++;
+		}
+	}
+
+	va_end (ap);
+	return length;
+}
+
 /*
 *   Pseudo tag support
 */
@@ -135,11 +287,11 @@ extern void writePseudoTag (
 		const char *const language)
 {
 	const int length = language
-	  ? fprintf (TagFile.fp, "%s%s%s%s\t%s\t%s\n",
-		     PSEUDO_TAG_PREFIX, tagName,
-		     PSEUDO_TAG_SEPARATOR, language, fileName, pattern)
-	  : fprintf (TagFile.fp, "%s%s\t%s\t/%s/\n",
-		     PSEUDO_TAG_PREFIX, tagName, fileName, pattern);
+	  ? fprintfEscaped (TagFile.fp, "%s%s%s%s\t%s\t%s\n",
+			    PSEUDO_TAG_PREFIX, tagName,
+			    PSEUDO_TAG_SEPARATOR, language, fileName, pattern)
+	  : fprintfEscaped (TagFile.fp, "%s%s\t%s\t/%s/\n",
+			    PSEUDO_TAG_PREFIX, tagName, fileName, pattern);
 
 	++TagFile.numTags.added;
 	rememberMaxLengths (strlen (tagName), (size_t) length);
@@ -521,7 +673,7 @@ static void writeEtagsIncludes (FILE *const fp)
 		for (i = 0  ;  i < stringListCount (Option.etagsInclude)  ;  ++i)
 		{
 			vString *item = stringListItem (Option.etagsInclude, i);
-			fprintf (fp, "\f\n%s,include\n", vStringValue (item));
+			fprintfEscaped (fp, "\f\n%s,include\n", vStringValue (item));
 		}
 	}
 }
@@ -558,7 +710,7 @@ extern void endEtagsFile (const char *const name)
 {
 	const char *line;
 
-	fprintf (TagFile.fp, "\f\n%s,%ld\n", name, (long) TagFile.etags.byteCount);
+	fprintfEscaped (TagFile.fp, "\f\n%s,%ld\n", name, (long) TagFile.etags.byteCount);
 	if (TagFile.etags.fp != NULL)
 	{
 		rewind (TagFile.etags.fp);
@@ -652,6 +804,7 @@ static int writeXrefEntry (const tagEntryInfo *const tag)
 			readSourceLine (TagFile.vLine, tag->filePosition, NULL);
 	int length;
 
+	/* FIXME */
 	if (Option.tagFileFormat == 1)
 		length = fprintf (TagFile.fp, "%-16s %4lu %-16s ", tag->name,
 				tag->lineNumber, tag->sourceFileName);
@@ -688,8 +841,8 @@ static int writeEtagsEntry (const tagEntryInfo *const tag)
 	int length;
 
 	if (tag->isFileEntry || (tag->lineNumberEntry && (tag->lineNumber == 1)))
-		length = fprintf (TagFile.etags.fp, "\177%s\001%lu,0\n",
-				tag->name, tag->lineNumber);
+		length = fprintfEscaped (TagFile.etags.fp, "\177%s\001%lu,0\n",
+					 tag->name, tag->lineNumber);
 	else
 	{
 		long seekValue;
@@ -701,8 +854,8 @@ static int writeEtagsEntry (const tagEntryInfo *const tag)
 		else
 			line [strlen (line) - 1] = '\0';
 
-		length = fprintf (TagFile.etags.fp, "%s\177%s\001%lu,%ld\n", line,
-				tag->name, tag->lineNumber, seekValue);
+		length = fprintfEscaped (TagFile.etags.fp, "%s\177%s\001%lu,%ld\n", line,
+					 tag->name, tag->lineNumber, seekValue);
 	}
 	TagFile.etags.byteCount += length;
 
@@ -721,52 +874,52 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 
 	if (tag->kindName != NULL && (Option.extensionFields.kindLong  ||
 		 (Option.extensionFields.kind  && tag->kind == '\0')))
-		length += fprintf (TagFile.fp,"%s\t%s%s", sep, kindKey, tag->kindName);
+		length += fprintfEscaped (TagFile.fp,"%s\t%s%s", sep, kindKey, tag->kindName);
 	else if (tag->kind != '\0'  && (Option.extensionFields.kind  ||
 			(Option.extensionFields.kindLong  &&  tag->kindName == NULL)))
-		length += fprintf (TagFile.fp, "%s\t%s%c", sep, kindKey, tag->kind);
+		length += fprintfEscaped (TagFile.fp, "%s\t%s%c", sep, kindKey, tag->kind);
 
 	if (Option.extensionFields.lineNumber)
-		length += fprintf (TagFile.fp, "%s\tline:%ld", sep, tag->lineNumber);
+		length += fprintfEscaped (TagFile.fp, "%s\tline:%ld", sep, tag->lineNumber);
 
 	if (Option.extensionFields.language  &&  tag->language != NULL)
-		length += fprintf (TagFile.fp, "%s\tlanguage:%s", sep, tag->language);
+		length += fprintfEscaped (TagFile.fp, "%s\tlanguage:%s", sep, tag->language);
 
 	if (Option.extensionFields.scope  &&
 			tag->extensionFields.scope [0] != NULL  &&
 			tag->extensionFields.scope [1] != NULL)
-		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
-				tag->extensionFields.scope [0],
-				tag->extensionFields.scope [1]);
+		length += fprintfEscaped (TagFile.fp, "%s\t%s:%s", sep,
+					  tag->extensionFields.scope [0],
+					  tag->extensionFields.scope [1]);
 
 	if (Option.extensionFields.typeRef  &&
 			tag->extensionFields.typeRef [0] != NULL  &&
 			tag->extensionFields.typeRef [1] != NULL)
-		length += fprintf (TagFile.fp, "%s\ttyperef:%s:%s", sep,
-				tag->extensionFields.typeRef [0],
-				tag->extensionFields.typeRef [1]);
+		length += fprintfEscaped (TagFile.fp, "%s\ttyperef:%s:%s", sep,
+					  tag->extensionFields.typeRef [0],
+					  tag->extensionFields.typeRef [1]);
 
 	if (Option.extensionFields.fileScope  &&  tag->isFileScope)
-		length += fprintf (TagFile.fp, "%s\tfile:", sep);
+		length += fprintfEscaped (TagFile.fp, "%s\tfile:", sep);
 
 	if (Option.extensionFields.inheritance  &&
 			tag->extensionFields.inheritance != NULL)
-		length += fprintf (TagFile.fp, "%s\tinherits:%s", sep,
-				tag->extensionFields.inheritance);
+		length += fprintfEscaped (TagFile.fp, "%s\tinherits:%s", sep,
+					  tag->extensionFields.inheritance);
 
 	if (Option.extensionFields.access  &&  tag->extensionFields.access != NULL)
-		length += fprintf (TagFile.fp, "%s\taccess:%s", sep,
-				tag->extensionFields.access);
+		length += fprintfEscaped (TagFile.fp, "%s\taccess:%s", sep,
+					  tag->extensionFields.access);
 
 	if (Option.extensionFields.implementation  &&
 			tag->extensionFields.implementation != NULL)
-		length += fprintf (TagFile.fp, "%s\timplementation:%s", sep,
-				tag->extensionFields.implementation);
+		length += fprintfEscaped (TagFile.fp, "%s\timplementation:%s", sep,
+					  tag->extensionFields.implementation);
 
 	if (Option.extensionFields.signature  &&
 			tag->extensionFields.signature != NULL)
-		length += fprintf (TagFile.fp, "%s\tsignature:%s", sep,
-				tag->extensionFields.signature);
+		length += fprintfEscaped (TagFile.fp, "%s\tsignature:%s", sep,
+					  tag->extensionFields.signature);
 
 	return length;
 #undef sep
@@ -799,13 +952,13 @@ static int writeLineNumberEntry (const tagEntryInfo *const tag)
 
 static int writeCtagsEntry (const tagEntryInfo *const tag)
 {
-	int length = fprintf (TagFile.fp, "%s\t%s\t",
+	int length = fprintfEscaped (TagFile.fp, "%s\t%s\t",
 		tag->name, tag->sourceFileName);
 
 	if (tag->lineNumberEntry)
 		length += writeLineNumberEntry (tag);
 	else if (tag->pattern)
-		length += fprintf(TagFile.fp, "%s", tag->pattern);
+		length += fprintfEscaped(TagFile.fp, "%s", tag->pattern);
 	else
 		length += writePatternEntry (tag);
 


### PR DESCRIPTION
**Warning: *Do NOT merge this just yet.*** *It is currently more of an issue with sample code than a real PR.*

What's wrong?
---
Nothing prevents the various tag fields (from tag name to tag signature through file name) from containing arbitrary data, including control characters like `\t` or `\n`.  The presence of most of these will break the output, especially `\t` and `\n` which are obviously used as part of the tag file structure.

Some parsers, like [the JavaScript one](/fishman/ctags/blob/master/jscript.c#L276), have limited handling of such input to mitigate possible problems, but this is often not enough (it for example won't help with file names) and is fragile as each parser has to do it manually.

What can we do?
---
I see two possible approaches:

1. Filter the offending bytes when creating the tag entry, in
   `makeTagEntry()`.  I see two implications worth noting with this
    approach:
    1. It requires string duplication that may be avoided with other
       solutions.
    2. It is an arbitrary limitation of the in-memory format, which may
       or may not be wanted (e.g. when making CTags a library).
2. Filter the offending bytes when writing the tag entry.  This has the
   advantage of only affecting the output format (the very goal of the
   change) and not the internal representation, so it has very low
   implication on how internals handle these.

This patch attached is a mostly working attempt at the second approach.  It isn't completely ready yet because it doesn't handle `%Ns` and the like that are use in 2 places (see the `FIXME`), but is a proof of concept.

The implementation here might *not* be the one we want to go with because it basically re-implements `fprintf()`, which is a non-trivial function for non-trivial cases: e.g. support for `%-Ns` is not trivial.

The advantage is that it requires minimal changes on how the output is generated, and that the escaping being implicit lowers a lot the risk of forgetting to escape some parts.  It also avoids having to duplicate strings to build the escaped version, as filtering can be done straight when producing the actual output in most cases.

Seriously?
---
For those who wonder how these can actually happen, there are two easy ways:

* Parse a file with e.g. a `\n` in the name:
  
  ```shell
  bash$ cat > $'/tmp/test\n.c' <<<'int main(void){}'
  bash$ ctags -o - /tmp/test*.c
  ```
  …and you'll see that the output is pretty much garbage as not only there's an extra `\n` but it also broke sorting.
* Parse a file that generates a tag with such a control character in it.  Simpler way I know is through a property in JavaScript or a `define()` in PHP, but I guess there might be many more:
  
  ```shell
  bash$ cat > /tmp/test.php <<<$'<?php define("hello\ndolly", 42);'
  bash$ ctags -o - /tmp/test.php
  ```

Conclusion
---
Of course the problem I raise here is highly unlikely to actually happen in most situations, as no sane person will put a `\t` or `\n` in her file names, nor in a PHP define (as AFAIK it not only is bizarre but also cannot actually be used) or a JavaScript object property (although there it *can* be used).

However, it can become actually relevant for function signatures, as parsers are supposed to basically report whatever is in them.  In case of e.g. argument default values, it is not crazy to imagine a `\t` or alike in a string default value.

Moreover, I think it's pretty important for CTags not to output invalid tag files even when fed weird input, as apparently many people use CTags one whatever junk they got.

So, what do you think?