### PR TITLE
Automatically re-generate Makefile when Makefile.in changed

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -167,6 +167,13 @@ etyperef.o: eiffel.c
 
 $(OBJECTS): $(HEADERS) config.h Makefile
 
+# Regenerate the Makefile whenever this file (it's source) changed.  Any target
+# should trigger this as it may affect their rules.  This implementation only
+# works with GNU make but should be harmless for other implementations.
+%: Makefile
+Makefile: Makefile.in config.status
+	./config.status --file $@
+
 #
 # generic install rules
 #


### PR DESCRIPTION
This avoids having an out-of-date copy of the Makefile when it source, Makefile.in, changed.

The implementation here only works with GNU Make, but it should not have undesirable effects with other Make implementations (if we ever support them, as it doesn't seem to be the case yet because of _testing.mak_).
