### PR TITLE
Fix build errors and warnings with VC2015 (7 days)

### DIFF
--- a/main/e_msoft.h
+++ b/main/e_msoft.h
@@ -41,7 +41,9 @@
 
 # define HAVE__FINDFIRST 1
 # define HAVE_DIRECT_H 1
-# define snprintf _snprintf
+# if _MSC_VER < 1900
+#  define snprintf _snprintf
+# endif
 # define findfirst_t intptr_t
 
 # ifndef _CRT_SECURE_NO_DEPRECATE

--- a/main/lxcmd.c
+++ b/main/lxcmd.c
@@ -53,7 +53,9 @@
 #ifdef HAVE_SYS_WAIT_H
 # include <sys/wait.h> /* for WIFEXITED and WEXITSTATUS */
 #endif
-#include <unistd.h>
+#ifdef HAVE_UNISTD_H
+# include <unistd.h>
+#endif
 
 
 #include "debug.h"

--- a/main/mbcs.c
+++ b/main/mbcs.c
@@ -12,7 +12,9 @@
 /*
 *   INCLUDE FILES
 */
-#define __USE_GNU
+#ifndef __USE_GNU
+# define __USE_GNU
+#endif
 #include "general.h"  /* must always come first */
 
 #ifdef HAVE_ICONV

--- a/main/parse.c
+++ b/main/parse.c
@@ -1269,7 +1269,7 @@ static kindOption *langKindOption (const langType language, const int flag)
 	return result;
 }
 
-extern boolean isLanguageKindEnabled (langType language, char kind)
+extern boolean isLanguageKindEnabled (const langType language, char kind)
 {
 	const kindOption *kindOpt;
 

--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -15,7 +15,8 @@ INCLUDES = -I. -Imain -Ignu_regex -Ifnmatch
 OPT = /O2
 !if "$(WITH_ICONV)" == "yes"
 DEFINES = $(DEFINES) -DHAVE_ICONV
-LIBS = $(LIBS) -liconv
+LIBS = $(LIBS) /libpath:$(ICONV_DIR)/lib iconv.lib
+INCLUDES = $(INCLUDES) -I$(ICONV_DIR)/include
 !endif
 
 ctags: ctags.exe


### PR DESCRIPTION
* VC2015 has snprintf.
* VC doesn't have unistd.h.
* __USE_GNU is already defined in makefiles.
* Definition of isLanguageKindEnabled was different from its
  declaration.
* Couldn't link with libiconv. Imported @koron's patch:
  https://github.com/koron/ctags/commit/f09817755ac218425e7e5c265f70b808a835f46b