### PR TITLE
beta: convert the encoding to utf-8(1 day)

### DIFF
--- a/parsers/beta.c
+++ b/parsers/beta.c
@@ -1,5 +1,5 @@
 /*
-*   Copyright (c) 1999-2000, Mjølner Informatics
+*   Copyright (c) 1999-2000, MjÃ¸lner Informatics
 *
 *   Written by Erik Corry <corry@mjolner.dk>
 *


### PR DESCRIPTION
It seems that coverall (or lcoveralls command) expects source code
files are encoded in UTF-8.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>