### PR TITLE
Reorganize docs folder to make it more readable

### DIFF
--- a/docs/building.rst
+++ b/docs/building.rst
@@ -1,11 +1,11 @@
 Building ctags
 =============================================================================
 
-.. include:: autotools.rst
+`Building with configure <autotools.rst>`_
 
-.. include:: windows.rst
+`Building/hacking/using on MS-Windows <windows.rst>`_
 
-.. include:: osx.rst
+`Building on Mac OS <osx.rst>`_
 
 Build system add possibility to change program name
 ---------------------------------------------------------------------

--- a/docs/other-projects.rst
+++ b/docs/other-projects.rst
@@ -47,7 +47,7 @@ These changes have been merged:
 * Some fixes for D parser
 * C++11's enum class/struct support
 
-.. include:: tracking.rst
+`Tracking other projects <tracking.rst>`_
 
 Softwares using ctags
 ----------------------------------------------------------------------

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -35,60 +35,26 @@ Contents
 
 .. raw:: pdf
 
-   PageBreak oneColumn
 
-.. include:: news.rst
-.. raw:: pdf
+`Introduced changes <news.rst>`_
 
-   PageBreak oneColumn
+`Choosing a proper parser in ctags <guessing.rst>`_
 
-.. include:: guessing.rst
-.. raw:: pdf
+`Building ctags <building.rst>`_
 
-   PageBreak oneColumn
+`Testing ctags <testing.rst>`_
 
-.. include:: building.rst
-.. raw:: pdf
+`Extending ctags with Regex parser (optlib) <optlib.rst>`_
 
-   PageBreak oneColumn
+`Extending ctags with xcmd <xcmd.rst>`_
 
-.. include:: testing.rst
-.. raw:: pdf
+`ctags Internal API <internal.rst>`_
 
-   PageBreak oneColumn
+`Tips for hacking <tips.rst>`_
 
-.. include:: optlib.rst
-.. raw:: pdf
+`Relationship between other projects <other-projects.rst>`_
 
-   PageBreak oneColumn
+`Tag Format <format.rst>`_
 
-.. include:: xcmd.rst
-.. raw:: pdf
-
-   PageBreak oneColumn
-
-.. include:: internal.rst
-.. raw:: pdf
-
-   PageBreak oneColumn
-
-.. include:: tips.rst
-.. raw:: pdf
-
-   PageBreak oneColumn
-
-.. include:: other-projects.rst
-.. raw:: pdf
-
-   PageBreak oneColumn
-
-.. include:: format.rst
-.. raw:: pdf
-
-   PageBreak oneColumn
-
-.. include:: developers.rst
-.. raw:: pdf
-
-   PageBreak oneColumn
+`Who we are <developers.rst>`_
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -5,13 +5,13 @@ It it difficult for us to know syntax of all languages supported in
 ctags. Test facility and test cases are quite import for maintaining
 ctags in limited resources.
 
-.. include:: units.rst
+`Units test facility <units.rst>`_
 
-.. include:: semifuzz.rst
+`Semi fuzz(Fuzz) testing <semifuzz.rst>`_
 
-.. include:: noise.rst
+`Noise testing <noise.rst>`_
 	     
-.. include:: tmain.rst
+`Tmain: a facility for testing main part <tmain.rst>`_
 
-.. include:: tinst.rst
+`Tinst installation test <tinst.rst>`_
 


### PR DESCRIPTION
This is done by:
move universal-ctags.rst to readme.rst
replace include sentences with links

Following discussions in: https://github.com/universal-ctags/ctags/issues/437