### PR TITLE
Fortran: support --fields=+S

### DIFF
--- a/Units/parser-fortran.r/fortran-signature.d/args.ctags
+++ b/Units/parser-fortran.r/fortran-signature.d/args.ctags
@@ -1,0 +1,2 @@
+--fields=+S 
+--Fortran-kinds=+LP

--- a/Units/parser-fortran.r/fortran-signature.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-signature.d/expected.tags
@@ -1,0 +1,9 @@
+a	input.f90	/^    integer :: a$/;"	L	subroutine:fnb	file:
+a	input.f90	/^    integer a,/;"	L	subroutine:suba	file:
+arg	input.f90	/^      type(atype) :: arg$/;"	L	prototype:subb	file:
+b	input.f90	/^    integer a, b$/;"	L	subroutine:suba	file:
+fna	input.f90	/^  real function fna(/;"	f	module:test_signature
+fnb	input.f90	/^  subroutine fnb$/;"	s	module:test_signature
+suba	input.f90	/^  subroutine suba /;"	s	module:test_signature	signature:(a, b)
+subb	input.f90	/^    subroutine subb /;"	P	module:test_signature	signature:(arg)
+test_signature	input.f90	/^module test_signature$/;"	m

--- a/Units/parser-fortran.r/fortran-signature.d/input.f90
+++ b/Units/parser-fortran.r/fortran-signature.d/input.f90
@@ -1,0 +1,25 @@
+module test_signature
+
+  interface
+    subroutine subb (arg)
+      type(atype) :: arg
+    end subroutine
+  end interface
+  
+contains
+  subroutine suba &
+      (a, &
+      ! comment
+    b)
+    integer a, b
+  end subroutine
+
+  real function fna()
+    use, intrinsic :: iso_c_binding
+  end function
+
+  subroutine fnb
+    integer :: a
+  end subroutine
+
+end module test_signature


### PR DESCRIPTION
Parse signature of Fortran subprogram and prototype. The signature of Fortran language has three forms:

1. No function arguments at all
```Fortran
   subroutine suba
   end subroutine
```
2. No function arguments but with parens
```Fortran
   subroutine suba()
   end subroutine
```
3. With function arguments
```Fortran
   subroutine suba(a, b)
     interger :: a, b
   end subroutine
```

In the first and second case, signature will set to NULL and will not write to tags file. In the last case, signature will be written with **--fields=+S** options.