### PR TITLE
options.c: Avoid redefining asprintf

### DIFF
--- a/main/options.c
+++ b/main/options.c
@@ -479,7 +479,7 @@ static vString* getHome (void)
 	}
 }
 
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(__USE_MINGW_ANSI_STDIO)
 
 /* Some versions of MinGW are missing _vscprintf's declaration, although they
  * still provide the symbol in the import library.


### PR DESCRIPTION
MinGW64 defines asprintf when __USE_MINGW_ANSI_STDIO is defined.

MSYS2 makepkg-mingw system automatically defines this macro. Without
this change, makepkg-mingw fails because asprintf is redefined in
options.c.