### PR TITLE
Add .gitignore, .hgignore and *~ emacs backup files to the built-in exclusion list

### DIFF
--- a/main/options.c
+++ b/main/options.c
@@ -2720,12 +2720,15 @@ extern void initOptions (void)
 	processExcludeOption (NULL, ".deps");
 	processExcludeOption (NULL, "EIFGEN");
 	processExcludeOption (NULL, ".git");
+	processExcludeOption (NULL, ".gitignore");
 	processExcludeOption (NULL, ".hg");
+	processExcludeOption (NULL, ".hgignore");
 	processExcludeOption (NULL, "PENDING");
 	processExcludeOption (NULL, "RCS");
 	processExcludeOption (NULL, "RESYNC");
 	processExcludeOption (NULL, "SCCS");
 	processExcludeOption (NULL, ".svn");
+	processExcludeOption (NULL, "*~");
 }
 
 extern void freeOptionResources (void)

--- a/main/options.c
+++ b/main/options.c
@@ -2721,6 +2721,7 @@ extern void initOptions (void)
 	processExcludeOption (NULL, "EIFGEN");
 	processExcludeOption (NULL, ".git");
 	processExcludeOption (NULL, ".gitignore");
+	processExcludeOption (NULL, ".gitattributes");
 	processExcludeOption (NULL, ".hg");
 	processExcludeOption (NULL, ".hgignore");
 	processExcludeOption (NULL, "PENDING");


### PR DESCRIPTION

Signed-off-by: Masatake YAMATO <yamato@redhat.com>