### PR TITLE
test.units: use TIMEOUT=5 by default

### DIFF
--- a/testing.mak
+++ b/testing.mak
@@ -125,7 +125,7 @@ fuzz: $(CTAGS_TEST)
 # UNITS Target
 #
 test.units: units
-units: TIMEOUT := 0
+units: TIMEOUT := 5
 units: $(CTAGS_TEST)
 	@ \
 	c="misc/units run \


### PR DESCRIPTION
I think it cannot hurt to timeout by default, and 5 seconds should be
long enough for the unit tests, which are meant to be small.
