### PR TITLE
Add C++11 override support(sf-bugs:367)

### DIFF
--- a/Units/cpp-override.d/args.ctags
+++ b/Units/cpp-override.d/args.ctags
@@ -1,0 +1,2 @@
+--c++-kinds=+p
+--fields=+S

--- a/Units/cpp-override.d/expected.tags
+++ b/Units/cpp-override.d/expected.tags
@@ -1,0 +1,6 @@
+Base	input.cpp	/^class Base$/;"	c	file:
+Derived	input.cpp	/^class Derived : public Base$/;"	c	file:
+foo	input.cpp	/^	virtual void foo() = 0;$/;"	p	class:Base	file:	signature:()
+foo	input.cpp	/^	virtual void foo() override;$/;"	p	class:Derived	file:	signature:()
+foo	input.cpp	/^void Base::foo()$/;"	f	class:Base	signature:()
+foo	input.cpp	/^void Derived::foo()$/;"	f	class:Derived	signature:()

--- a/Units/cpp-override.d/input.cpp
+++ b/Units/cpp-override.d/input.cpp
@@ -1,0 +1,18 @@
+class Base
+{
+public:
+	virtual void foo() = 0;
+};
+
+class Derived : public Base
+{
+	virtual void foo() override;
+};
+
+void Base::foo()
+{
+}
+
+void Derived::foo()
+{
+}

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -2289,7 +2289,12 @@ static boolean skipPostArgumentStuff (
 					break;
 
 				default:
-					if (isType (token, TOKEN_NONE))
+					/* "override" and "final" are only keywords in the declaration of a virtual
+					 * member function, so need to be handled specially, not as keywords */
+					if (isLanguage (Lang_cpp) && isType (token, TOKEN_NAME) &&
+						strcmp ("override", vStringValue (token->name)) == 0)
+						;
+					else if (isType (token, TOKEN_NONE))
 						;
 					else if (info->isKnrParamList  &&  info->parameterCount > 0)
 						++elementCount;


### PR DESCRIPTION
Revert the code change and see how the Derived::foo() declaration is missing from the tags file.

Bugreport: https://sourceforge.net/p/ctags/bugs/367/