### PR TITLE
c, d: wchar_t is not a keyword

### DIFF
--- a/Units/c-size_t-wchar_t-typedef.d/expected.tags
+++ b/Units/c-size_t-wchar_t-typedef.d/expected.tags
@@ -1,0 +1,2 @@
+size_t	input.c	/^typedef int size_t;$/;"	t	file:
+wchar_t	input.c	/^typedef int wchar_t;$/;"	t	file:

--- a/Units/c-size_t-wchar_t-typedef.d/input.c
+++ b/Units/c-size_t-wchar_t-typedef.d/input.c
@@ -1,0 +1,3 @@
+
+typedef int size_t;
+typedef int wchar_t;

--- a/Units/d-size_t-wchar_t-alias.d/expected.tags
+++ b/Units/d-size_t-wchar_t-alias.d/expected.tags
@@ -1,0 +1,2 @@
+size_t	input.d	/^alias size_t = int;$/;"	t	file:
+wchar_t	input.d	/^alias wchar_t = int;$/;"	t	file:

--- a/Units/d-size_t-wchar_t-alias.d/input.d
+++ b/Units/d-size_t-wchar_t-alias.d/input.d
@@ -1,0 +1,3 @@
+
+alias size_t = int;
+alias wchar_t = int;

--- a/c.c
+++ b/c.c
@@ -528,7 +528,7 @@ static const keywordDesc KeywordTable [] = {
      { "void",            KEYWORD_VOID,            { 1, 1, 1, 1, 1, 1 } },
      { "volatile",        KEYWORD_VOLATILE,        { 1, 1, 1, 1, 1, 0 } },
      { "wchar",           KEYWORD_WCHAR,           { 0, 0, 0, 1, 0, 0 } },
-     { "wchar_t",         KEYWORD_WCHAR_T,         { 1, 1, 1, 1, 0, 0 } },
+     { "wchar_t",         KEYWORD_WCHAR_T,         { 0, 1, 1, 0, 0, 0 } },
      { "while",           KEYWORD_WHILE,           { 1, 1, 1, 1, 1, 0 } },
      { "with",            KEYWORD_WITH,            { 0, 0, 0, 1, 0, 0 } },
 };


### PR DESCRIPTION
C: See ISO/IEC 9899:201x 6.4.1.
D: See http://dlang.org/lex#Keyword

---

Found in Geany, also affected CTags for the `wchar_t` part.
