### PR TITLE
C++11 stuff (override, final and noexcept)

### DIFF
--- a/Units/cxx11-final.d/args.ctags
+++ b/Units/cxx11-final.d/args.ctags
@@ -1,0 +1,2 @@
+--c++-kinds=+p
+--fields=+S

--- a/Units/cxx11-final.d/expected.tags
+++ b/Units/cxx11-final.d/expected.tags
@@ -3,6 +3,6 @@ Derived	input.cpp	/^class Derived final : public Base$/;"	c	file:
 final	input.cpp	/^	virtual void final();$/;"	p	class:Derived	file:	signature:()
 final	input.cpp	/^void Derived::final()$/;"	f	class:Derived	signature:()
 foo	input.cpp	/^	virtual void foo() = 0;$/;"	p	class:Base	file:	signature:()
-foo	input.cpp	/^	virtual void foo();$/;"	p	class:Derived	file:	signature:()
+foo	input.cpp	/^	virtual void foo() final;$/;"	p	class:Derived	file:	signature:()
 foo	input.cpp	/^void Base::foo()$/;"	f	class:Base	signature:()
 foo	input.cpp	/^void Derived::foo()$/;"	f	class:Derived	signature:()

--- a/Units/cxx11-final.d/expected.tags
+++ b/Units/cxx11-final.d/expected.tags
@@ -1,0 +1,8 @@
+Base	input.cpp	/^class Base$/;"	c	file:
+Derived	input.cpp	/^class Derived final : public Base$/;"	c	file:
+final	input.cpp	/^	virtual void final();$/;"	p	class:Derived	file:	signature:()
+final	input.cpp	/^void Derived::final()$/;"	f	class:Derived	signature:()
+foo	input.cpp	/^	virtual void foo() = 0;$/;"	p	class:Base	file:	signature:()
+foo	input.cpp	/^	virtual void foo();$/;"	p	class:Derived	file:	signature:()
+foo	input.cpp	/^void Base::foo()$/;"	f	class:Base	signature:()
+foo	input.cpp	/^void Derived::foo()$/;"	f	class:Derived	signature:()

--- a/Units/cxx11-final.d/input.cpp
+++ b/Units/cxx11-final.d/input.cpp
@@ -1,0 +1,23 @@
+class Base
+{
+public:
+	virtual void foo() = 0;
+};
+
+class Derived final : public Base
+{
+	virtual void foo();
+	virtual void final();
+};
+
+void Base::foo()
+{
+}
+
+void Derived::foo()
+{
+}
+
+void Derived::final()
+{
+}

--- a/Units/cxx11-final.d/input.cpp
+++ b/Units/cxx11-final.d/input.cpp
@@ -6,7 +6,7 @@ public:
 
 class Derived final : public Base
 {
-	virtual void foo();
+	virtual void foo() final;
 	virtual void final();
 };
 

--- a/Units/cxx11-noexcept.d/args.ctags
+++ b/Units/cxx11-noexcept.d/args.ctags
@@ -1,0 +1,2 @@
+--c++-kinds=+p
+--fields=+S

--- a/Units/cxx11-noexcept.d/expected.tags
+++ b/Units/cxx11-noexcept.d/expected.tags
@@ -1,0 +1,4 @@
+Base	input.cpp	/^class Base$/;"	c	file:
+bar	input.cpp	/^	virtual void bar() const noexcept = 0;$/;"	p	class:Base	file:	signature:() const
+baz	input.cpp	/^	int baz() noexcept { return 42; }$/;"	f	class:Base	signature:()
+foo	input.cpp	/^	virtual void foo() noexcept = 0;$/;"	p	class:Base	file:	signature:()

--- a/Units/cxx11-noexcept.d/input.cpp
+++ b/Units/cxx11-noexcept.d/input.cpp
@@ -1,0 +1,7 @@
+class Base
+{
+public:
+	virtual void foo() noexcept = 0;
+	virtual void bar() const noexcept = 0;
+	int baz() noexcept { return 42; }
+};

--- a/Units/cxx11-override.d/args.ctags
+++ b/Units/cxx11-override.d/args.ctags
@@ -1,0 +1,2 @@
+--c++-kinds=+p
+--fields=+S

--- a/Units/cxx11-override.d/expected.tags
+++ b/Units/cxx11-override.d/expected.tags
@@ -1,0 +1,8 @@
+Base	input.cpp	/^class Base$/;"	c	file:
+Derived	input.cpp	/^class Derived : public Base$/;"	c	file:
+foo	input.cpp	/^	virtual void foo() = 0;$/;"	p	class:Base	file:	signature:()
+foo	input.cpp	/^	virtual void foo() override;$/;"	p	class:Derived	file:	signature:()
+foo	input.cpp	/^void Base::foo()$/;"	f	class:Base	signature:()
+foo	input.cpp	/^void Derived::foo()$/;"	f	class:Derived	signature:()
+override	input.cpp	/^	virtual void override();$/;"	p	class:Derived	file:	signature:()
+override	input.cpp	/^void Derived::override()$/;"	f	class:Derived	signature:()

--- a/Units/cxx11-override.d/input.cpp
+++ b/Units/cxx11-override.d/input.cpp
@@ -1,0 +1,23 @@
+class Base
+{
+public:
+	virtual void foo() = 0;
+};
+
+class Derived : public Base
+{
+	virtual void foo() override;
+	virtual void override();
+};
+
+void Base::foo()
+{
+}
+
+void Derived::foo()
+{
+}
+
+void Derived::override()
+{
+}

--- a/Units/cxx14-combined.d/args.ctags
+++ b/Units/cxx14-combined.d/args.ctags
@@ -1,0 +1,2 @@
+--c++-kinds=+p
+--fields=+S

--- a/Units/cxx14-combined.d/expected.tags
+++ b/Units/cxx14-combined.d/expected.tags
@@ -1,0 +1,5 @@
+Base	input.cpp	/^struct Base {$/;"	s	file:
+Foo	input.cpp	/^struct Foo final : public Base {$/;"	s	file:
+bar	input.cpp	/^  static constexpr auto bar() noexcept { return 1; }$/;"	f	struct:Foo	signature:()
+baz	input.cpp	/^  virtual void baz() const throw() = 0;$/;"	p	struct:Base	file:	signature:() const
+baz	input.cpp	/^  virtual void baz() const throw() final override;$/;"	p	struct:Foo	file:	signature:() const

--- a/Units/cxx14-combined.d/input.cpp
+++ b/Units/cxx14-combined.d/input.cpp
@@ -1,0 +1,8 @@
+struct Base {
+  virtual void baz() const throw() = 0;
+};
+
+struct Foo final : public Base {
+  static constexpr auto bar() noexcept { return 1; }
+  virtual void baz() const throw() final override;
+};

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -2289,7 +2289,13 @@ static boolean skipPostArgumentStuff (
 					break;
 
 				default:
-					if (isType (token, TOKEN_NONE))
+					/* "override" and "final" are only keywords in the declaration of a virtual
+					 * member function, so need to be handled specially, not as keywords */
+					if (isLanguage(Lang_cpp) && isType (token, TOKEN_NAME) &&
+						(strcmp ("override", vStringValue (token->name)) == 0 ||
+						 strcmp ("final", vStringValue (token->name)) == 0))
+						;
+					else if (isType (token, TOKEN_NONE))
 						;
 					else if (info->isKnrParamList  &&  info->parameterCount > 0)
 						++elementCount;

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3062,8 +3062,18 @@ static void tagCheck (statementInfo *const st)
 					st->declaration == DECL_VERSION ||
 					st->declaration == DECL_PROGRAM)
 			{
-				if (isType (prev, TOKEN_NAME))
-					copyToken (st->blockName, prev);
+				const tokenInfo *name_token = prev;
+
+				/* C++ 11 allows class <name> final { ... } */
+				if (isLanguage (Lang_cpp) && isType (prev, TOKEN_NAME) &&
+					strcmp("final", vStringValue(prev->name)) == 0 &&
+					isType(prev2, TOKEN_NAME))
+				{
+					name_token = prev2;
+				}
+
+				if (isType (name_token, TOKEN_NAME))
+					copyToken (st->blockName, name_token);
 				else
 				{
 					/*  For an anonymous struct or union we use a unique ID
@@ -3075,7 +3085,7 @@ static void tagCheck (statementInfo *const st)
 					st->blockName->type = TOKEN_NAME;
 					st->blockName->keyword = KEYWORD_NONE;
 				}
-				qualifyBlockTag (st, prev);
+				qualifyBlockTag (st, name_token);
 			}
 			else if (isLanguage (Lang_csharp))
 				makeTag (prev, st, FALSE, TAG_PROPERTY);

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -78,7 +78,7 @@ typedef enum eKeywordId {
 	KEYWORD_LOCAL, KEYWORD_LONG,
 	KEYWORD_M_BAD_STATE, KEYWORD_M_BAD_TRANS, KEYWORD_M_STATE, KEYWORD_M_TRANS,
 	KEYWORD_MUTABLE,
-	KEYWORD_NAMESPACE, KEYWORD_NEW, KEYWORD_NEWCOV, KEYWORD_NATIVE,
+	KEYWORD_NAMESPACE, KEYWORD_NEW, KEYWORD_NEWCOV, KEYWORD_NATIVE, KEYWORD_NOEXCEPT,
 	KEYWORD_OPERATOR, KEYWORD_OUTPUT, KEYWORD_OVERLOAD, KEYWORD_OVERRIDE,
 	KEYWORD_PACKED, KEYWORD_PORT, KEYWORD_PACKAGE, KEYWORD_PRIVATE,
 	KEYWORD_PROGRAM, KEYWORD_PROTECTED, KEYWORD_PUBLIC,
@@ -510,6 +510,7 @@ static const keywordDesc KeywordTable [] = {
      { "native",          KEYWORD_NATIVE,          { 0, 0, 0, 0, 1, 0 } },
      { "new",             KEYWORD_NEW,             { 0, 1, 1, 1, 1, 0 } },
      { "newcov",          KEYWORD_NEWCOV,          { 0, 0, 0, 0, 0, 1 } },
+     { "noexcept",        KEYWORD_NOEXCEPT,        { 0, 1, 0, 0, 0, 0 } },
      { "null",            KEYWORD_NULL,            { 0, 0, 0, 1, 0, 0 } },
      { "operator",        KEYWORD_OPERATOR,        { 0, 1, 1, 1, 0, 0 } },
      { "out",             KEYWORD_OUT,             { 0, 0, 0, 1, 0, 0 } },
@@ -2252,6 +2253,7 @@ static boolean skipPostArgumentStuff (
 				case KEYWORD_THROW:     skipParens ();  break;
 				case KEYWORD_IF:        if (isLanguage (Lang_d)) skipParens ();  break;
 				case KEYWORD_TRY:                       break;
+				case KEYWORD_NOEXCEPT:                  break;
 
 				case KEYWORD_CONST:
 				case KEYWORD_VOLATILE:


### PR DESCRIPTION
Add support for some C++11 things:
* `final` contextual keywords on classes and structs
* `final` and `override` contextual keywords on methods (see also #405)
* `noexcept`

See also https://github.com/geany/geany/pull/544.  Note that some Geany commits referenced there are not yet merged into master, as I PR this here first to get comments and avoid further divergence.