### PR TITLE
Parse Fortran 2003 enum

### DIFF
--- a/Units/parser-fortran.r/fortran-enum.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-enum.d/expected.tags
@@ -1,0 +1,45 @@
+Constants	input.f90	/^module Constants$/;"	m
+E_e	input.f90	/^  real, parameter :: E_e /;"	v	module:Constants
+Named1	input.f90	/^  enum :: Named1$/;"	E	module:Constants
+Named2	input.f90	/^  enum Named2$/;"	E	module:Constants
+Named3	input.f90	/^  enum(8) Named3$/;"	E	module:Constants
+Named4	input.f90	/^  enum*8 Named4$/;"	E	module:Constants
+Named5	input.f90	/^  enum(8) :: Named5$/;"	E	module:Constants
+Named6	input.f90	/^  enum*8 :: Named6$/;"	E	module:Constants
+Named7	input.f90	/^  enum, bind(c) :: Named7$/;"	E	module:Constants
+a	input.f90	/^    enumerat/;"	N	module:Constants
+b	input.f90	/^    enumerator :: a, b,/;"	N	module:Constants
+black	input.f90	/^    enumerator :: red =1, blue, black /;"	N	module:Constants
+blue	input.f90	/^    enumerator :: red =1, blue,/;"	N	module:Constants
+bronze	input.f90	/^    enumerator gold, silver, bronze$/;"	N	module:Constants
+c	input.f90	/^    enumerator :: a, b, c$/;"	N	module:Constants
+gold	input.f90	/^    enumerator gold,/;"	N	module:Constants
+hc	input.f90	/^  real, parameter :: hc /;"	v	module:Constants
+lavender	input.f90	/^    enumerator :: pink, lavender$/;"	N	module:Constants
+pi	input.f90	/^  real, parameter :: pi /;"	v	module:Constants
+pink	input.f90	/^    enumerator :: pink,/;"	N	module:Constants
+purple	input.f90	/^    enumerator :: purple$/;"	N	module:Constants
+red	input.f90	/^    enumerator :: red /;"	N	module:Constants
+silver	input.f90	/^    enumerator gold, silver,/;"	N	module:Constants
+x1	input.f90	/^    enumerator :: x1,/;"	N	module:Constants
+x2	input.f90	/^    enumerator :: x2,/;"	N	module:Constants
+x3	input.f90	/^    enumerator :: x3,/;"	N	module:Constants
+x4	input.f90	/^    enumerator :: x4,/;"	N	module:Constants
+x5	input.f90	/^    enumerator :: x5,/;"	N	module:Constants
+x6	input.f90	/^    enumerator :: x6,/;"	N	module:Constants
+x7	input.f90	/^    enumerator :: x7,/;"	N	module:Constants
+y1	input.f90	/^    enumerator :: x1, y1,/;"	N	module:Constants
+y2	input.f90	/^    enumerator :: x2, y2,/;"	N	module:Constants
+y3	input.f90	/^    enumerator :: x3, y3,/;"	N	module:Constants
+y4	input.f90	/^    enumerator :: x4, y4,/;"	N	module:Constants
+y5	input.f90	/^    enumerator :: x5, y5,/;"	N	module:Constants
+y6	input.f90	/^    enumerator :: x6, y6,/;"	N	module:Constants
+y7	input.f90	/^    enumerator :: x7, y7,/;"	N	module:Constants
+yellow	input.f90	/^    enumerator yellow$/;"	N	module:Constants
+z1	input.f90	/^    enumerator :: x1, y1, z1$/;"	N	module:Constants
+z2	input.f90	/^    enumerator :: x2, y2, z2$/;"	N	module:Constants
+z3	input.f90	/^    enumerator :: x3, y3, z3$/;"	N	module:Constants
+z4	input.f90	/^    enumerator :: x4, y4, z4$/;"	N	module:Constants
+z5	input.f90	/^    enumerator :: x5, y5, z5$/;"	N	module:Constants
+z6	input.f90	/^    enumerator :: x6, y6, z6$/;"	N	module:Constants
+z7	input.f90	/^    enumerator :: x7, y7, z7$/;"	N	module:Constants

--- a/Units/parser-fortran.r/fortran-enum.d/input.f90
+++ b/Units/parser-fortran.r/fortran-enum.d/input.f90
@@ -1,0 +1,52 @@
+module Constants
+  implicit none
+
+  real, parameter :: pi = 4 * atan(1.0)
+  real, parameter :: E_e = 510998.91013
+
+  ! we now have enumerators in F2003/8, for the sake of interop with C
+  enum, bind(c) ! unnamed 1
+    enumerator :: red =1, blue, black =5
+    enumerator yellow
+    enumerator gold, silver, bronze
+    enumerator :: purple
+    enumerator :: pink, lavender
+  end enum
+
+  enum ! unnamed 2
+    enumerator :: a, b, c
+  end enum
+
+  enum :: Named1
+    enumerator :: x1, y1, z1
+  end enum
+
+  enum Named2
+    enumerator :: x2, y2, z2
+  end enum
+
+  enum(8) Named3
+    enumerator :: x3, y3, z3
+  end enum
+
+  enum*8 Named4
+    enumerator :: x4, y4, z4
+  end enum
+
+  enum(8) :: Named5
+    enumerator :: x5, y5, z5
+  end enum
+
+  enum*8 :: Named6
+    enumerator :: x6, y6, z6
+  end enum
+
+  enum, bind(c) :: Named7
+    enumerator :: x7, y7, z7
+  end enum
+
+  real, parameter :: hc = 12398.4193
+
+  public
+
+end module Constants


### PR DESCRIPTION
Fortran 2003 enums is:
```Fortran
enum, bind(c)
  enumerator [::] name1 [= val], ...
end enum
```
See https://books.google.com.hk/books?id=40UkLNQuAeoC&pg=PA114&lpg=PA114&dq=fortran+enumerator+type&source=bl&ots=WTou0LNC5z&sig=kV-2jyz4T2qUlCQ3T4jx3WeRJkc&hl=zh-CN&sa=X&ei=JZeSVbSSH5DYoAShrI6gDA&ved=0CEcQ6AEwBTgK#v=onepage&q=fortran%20enumerator%20type&f=false page 114
and http://www-01.ibm.com/support/knowledgecenter/SSGH4D_10.1.0/com.ibm.xlf101a.doc/xlflr/enum.htm%23enum

We shoud note that
+ bind(c) is mandatory
+ enum shoud have no name
+ enumerator should have no qualifier

The implementation of Geany is different https://github.com/geany/geany/commit/9520e7f7d7b7a9570db2feb165653ef1d68e547a which is based on
 http://docs.cray.com/books/S-3692-51/html-S-3692-51/z970507905n9123.html. The syntax is different:
+ kind selector can be used instead of bind(c)
+ enum can be given a name

The docs of ISO http://www.j3-fortran.org/doc/year/04/04-007.pdf page 66 don't allow for syntax of cray.