### PR TITLE
fix objc property error

### DIFF
--- a/Units/parser-objectivec.r/objectivec_property.h.d/expected.tags
+++ b/Units/parser-objectivec.r/objectivec_property.h.d/expected.tags
@@ -1,5 +1,5 @@
 Person	input.h	/^@interface Person : NSObject {$/;"	i	interface:
-age	input.h	/^-(id)initWithAge:(int)age;$/;"	p	interface:Person
+initWithAge:	input.h	/^-(id)initWithAge:(int)age;$/;"	m	interface:Person
 m_age	input.h	/^        int m_age;$/;"	F	interface:Person
 m_name	input.h	/^        NSString *m_name;$/;"	F	interface:Person
 personAge	input.h	/^@property(readonly) int personAge;$/;"	p	interface:Person

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -707,6 +707,7 @@ static void parseProperty (vString * const ident, objcToken what)
 	case Tok_semi:
 		addTag (tempName, K_PROPERTY);
 		vStringClear (tempName);
+		toDoNext = &parseMethods;
 		break;
 
 	default:


### PR DESCRIPTION
there have two bugs: 
first, in `ObjcKinds`, `Protocol` and `property` type both used token `p`, this may cause some conflict. 
I changed the protocol to upper case `P`.

second, in `parseProperty` function, it never set next operation, so if entering parsing property, it won't stop parsing property,  and after other type will parse fail.
here I fix it and set next to the `parseMethods` func, where parseProperty be used from.