### PR TITLE
python: Fix handling of inline comments

### DIFF
--- a/Units/python-comments.d/expected.tags
+++ b/Units/python-comments.d/expected.tags
@@ -1,0 +1,1 @@
+foo	input.py	/^import foo ## as bug1$/;"	i

--- a/Units/python-comments.d/input.py
+++ b/Units/python-comments.d/input.py
@@ -1,0 +1,8 @@
+
+import foo ## as bug1
+
+"hello" ## import bug2
+"hi" # something # class bug3
+
+for i in range(1, 2): ##class bug4
+    pass ## class bug5

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -225,8 +225,11 @@ static const char *skipEverything (const char *cp)
 	int match;
 	for (; *cp; cp++)
 	{
+		if (*cp == '#')
+			return strchr(cp, '\0');
+
 		match = 0;
-		if (*cp == '"' || *cp == '\'' || *cp == '#')
+		if (*cp == '"' || *cp == '\'')
 			match = 1;
 
 		/* these checks find unicode, binary (Python 3) and raw strings */


### PR DESCRIPTION
If there was two hashes (#) in an inline comment, only the content
between the two was considered a comment.

Found while reviewing #383.