### PR TITLE
Fortran: parse bind c attribute

### DIFF
--- a/Units/parser-fortran.r/fortran-bind-c.d/args.ctags
+++ b/Units/parser-fortran.r/fortran-bind-c.d/args.ctags
@@ -1,0 +1,1 @@
+--Fortran-kinds=+P

--- a/Units/parser-fortran.r/fortran-bind-c.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-bind-c.d/expected.tags
@@ -1,0 +1,5 @@
+a	input.f90	/^    real/;"	k	type:atype
+atype	input.f90	/^  type, bind(c) :: atype$/;"	t	module:test_bind_c
+global_flag	input.f90	/^  integer(C_INT), bind(C, name="_MyProject_flags") :: global_flag$/;"	v	module:test_bind_c
+print_c	input.f90	/^    subroutine print_c(/;"	P	module:test_bind_c
+test_bind_c	input.f90	/^module test_bind_c$/;"	m

--- a/Units/parser-fortran.r/fortran-bind-c.d/input.f90
+++ b/Units/parser-fortran.r/fortran-bind-c.d/input.f90
@@ -1,0 +1,25 @@
+! See https://gcc.gnu.org/onlinedocs/gfortran/Interoperability-with-C.html
+module test_bind_c
+  use iso_c_binding
+
+  ! test derived type
+  type, bind(c) :: atype
+    real(c_double) :: a
+  end type atype
+  ! this is
+  ! struct {
+  !   double a;
+  ! } atype;
+  ! in C language
+
+  ! test interoperable global variable
+  integer(C_INT), bind(C, name="_MyProject_flags") :: global_flag
+
+  ! test Interoperable Subroutines and Functions
+  interface
+    subroutine print_c(string) bind(C, name="print_C")
+      use iso_c_binding, only: c_char
+      character(kind=c_char) :: string(*)
+    end subroutine print_c
+  end interface
+end module test_bind_c

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -69,6 +69,7 @@ typedef enum eKeywordId {
 	KEYWORD_allocatable,
 	KEYWORD_assignment,
 	KEYWORD_automatic,
+	KEYWORD_bind,
 	KEYWORD_block,
 	KEYWORD_byte,
 	KEYWORD_cexternal,
@@ -248,6 +249,7 @@ static const keywordDesc FortranKeywordTable [] = {
 	{ "allocatable",    KEYWORD_allocatable  },
 	{ "assignment",     KEYWORD_assignment   },
 	{ "automatic",      KEYWORD_automatic    },
+	{ "bind",           KEYWORD_bind         },
 	{ "block",          KEYWORD_block        },
 	{ "byte",           KEYWORD_byte         },
 	{ "cexternal",      KEYWORD_cexternal    },
@@ -1364,6 +1366,7 @@ static tokenInfo *parseQualifierSpecList (tokenInfo *const token)
 
 			case KEYWORD_dimension:
 			case KEYWORD_intent:
+			case KEYWORD_bind:
 				readToken (token);
 				skipOverParens (token);
 				break;


### PR DESCRIPTION
BIND(C) attribute enables Fortran to interoperate with C. This is a Fortran 2003 feature. See also https://gcc.gnu.org/onlinedocs/gfortran/Interoperability-with-C.html