### PR TITLE
debug: Print currently parsed file and line number on asserting

### DIFF
--- a/main/debug.c
+++ b/main/debug.c
@@ -13,6 +13,8 @@
 #include "general.h"  /* must always come first */
 
 #include <ctype.h>
+#include <stdlib.h>
+#include <stdio.h>
 #include <stdarg.h>
 
 #include "debug.h"
@@ -104,6 +106,23 @@ extern void debugEntry (const tagEntryInfo *const tag)
 		printf ("#>");
 		fflush (stdout);
 	}
+}
+
+extern void debugAssert (const char *assertion, const char *file, unsigned int line, const char *function)
+{
+	fprintf(stderr, "ctags: %s:%u: %s%sAssertion `%s' failed.\n",
+	        file, line,
+	        function ? function : "", function ? ": " : "",
+	        assertion);
+	if (File.name)
+	{
+		fprintf(stderr, "ctags: %s:%u: parsing %s:%lu as %s\n",
+		        file, line,
+		        getSourceFileName(), getSourceLineNumber(),
+		        getSourceLanguageName());
+	}
+	fflush(stderr);
+	abort();
 }
 
 #endif

--- a/main/debug.h
+++ b/main/debug.h
@@ -27,7 +27,19 @@
 # define debug(level)      ((Option.debugLevel & (long)(level)) != 0)
 # define DebugStatement(x) x
 # define PrintStatus(x)    if (debug(DEBUG_STATUS)) printf x;
-# define Assert(c)         assert(c)
+# ifdef NDEBUG
+#  define Assert(c)
+# else
+   /* based on glibc's assert.h __ASSERT_FUNCTION */
+#  if defined (__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 4))
+#   define ASSERT_FUNCTION __PRETTY_FUNCTION__
+#  elif defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+#   define ASSERT_FUNCTION __func__
+#  else
+#   define ASSERT_FUNCTION ((const char*)0)
+#  endif
+#  define Assert(c) ((c) ? ((void)0) : debugAssert(#c, __FILE__, __LINE__, ASSERT_FUNCTION))
+# endif
 #else
 # define DebugStatement(x)
 # define PrintStatus(x)
@@ -62,6 +74,7 @@ extern void debugParseNest (const boolean increase, const unsigned int level);
 extern void debugCppNest (const boolean begin, const unsigned int level);
 extern void debugCppIgnore (const boolean ignore);
 extern void debugEntry (const tagEntryInfo *const tag);
+extern void debugAssert (const char *assertion, const char *file, unsigned int line, const char *function) attr__noreturn;
 
 #endif  /* _DEBUG_H */
 

--- a/main/general.h
+++ b/main/general.h
@@ -45,9 +45,11 @@
 #  define __unused__ __attribute__((unused))
 # endif
 # define __printf__(s,f)  __attribute__((format (printf, s, f)))
+# define attr__noreturn __attribute__((__noreturn__))
 #else
 # define __unused__
 # define __printf__(s,f)
+# define attr__noreturn
 #endif
 
 /*


### PR DESCRIPTION
If an assertion occurs during parsing of a file, print the location in the parsed input where the assertion occurred.

Closes #420.