### PR TITLE
Enable gcov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 test.*.diff
 *.gcno
 *.gcda
+*.gcov
 *.o
 *.od
 *.obj

--- a/Makefile.in
+++ b/Makefile.in
@@ -38,7 +38,7 @@ endif
 DEFS	= @DEFS@
 CPPFLAGS = @CPPFLAGS@
 CFLAGS	= @CFLAGS@
-LDFLAGS	= @LDFLAGS@
+LDFLAGS	= @LDFLAGS@ $(COVERAGE_LDFLAGS)
 LIBOBJS = @LIBOBJS@
 LIBS	= @LIBS@
 EXEEXT	= @EXEEXT@
@@ -59,7 +59,12 @@ TINST_ROOT=tinst-root
 #CFLAGS	= -O
 #LDFLAGS=
 
-ALL_CFLAGS = $(CFLAGS) -Wall
+ifdef COVERAGE
+COVERAGE_CFLAGS=--coverage
+COVERAGE_LDFLAGS=--coverage
+endif
+
+ALL_CFLAGS = $(CFLAGS) -Wall $(COVERAGE_CFLAGS)
 
 DEBUG_CPPFLAGS ?= -DDEBUG
 ALL_CPPFLAGS = $(CPPFLAGS)			\
@@ -336,9 +341,10 @@ tags: $(CTAGS_EXEC)
 TAGS: $(CTAGS_EXEC)
 	./$(CTAGS_EXEC) -e $(srcdir)/*
 
-clean: clean-units
+clean: clean-units clean-gcov
 	rm -f $(OBJECTS) $(CTAGS_EXEC) tags TAGS $(READ_LIB) 
 	rm -f etyperef$(EXEEXT) etyperef.$(OBJEXT)
+	rm -f $(SOURCES:.c=.gcno)
 
 mostlyclean: clean
 
@@ -376,7 +382,7 @@ ifdef TRAVIS
 SHOW_DIFF_OUTPUT=--show-diff-output
 endif
 
-.PHONY: check units fuzz noise clean-units
+.PHONY: check units fuzz noise clean-units clean-gcov
 check: units
 
 #
@@ -448,5 +454,16 @@ tinst:
 #
 codecheck:
 	$(SHELL) misc/src-check
+
+#
+# Report coverage (usable only if ctags is built with COVERAGE=1.)
+#
+run-gcov:
+	$(CTAGS_TEST) -o - $$(find ./Units -name 'input.*'| grep -v '.*b/.*') > /dev/null
+	gcov $$(find -name '*.gcda')
+
+clean-gcov:
+	rm -f $(SOURCES:.c=.gcda)
+	rm -f $(srcdir)/*.gcov
 
 # vi:set tabstop=8:

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -20,3 +20,15 @@ Finding performance bottleneck
 ------------------------------------------------------------
 
 See https://wiki.geany.org/howtos/profiling/gperftools and #383
+
+Checking coverage
+------------------------------------------------------------
+After doing make clean, you can build coverage measuring ready
+ctags by make COVERAGE=1. At this time *.gcno files are generated
+by the compiler. *.gcno files can be removed with make clean.
+
+After building ctags, you can run run-gcov target.  When running
+*.gcda files.  The target runs ctags withh all input files under
+Units/**/input.*; and call gcov. Human readable result is printed. The
+detail can be shown in *.gcov. files. *.gcda files and *.gcov files
+can be removed with make clean-gcov.


### PR DESCRIPTION
Usage:
After doing make clean, you can build coverage measuring ready
ctags by make COVERAGE=1. At this time *.gcno files are generated
by the compiler. *.gcno files can be removed with make clean.

After building ctags, you can run run-gcov target.  When running
*.gcda files.  The target runs ctags withh all input files under
Units/**/input.*; and call gcov. Human readable result is printed. The
detail can be shown in *.gcov. files. *.gcda files and *.gcov files
can be removed with make clean-gcov.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>