### PR TITLE
Support Fortran file extensions .f03, .f08 and .f15

### DIFF
--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -2441,9 +2441,9 @@ static void initialize (const langType language)
 extern parserDefinition* FortranParser (void)
 {
 	static const char *const extensions [] = {
-		"f", "for", "ftn", "f77", "f90", "f95",
+		"f", "for", "ftn", "f77", "f90", "f95", "f03", "f08", "f15",
 #ifndef CASE_INSENSITIVE_FILENAMES
-		"F", "FOR", "FTN", "F77", "F90", "F95",
+		"F", "FOR", "FTN", "F77", "F90", "F95", "F03", "F08", "F15",
 #endif
 		NULL
 	};


### PR DESCRIPTION
See http://gcc.gnu.org/onlinedocs/gfortran/GNU-Fortran-and-GCC.html
See also http://fortranwiki.org/fortran/show/File+extensions