### PR TITLE
Implemented a basic parser for Perl 6 - issue #473

### DIFF
--- a/Units/perl6-bunch1.d/expected.tags
+++ b/Units/perl6-bunch1.d/expected.tags
@@ -1,0 +1,51 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Universal Ctags	//
+!_TAG_PROGRAM_URL	https://github.com/universal-ctags/ctags	/official site/
+!_TAG_PROGRAM_VERSION	Development	//
+JSONPrettyActions	input.pm	/^my class JSONPrettyActions {$/;"	c
+JSONPrettyGrammar	input.pm	/^my grammar JSONPrettyGrammar {$/;"	g
+TOP	input.pm	/^    method TOP($\/) {$/;"	m
+TOP	input.pm	/^    token TOP       { ^ \\s* [ <object> | <array> ] \\s* $ }$/;"	t
+array	input.pm	/^    method array($\/) {$/;"	m
+array	input.pm	/^    rule array      { '[' ~ ']' <arraylist>    }$/;"	u
+arraylist	input.pm	/^    method arraylist($\/) {$/;"	m
+arraylist	input.pm	/^    rule arraylist  {  <value> * % [ \\, ]        }$/;"	u
+from-json	input.pm	/^sub from-json($text) {$/;"	s
+object	input.pm	/^    method object($\/) {$/;"	m
+object	input.pm	/^    rule object     { '{' ~ '}' <pairlist>     }$/;"	u
+pair	input.pm	/^    method pair($\/) {$/;"	m
+pair	input.pm	/^    rule pair       { <string> ':' <value>     }$/;"	u
+pairlist	input.pm	/^    method pairlist($\/) {$/;"	m
+pairlist	input.pm	/^    rule pairlist   { <pair> * % \\,            }$/;"	u
+str	input.pm	/^    method str($\/)               { make ~$\/ }$/;"	m
+str	input.pm	/^    token str {$/;"	t
+str_escape	input.pm	/^    method str_escape($\/) {$/;"	m
+str_escape	input.pm	/^    token str_escape {$/;"	t
+string	input.pm	/^    method string($\/) {$/;"	m
+string	input.pm	/^    token string {$/;"	t
+to-json	input.pm	/^multi sub to-json(Associative:D $d, :$indent = 0, :$first = 0) {$/;"	s
+to-json	input.pm	/^multi sub to-json(Bool:D $d, :$indent = 0, :$first = 0) { (' ' x $first) ~ ($d ?? 'true' !! 'false') }$/;"	s
+to-json	input.pm	/^multi sub to-json(Mu:D $s, :$indent = 0, :$first = 0) {$/;"	s
+to-json	input.pm	/^multi sub to-json(Mu:U $, :$indent = 0, :$first = 0) { 'null' }$/;"	s
+to-json	input.pm	/^multi sub to-json(Positional:D $d, :$indent = 0, :$first = 0) {$/;"	s
+to-json	input.pm	/^multi sub to-json(Real:D $d, :$indent = 0, :$first = 0) { (' ' x $first) ~ ~$d }$/;"	s
+to-json	input.pm	/^multi sub to-json(Str:D $d, :$indent = 0, :$first = 0) {$/;"	s
+to-json	input.pm	/^multi sub to-json(Version:D $v, :$indent = 0, :$first = 0) { to-json(~$v, :$indent, :$first) }$/;"	s
+to-json	input.pm	/^proto sub to-json($, :$indent = 0, :$first = 0) {*}$/;"	s
+value	input.pm	/^    proto token value {*};$/;"	t
+value:sym	input.pm	/^    method value:sym<array>($\/)  { make $<array>.ast }$/;"	m
+value:sym	input.pm	/^    method value:sym<false>($\/)  { make Bool::False }$/;"	m
+value:sym	input.pm	/^    method value:sym<null>($\/)   { make Any }$/;"	m
+value:sym	input.pm	/^    method value:sym<number>($\/) { make +$\/.Str }$/;"	m
+value:sym	input.pm	/^    method value:sym<object>($\/) { make $<object>.ast }$/;"	m
+value:sym	input.pm	/^    method value:sym<string>($\/) { make $<string>.ast }$/;"	m
+value:sym	input.pm	/^    method value:sym<true>($\/)   { make Bool::True  }$/;"	m
+value:sym	input.pm	/^    token value:sym<array>   { <array>  };$/;"	t
+value:sym	input.pm	/^    token value:sym<false>   { <sym>    };$/;"	t
+value:sym	input.pm	/^    token value:sym<null>    { <sym>    };$/;"	t
+value:sym	input.pm	/^    token value:sym<number> {$/;"	t
+value:sym	input.pm	/^    token value:sym<object>  { <object> };$/;"	t
+value:sym	input.pm	/^    token value:sym<string>  { <string> }$/;"	t
+value:sym	input.pm	/^    token value:sym<true>    { <sym>    };$/;"	t

--- a/Units/perl6-bunch1.d/input.pm
+++ b/Units/perl6-bunch1.d/input.pm
@@ -1,0 +1,120 @@
+my class JSONPrettyActions {
+    method TOP($/) {
+        make $/.values.[0].ast;
+    };
+    method object($/) {
+        make $<pairlist>.ast.hash.item;
+    }
+
+    method pairlist($/) {
+        make $<pair>>>.ast.flat;
+    }
+
+    method pair($/) {
+        make $<string>.ast => $<value>.ast;
+    }
+
+    method array($/) {
+        make $<arraylist>.ast.item;
+    }
+
+    method arraylist($/) {
+        make [$<value>>>.ast];
+    }
+
+    method string($/) {
+        make $0.elems == 1
+            ?? ($0[0].<str> || $0[0].<str_escape>).ast
+            !! join '', $0.list.map({ (.<str> || .<str_escape>).ast });
+    }
+    method value:sym<number>($/) { make +$/.Str }
+    method value:sym<string>($/) { make $<string>.ast }
+    method value:sym<true>($/)   { make Bool::True  }
+    method value:sym<false>($/)  { make Bool::False }
+    method value:sym<null>($/)   { make Any }
+    method value:sym<object>($/) { make $<object>.ast }
+    method value:sym<array>($/)  { make $<array>.ast }
+
+    method str($/)               { make ~$/ }
+
+    my %esc = '\\' => "\\",
+              '/'  => "/",
+              'b'  => "\b",
+              'n'  => "\n",
+              't'  => "\t",
+              'f'  => "\f",
+              'r'  => "\r",
+              '"'  => "\"";
+    method str_escape($/) {
+        make $<xdigit> ?? chr(:16($<xdigit>.join)) !! %esc.AT-KEY(~$/);
+    }
+}
+
+my grammar JSONPrettyGrammar {
+    token TOP       { ^ \s* [ <object> | <array> ] \s* $ }
+    rule object     { '{' ~ '}' <pairlist>     }
+    rule pairlist   { <pair> * % \,            }
+    rule pair       { <string> ':' <value>     }
+    rule array      { '[' ~ ']' <arraylist>    }
+    rule arraylist  {  <value> * % [ \, ]        }
+
+    proto token value {*};
+    token value:sym<number> {
+        '-'?
+        [ 0 | <[1..9]> <[0..9]>* ]
+        [ \. <[0..9]>+ ]?
+        [ <[eE]> [\+|\-]? <[0..9]>+ ]?
+    }
+    token value:sym<true>    { <sym>    };
+    token value:sym<false>   { <sym>    };
+    token value:sym<null>    { <sym>    };
+    token value:sym<object>  { <object> };
+    token value:sym<array>   { <array>  };
+    token value:sym<string>  { <string> }
+
+    token string {
+        \" ~ \" ( <str> | \\ <str_escape> )*
+    }
+
+    token str {
+        <-["\\\t\n]>+
+    }
+
+    token str_escape {
+        <["\\/bfnrt]> | u <xdigit>**4
+    }
+}
+
+proto sub to-json($, :$indent = 0, :$first = 0) {*}
+
+multi sub to-json(Version:D $v, :$indent = 0, :$first = 0) { to-json(~$v, :$indent, :$first) }
+multi sub to-json(Real:D $d, :$indent = 0, :$first = 0) { (' ' x $first) ~ ~$d }
+multi sub to-json(Bool:D $d, :$indent = 0, :$first = 0) { (' ' x $first) ~ ($d ?? 'true' !! 'false') }
+multi sub to-json(Str:D $d, :$indent = 0, :$first = 0) {
+    (' ' x $first) ~ '"'
+    ~ $d.trans(['"', '\\', "\b", "\f", "\n", "\r", "\t"]
+            => ['\"', '\\\\', '\b', '\f', '\n', '\r', '\t'])\
+            .subst(/<-[\c32..\c126]>/, { ord(~$_).fmt('\u%04x') }, :g)
+    ~ '"'
+}
+multi sub to-json(Positional:D $d, :$indent = 0, :$first = 0) {
+    (' ' x $first) ~ "\["
+            ~ ($d ?? $d.map({ "\n" ~ to-json($_, :indent($indent + 2), :first($indent + 2)) }).join(",") ~ "\n" ~ (' ' x $indent) !! ' ')
+            ~ ']';
+}
+multi sub to-json(Associative:D $d, :$indent = 0, :$first = 0) {
+    (' ' x $first) ~ "\{"
+            ~ ($d ?? $d.map({ "\n" ~ to-json(.key, :first($indent + 2)) ~ ' : ' ~ to-json(.value, :indent($indent + 2)) }).join(",") ~ "\n" ~ (' ' x $indent) !! ' ')
+            ~ '}';
+}
+
+multi sub to-json(Mu:U $, :$indent = 0, :$first = 0) { 'null' }
+multi sub to-json(Mu:D $s, :$indent = 0, :$first = 0) {
+    die "Can't serialize an object of type " ~ $s.WHAT.perl
+}
+
+sub from-json($text) {
+    my $a = JSONPrettyActions.new();
+    my $o = JSONPrettyGrammar.parse($text, :actions($a));
+    $o.ast;
+}

--- a/Units/perl6-bunch2.d/expected.tags
+++ b/Units/perl6-bunch2.d/expected.tags
@@ -1,0 +1,89 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Universal Ctags	//
+!_TAG_PROGRAM_URL	https://github.com/universal-ctags/ctags	/official site/
+!_TAG_PROGRAM_VERSION	Development	//
+BUILD	input.pm	/^        submethod BUILD(:&!setup) { }$/;"	b
+Channel	input.pm	/^    method Channel(Supply:D:) {$/;"	m
+OnSupply	input.pm	/^    my class OnSupply does Supply {$/;"	c
+Promise	input.pm	/^    method Promise(Supply:D:) {$/;"	m
+Supply	input.pm	/^    method Supply(Supply:) { self }$/;"	m
+Supply	input.pm	/^my role Supply {$/;"	r
+SupplyOperations	input.pm	/^my class SupplyOperations is repr('Uninstantiable') { ... }$/;"	c
+Tap	input.pm	/^my class Tap {$/;"	c
+X::Supply::Combinator	input.pm	/^my class X::Supply::Combinator is Exception {$/;"	c
+X::Supply::On::BadSetup	input.pm	/^my class X::Supply::On::BadSetup is Exception {$/;"	c
+X::Supply::On::NoEmit	input.pm	/^my class X::Supply::On::NoEmit is Exception {$/;"	c
+act	input.pm	/^    method act(Supply:D: &actor) {$/;"	m
+add	input.pm	/^            sub add ($source, $what, $index?) {$/;"	s
+add_source	input.pm	/^        method !add_source($/;"	m
+batch	input.pm	/^    method batch(Supply:D $self: :$elems, :$seconds ) {$/;"	m
+categorize	input.pm	/^    multi method categorize(Supply:D: %mapper )  {$/;"	m
+categorize	input.pm	/^    multi method categorize(Supply:D: &mapper )  {$/;"	m
+categorize	input.pm	/^    multi method categorize(Supply:D: @mapper )  {$/;"	m
+categorize	input.pm	/^    proto method categorize (|) { * }$/;"	m
+classify	input.pm	/^    multi method classify(Supply:D: %mapper )  {$/;"	m
+classify	input.pm	/^    multi method classify(Supply:D: &mapper )  {$/;"	m
+classify	input.pm	/^    multi method classify(Supply:D: @mapper )  {$/;"	m
+close	input.pm	/^    method close (Tap:D:) { $!supply.close(self) }$/;"	m
+close	input.pm	/^    multi method close(Supply:D: Tap $t) {$/;"	m
+close	input.pm	/^    multi method close(Supply:D:) { self.close($_) for self.tappers }$/;"	m
+close	input.pm	/^    proto method close(|) { * }$/;"	m
+delay	input.pm	/^    method delay(Supply:D: $time, :$scheduler = $*SCHEDULER) {$/;"	m
+delayed	input.pm	/^    method delayed(Supply:D: $time, :$scheduler = $*SCHEDULER) {$/;"	m
+do	input.pm	/^    method do(Supply:D $self: &side_effect) {$/;"	m
+done	input.pm	/^        method done() {$/;"	m
+done	input.pm	/^    method done(Supply:D:) {$/;"	m
+elems	input.pm	/^    method elems(Supply:D $self: $seconds? ) {$/;"	m
+emit	input.pm	/^        method emit(\\msg) {$/;"	m
+emit	input.pm	/^    method emit(Supply:D: \\msg) {$/;"	m
+flat	input.pm	/^    method flat(Supply:D: )              { SupplyOperations.flat(self) }$/;"	m
+flush	input.pm	/^                sub flush {$/;"	s
+flush	input.pm	/^                sub flush() {$/;"	s
+for	input.pm	/^    method for(Supply:U: |c) {$/;"	m
+from-list	input.pm	/^    method from-list(Supply:U: |c)       { SupplyOperations.from-list(|c) }$/;"	m
+grab	input.pm	/^    method grab(Supply:D $self: &when_done) {$/;"	m
+grep	input.pm	/^    method grep(Supply:D: Mu $test)      { SupplyOperations.grep(self, $test) }$/;"	m
+interval	input.pm	/^    method interval(Supply:U: |c)        { SupplyOperations.interval(|c) }$/;"	m
+last	input.pm	/^    method last(Supply:D $self: Int $number = 1) {  # should be Natural$/;"	m
+lines	input.pm	/^    method lines(Supply:D $self: :$chomp = True ) {$/;"	m
+list	input.pm	/^    method list(Supply:D:) {$/;"	m
+live	input.pm	/^        method live { $!live }$/;"	m
+live	input.pm	/^    method live(Supply:D:) { True };$/;"	m
+map	input.pm	/^    method map(Supply:D: &mapper)        { SupplyOperations.map(self, &mapper) }$/;"	m
+max	input.pm	/^    method max(Supply:D $self: &by = &infix:<cmp>) {$/;"	m
+merge	input.pm	/^    method merge(*@s) {$/;"	m
+message	input.pm	/^    method message() { "Can only use $!combinator to combine defined Supply objects" }$/;"	m
+message	input.pm	/^    method message() {$/;"	m
+migrate	input.pm	/^    method migrate(Supply:D: )           { SupplyOperations.migrate(self) }$/;"	m
+min	input.pm	/^    method min(Supply:D $self: &by = &infix:<cmp>) {$/;"	m
+minmax	input.pm	/^    method minmax(Supply:D $self: &by = &infix:<cmp>) {$/;"	m
+more	input.pm	/^    method more(Supply:D: \\msg) {$/;"	m
+next-batch	input.pm	/^                sub next-batch() {$/;"	s
+on	input.pm	/^sub on(&setup) {$/;"	s
+on-demand	input.pm	/^    method on-demand(Supply:U: |c)       { SupplyOperations.on-demand(|c) }$/;"	m
+on_demand	input.pm	/^    method on_demand(Supply:U: |c)       {$/;"	m
+quit	input.pm	/^        method quit($ex) {$/;"	m
+quit	input.pm	/^    method quit(Supply:D: $ex) {$/;"	m
+reduce	input.pm	/^    method reduce(Supply:D $self: &with) {$/;"	m
+reverse	input.pm	/^    method reverse(Supply:D:)                 { self.grab( {.reverse} ) }$/;"	m
+rotor	input.pm	/^    multi method rotor(Supply:D $self: *@cycle, :$partial) {$/;"	m
+rotor	input.pm	/^    multi method rotor(Supply:D:) {$/;"	m
+rotor	input.pm	/^    proto method rotor(|) {*}$/;"	m
+schedule-on	input.pm	/^    method schedule-on(Supply:D: Scheduler $scheduler) {$/;"	m
+schedule_on	input.pm	/^    method schedule_on(Supply:D: Scheduler $scheduler) {$/;"	m
+sort	input.pm	/^    method sort(Supply:D: &by = &infix:<cmp>) { self.grab( {.sort(&by)} ) }$/;"	m
+squish	input.pm	/^    method squish(Supply:D $self: :&as, :&with is copy) {$/;"	m
+stable	input.pm	/^    method stable(Supply:D: $time, :$scheduler = $*SCHEDULER) {$/;"	m
+start	input.pm	/^    method start(Supply:D: &startee)     { SupplyOperations.start(self, &startee) }$/;"	m
+tap	input.pm	/^        method tap(|c) {$/;"	m
+tap	input.pm	/^    method tap(Supply:D: &emit = -> $ { }, :&done,:&quit={die $_},:&closing) {$/;"	m
+tappers	input.pm	/^    method tappers(Supply:D:) {$/;"	m
+taps	input.pm	/^    method taps(Supply:D:) { +@!tappers }$/;"	m
+uniq	input.pm	/^    method uniq(Supply:D: |c) {$/;"	m
+unique	input.pm	/^    method unique(Supply:D $self: :&as, :&with, :$expires) {$/;"	m
+wait	input.pm	/^    method wait(Supply:D:) {$/;"	m
+words	input.pm	/^    method words(Supply:D $self:) {$/;"	m
+zip	input.pm	/^    method zip(*@s, :&with is copy = &[,]) {$/;"	m
+zip-latest	input.pm	/^    method zip-latest(*@s, :&with is copy = &[,], :$initial ) {$/;"	m

--- a/Units/perl6-bunch2.d/input.pm
+++ b/Units/perl6-bunch2.d/input.pm
@@ -1,0 +1,956 @@
+# Anything that can be subscribed to does this role. It provides the basic
+# supply management infrastructure, as well as various coercions that
+# turn Supply-like things into something else and convenience forms of calls
+# to SupplyOperations.
+
+my class SupplyOperations is repr('Uninstantiable') { ... }
+my class X::Supply::Combinator is Exception {
+    has $.combinator;
+    method message() { "Can only use $!combinator to combine defined Supply objects" }
+}
+
+my class Tap {
+    has &.emit;
+    has &.done;
+    has &.quit;
+    has &.closing;
+    has $.supply;
+
+    method close (Tap:D:) { $!supply.close(self) }
+}
+
+my role Supply {
+    has $!tappers_lock = Lock.new;
+    has @!tappers;
+    has $!been_tapped;
+    has @!paused;
+
+    method tap(Supply:D: &emit = -> $ { }, :&done,:&quit={die $_},:&closing) {
+        my $tap = Tap.new(:&emit, :&done, :&quit, :&closing, :supply(self));
+        $!tappers_lock.protect({
+            @!tappers.push($tap);
+            if @!paused -> \todo {
+                $tap.emit().($_) for todo;
+                @!paused = ();
+            }
+            $!been_tapped = True;
+        });
+        $tap
+    }
+
+    proto method close(|) { * }
+    multi method close(Supply:D:) { self.close($_) for self.tappers }
+    multi method close(Supply:D: Tap $t) {
+        my $found;
+        $!tappers_lock.protect({
+            @!tappers .= grep( { $_ === $t ?? !($found = True) !! True } );
+        });
+        if $t.closing -> &closing {
+            closing();
+        }
+        $found // False;
+    }
+
+    method tappers(Supply:D:) {
+        # Shallow clone to provide safe snapshot.
+        my @tappers;
+        $!tappers_lock.protect({ @tappers = @!tappers });
+        @tappers
+    }
+
+    method emit(Supply:D: \msg) {
+        if self.tappers -> \tappers {
+            .emit().(msg) for tappers;
+        }
+        elsif !$!been_tapped {
+            $!tappers_lock.protect({ @!paused.push: msg });
+        }
+        Nil;
+    }
+
+    method more(Supply:D: \msg) {
+        DEPRECATED('emit', |<2014.10 2015.09>);
+        self.emit(msg);
+    }
+
+    method done(Supply:D:) {
+        for self.tappers -> $t {
+            my $l = $t.done();
+            $l() if $l;
+        }
+        Nil;
+    }
+
+    method quit(Supply:D: $ex) {
+        for self.tappers -> $t {
+            my $f = $t.quit();
+            $f($ex) if $f;
+        }
+        Nil;
+    }
+
+    method taps(Supply:D:) { +@!tappers }
+    method live(Supply:D:) { True };
+
+    method Supply(Supply:) { self }
+    method Channel(Supply:D:) {
+        my $c = Channel.new();
+        self.tap( -> \val { $c.send(val) },
+          done => { $c.close },
+          quit => -> $ex { $c.quit($ex) });
+        $c
+    }
+
+    method Promise(Supply:D:) {
+        my $l = Lock.new;
+        my $p = Promise.new;
+        my $v = $p.vow;
+        my $t = self.tap(
+          -> \val {
+              $l.protect( {
+                  if $p.status == Planned {
+                      $v.keep(val);
+                      $t.close()
+                  }
+              } );
+          },
+          done => { $v.break("No value received") },
+          quit => -> \ex {
+              $l.protect( {
+                  if $p.status == Planned {
+                      $v.break(ex);
+                      $t.close()
+                  }
+              } );
+          },
+        );
+        $p
+    }
+
+    method wait(Supply:D:) {
+        my $l = Lock.new;
+        my $p = Promise.new;
+        my $t = self.tap( -> \val {},
+          done => {
+              $l.protect( {
+                  if $p.status == Planned {
+                      $p.keep(True);
+                      $t.close()
+                  }
+              } );
+          },
+          quit => -> \ex {
+              $l.protect( {
+                  if $p.status == Planned {
+                      $p.break(ex);
+                      $t.close()
+                  }
+              } );
+          },
+        );
+        $p.result
+    }
+
+    method list(Supply:D:) {
+        # Use a Channel to handle any asynchrony.
+        self.Channel.list;
+    }
+
+    method on-demand(Supply:U: |c)       { SupplyOperations.on-demand(|c) }
+    method from-list(Supply:U: |c)       { SupplyOperations.from-list(|c) }
+    method interval(Supply:U: |c)        { SupplyOperations.interval(|c) }
+    method flat(Supply:D: )              { SupplyOperations.flat(self) }
+    method grep(Supply:D: Mu $test)      { SupplyOperations.grep(self, $test) }
+    method map(Supply:D: &mapper)        { SupplyOperations.map(self, &mapper) }
+    method schedule-on(Supply:D: Scheduler $scheduler) {
+        SupplyOperations.schedule-on(self, $scheduler);
+    }
+    method start(Supply:D: &startee)     { SupplyOperations.start(self, &startee) }
+    method stable(Supply:D: $time, :$scheduler = $*SCHEDULER) {
+        SupplyOperations.stable(self, $time, :$scheduler);
+    }
+    method delay(Supply:D: $time, :$scheduler = $*SCHEDULER) {
+        DEPRECATED('delayed', '2015.02', '2015.09');
+        SupplyOperations.delayed(self, $time, :$scheduler);
+    }
+    method delayed(Supply:D: $time, :$scheduler = $*SCHEDULER) {
+        SupplyOperations.delayed(self, $time, :$scheduler)
+    }
+    method migrate(Supply:D: )           { SupplyOperations.migrate(self) }
+
+    multi method classify(Supply:D: &mapper )  {
+        SupplyOperations.classify(self, &mapper);
+    }
+    multi method classify(Supply:D: %mapper )  {
+        SupplyOperations.classify(self, { %mapper{$^a} });
+    }
+    multi method classify(Supply:D: @mapper )  {
+        SupplyOperations.classify(self, { @mapper[$^a] });
+    }
+
+    proto method categorize (|) { * }
+    multi method categorize(Supply:D: &mapper )  {
+        SupplyOperations.classify(self, &mapper, :multi);
+    }
+    multi method categorize(Supply:D: %mapper )  {
+        SupplyOperations.classify(self, { %mapper{$^a} }, :multi);
+    }
+    multi method categorize(Supply:D: @mapper )  {
+        SupplyOperations.classify(self, { @mapper[$^a] }, :multi);
+    }
+
+    method act(Supply:D: &actor) {
+        self.do(&actor).tap(|%_) # need "do" for serializing callbacks
+    }
+
+    method do(Supply:D $self: &side_effect) {
+        on -> $res {
+            $self => -> \val { side_effect(val); $res.emit(val) }
+        }
+    }
+
+    method unique(Supply:D $self: :&as, :&with, :$expires) {
+        on -> $res {
+            $self => do {
+                if $expires {
+                    if &with and &with !=== &[===] {
+                        my @seen;  # really Mu, but doesn't work in settings
+                        my Mu $target;
+                        &as
+                          ?? -> \val {
+                              my $now := now;
+                              $target = &as(val);
+                              my $index =
+                                @seen.first-index({&with($target,$_[0])});
+                              if $index.defined {
+                                  if $now > @seen[$index][1] {  # expired
+                                      @seen[$index][1] = $now+$expires;
+                                      $res.emit(val);
+                                  }
+                              }
+                              else {
+                                  @seen.push: [$target, $now+$expires];
+                                  $res.emit(val);
+                              }
+                          }
+                          !! -> \val {
+                              my $now := now;
+                              my $index =
+                                @seen.first-index({&with(val,$_[0])});
+                              if $index.defined {
+                                  if $now > @seen[$index][1] {  # expired
+                                      @seen[$index][1] = $now+$expires;
+                                      $res.emit(val);
+                                  }
+                              }
+                              else {
+                                  @seen.push: [val, $now+$expires];
+                                  $res.emit(val);
+                              }
+                          };
+                    }
+                    else {
+                        my $seen := nqp::hash();
+                        my str $target;
+                        &as
+                          ?? -> \val {
+                              my $now := now;
+                              $target = nqp::unbox_s(&as(val).WHICH);
+                              if !nqp::existskey($seen,$target) ||
+                                $now > nqp::atkey($seen,$target) { #expired
+                                  $res.emit(val);
+                                  nqp::bindkey($seen,$target,$now+$expires);
+                              }
+                          }
+                          !! -> \val {
+                              my $now := now;
+                              $target = nqp::unbox_s(val.WHICH);
+                              if !nqp::existskey($seen,$target) ||
+                                $now > nqp::atkey($seen,$target) { #expired
+                                  $res.emit(val);
+                                  nqp::bindkey($seen,$target,$now+$expires);
+                              }
+                          };
+                    }
+                }
+                else { # !$!expires
+                    if &with and &with !=== &[===] {
+                        my @seen;  # really Mu, but doesn't work in settings
+                        my Mu $target;
+                        &as
+                          ?? -> \val {
+                              $target = &as(val);
+                              if @seen.first({ &with($target,$_) } ) =:= Nil {
+                                  @seen.push($target);
+                                  $res.emit(val);
+                              }
+                          }
+                          !! -> \val {
+                              if @seen.first({ &with(val,$_) } ) =:= Nil {
+                                  @seen.push(val);
+                                  $res.emit(val);
+                              }
+                          };
+                    }
+                    else {
+                        my $seen := nqp::hash();
+                        my str $target;
+                        &as
+                          ?? -> \val {
+                              $target = nqp::unbox_s(&as(val).WHICH);
+                              unless nqp::existskey($seen, $target) {
+                                  nqp::bindkey($seen, $target, 1);
+                                  $res.emit(val);
+                              }
+                          }
+                          !! -> \val {
+                              $target = nqp::unbox_s(val.WHICH);
+                              unless nqp::existskey($seen, $target) {
+                                  nqp::bindkey($seen, $target, 1);
+                                  $res.emit(val);
+                              }
+                          };
+                    }
+                }
+            }
+        }
+    }
+
+    method squish(Supply:D $self: :&as, :&with is copy) {
+        &with //= &[===];
+        on -> $res {
+            my @secret;
+            $self => do {
+                my Mu $last = @secret;
+                my Mu $target;
+                &as
+                  ?? -> \val {
+                      $target = &as(val);
+                      unless &with($target,$last) {
+                          $last = $target;
+                          $res.emit(val);
+                      }
+                  }
+                  !! -> \val {
+                      unless &with(val,$last) {
+                          $last = val;
+                          $res.emit(val);
+                      }
+                  };
+            }
+        }
+    }
+
+    proto method rotor(|) {*}
+    multi method rotor(Supply:D:) {
+        DEPRECATED('.rotor( $elems => -$gap )',|<2015.04 2015.09>);
+        self.rotor( (2 => -1) );
+    }
+    multi method rotor(Supply:D $self: *@cycle, :$partial) {
+        my @c := @cycle.infinite ?? @cycle !! @cycle xx *;
+
+        on -> $res {
+            $self => do {
+                my Int $elems;
+                my Int $gap;
+                my int $to-skip;
+                my int $skip;
+                sub next-batch() {
+                    given @c.shift {
+                        when Pair {
+                            $elems   = +.key;
+                            $gap     = +.value;
+                            $to-skip = $gap > 0 ?? $gap !! 0;
+                        }
+                        default {
+                            $elems   = +$_;
+                            $gap     = 0;
+                            $to-skip = 0;
+                        }
+                    }
+                }
+                next-batch;
+
+                my @batched;
+                sub flush() {
+                    $res.emit( [@batched] );
+                    @batched.splice( 0, +@batched + $gap );
+                    $skip = $to-skip;
+                }
+
+                {
+                    emit => -> \val {
+                        @batched.push: val unless $skip && $skip--;
+                        if @batched.elems == $elems {
+                            flush;
+                            next-batch;
+                        }
+                    },
+                    done => {
+                        flush if @batched and $partial;
+                        $res.done;
+                    }
+                }
+            }
+        }
+    }
+
+    method batch(Supply:D $self: :$elems, :$seconds ) {
+
+        return $self if (!$elems or $elems == 1) and !$seconds;  # nothing to do
+
+        on -> $res {
+            $self => do {
+                my @batched;
+                my $last_time;
+                sub flush {
+                    $res.emit([@batched]);
+                    @batched = ();
+                }
+
+                {
+                    emit => do {
+                        if $seconds {
+                            $last_time = time div $seconds;
+
+                            $elems # and $seconds
+                              ??  -> \val {
+                                  my $this_time = time div $seconds;
+                                  if $this_time != $last_time {
+                                      flush if @batched;
+                                      $last_time = $this_time;
+                                      @batched.push: val;
+                                  }
+                                  else {
+                                      @batched.push: val;
+                                      flush if @batched.elems == $elems;
+                                  }
+                              }
+                              !! -> \val {
+                                  my $this_time = time div $seconds;
+                                  if $this_time != $last_time {
+                                      flush if @batched;
+                                      $last_time = $this_time;
+                                  }
+                                  @batched.push: val;
+                              }
+                        }
+                        else { # just $elems
+                            -> \val {
+                                @batched.push: val;
+                                flush if @batched.elems == $elems;
+                            }
+                        }
+                    },
+                    done => {
+                        flush if @batched;
+                        $res.done;
+                    }
+                }
+            }
+        }
+    }
+
+    method lines(Supply:D $self: :$chomp = True ) {
+
+        on -> $res {
+            $self => do {
+                my str $str;
+                my int $chars;
+                my int $left;
+                my int $pos;
+                my int $nextpos;
+                my int $found;
+                my int $cr;
+                my int $crlf;
+
+                {
+                    emit => -> \val {
+                        $str   = $str ~ nqp::unbox_s(val);
+                        $chars = nqp::chars($str);
+                        $pos   = 0;
+
+                        while ($left = $chars - $pos) > 0 {
+                            $nextpos = nqp::findcclass(
+                              nqp::const::CCLASS_NEWLINE, $str, $pos, $left
+                            );
+
+                            # no trailing line delimiter, so go buffer
+                            last unless nqp::iscclass(
+                              nqp::const::CCLASS_NEWLINE, $str, $nextpos
+                            );
+
+                            # potentially broken CRLF, so go buffer
+                            $cr = nqp::ordat($str, $nextpos) == 13;    # CR
+                            last if $cr == 1 and $nextpos + 1 == $chars;
+
+                            $crlf = $cr
+                              && nqp::ordat($str, $nextpos + 1) == 10; # LF
+
+                            if $chomp {
+                                $res.emit( ($found = $nextpos - $pos)
+                                  ?? nqp::box_s(
+                                       nqp::substr($str, $pos, $found), Str)
+                                  !! ''
+                                );
+                                $pos = $nextpos + 1 + $crlf;
+                            }
+                            else {
+                                $found = $nextpos - $pos + 1 + $crlf;
+                                $res.emit( nqp::box_s(
+                                  nqp::substr($str, $pos, $found), Str)
+                                );
+                                $pos = $pos + $found;
+                            }
+                        }
+                        $str = $pos < $chars
+                          ?? nqp::substr($str,$pos)
+                          !! '';
+                    },
+                    done => {
+                        if $str {
+                            $chars = nqp::chars($str);
+                            $res.emit( $chomp
+                              && nqp::ordat($str, $chars - 1) == 13    # CR
+                              ?? nqp::box_s(nqp::substr($str,0,$chars - 1),Str)
+                              !! nqp::box_s($str, Str)
+                            );
+                        }
+                        $res.done;
+                    }
+                }
+            }
+        }
+    }
+
+    method words(Supply:D $self:) {
+
+        on -> $res {
+            $self => do {
+                my str $str;
+                my int $chars;
+                my int $left;
+                my int $pos;
+                my int $nextpos;
+                my int $found;
+                my int $cr;
+                my int $crlf;
+
+                {
+                    emit => -> \val {
+                        $str   = $str ~ nqp::unbox_s(val);
+                        $chars = nqp::chars($str);
+                        $pos   = nqp::findnotcclass(
+                          nqp::const::CCLASS_WHITESPACE, $str, 0, $chars);
+
+                        while ($left = $chars - $pos) > 0 {
+                            $nextpos = nqp::findcclass(
+                              nqp::const::CCLASS_WHITESPACE, $str, $pos, $left
+                            );
+
+                            last unless $left = $chars - $nextpos; # broken word
+
+                            $res.emit( nqp::box_s(
+                              nqp::substr( $str, $pos, $nextpos - $pos ), Str)
+                            );
+
+                            $pos = nqp::findnotcclass(
+                              nqp::const::CCLASS_WHITESPACE,$str,$nextpos,$left);
+                        }
+                        $str = $pos < $chars
+                          ?? nqp::substr($str,$pos)
+                          !! '';
+                    },
+                    done => {
+                        $res.emit( nqp::box_s($str, Str) ) if $str;
+                        $res.done;
+                    }
+                }
+            }
+        }
+    }
+
+    method elems(Supply:D $self: $seconds? ) {
+
+        on -> $res {
+            $self => do {
+                my $elems = 0;
+                my $last_time;
+                my $last_elems;
+
+                {
+                    emit => do {
+                        if $seconds {
+                            $last_time  = time div $seconds;
+                            $last_elems = $elems;
+                            -> \val {
+                                  $last_elems = ++$elems;
+                                  my $this_time = time div $seconds;
+                                  if $this_time != $last_time {
+                                      $res.emit($elems);
+                                      $last_time = $this_time;
+                                  }
+                            }
+                        }
+                        else {
+                            -> \val { $res.emit(++$elems) }
+                        }
+                    },
+                    done => {
+                        $res.emit($elems) if $seconds and $elems != $last_elems;
+                        $res.done;
+                    }
+                }
+            }
+        }
+    }
+
+    method last(Supply:D $self: Int $number = 1) {  # should be Natural
+        on -> $res {
+            $self => do {
+                my @seen;
+                {
+                    emit => $number == 1
+                      ?? -> \val { @seen[0] = val }
+                      !! -> \val {
+                          @seen.shift if +@seen == $number;
+                          @seen.push: val;
+                      },
+                    done => {
+                        $res.emit($_) for @seen;
+                        $res.done;
+                    }
+                }
+            }
+        }
+    }
+
+    method min(Supply:D $self: &by = &infix:<cmp>) {
+        my &cmp = &by.arity == 2 ?? &by !! { by($^a) cmp by($^b) }
+        on -> $res {
+            $self => do {
+                my $min;
+                {
+                    emit => -> \val {
+                        if val.defined and !$min.defined || cmp(val,$min) < 0 {
+                            $res.emit( $min = val );
+                        }
+                    },
+                    done => { $res.done }
+                }
+            }
+        }
+    }
+
+    method max(Supply:D $self: &by = &infix:<cmp>) {
+        my &cmp = &by.arity == 2 ?? &by !! { by($^a) cmp by($^b) }
+        on -> $res {
+            $self => do {
+                my $max;
+                {
+                    emit => -> \val {
+                        if val.defined and !$max.defined || cmp(val,$max) > 0 {
+                            $res.emit( $max = val );
+                        }
+                    },
+                    done => { $res.done }
+                }
+            }
+        }
+    }
+
+    method minmax(Supply:D $self: &by = &infix:<cmp>) {
+        my &cmp = &by.arity == 2 ?? &by !! { by($^a) cmp by($^b) }
+        on -> $res {
+            $self => do {
+                my $min;
+                my $max;
+                {
+                    emit => -> \val {
+                        if val.defined {
+                            if !$min.defined {
+                                $res.emit( Range.new($min = val, $max = val) );
+                            }
+                            elsif cmp(val,$min) < 0 {
+                                $res.emit( Range.new( $min = val, $max ) );
+                            }
+                            elsif cmp(val,$max) > 0 {
+                                $res.emit( Range.new( $min, $max = val ) );
+                            }
+                        }
+                    },
+                    done => { $res.done }
+                }
+            }
+        }
+    }
+
+    method reduce(Supply:D $self: &with) {
+        on -> $res {
+            $self => do {
+                my $notfirst;
+                my $reduced;
+                {
+                    emit => -> \val {
+                        $reduced = $notfirst ?? with($reduced,val) !! val;
+                        $res.emit($reduced);
+                        once $notfirst = True;
+                    },
+                    done => { $res.done }
+                }
+            }
+        }
+    }
+
+    method grab(Supply:D $self: &when_done) {
+        on -> $res {
+            $self => do {
+                my @seen;
+                {
+                    emit => -> \val { @seen.push: val },
+                    done => {
+                        $res.emit($_) for when_done(@seen);
+                        $res.done;
+                    }
+                }
+            }
+        }
+    }
+
+    method reverse(Supply:D:)                 { self.grab( {.reverse} ) }
+    method sort(Supply:D: &by = &infix:<cmp>) { self.grab( {.sort(&by)} ) }
+
+    method merge(*@s) {
+        @s.unshift(self) if self.DEFINITE;  # add if instance method
+        return Supply unless +@s;           # nothing to be done
+
+        X::Supply::Combinator.new(
+           combinator => 'merge'
+        ).throw if NOT_ALL_DEFINED_TYPE(@s,Supply);
+
+        return @s[0]  if +@s == 1;          # nothing to be done
+
+        my $dones = 0;
+        on -> $res {
+            @s => {
+                emit => -> \val { $res.emit(val) },
+                done => { $res.done() if ++$dones == +@s }
+            },
+        }
+    }
+
+    method zip(*@s, :&with is copy = &[,]) {
+        @s.unshift(self) if self.DEFINITE;  # add if instance method
+        return Supply unless +@s;           # nothing to be done
+
+        X::Supply::Combinator.new(
+           combinator => 'zip'
+        ).throw if NOT_ALL_DEFINED_TYPE(@s,Supply);
+
+        return @s[0]  if +@s == 1;          # nothing to be done
+
+        my @values = ( [] xx +@s );
+        on -> $res {
+            @s => -> $val, $index {
+                @values[$index].push($val);
+                if all(@values) {
+                    $res.emit( [[&with]] @values>>.shift );
+                }
+            }
+        }
+    }
+
+    method zip-latest(*@s, :&with is copy = &[,], :$initial ) {
+        @s.unshift(self) if self.DEFINITE;  # add if instance method
+        return Supply unless +@s;           # nothing to do.
+
+        X::Supply::Combinator.new(
+           combinator => 'zip-latest'
+        ).throw if NOT_ALL_DEFINED_TYPE(@s,Supply);
+
+        return @s[0] if +@s == 1;           # nothing to do.
+
+        my @values;
+
+        my $uninitialised = +@s; # how many supplies have yet to emit until we
+                                 # can start emitting, too?
+
+        if $initial {
+            @values = @$initial;
+            $uninitialised = 0 max $uninitialised - @$initial;
+        }
+
+        my $dones = 0;
+
+        on -> $res {
+            @s => do {
+                {
+                emit => -> $val, $index {
+                    if $uninitialised > 0 && not @values.EXISTS-POS($index) {
+                        --$uninitialised;
+                    }
+                    @values[$index] = $val;
+                    unless $uninitialised {
+                        $res.emit( [[&with]] @values );
+                    }
+                },
+                done => { $res.done() if ++$dones == +@s }
+                }
+            }
+        }
+    }
+
+    method for(Supply:U: |c) {
+        DEPRECATED('from-list',|<2015.01 2015.09>);
+        SupplyOperations.from-list(|c);
+    }
+    method on_demand(Supply:U: |c)       {
+        DEPRECATED('on-demand',|<2015.03 2015.09>);
+        SupplyOperations.on-demand(|c);
+    }
+    method schedule_on(Supply:D: Scheduler $scheduler) {
+        DEPRECATED('schedule-on',|<2015.03 2015.09>);
+        SupplyOperations.schedule-on(self, $scheduler);
+    }
+    method uniq(Supply:D: |c) {
+        DEPRECATED('unique', |<2014.11 2015.09>);
+        self.unique(|c);
+    }
+}
+
+# The on meta-combinator provides a mechanism for implementing thread-safe
+# combinators on Supplies. It subscribes to a bunch of sources, but will
+# only let one of the specified callbacks to handle their emit/done/quit run
+# at a time. A little bit actor-like.
+my class X::Supply::On::BadSetup is Exception {
+    method message() {
+        "on requires a callable that returns a list of pairs with Supply keys"
+    }
+}
+my class X::Supply::On::NoEmit is Exception {
+    method message() {
+        "on requires that emit be specified for each supply"
+    }
+}
+sub on(&setup) {
+    my class OnSupply does Supply {
+        has &!setup;
+        has Bool $!live = False;
+
+        submethod BUILD(:&!setup) { }
+
+        method !add_source(
+          $source, $lock, $index, :&done is copy, :&quit is copy,
+          :&emit is copy, :&more   # more deprecated, emit must be changeable
+        ) {
+            DEPRECATED('emit => {...}', |<2014.10 2015.09>) if &more;
+            $!live ||= True if $source.live;
+            &emit //= &more // X::Supply::On::NoEmit.new.throw;
+            &done //= { self.done };
+            &quit //= -> $ex { self.quit($ex) };
+
+            my &tap_emit = &emit.arity == 2
+              ?? -> \val {
+                  $lock.protect({ emit(val,$index) });
+                  CATCH { default { self.quit($_) } }
+              }
+              !!  -> \val {
+                  $lock.protect({ emit(val) });
+                  CATCH { default { self.quit($_) } }
+              };
+
+            my &tap_done = &done.arity == 1
+              ?? {
+                  $lock.protect({ done($index) });
+                  CATCH { default { self.quit($_) } }
+              }
+              !! {
+                  $lock.protect({ done() });
+                  CATCH { default { self.quit($_) } }
+              };
+
+            my &tap_quit = &quit.arity == 2
+              ?? -> $ex {
+                  $lock.protect({ quit($ex,$index) });
+                  CATCH { default { self.quit($_) } }
+              }
+              !! -> $ex {
+                  $lock.protect({ quit($ex) });
+                  CATCH { default { self.quit($_) } }
+              };
+
+            $source.tap( &tap_emit, done => &tap_done, quit => &tap_quit );
+        }
+
+        method live { $!live }
+        method tap(|c) {
+            my @to_close;
+            my $sub = self.Supply::tap( |c, closing => {.close for @to_close});
+            my @tappers = &!setup(self);
+            my $lock    = Lock.new;
+
+            sub add ($source, $what, $index?) {
+                unless nqp::istype($source,Supply) {
+                    X::Supply::On::BadSetup.new.throw;
+                }
+                given $what {
+                    when EnumMap {
+                        @to_close.push(self!add_source($source, $lock, $index, |$what));
+                    }
+                    when Callable {
+                        @to_close.push(self!add_source($source, $lock, $index, emit => $what));
+                    }
+                    default {
+                        X::Supply::On::BadSetup.new.throw;
+                    }
+                }
+            }
+
+            for @tappers -> $tap {
+                unless nqp::istype($tap,Pair) {
+                    X::Supply::On::BadSetup.new.throw;
+                }
+                given $tap.key {
+                    when Positional {
+                        my $todo := $tap.value;
+                        for .list.kv -> $index, $supply {
+                            add( $supply, $todo, $index );
+                        }
+                    }
+                    when Supply {
+                        add( $_, $tap.value );
+                    }
+                    default {
+                        X::Supply::On::BadSetup.new.throw;
+                    }
+                }
+            }
+            $sub
+        }
+
+        method emit(\msg) {
+            for self.tappers {
+                .emit().(msg)
+            }
+            Nil;
+        }
+
+        method done() {
+            for self.tappers {
+                if .done -> $l { $l() }
+            }
+            Nil;
+        }
+
+        method quit($ex) {
+            for self.tappers {
+                if .quit -> $t { $t($ex) }
+            }
+            Nil;
+        }
+    }
+
+    OnSupply.new(:&setup)
+}
+
+# vim: ft=perl6 expandtab sw=4

--- a/main/parse.h
+++ b/main/parse.h
@@ -40,6 +40,7 @@ typedef void (*simpleParser) (void);
 typedef rescanReason (*rescanParser) (const unsigned int passCount);
 typedef void (*parserInitialize) (langType language);
 typedef void (*parserFinalize) (langType language);
+typedef langType (*specialiedLanguageSelector) (FILE *);
 
 /*
  * Predefined kinds
@@ -97,6 +98,8 @@ typedef struct {
 	parserFinalize finalize;       /* finalize routine, if needed */
 	simpleParser parser;           /* simple parser (common case) */
 	rescanParser parser2;          /* rescanning parser (unusual case) */
+    specialiedLanguageSelector
+        selectLanguage;            /* may be used to resolve conflicts */
 	unsigned int method;           /* See PARSE__... definitions above */
 	tgTableEntry *tgEntries;
 	boolean useCork;
@@ -201,6 +204,7 @@ extern void printXcmdKinds (const langType language, boolean indent);
 extern void freeXcmdResources (void);
 extern void useXcmdMethod (const langType language);
 extern void notifyAvailabilityXcmdMethod (const langType language);
+extern langType pickPerlVersion (FILE *);
 
 #endif  /* _PARSE_H */
 

--- a/main/parsers.h
+++ b/main/parsers.h
@@ -47,6 +47,7 @@
 	OcamlParser, \
 	PascalParser, \
 	PerlParser, \
+	Perl6Parser, \
 	PhpParser, \
 	PythonParser, \
 	RexxParser, \

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -533,6 +533,7 @@ extern parserDefinition* PerlParser (void)
 	def->kindCount  = KIND_COUNT (PerlKinds);
 	def->extensions = extensions;
 	def->parser     = findPerlTags;
+	def->selectLanguage = pickPerlVersion;
 	return def;
 }
 

--- a/parsers/perl6.c
+++ b/parsers/perl6.c
@@ -1,0 +1,325 @@
+/*
+ * perl6.c -- Perl6 parser.
+ * Author: Dmitri Tikhonov <dmitri@cpan.org>
+ *
+ * This is a very basic Perl 6 parser.  It does not know how to:
+ *   - skip POD;
+ *   - skip multiline comments;
+ *   - skip quoted strings;
+ *   - generate fully-qualified tags.
+ *
+ * This source code is released for free distribution under the terms of
+ * the GNU General Public License.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "general.h"
+#include "debug.h"
+#include "entry.h"
+#include "options.h"
+#include "read.h"
+#include "routines.h"
+#include "vstring.h"
+
+enum perl6Kind {
+    K_NONE = -1,
+    K_CLASS,
+    K_GRAMMAR,
+    K_METHOD,
+    K_MODULE,
+    K_ROLE,
+    K_RULE,
+    K_SUBMETHOD,
+    K_SUBROUTINE,
+    K_TOKEN,
+};
+
+static kindOption perl6Kinds[] = {
+    [K_CLASS]       = { TRUE,  'c', "class",      "classes" },
+    [K_GRAMMAR]     = { TRUE,  'g', "grammar",    "grammars" },
+    [K_METHOD]      = { TRUE,  'm', "method",     "methods" },
+    [K_MODULE]      = { TRUE,  'o', "module",     "modules" },
+    [K_ROLE]        = { TRUE,  'r', "role",       "roles" },
+    [K_RULE]        = { TRUE,  'u', "rule",       "rules" },
+    [K_SUBMETHOD]   = { TRUE,  'b', "submethod",  "submethods" },
+    [K_SUBROUTINE]  = { TRUE,  's', "subroutine", "subroutines" },
+    [K_TOKEN]       = { TRUE,  't', "token",      "tokens" },
+};
+
+enum token {
+    T_CLASS,
+    T_GRAMMAR,
+    T_METHOD,
+    T_MODULE,
+    T_MULTI,
+    T_MY,
+    T_OUR,
+    T_PROTO,
+    T_ROLE,
+    T_RULE,
+    T_SUB,
+    T_SUBMETHOD,
+    T_UNIT,
+    T_TOKEN,
+};
+
+static const enum perl6Kind token2kind[] = {
+    [T_CLASS]       = K_CLASS,
+    [T_GRAMMAR]     = K_GRAMMAR,
+    [T_METHOD]      = K_METHOD,
+    [T_MODULE]      = K_MODULE,
+    [T_MULTI]       = K_SUBROUTINE,
+    [T_MY]          = K_NONE,
+    [T_OUR]         = K_NONE,
+    [T_PROTO]       = K_NONE,
+    [T_ROLE]        = K_ROLE,
+    [T_RULE]        = K_RULE,
+    [T_SUB]         = K_SUBROUTINE,
+    [T_SUBMETHOD]   = K_SUBMETHOD,
+    [T_UNIT]        = K_NONE,
+    [T_TOKEN]       = K_TOKEN,
+};
+
+#define STRLEN(s) (sizeof(s) - 1)
+#define STREQN(s, token) (0 == strncmp(s, token, STRLEN(token)))
+
+static enum token
+matchToken (const char *s, int len)
+{
+    switch (len) {
+        case 2:
+            if (STREQN(s, "my"))                return T_MY;
+            break;
+        case 3:
+            switch (s[0]) {
+                case 'o':
+                    if (STREQN(s, "our"))       return T_OUR;
+                    break;
+                case 's':
+                    if (STREQN(s, "sub"))       return T_SUB;
+                    break;
+            }
+            break;
+        case 4:
+            switch (s[1]) {
+                case 'o':
+                    if (STREQN(s, "role"))      return T_ROLE;
+                    break;
+                case 'u':
+                    if (STREQN(s, "rule"))      return T_RULE;
+                    break;
+                case 'n':
+                    if (STREQN(s, "unit"))      return T_UNIT;
+                    break;
+            }
+            break;
+        case 5:
+            switch (s[0]) {
+                case 'c':
+                    if (STREQN(s, "class"))     return T_CLASS;
+                    break;
+                case 'm':
+                    if (STREQN(s, "multi"))     return T_MULTI;
+                    break;
+                case 'p':
+                    if (STREQN(s, "proto"))     return T_PROTO;
+                    break;
+                case 't':
+                    if (STREQN(s, "token"))     return T_TOKEN;
+                    break;
+            }
+            break;
+        case 6:
+            switch (s[1]) {
+                case 'e':
+                    if (STREQN(s, "method"))    return T_METHOD;
+                    break;
+                case 'o':
+                    if (STREQN(s, "module"))    return T_MODULE;
+                    break;
+            }
+            break;
+        case 7:
+            if (STREQN(s, "grammar"))           return T_GRAMMAR;
+            break;
+        case 9:
+            if (STREQN(s, "submethod"))         return T_SUBMETHOD;
+            break;
+    }
+    return -1;
+}
+
+static int validPerl6Identifier[0x100] = {
+/* r!perl -e "print qq([(int)'\$_'] = 1,\n)for a..z,A..Z,0..9,':','-','_'"|fmt
+ */
+    [(int)'a'] = 1, [(int)'b'] = 1, [(int)'c'] = 1, [(int)'d'] = 1,
+    [(int)'e'] = 1, [(int)'f'] = 1, [(int)'g'] = 1, [(int)'h'] = 1,
+    [(int)'i'] = 1, [(int)'j'] = 1, [(int)'k'] = 1, [(int)'l'] = 1,
+    [(int)'m'] = 1, [(int)'n'] = 1, [(int)'o'] = 1, [(int)'p'] = 1,
+    [(int)'q'] = 1, [(int)'r'] = 1, [(int)'s'] = 1, [(int)'t'] = 1,
+    [(int)'u'] = 1, [(int)'v'] = 1, [(int)'w'] = 1, [(int)'x'] = 1,
+    [(int)'y'] = 1, [(int)'z'] = 1, [(int)'A'] = 1, [(int)'B'] = 1,
+    [(int)'C'] = 1, [(int)'D'] = 1, [(int)'E'] = 1, [(int)'F'] = 1,
+    [(int)'G'] = 1, [(int)'H'] = 1, [(int)'I'] = 1, [(int)'J'] = 1,
+    [(int)'K'] = 1, [(int)'L'] = 1, [(int)'M'] = 1, [(int)'N'] = 1,
+    [(int)'O'] = 1, [(int)'P'] = 1, [(int)'Q'] = 1, [(int)'R'] = 1,
+    [(int)'S'] = 1, [(int)'T'] = 1, [(int)'U'] = 1, [(int)'V'] = 1,
+    [(int)'W'] = 1, [(int)'X'] = 1, [(int)'Y'] = 1, [(int)'Z'] = 1,
+    [(int)'0'] = 1, [(int)'1'] = 1, [(int)'2'] = 1, [(int)'3'] = 1,
+    [(int)'4'] = 1, [(int)'5'] = 1, [(int)'6'] = 1, [(int)'7'] = 1,
+    [(int)'8'] = 1, [(int)'9'] = 1, [(int)':'] = 1, [(int)'-'] = 1,
+    [(int)'_'] = 1,
+};
+
+static int validMethodPrefix[0x100] = {
+    [(int)'!'] = 1, [(int)'^'] = 1,
+};
+
+static const int kindMayHaveMethodPrefix = (1 << K_SUBMETHOD) |
+                                           (1 << K_METHOD)    ;
+
+/* Trim identifier pointed to by ps, possibly advancing it, and return
+ * the length of the valid portion.  If the returned value is zero, the
+ * identifier is invalid.
+ */
+static int
+trimIdentifier (enum perl6Kind kind, const char **ps, int len)
+{
+    Assert(len > 0);
+    const char *const end = *ps + len;
+    const char *s = *ps;
+    /* Trim the front if possible: */
+    s += (kindMayHaveMethodPrefix & (1 << kind)) &&
+         validMethodPrefix[(int)*s];
+    /* Record the start of identifier: */
+    *ps = s;
+    /* Continuous string of valid characters: */
+    while (s < end && validPerl6Identifier[(int)*s])
+        ++s;
+    /* sub multi infix:<...>        -- we want the "infix" only */
+    while (s - *ps > 0 && ':' == s[-1])
+        --s;
+    /* It's ok if this is zero: */
+    return s - *ps;
+}
+
+struct p6Ctx {
+    enum token  tokens[128 /* unlikely to need more than this */];
+    int         n_tokens;
+    vString    *name;
+    const char *line;      /* Saved from fileReadLine() */
+};
+
+static void
+makeTag (struct p6Ctx *ctx, int kind, const char *name, int len)
+{
+    tagEntryInfo entry;
+    vStringNCopyS(ctx->name, name, len);
+    initTagEntry(&entry, vStringValue(ctx->name));
+    entry.kind     = perl6Kinds[kind].letter;
+    entry.kindName = perl6Kinds[kind].name;
+    makeTagEntry(&entry);
+}
+
+static void
+possiblyMakeTag (struct p6Ctx *ctx, const char *s, int len)
+{
+    Assert(ctx->n_tokens > 0);
+    enum perl6Kind kind = token2kind[ ctx->tokens[ctx->n_tokens - 1] ];
+    if (K_NONE != kind && perl6Kinds[kind].enabled
+                       && (len = trimIdentifier(kind, &s, len)) > 0)
+        makeTag(ctx, kind, s, len);
+}
+
+static void
+initP6Ctx (struct p6Ctx *ctx)
+{
+    ctx->n_tokens = 0;
+    ctx->name = vStringNew();
+    ctx->line = NULL;
+}
+
+static void
+deinitP6Ctx (struct p6Ctx *ctx)
+{
+    vStringDelete(ctx->name);
+}
+
+/* Read next contiguous sequence of non-whitespace characters, store
+ * the address in `ptok', and return its length.  Return value of zero
+ * means EOF.
+ *
+ * TODO: Currently, POD and multi-line comments are not handled.
+ */
+static int
+getNonSpaceStr (struct p6Ctx *ctx, const char **ptok)
+{
+    const char *s = ctx->line;
+    if (!s) {
+next_line:
+        s = (const char *) fileReadLine();
+        if (!s)
+            return 0;                           /* EOF */
+    }
+    while (*s && isspace(*s))                   /* Skip whitespace */
+        ++s;
+    if ('#' == *s)
+        goto next_line;
+    int non_white_len = strcspn(s, ",; \t");
+    if (non_white_len) {
+        ctx->line = s + non_white_len;          /* Save state */
+        *ptok = s;
+        return non_white_len;
+    } else
+        goto next_line;
+}
+
+static void
+findPerl6Tags (void)
+{
+    struct p6Ctx ctx;
+
+#define RESET_TOKENS() do { ctx.n_tokens = 0; } while (0)
+
+#define PUSH_TOKEN(_t_) do {                                            \
+    if (ctx.n_tokens < sizeof(ctx.tokens) / sizeof(ctx.tokens[0])) {    \
+        ctx.tokens[ ctx.n_tokens ] = _t_;                               \
+        ++ctx.n_tokens;                                                 \
+    } else {                                                            \
+        Assert(!"Token stack overflown: this is quite odd");            \
+        RESET_TOKENS();                                                 \
+    }                                                                   \
+} while (0)
+
+    initP6Ctx(&ctx);
+
+    const char *s;
+    int len;
+
+    while ((len = getNonSpaceStr(&ctx, &s)) > 0) {
+        enum token token = matchToken(s, len);
+        if ((int) token >= 0) {
+            PUSH_TOKEN(token);
+        } else if (ctx.n_tokens > 0) {
+            possiblyMakeTag(&ctx, s, len);
+            RESET_TOKENS();
+        }
+    }
+
+    deinitP6Ctx(&ctx);
+}
+
+parserDefinition *
+Perl6Parser (void)
+{
+    static const char *const extensions[] = { "p6", "pm6", "pm", "pl6", NULL };
+    parserDefinition* def = parserNew("Perl6");
+    def->kinds      = perl6Kinds;
+    def->kindCount  = KIND_COUNT(perl6Kinds);
+    def->extensions = extensions;
+    def->parser     = findPerl6Tags;
+    def->selectLanguage = pickPerlVersion;
+    return def;
+}

--- a/source.mak
+++ b/source.mak
@@ -61,6 +61,7 @@ PARSER_SOURCES =				\
 	$(PARSER_DIR)/ocaml.c			\
 	$(PARSER_DIR)/pascal.c			\
 	$(PARSER_DIR)/perl.c			\
+	$(PARSER_DIR)/perl6.c			\
 	$(PARSER_DIR)/php.c			\
 	$(PARSER_DIR)/python.c			\
 	$(PARSER_DIR)/rexx.c			\


### PR DESCRIPTION
An interesting change is the introduction of selectLanguage function
pointer to parserDefinition.  This is done to select Perl 5 or Perl
6 parser for files with extension .pm -- Perl 6 uses .pm and .pm6 for
its modules.