### PR TITLE
main: rearrange the locations of #ifdef/#endif for xcmd related code(1 day)

### DIFF
--- a/main/lxcmd.c
+++ b/main/lxcmd.c
@@ -1139,11 +1139,11 @@ static boolean invokeXcmdPath (const char* const fileName, xcmdPath* path, const
 
 #endif
 
+#ifdef HAVE_COPROC
 extern boolean invokeXcmd (const char* const fileName, const langType language)
 {
 	boolean result = FALSE;
 
-#ifdef HAVE_COPROC
 	if (language != LANG_IGNORE  &&  language <= SetUpper  &&
 		Sets [language].count > 0)
 	{
@@ -1158,6 +1158,6 @@ extern boolean invokeXcmd (const char* const fileName, const langType language)
 		}
 
 	}
-#endif
 	return result;
 }
+#endif

--- a/main/parse.c
+++ b/main/parse.c
@@ -1774,6 +1774,7 @@ static boolean createTagsWithFallback (
 	return tagFileResized;
 }
 
+#ifdef HAVE_COPROC
 static boolean createTagsWithXcmd (
 		const char *const fileName, const langType language)
 {
@@ -1790,6 +1791,7 @@ static boolean createTagsWithXcmd (
 
 	return tagFileResized;
 }
+#endif
 
 static void printGuessedParser (const char* const fileName, langType language)
 {


### PR DESCRIPTION
This commit suppresses following messages warned when coproc is not available:

    main/parse.c: In function ‘createTagsWithXcmd’:
    main/parse.c:1784:20: warning: implicit declaration of function ‘invokeXcmd’ [-Wimplicit-function-declaration]
       tagFileResized = invokeXcmd (fileName, language);
			^
    main/parse.c: At top level:
    main/parse.c:1777:16: warning: ‘createTagsWithXcmd’ defined but not used [-Wunused-function]
     static boolean createTagsWithXcmd (
		    ^

Signed-off-by: Masatake YAMATO <yamato@redhat.com>