### PR TITLE
Sort --help output

### DIFF
--- a/main/options.c
+++ b/main/options.c
@@ -246,12 +246,6 @@ static optionDescription LongOptionDescription [] = {
  {1,"      Include reference to 'file' in Emacs-style tag file (requires -e)."},
  {1,"  --exclude=pattern"},
  {1,"      Exclude files and directories matching 'pattern'."},
-#ifdef HAVE_ICONV
- {1,"  --input-encoding=encoding"},
- {1,"      Specify encoding of all of source files."},
- {1,"  --input-encoding-<LANG>=encoding"},
- {1,"      Specify encoding of the LANG source files."},
-#endif
  {0,"  --excmd=number|pattern|mix"},
 #ifdef MACROS_USE_PATTERNS
  {0,"       Uses the specified type of EX command to locate tags [pattern]."},
@@ -287,6 +281,12 @@ static optionDescription LongOptionDescription [] = {
  {1,"       Print this option summary."},
  {1,"  --if0=[yes|no]"},
  {1,"       Should code within #if 0 conditional branches be parsed [no]?"},
+#ifdef HAVE_ICONV
+ {1,"  --input-encoding=encoding"},
+ {1,"      Specify encoding of all of source files."},
+ {1,"  --input-encoding-<LANG>=encoding"},
+ {1,"      Specify encoding of the LANG source files."},
+#endif
  {1,"  --kinds-<LANG>=[+|-]kinds, or"},
  {1,"  --<LANG>-kinds=[+|-]kinds"},
  {1,"       Enable/disable tag kinds for language <LANG>."},
@@ -324,13 +324,13 @@ static optionDescription LongOptionDescription [] = {
  {1,"       Output list of language mappings."},
  {1,"  --map-<LANG>=[+]map"},
  {1,"       Alternative version of --langmap option."},
+ {1,"  --options=file"},
+ {1,"       Specify file from which command line options should be read."},
 #ifdef HAVE_ICONV
  {1,"  --output-encoding=encoding"},
  {1,"      The encoding to write the tag file in. Defaults to UTF-8 if --input-encoding"},
  {1,"      is specified, otherwise no conversion is performed."},
 #endif
- {1,"  --options=file"},
- {1,"       Specify file from which command line options should be read."},
  {0,"  --print-language"},
  {0,"       Don't make tags file but just print the guessed language name for input file."},
  {1,"  --quiet=[yes|no]"},


### PR DESCRIPTION
The output of `ctags --help` was not sorted in alphabetical order after
the support of encoding options.