### PR TITLE
units, ruby: new bug case reported in #455

### DIFF
--- a/Units/ruby-class-method-in-lt-lt-self.b/expected.tags
+++ b/Units/ruby-class-method-in-lt-lt-self.b/expected.tags
@@ -1,0 +1,2 @@
+C	input.rb	/^class C$/;"	c
+foo	input.rb	/^    def foo() end$/;"	F	class:C

--- a/Units/ruby-class-method-in-lt-lt-self.b/input.rb
+++ b/Units/ruby-class-method-in-lt-lt-self.b/input.rb
@@ -1,0 +1,7 @@
+# (Taken from #455 opened by @mlslav).
+class C
+  class << self
+    def foo() end
+  end
+end
+


### PR DESCRIPTION
This test case represents a bug report of #455.
The input.rb is completely based on a comment by @mislav in #455.