### PR TITLE
Various Ruby fixes

### DIFF
--- a/Units/review-needed.r/simple.rb.t/expected.tags
+++ b/Units/review-needed.r/simple.rb.t/expected.tags
@@ -1,9 +1,9 @@
-ClassExample	input.rb	/^    class ClassExample$/;"	c	class:ModuleExample
+ClassExample	input.rb	/^    class ClassExample$/;"	c	module:ModuleExample
 ModuleExample	input.rb	/^module ModuleExample$/;"	m
 `	input.rb	/^        def `(command)$/;"	f	class:ModuleExample.ClassExample
 class_method	input.rb	/^        def class_method$/;"	f	class:ModuleExample.ClassExample
 class_method_exclamation!	input.rb	/^        def class_method_exclamation!$/;"	f	class:ModuleExample.ClassExample
 class_method_question?	input.rb	/^        def class_method_question?$/;"	f	class:ModuleExample.ClassExample
-module_method	input.rb	/^    def module_method$/;"	f	class:ModuleExample
+module_method	input.rb	/^    def module_method$/;"	f	module:ModuleExample
 singleton_class_method	input.rb	/^        def ClassExample.singleton_class_method$/;"	F	class:ModuleExample.ClassExample
-singleton_module_method	input.rb	/^    def ModuleExample.singleton_module_method$/;"	F	class:ModuleExample
+singleton_module_method	input.rb	/^    def ModuleExample.singleton_module_method$/;"	F	module:ModuleExample

--- a/Units/ruby-block-call.d/expected.tags
+++ b/Units/ruby-block-call.d/expected.tags
@@ -1,0 +1,2 @@
+nothing	input.rb	/^def nothing$/;"	f
+plop	input.rb	/^def plop$/;"	f

--- a/Units/ruby-block-call.d/input.rb
+++ b/Units/ruby-block-call.d/input.rb
@@ -1,0 +1,10 @@
+
+def plop
+	[ 1, 2, 3, 4 ].each do |x|
+		x > 0
+	end.all?
+end
+
+def nothing
+	puts "nothing"
+end

--- a/Units/ruby-class-method-in-lt-lt-self.d/expected.tags
+++ b/Units/ruby-class-method-in-lt-lt-self.d/expected.tags
@@ -1,3 +1,2 @@
 C	input.rb	/^class C$/;"	c
-bar	input.rb	/^  def bar(); end$/;"	f	class:C
 foo	input.rb	/^    def foo() end$/;"	F	class:C

--- a/Units/ruby-class-method-in-lt-lt-self.d/input.rb
+++ b/Units/ruby-class-method-in-lt-lt-self.d/input.rb
@@ -1,0 +1,6 @@
+# (Taken from #455 opened by @mislav).
+class C
+  class << self
+    def foo() end
+  end
+end

--- a/Units/ruby-doc.d/expected.tags
+++ b/Units/ruby-doc.d/expected.tags
@@ -1,0 +1,4 @@
+f0	input.rb	/^def f0; end$/;"	f
+f1	input.rb	/^def f1; end$/;"	f
+f2	input.rb	/^def f2; end$/;"	f
+f3	input.rb	/^def f3; end$/;"	f

--- a/Units/ruby-doc.d/input.rb
+++ b/Units/ruby-doc.d/input.rb
@@ -1,0 +1,22 @@
+def f0; end
+
+=begin
+def bug1
+end
+=end
+
+def f1; end
+
+=begin 
+def bug2
+end
+=end
+
+def f2; end
+
+=begin	def doesntcount end
+def bug3
+end
+=end def notparsed end
+
+def f3; end

--- a/Units/ruby-namespaced-class.d/expected.tags
+++ b/Units/ruby-namespaced-class.d/expected.tags
@@ -1,3 +1,3 @@
 A	input.rb	/^module A$/;"	m
-B	input.rb	/^  module B$/;"	m	class:A
-C	input.rb	/^class A::B::C; end$/;"	c	class:A.B
+B	input.rb	/^  module B$/;"	m	module:A
+C	input.rb	/^class A::B::C; end$/;"	c	module:A.B

--- a/Units/ruby-namespaced-class.d/expected.tags
+++ b/Units/ruby-namespaced-class.d/expected.tags
@@ -1,0 +1,3 @@
+A	input.rb	/^module A$/;"	m
+B	input.rb	/^  module B$/;"	m	class:A
+C	input.rb	/^class A::B::C; end$/;"	c	class:A.B

--- a/Units/ruby-namespaced-class.d/input.rb
+++ b/Units/ruby-namespaced-class.d/input.rb
@@ -1,0 +1,8 @@
+module A
+  module B
+  end
+end
+
+class A::B::C; end
+
+puts A::B::C

--- a/Units/ruby-scope-after-anonymous-class.d/expected.tags
+++ b/Units/ruby-scope-after-anonymous-class.d/expected.tags
@@ -1,0 +1,3 @@
+C	input.rb	/^class C$/;"	c
+bar	input.rb	/^  def bar(); end$/;"	f	class:C
+foo	input.rb	/^    def foo() end$/;"	f	class:C

--- a/Units/ruby-scope-after-anonymous-class.d/input.rb
+++ b/Units/ruby-scope-after-anonymous-class.d/input.rb
@@ -1,0 +1,10 @@
+class C
+  class << self
+    def foo() end
+  end
+  
+  def bar(); end
+end
+
+puts C.foo
+puts C.new.bar

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -450,7 +450,24 @@ static void findRubyTags (void)
 		}
 		else if (canMatchKeyword (&cp, "def"))
 		{
-			readAndEmitTag (&cp, K_METHOD);
+			rubyKind kind = K_METHOD;
+			NestingLevel *nl = nestingLevelsGetCurrent (nesting);
+
+			/* if the def is inside an unnamed scope at the class level, assume
+			 * it's from a singleton from a construct like this:
+			 *
+			 * class C
+			 *   class << self
+			 *     def singleton
+			 *       ...
+			 *     end
+			 *   end
+			 * end
+			 */
+			if (nl && nl->type == K_CLASS && vStringLength (nl->name) == 0)
+				kind = K_SINGLETON;
+
+			readAndEmitTag (&cp, kind);
 		}
 		else if (canMatchKeyword (&cp, "describe"))
 		{

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -19,6 +19,7 @@
 
 #include <string.h>
 
+#include "debug.h"
 #include "entry.h"
 #include "parse.h"
 #include "nestlevel.h"
@@ -172,6 +173,8 @@ static void emitRubyTag (vString* name, rubyKind kind)
 {
 	tagEntryInfo tag;
 	vString* scope;
+	rubyKind parent_kind = K_UNDEFINED;
+	NestingLevel *lvl;
 	const char *unqualified_name;
 	const char *qualified_name;
 
@@ -181,6 +184,9 @@ static void emitRubyTag (vString* name, rubyKind kind)
 
 	vStringTerminate (name);
 	scope = nestingLevelsToScope (nesting);
+	lvl = nestingLevelsGetCurrent (nesting);
+	if (lvl)
+		parent_kind = lvl->type;
 
 	qualified_name = vStringValue (name);
 	unqualified_name = strrchr (qualified_name, SCOPE_SEPARATOR);
@@ -192,6 +198,8 @@ static void emitRubyTag (vString* name, rubyKind kind)
 				vStringPut (scope, SCOPE_SEPARATOR);
 			vStringNCatS (scope, qualified_name,
 			              unqualified_name - qualified_name);
+			/* assume module parent type for a lack of a better option */
+			parent_kind = K_MODULE;
 		}
 		unqualified_name++;
 	}
@@ -200,7 +208,10 @@ static void emitRubyTag (vString* name, rubyKind kind)
 
 	initTagEntry (&tag, unqualified_name);
 	if (vStringLength (scope) > 0) {
-	    tag.extensionFields.scope [0] = "class";
+		Assert (0 <= parent_kind &&
+		        (size_t) parent_kind < (sizeof RubyKinds / sizeof RubyKinds[0]));
+
+	    tag.extensionFields.scope [0] = RubyKinds [parent_kind].name;
 	    tag.extensionFields.scope [1] = vStringValue (scope);
 	}
 	tag.kindName = RubyKinds [kind].name;

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -330,6 +330,8 @@ static void findRubyTags (void)
 			inMultiLineComment = FALSE;
 			continue;
 		}
+		if (inMultiLineComment)
+			continue;
 
 		skipWhitespace (&cp);
 

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -51,6 +51,8 @@ static stringList* nesting = NULL;
 *   FUNCTION DEFINITIONS
 */
 
+static void enterUnnamedScope (void);
+
 /*
 * Returns a string describing the scope in 'list'.
 * We record the current scope as a list of entered scopes.
@@ -343,6 +345,7 @@ static void readAndEmitTag (const unsigned char** cp, rubyKind expected_kind)
 			*
 			* For now, we don't create any.
 			*/
+			enterUnnamedScope ();
 		}
 		else
 		{

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -109,9 +109,14 @@ static boolean canMatch (const unsigned char** s, const char* literal,
 	return TRUE;
 }
 
+static boolean isIdentChar (int c)
+{
+	return (isalnum (c) || c == '_');
+}
+
 static boolean notIdentChar (int c)
 {
-	return ! (isalnum (c) || c == '_');
+	return ! isIdentChar (c);
 }
 
 static boolean notOperatorChar (int c)
@@ -255,19 +260,19 @@ static rubyKind parseIdentifier (
 	const char* also_ok;
 	if (kind == K_METHOD)
 	{
-		also_ok = "_.?!=";
+		also_ok = ".?!=";
 	}
 	else if (kind == K_SINGLETON)
 	{
-		also_ok = "_?!=";
+		also_ok = "?!=";
 	}
 	else if (kind == K_DESCRIBE || kind == K_CONTEXT)
 	{
-		also_ok = " ,\".#_?!='/-";
+		also_ok = " ,\".#?!='/-";
 	}
 	else
 	{
-		also_ok = "_";
+		also_ok = "";
 	}
 
 	skipWhitespace (cp);
@@ -288,7 +293,7 @@ static rubyKind parseIdentifier (
 	}
 
 	/* Copy the identifier into 'name'. */
-	while (**cp != 0 && (**cp == ':' || isalnum (**cp) || charIsIn (**cp, also_ok)))
+	while (**cp != 0 && (**cp == ':' || isIdentChar (**cp) || charIsIn (**cp, also_ok)))
 	{
 		char last_char = **cp;
 
@@ -520,7 +525,7 @@ static void findRubyTags (void)
 			{
 				do
 					++cp;
-				while (isalnum (*cp) || *cp == '_');
+				while (isIdentChar (*cp));
 			}
 		}
 	}


### PR DESCRIPTION
* Fix handling of documentation contents
* Fix matching keywords (https://github.com/geany/geany/issues/587)
* Fix parsing qualified identifiers (#452)
* Fix scope after anonymous classes
* Report correct scope type (instead of always "class")
* Report methods inside an anonymous class (inside a class) as singletons (#455)

Disclaimer: I don't know Ruby (at all).  The fixes here are based on reports, inspection of some Ruby resources (quick look at some more or less formal definitions) and inspecting the interpreter behavior (e.g. for what's valid).