### PR TITLE
Add simple regex parser for Jade mixins

### DIFF
--- a/jade.c
+++ b/jade.c
@@ -1,0 +1,18 @@
+#include "general.h"
+#include "parse.h"
+
+static void installJadeParser (const langType language)
+{
+  addTagRegex(language, "^mixin[ \t]*([a-sA-Z0-9_]+)", "\\1", "d,definition", NULL);
+}
+
+
+extern parserDefinition* JadeParser (void)
+{
+  static const char* extensions[] = { "jade", NULL };
+  parserDefinition* def = parserNew("Jade");
+  def->extensions       = extensions;
+  def->initialize       = installJadeParser;
+  def->method           = METHOD_REGEX;
+  return def;
+}

--- a/parsers.h
+++ b/parsers.h
@@ -37,6 +37,7 @@
 	FortranParser, \
 	GoParser, \
 	HtmlParser, \
+	JadeParser, \
 	JavaParser, \
 	JavaScriptParser, \
 	JsonParser, \

--- a/source.mak
+++ b/source.mak
@@ -31,6 +31,7 @@ SOURCES = \
 	go.c \
 	html.c \
 	htable.c \
+	jade.c \
 	jscript.c \
 	json.c \
 	keyword.c \


### PR DESCRIPTION
Straightforward definition of a regex-based parser for Jade mixin definitions.  Tested on my local machine and it works as expected. @fishman 