### PR TITLE
c++: Handle C++11 '= delete'

### DIFF
--- a/Units/cxx11-delete.d/args.ctags
+++ b/Units/cxx11-delete.d/args.ctags
@@ -1,0 +1,2 @@
+--c++-kinds=+p
+--fields=+S

--- a/Units/cxx11-delete.d/expected.tags
+++ b/Units/cxx11-delete.d/expected.tags
@@ -1,0 +1,3 @@
+Del	input.cpp	/^    Del(const Del &) = delete;$/;"	p	class:Del	file:	signature:(const Del &)
+Del	input.cpp	/^class Del$/;"	c	file:
+operator =	input.cpp	/^    void operator=(const Del& rDel) = delete;$/;"	p	class:Del	file:	signature:(const Del& rDel)

--- a/Units/cxx11-delete.d/input.cpp
+++ b/Units/cxx11-delete.d/input.cpp
@@ -1,0 +1,6 @@
+class Del
+{
+private:
+    Del(const Del &) = delete;
+    void operator=(const Del& rDel) = delete;
+};

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -2655,7 +2655,7 @@ static void analyzeParens (statementInfo *const st)
 				 ! st->gotParenName  &&
 				 (! info.isParamList || ! st->haveQualifyingName  ||
 				  c == '('  ||
-				  (c == '='  &&  st->implementation != IMP_VIRTUAL) ||
+				  (c == '='  &&  st->implementation != IMP_VIRTUAL && !isLanguage (Lang_cpp)) ||
 				  (st->declaration == DECL_NONE  &&  isOneOf (c, ",;"))))
 		{
 			token->type = TOKEN_NAME;


### PR DESCRIPTION
In C++03 '= 0' was only valid if the member function was virtual, but in
C++11 '=' may be used for non-virtual member functions, too.

Without the change, the 'Del::operator =' declaration is not found in
the testcase.