### PR TITLE
Small rewording of the warning for when `autoheader` was not run

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,8 @@ AC_INIT([ctags],[fishman])
 AC_CONFIG_HEADERS([config.h])
 if ! test -e "${srcdir}/config.h.in"; then
    echo "---"
-   echo "--- ${srcdir}/config.h.in IS NOT FOUND." 1>&2
-   echo "--- YOU MIGHT JUST RUN autoconf" 1>&2
+   echo "--- ${srcdir}/config.h.in WAS NOT FOUND." 1>&2
+   echo "--- YOU MIGHT HAVE RUN autoconf ONLY" 1>&2
    echo "--- BUT YOU MAY HAVE TO RUN autoreconf." 1>&2
    echo "---"
    exit 1


### PR DESCRIPTION
I'm not a native speaker but this looks more correct and clear to me.
