### PR TITLE
m4: make the parser optional (2 days)

### DIFF
--- a/Units/parser-m4.r/m4-comment.d/args.ctags
+++ b/Units/parser-m4.r/m4-comment.d/args.ctags
@@ -1,2 +1,3 @@
 --options=m4
+--languages=+m4
 --m4-kinds=+I

--- a/Units/parser-m4.r/m4-multi-undef.b/args.ctags
+++ b/Units/parser-m4.r/m4-multi-undef.b/args.ctags
@@ -1,1 +1,2 @@
 --options=m4
+--languages=+m4

--- a/Units/parser-m4.r/m4-simple.d/args.ctags
+++ b/Units/parser-m4.r/m4-simple.d/args.ctags
@@ -1,2 +1,3 @@
 --options=m4
+--languages=+m4
 --m4-kinds=+I

--- a/data/optlib/m4.ctags
+++ b/data/optlib/m4.ctags
@@ -22,6 +22,7 @@
 #
 #
 --langdef=m4
+--languages=-m4
 --map-m4=+.m4
 
 #


### PR DESCRIPTION
You can turn it on with --languages=+m4.

I will add more small regex based parsers for rather minor languages.
These are for making hyper text with pygments. Many part of users may not have interests 
tags for such minor langauges, I disable it by default.