### PR TITLE
main, lregex: remove {optional} long flag (3 days)

### DIFF
--- a/Tmain/lregex-list-kinds.d/run.sh
+++ b/Tmain/lregex-list-kinds.d/run.sh
@@ -2,9 +2,10 @@ CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE -o - \
 	 --langdef=foo \
-	 --regex-foo=/a/\0/a/{optional} --foo-kinds=+a \
+	 --regex-foo=/a/\0/a/ --kinds-foo=-a --foo-kinds=+a \
 	 --regex-foo=/b/\0/b/ --foo-kinds=-b \
-	 --regex-foo=/c/\0/c/{optional} \
+	 --regex-foo=/c/\0/c/ \
+	 --kinds-foo=-c \
 	 --regex-foo=/d/\0/d/ \
 	 --list-kinds=foo
 

--- a/data/optlib/gdbinit.ctags
+++ b/data/optlib/gdbinit.ctags
@@ -39,7 +39,8 @@
 ##
 ## document
 ##
---regex-gdbinit=/^document[[:space:]]+([^[:space:]]+)$/\1/D,document/{optional}
+--regex-gdbinit=/^document[[:space:]]+([^[:space:]]+)$/\1/D,document/
+--kinds-gdbinit=-D
 
 ##
 ## set $...
@@ -49,4 +50,5 @@
 ##
 ## __...set $...
 ##
---regex-gdbinit=/^[[:space:]]+set[[:space:]]+\$([a-zA-Z0-9_]+)[[:space:]]*=/\1/l,local-variable/{optional}
+--regex-gdbinit=/^[[:space:]]+set[[:space:]]+\$([a-zA-Z0-9_]+)[[:space:]]*=/\1/l,local-variable/
+--kinds-gdbinit=-l

--- a/data/optlib/m4.ctags
+++ b/data/optlib/m4.ctags
@@ -88,4 +88,5 @@
 # include(NAME)
 # m4_include(NAME)
 #
---regex-m4=/^[[:space:]]*(m4_)?s?include\([[`]?([^]')]+)[]']?\)/\2/I,inclusion/{exclusive}{optional}
+--regex-m4=/^[[:space:]]*(m4_)?s?include\([[`]?([^]')]+)[]']?\)/\2/I,inclusion/{exclusive}
+--kinds-m4=-I

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -333,20 +333,6 @@ is imperfect approach for ignoring text insides comments but it may
 be better than nothing. Ghost kind is assigned to the empty name
 pattern. (See "Ghost kind in regex parser".)
 
-Optional flag in regex
----------------------------------------------------------------------
-
-Kinds defined with ``--regex-<LANG>`` was
-enabled by default. A kind disabled by default can be defined
-with new flag ``optional`` (long only) like::
-
-	--m4-regex=/[[:space:]]include\(`([^']+)'/\1/I,inclusion/x{optional}
-
-A user can turn on this pattern with::
-
-       --m4-kinds=+I
-
-
 Ghost kind in regex parser
 ---------------------------------------------------------------------
 

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -260,18 +260,8 @@ static void pre_ptrn_flag_exclusive_long (const char* const s __unused__, const 
 	pre_ptrn_flag_exclusive_short ('x', data);
 }
 
-static void ptrn_flag_optional_long (const char* const s, const char* const unused __unused__, void* data)
-{
-	regexPattern *ptrn = data;
-	ptrn->u.tag.kind->enabled = FALSE;
-}
-
 static flagDefinition prePtrnFlagDef[] = {
 	{ 'x',  "exclusive", pre_ptrn_flag_exclusive_short, pre_ptrn_flag_exclusive_long },
-};
-
-static flagDefinition ptrnFlagDef[] = {
-	{ '\0', "optional",  NULL, ptrn_flag_optional_long  },
 };
 
 static struct sKind *kindNew ()
@@ -379,7 +369,6 @@ static regexPattern *addCompiledTagPattern (
 		ptrn->u.tag.kind->name    = kindName? eStrdup (kindName): NULL;
 		ptrn->u.tag.kind->description = description? eStrdup (description): NULL;
 	}
-	flagsEval (flags, ptrnFlagDef, COUNT(ptrnFlagDef), ptrn);
 
 	return ptrn;
 }
@@ -395,7 +384,6 @@ static void addCompiledCallbackPattern (
 	ptrn->type    = PTRN_CALLBACK;
 	ptrn->u.callback.function = callback;
 	ptrn->exclusive = exclusive;
-	flagsEval (flags, ptrnFlagDef, COUNT(ptrnFlagDef), ptrn);
 }
 
 


### PR DESCRIPTION
{optional} long is redundant. It can be replaed with --kind-<LANG>=-
option.

Note about compatibilities:  I introduced it and exuberant ctags doesn't have it.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>