### PR TITLE
Fix typos

### DIFF
--- a/ctags.1.in
+++ b/ctags.1.in
@@ -684,7 +684,7 @@ specified, it should contain one option per line. If a directory is
 specified(and scandir function is available at build configuration time),
 files suffixed with .ctags or .conf under the directory are read. (On MSDOS
 or MSWindows this directory traverse feature is temporary disable because the
-contributor of this feature has no access to the platfroms.
+contributor of this feature has no access to the platforms.
 Volunters are welcome).
 As a special case, if
 \fB\-\-options\fP=\fINONE\fP is specified as the first option on the command

--- a/docs/guessing.rst
+++ b/docs/guessing.rst
@@ -111,7 +111,7 @@ If no parser is selected, ``NONE`` is printed as parser name.
 Guessing from keywords
 ---------------------------------------------------------------------
 
-Not implementated.
+Not implemented.
 
 Some parses have keywords table. We can utilize them to guess
 the language of input files.

--- a/docs/internal.rst
+++ b/docs/internal.rst
@@ -31,8 +31,8 @@ parser does not set `useCork` field. `writeTagEntry` calls one of
 three functions, `writeTagsEntry`, `writeXrefEntry` or `writeCtagsEntry`.
 One of them is chosen depending on the arguments passed to ctags.
 
-If `useCork` is set, the tag informations goes to a queue on memroy.
-The queu is flushed when `useCork` in unset. See `cork API` for more
+If `useCork` is set, the tag informations goes to a queue on memory.
+The queue is flushed when `useCork` in unset. See `cork API` for more
 details.
 
 cork API

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -54,7 +54,7 @@ Tagging #undef
 Wildcard in options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For the purpose gathering as mach as possible information from source
+For the purpose gathering as much as possible information from source
 code "wildcard"(``*``) in option is introduced.
 
 ``--fields=*``
@@ -83,18 +83,18 @@ There were 3 classes of message in ctags:
 
 *fatal*
 
-	A ciritical error is occured. ctags aborts the execution.
+	A critical error is occurred. ctags aborts the execution.
 
 *warning*
 
-	An error is occured but ctags continues the execution.
+	An error is occurred but ctags continues the execution.
 
 *verbose*
 
-	Mainly for debugging prupose.
+	Mainly for debugging purpose.
 
 
 *notice* is a new class of message. It is less important than warning*
 *but more important for users than *verbose*. Generally the user can
 *ignore *notice*. With ``--quiet`` option can be used to turn off the
-priting the *notice* class messages.
+printing the *notice* class messages.

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -207,7 +207,7 @@ weaknesses exist in this implementation.
   of NFS.
 
 * The configuration defined by the system administrator cannot be
-  overriden.
+  overridden.
 
   A user must accept all configuration including ``--options=``
   in */etc/ctags.conf* and */usr/local/etc/ctags.conf*.

--- a/docs/other-projects.rst
+++ b/docs/other-projects.rst
@@ -59,13 +59,13 @@ pygments
 	at names and lines in tags file. scopes and kinds are not
 	used.
 
-	As far as I(Masataake YAMATO) tried, using pygments from ctags
-	is not so useful. There are critical gap betwenn ctags and pygments.
+	As far as I(Masatake YAMATO) tried, using pygments from ctags
+	is not so useful. There are critical gap between ctags and pygments.
 	ctags focuses on identifiers. pygments focuses on keywords.
 
 GNU global
 
-	I(Masatke YAMATO) don't inspect this much but GNU global uses
+	I(Masatake YAMATO) don't inspect this much but GNU global uses
 	ctags internally.
 
 	A person at GNU global project proposed an extension for the tags file
@@ -79,16 +79,16 @@ GNU source highlight
 	as input for making hyperlinks.
 	http://www.gnu.org/software/src-highlite/source-highlight.html#Generating-References
 
-	I(Masatke YAMATO) have not tried the feature yet.
+	I(Masatake YAMATO) have not tried the feature yet.
 
 OpenGrok
 	
-	I(Masatke YAMATO) don't inspect this much but OpenGrok uses
+	I(Masatake YAMATO) don't inspect this much but OpenGrok uses
 	ctags internally.
 
-Linux kenrel
+Linux kernel
 
-	See linux/scripts/tags.sh of Linux kenrel source tree.
+	See linux/scripts/tags.sh of Linux kernel source tree.
 	It utilizes c parser to the utmost limit.
 
 	

--- a/docs/semifuzz.rst
+++ b/docs/semifuzz.rst
@@ -24,7 +24,7 @@ with a non-zero status. The timeout will be reported as following::
 
 This means that if C parser doesn't stop within N seconds when
 *Units/test.vhd.t/input.vhd* is given as an input, timeout will
-interrup ctags. The default duration can be changed using
+interrupt ctags. The default duration can be changed using
 ``TIMEOUT=N`` argument in *make* command. If there is no timeout but
 the exit status is non-zero, the target reports it as following::
 

--- a/docs/units.rst
+++ b/docs/units.rst
@@ -5,7 +5,7 @@
 
 ----
 
-Exuberant ctags has a test facility. The test casse were *Test*
+Exuberant ctags has a test facility. The test case were *Test*
 directory. So Here I call it *Test*.
 
 Main aim of the facility is detecting regression. All files under Test
@@ -59,7 +59,7 @@ have its own directory under Units directory.
 	In such case you don't have write ``-e`` to ``args.ctags``.
 	THe test facility sets ``-e`` automatically.
 
-	If you want to test corss reference output (specified with ``-x`` ),
+	If you want to test cross reference output (specified with ``-x`` ),
 	Use **.tags-x** as suffix instead of **.tags**.
 	In such case you don't have write ``-x`` to ``args.ctags``.
 	THe test facility sets ``-x`` automatically.

--- a/docs/xcmd.rst
+++ b/docs/xcmd.rst
@@ -156,7 +156,7 @@ Following example is taken from ``CoffeeTags``::
 	!_TAG_PROGRAM_URL	https://github.com/lukaszkorecki/CoffeeTags	/GitHub repository/
 	!_TAG_PROGRAM_VERSION	0.5.0	//
 
-ctags merges the Psuedo-tag lines with ``!LANG`` suffix::
+ctags merges the Pseudo-tag lines with ``!LANG`` suffix::
 
 	$ ./ctags   --language-force=coffee foo.coffee; cat tags | grep '^!'
 	!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
@@ -217,7 +217,7 @@ Here is an example taken from ``data/optlib/coffee.ctags``::
 	--coffee-map=+.coffee
 	--coffee-xcmd=coffeetags
 
-Finnaly you have to add these new two files to ``Makefile.in``.
+Finally you have to add these new two files to ``Makefile.in``.
 Add the name of driver file to ``DRIVERS`` variable like::
 
 	DRIVERS = coffeetags

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -1,4 +1,4 @@
-# Makefile for Unverisal Ctags under Win32 with MinGW compiler
+# Makefile for Universal Ctags under Win32 with MinGW compiler
 
 include source.mak
 


### PR DESCRIPTION
Note: I found that some files still uses the old name 'exuberant ctags', but I didn't update them. Just fixed typos.
E.g. ctags.1.in, ctags.spec, maintainer.mak, ...

\# Vim's built-in spellchecker helps me a lot to find these typos.