### PR TITLE
core: Double extension file names support

### DIFF
--- a/docs/f-news.rst
+++ b/docs/f-news.rst
@@ -200,15 +200,18 @@ file name. So this feature is enabled only if the option
 is given. If you like this feature, you can put
 ``--guess-language-eagerly`` to your .ctags.
 
-Better parser selection for template files
+Double extension file names
 ---------------------------------------------------------------------
-Consider an input file name *foo.c.in*.  Suffix *.in* is popular as a
-name for template files.  Well-known one is *config.h.in* used in GNU
-autotools.
+Consider an input file named *foo.c.in*. The *.in* suffix is popular
+when naming template files. A well-known example is *config.h.in*,
+which is used by GNU autotools.
 
-ctags used suffix here *\*.in* for choosing a parser. *.in* shows
-nothing about the language used in the input file. When fishman-ctags
-finds *.in* as suffix, fishman-ctags checks the next suffix, here *.c*.
+In this example, ctags would use the *\*.in* suffix to select the
+parser, but this suffix has no relation with any parser. When
+exuberant-ctags is unable to identify the parser from the file
+extension it tries removing the extension before giving up.
+As such, in the example above *foo.c* would be used, resulting in a
+correct parser detection.
 
 Dry running
 ---------------------------------------------------------------------

--- a/parse.c
+++ b/parse.c
@@ -720,11 +720,13 @@ getFileLanguageInternal (const char *const fileName)
         goto cleanup;
 
     {
-        const char* const tExt = ".in";
-        templateBaseName = baseFilenameSansExtensionNew (fileName, tExt);
+        /* Try obtaining language from file name after removing extension.
+         * This should make it possible to correctly detect file type on
+         * files named foo.c.in, foo.c.bak, etc */
+        templateBaseName = baseFilenameSansExtension (fileName);
         if (templateBaseName)
         {
-            verbose ("	pattern + template(%s): %s\n", tExt, templateBaseName);
+            verbose ("	pattern (without extension): %s\n", templateBaseName);
             GLC_FOPEN_IF_NECESSARY(&glc, cleanup);
             rewind(glc.input);
             language = getPatternLanguage(templateBaseName, &glc);

--- a/routines.c
+++ b/routines.c
@@ -664,22 +664,19 @@ extern char* templateFileExtensionNew (const char *const fileName,
 		return NULL;
 }
 
-extern char* baseFilenameSansExtensionNew (const char *const fileName,
-					   const char *const templateExt)
+extern char* baseFilenameSansExtension (const char *const fileName)
 {
 	const char *pDelimiter = NULL;
 	const char *const base = baseFilename (fileName);
 	char* shorten_base;
 
-	pDelimiter = strrchr (base, templateExt[0]);
-
-	if (pDelimiter && (strcmp (pDelimiter, templateExt) == 0))
+	pDelimiter = fileExtension (base);
+	if (strlen (pDelimiter) > 0)
 	{
-		shorten_base = eStrndup (base, pDelimiter - base);
+		shorten_base = eStrndup (base, pDelimiter - base - 1);
 		return shorten_base;
 	}
-	else
-		return NULL;
+	return NULL;
 }
 
 extern boolean isAbsolutePath (const char *const path)

--- a/routines.h
+++ b/routines.h
@@ -135,7 +135,7 @@ extern char* relativeFilename (const char *file, const char *dir);
 extern FILE *tempFile (const char *const mode, char **const pName);
 
 extern char* templateFileExtensionNew (const char *const fileName, const char *const templateExt);
-extern char* baseFilenameSansExtensionNew (const char *const fileName, const char *const templateExt);
+extern char* baseFilenameSansExtension (const char *const fileName);
 
 #endif  /* _ROUTINES_H */
 


### PR DESCRIPTION
Extend the foo.c.in parser selection algorithm to work with any other double
extension file name.
