### PR TITLE
Remove Darren's mail address from --version output and pseudo tags(3 days)

### DIFF
--- a/Tmain/input-encoding-option.d/tags-expected.txt
+++ b/Tmain/input-encoding-option.d/tags-expected.txt
@@ -1,8 +1,8 @@
 !_TAG_FILE_ENCODING	UTF-8	//
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
-!_TAG_PROGRAM_NAME	Universal Ctags	//
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/
 !_TAG_PROGRAM_VERSION	Development	//
 Foo	input.java	/^	public Foo() { \/\/ コンストラクタ$/;"	m	class:Foo

--- a/Tmain/output-encoding-option.d/tags-expected.txt
+++ b/Tmain/output-encoding-option.d/tags-expected.txt
@@ -1,8 +1,8 @@
 !_TAG_FILE_ENCODING	cp932	//
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
-!_TAG_PROGRAM_NAME	Universal Ctags	//
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/
 !_TAG_PROGRAM_VERSION	Development	//
 Foo	input.java	/^	public Foo() { \/\/ コンストラクタ$/;"	m	class:Foo

--- a/main/ctags.h
+++ b/main/ctags.h
@@ -17,9 +17,8 @@
 #endif
 #define PROGRAM_NAME      "Universal Ctags"
 #define PROGRAM_URL       "https://ctags.io/"
-#define PROGRAM_COPYRIGHT "Copyright (C) 1996-2009"
-#define AUTHOR_NAME       "Darren Hiebert"
-#define AUTHOR_EMAIL      "dhiebert@users.sourceforge.net"
+#define PROGRAM_COPYRIGHT "Copyright (C) 2015"
+#define AUTHOR_NAME       "Universal Ctags Team"
 
 #endif	/* _CTAGS_H */
 

--- a/main/entry.c
+++ b/main/entry.c
@@ -178,8 +178,8 @@ static void addPseudoTags (void)
 			(Option.sorted == SO_SORTED ? "1" : "0"),
 			"0=unsorted, 1=sorted, 2=foldcase",
 			NULL);
-		writePseudoTag ("TAG_PROGRAM_AUTHOR",  AUTHOR_NAME,  AUTHOR_EMAIL, NULL);
-		writePseudoTag ("TAG_PROGRAM_NAME",    PROGRAM_NAME, "", NULL);
+		writePseudoTag ("TAG_PROGRAM_AUTHOR",  AUTHOR_NAME,  "", NULL);
+		writePseudoTag ("TAG_PROGRAM_NAME",    PROGRAM_NAME, "Derived from Exuberant Ctags", NULL);
 		writePseudoTag ("TAG_PROGRAM_URL",     PROGRAM_URL,  "official site", NULL);
 		writePseudoTag ("TAG_PROGRAM_VERSION", PROGRAM_VERSION, "", NULL);
 #ifdef HAVE_ICONV

--- a/main/options.c
+++ b/main/options.c
@@ -1194,8 +1194,12 @@ static void printProgramIdentification (void)
 	printf ("%s %s, %s %s\n",
 	        PROGRAM_NAME, PROGRAM_VERSION,
 	        PROGRAM_COPYRIGHT, AUTHOR_NAME);
+	printf ("Universal Ctags is derived from Exuberant Ctags.\n");
+	printf ("Exuberant Ctags 5.8, Copyright (C) 1996-2009 Darren Hiebert\n");
+
 	printf ("  Compiled: %s, %s\n", __DATE__, __TIME__);
-	printf ("  Addresses: <%s>, %s\n", AUTHOR_EMAIL, PROGRAM_URL);
+	printf ("  URL: %s\n", PROGRAM_URL);
+
 	printFeatureList ();
 }
 


### PR DESCRIPTION
Close #472.


We are afraid that bugs about our code go to Darren.
So in this commit I remove his mail address from both
--version output and pseudo tags.

However, I embed/keep pointers to the original great work.

Here are new results:

    $ ./ctags --version
    Universal Ctags Development, Copyright (C) 2015 Universal Ctags Team
    Universal Ctags is derived from Exuberant Ctags.
    Exuberant Ctags 5.8, Copyright (C) 1996-2009 Darren Hiebert
      Compiled: Aug  1 2015, 15:34:40
      URL: https://ctags.io/
      Optional compiled features: +wildcards, +regex, +multibyte, +debug, +option-directory, +coproc

    $ ./ctags /dev/zero
    $ cat tags
    !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
    !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
    !_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
    !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
    !_TAG_PROGRAM_URL	https://ctags.io/	/official site/
    !_TAG_PROGRAM_VERSION	Development	//

Signed-off-by: Masatake YAMATO <yamato@redhat.com>