### PR TITLE
core: Remove no longer used function templateFileExtensionNew

### DIFF
--- a/routines.c
+++ b/routines.c
@@ -641,29 +641,6 @@ extern const char *fileExtension (const char *const fileName)
 	return extension;
 }
 
-extern char* templateFileExtensionNew (const char *const fileName,
-				       const char *const templateExt)
-{
-	const char *pDelimiter = NULL;
-	const char *const base = baseFilename (fileName);
-	char* shorten_base;
-	const char* ext;
-	char* r;
-
-	pDelimiter = strrchr (base, templateExt[0]);
-
-	if (pDelimiter && (strcmp (pDelimiter, templateExt) == 0))
-	{
-		shorten_base = eStrndup (base, pDelimiter - base);
-		ext = fileExtension (shorten_base);
-		r = eStrdup (ext);
-		eFree (shorten_base);
-		return r;
-	}
-	else
-		return NULL;
-}
-
 extern char* baseFilenameSansExtensionNew (const char *const fileName,
 					   const char *const templateExt)
 {

--- a/routines.h
+++ b/routines.h
@@ -134,7 +134,6 @@ extern char* absoluteDirname (char *file);
 extern char* relativeFilename (const char *file, const char *dir);
 extern FILE *tempFile (const char *const mode, char **const pName);
 
-extern char* templateFileExtensionNew (const char *const fileName, const char *const templateExt);
 extern char* baseFilenameSansExtensionNew (const char *const fileName, const char *const templateExt);
 
 #endif  /* _ROUTINES_H */


### PR DESCRIPTION
This function was introduced in commit 54c36cb, but the code that used it was
removed in commit 9357800.
