### PR TITLE
Add .ctags files to exclude test data

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -1,0 +1,3 @@
+# Exclude directories that don't contain real code
+--exclude=Units
+--exclude=Test


### PR DESCRIPTION
When you generate a tags file for the ctags repo, all the test data is included. This .ctags files excludes the two directories that contain this test data.
