### PR TITLE
Rename to Universal Ctags(5 days)

### DIFF
--- a/ctags.1.in
+++ b/ctags.1.in
@@ -809,7 +809,7 @@ are read from these sources. The default is \fIno\fP.
 .TP 5
 \fB\-\-version\fP
 Prints a version identifier for \fB@ctags_name_executable@\fP to standard output, and then
-exits. This is guaranteed to always contain the string "Exuberant Ctags".
+exits. This is guaranteed to always contain the string "Universal Ctags".
 
 
 .SH "OPERATIONAL DETAILS"


### PR DESCRIPTION
Related: #460 

@masatake's comment from https://github.com/k-takata/ctags/commit/15ac5bb6891e4778d077b46d44f6ca5d9eb25a07#commitcomment-12359250:

> A script in linux kernel source tree runs ctags. The script expects "exuberant" in --version.
> https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/scripts/tags.sh#n276
> 
> I would like to use u-ctags when reading the kernel.
> 
> I would like to discuss about the output of --version with the other members.
