### PR TITLE
landscape: Ignore units

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,0 +1,2 @@
+ignore-paths:
+    - Units


### PR DESCRIPTION
I have no clue about it, but apparently someone enabled landscape.io here?  If we do that, we're gonna want to ignore Units.  Patch here (should) do it.