### PR TITLE
Fortran: parse Fortran 2003 procedure qualifier keywords

### DIFF
--- a/Units/fortran-procedure-qualifiers.d/expected.tags
+++ b/Units/fortran-procedure-qualifiers.d/expected.tags
@@ -1,0 +1,7 @@
+add	input.f90	/^    procedure, pass :: add$/;"	k	type:atype
+append	input.f90	/^    procedure, pass(self) :: append$/;"	k	type:atype
+atype	input.f90	/^  type atype$/;"	t	module:test
+list	input.f90	/^    procedure, deferred :: list$/;"	k	type:atype
+print	input.f90	/^    procedure, nopass :: print$/;"	k	type:atype
+test	input.f90	/^module test$/;"	m
+write	input.f90	/^    procedure, non_overridable :: write$/;"	k	type:atype

--- a/Units/fortran-procedure-qualifiers.d/input.f90
+++ b/Units/fortran-procedure-qualifiers.d/input.f90
@@ -1,0 +1,10 @@
+module test
+  type atype
+  contains
+    procedure, pass :: add
+    procedure, pass(self) :: append
+    procedure, nopass :: print
+    procedure, non_overridable :: write
+    procedure, deferred :: list
+  end type atype
+end module test

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -106,6 +106,7 @@ typedef enum eKeywordId {
 	KEYWORD_optional,
 	KEYWORD_parameter,
 	KEYWORD_pascal,
+	KEYWORD_pass,
 	KEYWORD_pexternal,
 	KEYWORD_pglobal,
 	KEYWORD_pointer,
@@ -273,6 +274,7 @@ static const keywordDesc FortranKeywordTable [] = {
 	{ "optional",       KEYWORD_optional     },
 	{ "parameter",      KEYWORD_parameter    },
 	{ "pascal",         KEYWORD_pascal       },
+	{ "pass",           KEYWORD_pass         },
 	{ "pexternal",      KEYWORD_pexternal    },
 	{ "pglobal",        KEYWORD_pglobal      },
 	{ "pointer",        KEYWORD_pointer      },
@@ -1286,6 +1288,7 @@ static void parseExtendsQualifier (tokenInfo *const token,
  *      or POINTER
  *      or SAVE
  *      or TARGET
+ *      or PASS
  * 
  *  component-attr-spec
  *      is POINTER
@@ -1322,6 +1325,12 @@ static tokenInfo *parseQualifierSpecList (tokenInfo *const token)
 			case KEYWORD_extends:
 				readToken (token);
 				parseExtendsQualifier (token, qualifierToken);
+				break;
+
+			case KEYWORD_pass:
+				readToken (token);
+				if (isType (token, TOKEN_PAREN_OPEN))
+					skipOverParens (token);
 				break;
 
 			default: skipToToken (token, TOKEN_STATEMENT_END); break;

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -77,6 +77,7 @@ typedef enum eKeywordId {
 	KEYWORD_complex,
 	KEYWORD_contains,
 	KEYWORD_data,
+	KEYWORD_deferred,
 	KEYWORD_dimension,
 	KEYWORD_dllexport,
 	KEYWORD_dllimport,
@@ -246,6 +247,7 @@ static const keywordDesc FortranKeywordTable [] = {
 	{ "complex",        KEYWORD_complex      },
 	{ "contains",       KEYWORD_contains     },
 	{ "data",           KEYWORD_data         },
+	{ "deferred",       KEYWORD_deferred     },
 	{ "dimension",      KEYWORD_dimension    },
 	{ "dll_export",     KEYWORD_dllexport    },
 	{ "dll_import",     KEYWORD_dllimport    },
@@ -1292,6 +1294,7 @@ static void parseExtendsQualifier (tokenInfo *const token,
  *      or TARGET
  *      or PASS
  *      or NOPASS
+ *      or DEFERRED
  * 
  *  component-attr-spec
  *      is POINTER
@@ -1317,6 +1320,7 @@ static tokenInfo *parseQualifierSpecList (tokenInfo *const token)
 			case KEYWORD_save:
 			case KEYWORD_target:
 			case KEYWORD_nopass:
+			case KEYWORD_deferred:
 				readToken (token);
 				break;
 

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -103,6 +103,7 @@ typedef enum eKeywordId {
 	KEYWORD_map,
 	KEYWORD_module,
 	KEYWORD_namelist,
+	KEYWORD_non_overridable,
 	KEYWORD_nopass,
 	KEYWORD_operator,
 	KEYWORD_optional,
@@ -273,6 +274,7 @@ static const keywordDesc FortranKeywordTable [] = {
 	{ "map",            KEYWORD_map          },
 	{ "module",         KEYWORD_module       },
 	{ "namelist",       KEYWORD_namelist     },
+	{ "non_overridable", KEYWORD_non_overridable },
 	{ "nopass",         KEYWORD_nopass       },
 	{ "operator",       KEYWORD_operator     },
 	{ "optional",       KEYWORD_optional     },
@@ -1295,6 +1297,7 @@ static void parseExtendsQualifier (tokenInfo *const token,
  *      or PASS
  *      or NOPASS
  *      or DEFERRED
+ *      or NON_OVERRIDABLE
  * 
  *  component-attr-spec
  *      is POINTER
@@ -1321,6 +1324,7 @@ static tokenInfo *parseQualifierSpecList (tokenInfo *const token)
 			case KEYWORD_target:
 			case KEYWORD_nopass:
 			case KEYWORD_deferred:
+			case KEYWORD_non_overridable:
 				readToken (token);
 				break;
 

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -102,6 +102,7 @@ typedef enum eKeywordId {
 	KEYWORD_map,
 	KEYWORD_module,
 	KEYWORD_namelist,
+	KEYWORD_nopass,
 	KEYWORD_operator,
 	KEYWORD_optional,
 	KEYWORD_parameter,
@@ -270,6 +271,7 @@ static const keywordDesc FortranKeywordTable [] = {
 	{ "map",            KEYWORD_map          },
 	{ "module",         KEYWORD_module       },
 	{ "namelist",       KEYWORD_namelist     },
+	{ "nopass",         KEYWORD_nopass       },
 	{ "operator",       KEYWORD_operator     },
 	{ "optional",       KEYWORD_optional     },
 	{ "parameter",      KEYWORD_parameter    },
@@ -1289,6 +1291,7 @@ static void parseExtendsQualifier (tokenInfo *const token,
  *      or SAVE
  *      or TARGET
  *      or PASS
+ *      or NOPASS
  * 
  *  component-attr-spec
  *      is POINTER
@@ -1313,6 +1316,7 @@ static tokenInfo *parseQualifierSpecList (tokenInfo *const token)
 			case KEYWORD_public:
 			case KEYWORD_save:
 			case KEYWORD_target:
+			case KEYWORD_nopass:
 				readToken (token);
 				break;
 


### PR DESCRIPTION
Fortran 2003 introduces **pass**, **nopass**, **deferred**, **non_overridable** as procedure qualifiers. This PR provides a patch to parse these keywords.