### PR TITLE
Move to Github organization

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -54,7 +54,7 @@ Building
 
   First time:
 
-    git clone git://github.com/fishman/ctags.git    
+    git clone git://github.com/universal-ctags/ctags.git
     cd ctags
     autoheader
     autoconf

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-[![Build Status](https://travis-ci.org/fishman/ctags.svg?branch=master)](https://travis-ci.org/fishman/ctags)
+[![Build Status](https://travis-ci.org/universal-ctags/ctags.svg?branch=master)](https://travis-ci.org/universal-ctags/ctags)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/4355/badge.svg)](https://scan.coverity.com/projects/4355)
 
 This project continues the development of exuberant-ctags, but with the work
 hosted at github.
 
 The purpose of the project is preparing and maintaining common/unified working
-space where people interested in making exuberant-ctags better can work
+space where people interested in making universal-ctags better can work
 together.
 
 Pull-requests are welcome!

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #	Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.61])
-AC_INIT([ctags],[exuberant])
+AC_INIT([ctags],[universal])
 AC_CONFIG_HEADERS([config.h])
 if ! test -e "${srcdir}/config.h.in"; then
    echo "---"

--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -2,7 +2,7 @@ Who we are
 ============================================================
 
 Please, add your name, background and interests here If you are
-interested in contributing to exuberant-ctags steadily. So we can
+interested in contributing to universal-ctags steadily. So we can
 dispatch a task and/or an issue to the right person!
 
 (Keep the list in alphabetical order.)
@@ -33,7 +33,7 @@ Masatake YAMATO <yamato@redhat.com>
 	I'm using ctags in batch jobs running on my source code base
 	where most of all source code in Fedora are deployed.  I'm an
 	Emacs user, so generally I don't use ctags interactively
-	except when hacking exuberant-ctags. Therefore my primary goal
+	except when hacking universal-ctags. Therefore my primary goal
 	is to improve the robustness of parsers: I introduced Units
 	test facility and badinput command for achieving the goal.
 	The secondary goal is to support more languages and formats: I

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -5,7 +5,7 @@ Introduced changes
 
 ----
 
-Many changes have been introduced in exuberant-ctags. Use git-log to
+Many changes have been introduced in universal-ctags. Use git-log to
 review changes not enumerated here, especially in language parsers.
 
 Importing most of the changes from exuberant-ctags
@@ -159,7 +159,7 @@ Editors like vim and emacs recognize special patterns in files called
 modelines. The line is inserted by a user of the text editor and can
 be used to set the file type (Vim) or mode (emacs).
 
-exuberant-ctags also recognizes these modeline and selects a language parser
+universal-ctags also recognizes these modeline and selects a language parser
 based on it if ``--guess-language-eagerly`` (or ``-G``) option is given.
 
 
@@ -240,11 +240,11 @@ exuberant-ctags provides the way to customize ctags with options like
 written can be loaded with ``--options=OPTION_FILE``.
 
 This feature was extended such that ctags treats option files
-as libraries. Developers of exuberant-ctags can maintain option files
-as part of exuberant-ctags, making part of its release. With ``make
+as libraries. Developers of universal-ctags can maintain option files
+as part of universal-ctags, making part of its release. With ``make
 install`` they are also installed along with ctags command.
 
-exuberant-ctags prepares directories where the option files are installed.
+universal-ctags prepares directories where the option files are installed.
 
 Consider a GNU/Linux distribution.
 The following directories are searched when loading an option file:
@@ -363,7 +363,7 @@ Loading option recursively
 
 The option file loading rules explained in "Option library" is more
 complex. If a directory is specified as parameter for ``--option`` instead
-of a file, exuberant-ctags loads option files under the directory
+of a file, universal-ctags loads option files under the directory
 recursively.
 
 Consider the following command line on a GNU/Linux distribution::
@@ -419,7 +419,7 @@ Following files can be used for this purpose.
 * /etc/ctags.conf
 * /usr/local/etc/ctags.conf
 
-This preloading feature comes from exuberant-ctags. However, two
+This preloading feature comes from universal-ctags. However, two
 weaknesses exist in this implementation.
 
 * The file must be edited when an option library is to be loaded.
@@ -460,7 +460,7 @@ with two restrictions:
   Once a directory is traversed, another directory with the same name is
   not traversed.
 
-  exuberant-ctags prepares */usr/share/ctags/preload/default.ctags*.
+  universal-ctags prepares */usr/share/ctags/preload/default.ctags*.
   If you want ctags not to load it, make an empty file at
   *~/.ctags/default.ctags*. To customize
   */usr/share/ctags/preload/default.ctags*, copy the file to
@@ -498,7 +498,7 @@ maintain them.
 For both users and developers the variety of short flags are just
 nightmares.
 
-So exuberant-ctags now includes an API for defining long flags, which can be
+So universal-ctags now includes an API for defining long flags, which can be
 used as aliases for short flags. The long flags requires more typing
 but are more readable.
 
@@ -665,7 +665,7 @@ directly because ctags requires very specific behaviors (protocol).
 Generally available tags generator like CoffeeTags don't conform with
 the expected protocol. Executables under the built-in search
 path are expected to fill the gap between generally available tags
-generator and exuberant-ctags. This is the reason why the name
+generator and universal-ctags. This is the reason why the name
 *drivers* is used as part of built-in search path.
 
 To write a driver for a tags generator, please read
@@ -758,7 +758,7 @@ Build system add possibility to change program name
 ---------------------------------------------------------------------
 
 As on some systems (e.g. BSD) there is a 'ctags' program in the base
-system it's somewhat inconvenient to have the same name for exuberant ctags
+system it's somewhat inconvenient to have the same name for universal-ctags
 During ``configure`` you can now change the output executable name.
 
 Add a prefix 'ex' which will result in 'ctags' transformed into 'exctags'

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -7,10 +7,10 @@ Contributing an optlib
 
 You are welcome.
 
-exuberant-ctags provides a facility for "Option library".
+universal-ctags provides a facility for "Option library".
 Read "Option library" about the concept and usage first.
 
-Here I will explain how to merge your .ctags into exuberant-ctags as
+Here I will explain how to merge your .ctags into universal-ctags as
 part of option library. Here I assume you consider contributing
 an option library in which a regex based language parser is defined.
 See `How to Add Support for a New Language to Exuberant Ctags (EXTENDING)`_
@@ -25,7 +25,7 @@ deals with. Assume source files written in Swine language have a suffix
 
 Changes in options
 ---------------------------------------------------------------------
-exuberant-ctags prepares aliases for options.
+universal-ctags prepares aliases for options.
 
 ========================= ====================
 Exuberant                 New aliases
@@ -80,7 +80,7 @@ or later version" may be required.
 *Units* test cases
 ---------------------------------------------------------------------
 
-We, exuberant-ctags developers don't have enough time to learn all
+We, universal-ctags developers don't have enough time to learn all
 languages supported by ctags. In other word, we cannot review the
 code. Only test cases help us to know whether a contributed option
 library works well or not. We may reject any contribution without
@@ -159,4 +159,4 @@ Pull-request
 ---------------------------------------------------------------------
 
 Remember your *.ctags* is treasure and can be shared as a first class
-software component in exuberant-ctags.  Again, pull-requests are welcome.
+software component in universal-ctags.  Again, pull-requests are welcome.

--- a/docs/tracking.rst
+++ b/docs/tracking.rst
@@ -9,7 +9,7 @@ I consider tracking activities as the first class fruits
 of this project.
 
 
-exuberant-ctags
+universal-ctags
 ----------------------------------------------------------------------
 
 subversion
@@ -28,18 +28,18 @@ subversion
   ::
 
       <svn>
-      => <git: local exuberant repo>
-	 => <git: local exuberant repo>
+      => <git: local universal-ctags repo>
+	 => <git: local universal-ctags repo>
 
 
-  1. prepare your own exuberant repo: a local git repo cloned from github.
+  1. prepare your own universal-ctags repo: a local git repo cloned from github.
      You may know how to do it :)
 
      ::
     
-	$ git clone https://github.com/fishman/ctags.git
+	$ git clone https://github.com/universal-ctags/ctags.git
 
-  2. prepare exuberant SVN repo: a local git repo clone from exuberant svn tree.
+  2. prepare exuberant-ctags SVN repo: a local git repo clone from exuberant-ctags svn tree.
 
     The original clone is already part of exuberant tree.
 
@@ -61,14 +61,14 @@ subversion
 
   4. cherry-pick
 
-     4.1. Make a branch at local exuberant repo and switch to it.
+     4.1. Make a branch at local universal-ctags repo and switch to it.
 
      4.2. Do cherry-pick like::
 
 	 	$ git cherry-pick -s -x c81a8ce
 
      You can find commit id on the another terminal
-     <git: local exuberant repo>::
+     <git: local universal-ctags repo>::
 
 	 	$ git log
 	 
@@ -81,7 +81,7 @@ subversion
 
 	 $ git reset --hard
 
-     <git: local exuberant repo>
+     <git: local universal-ctags repo>
       at the branch for picking.
 
 bugs
@@ -176,29 +176,29 @@ Patches are always there. So it is easy to evaluate the value:)
 
    <67> Objective C language parser
 
-	* This is the implementation is we have in exuberant tree.
+	* This is the implementation we have in universal-ctags tree.
 
    <65> absoluteFilename uses strcpy on overlapping strings
 
-	* Fixed in exuberant tree, however the ticket is still open::
+	* Fixed in universal-ctags tree, however the ticket is still open::
 
    		d2bdf505abb7569deae2b50305ea1edce6208557
 
    <64> Fix strcpy() misuse
 
-	* Fixed in exuberant tree, however the ticket is still open::
+	* Fixed in universal-ctags tree, however the ticket is still open::
 
 		d2bdf505abb7569deae2b50305ea1edce6208557
 
    <51> Ada support
 
-	* Ada support is now available in exuberant tree::
+	* Ada support is now available in universal-ctags tree::
 
 		4b6b4a72f3d2d4ef969d7c650de1829d79f0ea7c
 
    <38> Ada support
 
-	* Ada support is now available in exuberant tree::
+	* Ada support is now available in universal-ctags tree::
 
 		4b6b4a72f3d2d4ef969d7c650de1829d79f0ea7c
 
@@ -269,52 +269,52 @@ http://pkgs.fedoraproject.org/cgit/ctags.git/tree/ctags.spec
 
 <ctags-5.7-destdir.patch>
 
-	This patch was merged in exuberant ctags git tree::
+	This patch was merged in universal-ctags git tree::
 
 		d4b5972427a46cbdcbfb050a944cf62b300676be
 
 <ctags-5.7-segment-fault.patch>
 
-	This patch was merged in exuberant ctags git tree::
+	This patch was merged in universal-ctags git tree::
 
 		8cc2b482f6c7257c5151893a6d02b8c79851fedd
 
 (ctags-5.8-cssparse.patch)
 
-	Not in exuberant tree.
+	Not in universal-ctags tree.
 
 	The reproducer is attached to following page:
 	https://bugzilla.redhat.com/show_bug.cgi?id=852101
 
-	However, exuberant-ctags doesn't reproduce with it.
+	However, universal-ctags doesn't reproduce with it.
 
 	I, Masatake YAMATO, read the patch.  However, I don't
 	understand the patch.  
 
 <ctags-5.8-css.patch>
 
-	This patch was merged in exuberant ctags git tree::
+	This patch was merged in universal-ctags git tree::
 
 		80c1522a36df3ba52b8b7cd7f5c79d5c30437a63
 
 <ctags-5.8-memmove.patch>
 
 	This patch was merged in exuberant ctags svn tree.
-	As the result this patch is in exuberant tree::
+	As the result this patch is in universal-ctags tree::
 
 		d2bdf505abb7569deae2b50305ea1edce6208557
 
 <ctags-5.8-ocaml-crash.patch>
 
 	This patch was merged in exuberant ctags svn tree.
-	As the result this patch is in exuberant tree::
+	As the result this patch is in universal-ctags tree::
 
 		ddb29762b37d60a875252dcc401de0b7479527b1
 
 <ctags-5.8-format-security.patch>
 
 	This patch was merged in exuberant ctags svn tree.
-	As the result this patch is in exuberant tree::
+	As the result this patch is in universal-ctags tree::
 
 		2f7a78ce21e4156ec3e63c821827cf1d5680ace8
 
@@ -327,7 +327,7 @@ http://anonscm.debian.org/cgit/users/cjwatson/exuberant-ctags.git/tree/debian/pa
 
 (python-disable-imports.patch)
 
-	Not in exuberant tree.
+	Not in universal-ctags tree.
 	
 	I don't want to merge this patch. I think ctags should extract
 	as much as possible information from input source code.
@@ -421,12 +421,12 @@ This is a gold mine of xcmd and optlib.
 External command(xcmd)
 ----------------------------------------------------------------------
 
-Near feature exuberant-ctags can invoke external command as a
+Near feature universal-ctags can invoke external command as a
 specialized parser though some glue code or script may be
 needed. Sometimes we may have to hack the external command to adjust
-the interface between the command and exuberant-ctags.
+the interface between the command and universal-ctags.
 
-So let's track external commands maintained out exuberant-ctags. If we
+So let's track external commands maintained out universal-ctags. If we
 prepare glue code or script, mark it with <>, and if not, mark it with
 ().
 

--- a/docs/universal-ctags.rst
+++ b/docs/universal-ctags.rst
@@ -6,28 +6,29 @@
 ..
 
 ========================================================================
-exuberant-ctags hacking guide
+universal-ctags hacking guide
 ========================================================================
 
 
 
 :Version: Draft
-:Authors: exuberant-ctags developers
-:Web Page: https://github.com/fishman/ctags
+:Authors: universal-ctags developers
+:Web Page: https://github.com/universal-ctags/ctags
 
 Introduction
 ======================================================================
-exuberant-ctags github area has the objective of continuing the
-development from what existed in the Sourceforge area. Gihub
+universal-ctags has the objective of continuing the
+development from what existed in the Sourceforge area. Github
 exuberant-ctags repository was started by Reza Jelveh
-<reza.jelveh@gmail.com>.
+<reza.jelveh@gmail.com> and was later moved to the universal-ctags
+organization.
 
 The goal of the project is preparing and maintaining common/unified
 space where people interested in making ctags better can work
 together.
 
 This guide is for developers. ctags.1 man page is for users.
-Though ctags.1 is not updated yet because exuberant-ctags is still in
+Though ctags.1 is not updated yet because universal-ctags is still in
 development.
 
 Proofreading and pull-requests are welcome!

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -5,7 +5,7 @@ Building/hacking/using on MS-Windows
 
 ----
 
-This part of the documentation is written by Frank Fesevur, co-maintainer of exuberant-ctags and the maintainer of the Windows port of this project. It is still very much work in progress. Things still need to be written down, tested or even investigated. When building for Windows you need to know there are many compilers and many building environments. This is a summary of available options and things that have been tested so far.
+This part of the documentation is written by Frank Fesevur, co-maintainer of universal-ctags and the maintainer of the Windows port of this project. It is still very much work in progress. Things still need to be written down, tested or even investigated. When building for Windows you need to know there are many compilers and many building environments. This is a summary of available options and things that have been tested so far.
 
 
 Compilers

--- a/docs/xcmd.rst
+++ b/docs/xcmd.rst
@@ -6,11 +6,11 @@ xcmd protocol and writing a driver
 ----
 
 About the way to utilize external parser commands, see 
-"External parser command" in "Changes in exuberant-ctags".
+"External parser command" in "Changes in universal-ctags".
 
 Here I explain the way to write a xcmd driver.
 
-Interaction between exuberant-ctags and xcmd is explained in "xcmd
+Interaction between universal-ctags and xcmd is explained in "xcmd
 protocol". Generally available tags generator like CoffeeTags doesn't
 conform to the protocol. Your driver must fill the gap.
 


### PR DESCRIPTION
I am aware that we are still not using github's organization, so I'm basically using this PR as a way of asking for status information this migration.
In issue #101 we arrived at the conclusion that we should keep "Exuberant Ctags" name.