### PR TITLE
a prototype of our own budge (7 days)

### DIFF
--- a/misc/budge
+++ b/misc/budge
@@ -1,0 +1,75 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------------------
+# Show the ratio of the number of files handled by ctags to the number of all files of ctags source directory.
+# -----------------------------------------------------------------------------------------
+: ${CTAGS_TEST:=./ctags}
+
+#
+# Report all unsupported files
+#
+VERBOSE=0
+
+print_help()
+{
+    echo "Usage:"
+    echo "	$0 -h|--help"
+    echo "	$0 [-v|--verbose [-v|--verbose]]"
+    exit $1
+}
+
+while [ $# -gt 0 ]; do
+    case $1 in
+	-h|--help)
+	    print_help 0
+	    ;;
+	-v|--verbose)
+	    VERBOSE=`expr $VERBOSE + 1`
+	    ;;
+	-*)
+	    echo "unknown option: $1"
+	    print_help 1
+	    ;;
+	*)
+	    echo "unknown expected argument: $1"
+	    print_help 1
+	    ;;
+    esac
+    shift
+done
+
+CMDLINE="${CTAGS_TEST} --quiet --options=NONE -G --options=./.ctags --data-dir=+./data --languages=all --options=misc/budge.ctags -R --print-language"
+ALL_FILES=$(git ls-files)
+
+TOTAL=0
+HAS_PARSER=0
+member()
+{
+    local input=$1
+    local f
+    for f in $ALL_FILES; do
+	if [ "$f" = "$input" ]; then
+	    return 0
+	fi
+    done
+    return 1
+}
+
+INPUT=
+LANG=
+${CMDLINE} | { while IFS=': 	' read INPUT LANG; do
+		   if member "$INPUT"; then
+		       if [ "$LANG" != NONE ]; then
+			   if [ "$VERBOSE" -gt 1 ]; then
+			       printf "%-60s %s\n" $INPUT $LANG
+			   fi
+			   HAS_PARSER=$(( HAS_PARSER + 1 ))
+		       else
+			   if [ "${VERBOSE}" -gt 0 ]; then
+			       printf "%-60s %s\n" $INPUT NONE
+			   fi
+		       fi
+		       TOTAL=$(( TOTAL + 1 ))
+		   fi
+	       done
+	       echo "[ctags|$(expr 100 '*' $HAS_PARSER  / $TOTAL)%]"
+}

--- a/misc/budge.ctags
+++ b/misc/budge.ctags
@@ -1,0 +1,7 @@
+#
+# In the future these should be preload'ed
+#
+--options=ctags
+--options=mib
+--options=m4
+--options=gdbinit


### PR DESCRIPTION
How ctags source code is coverted by ctags?

This script shows the ratio of the number of files handled by ctags to
the number of all files of ctags source directory.

Usage(simple):

    $  bash misc/budge
    [ctags|87%]

Usage(verbose):

    $ VERBOSE=1 dash misc/budge
    README.md: NONE
    ctags.1.in: NONE
    .indent.pro: NONE
    COPYING: NONE
    docs/output-tag-stream.svg: NONE
    .travis.yml: NONE
    old-docs/FAQ: NONE
    old-docs/INSTALL.oth: NONE
    old-docs/website/FORMAT: NONE
    old-docs/website/ctags.xcf: NONE
    old-docs/website/ctags.png: NONE
    old-docs/INSTALL: NONE
    old-docs/NEWS.exuberant: NONE
    old-docs/README.exuberant: NONE
    old-docs/MAINTAINERS: NONE
    .gdbinit: NONE
    Eiffel/Ace.ace: NONE
    ctags.spec: NONE
    configure.ac: NONE
    win32/ctags_vs2013.vcxproj: NONE
    win32/ctags_vs2013.vcxproj.filters: NONE
    win32/ctags_vs2013.sln: NONE
    gnu_regex/README.txt: NONE
    [ctags|87%]

This is related to my plan: https://github.com/universal-ctags/universal-ctags.github.io/issues/9

Signed-off-by: Masatake YAMATO <yamato@redhat.com>