### PR TITLE
tex: don't make a tag for a zero length name

### DIFF
--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -453,8 +453,11 @@ static boolean parseTag (tokenInfo *const token, texKind kind)
 		if (useLongName)
 		{
 			vStringTerminate (fullname);
-			vStringCopy (name->string, fullname);
-			makeTexTag (name, kind);
+			if (vStringLength (fullname) > 0)
+			{
+				vStringCopy (name->string, fullname);
+				makeTexTag (name, kind);
+			}
 		}
 	}
 


### PR DESCRIPTION
ctags warns when following input gives:

     \section{}

because a zero length name is passed to makeTagEntry.

This patch makes the tex parser not pass such
zero length names.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>