### PR TITLE
tinst: installation test facility

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -1,2 +1,3 @@
 # Exclude directories that don't contain real code
 --exclude=Units
+--exclude=tinst-root

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ win32/[Rr]elease/
 win32/[Dd]ebug/
 perf.data*
 a.out
+tinst-root

--- a/Makefile.in
+++ b/Makefile.in
@@ -43,7 +43,7 @@ LIBOBJS = @LIBOBJS@
 LIBS	= @LIBS@
 EXEEXT	= @EXEEXT@
 OBJEXT	= @OBJEXT@
-
+TINST_ROOT=tinst-root
 # If you cannot run the "configure" script to set the variables above, then
 # uncomment the defines below and customize them for your environment. If
 # your system does not support symbolic (soft) links, then remove the -s
@@ -435,4 +435,12 @@ tmain: $(CTAGS_TEST)
 		$(VALGRIND) \
 		$(SHOW_DIFF_OUTPUT)"; \
 	 $(SHELL) $${c} Tmain
+
+#
+# Test installation
+#
+tinst:
+	rm -rf $$(pwd)/$(TINST_ROOT)
+	$(SHELL) misc/tinst $$(pwd)/$(TINST_ROOT)
+
 # vi:set tabstop=8:

--- a/misc/tinst
+++ b/misc/tinst
@@ -1,0 +1,161 @@
+#!/bin/sh
+TINST_ROOT=
+
+ERROR ()
+{
+    local status="$1"
+    local msg="$2"
+    shift 2
+    echo "$msg" 1>&2
+    exit $status
+}
+
+MSG_title()
+{
+    printf '%-70s' "${1}"
+}
+
+MSG_passed()
+{
+    echo passed
+}
+
+MSG_failed()
+{
+    echo failed
+}
+
+MSG_done()
+{
+    echo done
+}
+
+
+T_existing()
+{
+    local f=$1
+    shift
+    local op
+    local r=0
+
+    for op in "$@"; do
+	case "$op" in
+	    -d)
+		MSG_title "The existence of $f as a directory"
+		;;	    
+	    -f)
+		MSG_title "The existence of $f as an file"
+		;;
+	    -r)
+		MSG_title "The read mode of $f"
+		;;
+	    -x)
+		MSG_title "The existence of $f as an executable"
+		;;
+	    *)
+		MSG_title "The existence of $f with $op operator"
+		;;
+	esac
+	if [ $op ${TINST_ROOT}/$f ]; then
+	    MSG_passed
+	else
+	    MSG_failed
+	    r=$(( r + 1 ))
+	fi
+    done
+    return ${r}
+}
+
+prepare()
+{
+    local root=$1
+
+
+    MSG_title "Preparing installation tests"
+    
+    if ! [ -e ./configure ]; then
+	ERROR 2 "cannot find configure script"
+    fi
+
+    mkdir -p "$1"
+
+    if ! [ -d "$1" ]; then
+	ERROR 2 "failed in directory creation: $1"
+    fi
+
+    rm Makefile
+
+    if ! ./configure --prefix=$1 > /dev/null; then
+	ERROR 2 "failed in running configure script $1"
+    fi
+
+    if ! [ -e Makefile ]; then
+	ERROR 2 "cannot find Makefile"
+    fi
+
+    if ! make > /dev/null; then
+	ERROR 2 "failed in building ctags"
+    fi
+
+    if ! make install > /dev/null; then
+	ERROR 2 "failed in installing ctags"
+    fi    
+
+    MSG_done
+    return 0
+}
+
+cleanup()
+{
+    MSG_title "Cleanup installation tests"
+    MSG_done
+    return 0
+}
+
+check()
+{
+    T_existing /bin/ctags -f -x
+    T_existing /bin/readtags -f -x
+
+    T_existing /libexec/ctags/drivers/coffeetags -f -x
+    T_existing /etc/ctags/optlib   -d -x -r
+    T_existing /etc/ctags/preload  -d -x -r
+    T_existing /etc/ctags/corpora  -d -x -r
+    
+    T_existing /share/ctags/optlib/m4.ctags -f -r
+    T_existing /share/ctags/optlib/coffee.ctags -f -r
+    T_existing /share/ctags/optlib/ctags.ctags -f -r
+    T_existing /share/ctags/optlib/mib.ctags -f -r
+
+    T_existing /share/ctags/preload/default.ctags -f -r
+    
+    T_existing /share/ctags/corpora/ctags.ctags -f -r
+    T_existing  /share/ctags/corpora/RFC1213-MIB.txt -f -r
+    
+    T_existing /share/man/man1/ctags.1 -f -r
+}
+
+main()
+{
+    local root
+    local status
+
+    if [ $# = 1 ]; then
+	root=$1
+	shift
+    else
+	ERROR 2 "A installation root must be ginve as the first argument"
+    fi
+    
+    prepare "${root}"
+
+    TINST_ROOT=${root}
+    check
+    status=$?
+
+    cleanup "${root}"
+
+    return $status
+}
+
+main "$@"

--- a/mkinstalldirs
+++ b/mkinstalldirs
@@ -20,7 +20,7 @@ do
      esac
 
      if test ! -d "$pathcomp"; then
-        echo "mkdir $pathcomp" 1>&2
+        echo "mkdir $pathcomp"
 
         mkdir "$pathcomp" || lasterr=$?
 


### PR DESCRIPTION
Both test facilities units and tmain focused on ctags behavior before installing.
In other hand tinst focuses on something after  installing.

Currently tinst checks files and directories are placed as expected.

As default behavior tinst installs ctags into $(pwd)/tinst-root and check
files and directories under tinst-root.
