### PR TITLE
Fix that writing tags to stdout didn't work with MSYS2(masatake: till Aug 23)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -357,7 +357,7 @@ fi
 # Checks for header files
 # -----------------------
 
-AC_CHECK_HEADERS_ONCE([dirent.h fcntl.h stat.h stdlib.h string.h])
+AC_CHECK_HEADERS_ONCE([dirent.h fcntl.h io.h stat.h stdlib.h string.h])
 AC_CHECK_HEADERS_ONCE([time.h types.h unistd.h])
 AC_CHECK_HEADERS_ONCE([sys/dir.h sys/stat.h sys/times.h sys/types.h sys/wait.h])
 

--- a/main/e_msoft.h
+++ b/main/e_msoft.h
@@ -34,6 +34,7 @@
 #define HAVE_TEMPNAM 1
 #define HAVE_FNMATCH 1
 #define HAVE_FNMATCH_H 1
+#define HAVE_PUTENV 1
 #define tempnam(dir,pfx) _tempnam(dir,pfx)
 #define TMPDIR "\\"
 

--- a/main/entry.c
+++ b/main/entry.c
@@ -414,7 +414,9 @@ extern void openTagFile (void)
 	/*  Open the tags file.
 	 */
 	if (TagsToStdout)
-		TagFile.fp = tempFile ("w", &TagFile.name);
+		/* Open a tempfile with read and write mode. Read mode is used when
+		 * write the result to stdout. */
+		TagFile.fp = tempFile ("w+", &TagFile.name);
 	else
 	{
 		boolean fileExists;
@@ -494,10 +496,8 @@ static void sortTagFile (void)
 #endif
 		}
 		else if (TagsToStdout)
-			catFile (tagFileName ());
+			catFile (TagFile.fp);
 	}
-	if (TagsToStdout)
-		remove (tagFileName ());  /* remove temporary file */
 }
 
 static void resizeTagFile (const long newSize)
@@ -550,12 +550,15 @@ extern void closeTagFile (const boolean resize)
 
 	if (Option.etags)
 		writeEtagsIncludes (TagFile.fp);
+	fflush (TagFile.fp);
 	abort_if_ferror (TagFile.fp);
 	desiredSize = ftell (TagFile.fp);
 	fseek (TagFile.fp, 0L, SEEK_END);
 	size = ftell (TagFile.fp);
-	if (fclose (TagFile.fp) != 0)
-		error (FATAL | PERROR, "cannot close tag file");
+	if (! TagsToStdout)
+		/* The tag file should be closed before resizing. */
+		if (fclose (TagFile.fp) != 0)
+			error (FATAL | PERROR, "cannot close tag file");
 
 	if (resize  &&  desiredSize < size)
 	{
@@ -565,6 +568,12 @@ extern void closeTagFile (const boolean resize)
 		resizeTagFile (desiredSize);
 	}
 	sortTagFile ();
+	if (TagsToStdout)
+	{
+		if (fclose (TagFile.fp) != 0)
+			error (FATAL | PERROR, "cannot close tag file");
+		remove (tagFileName ());  /* remove temporary file */
+	}
 	eFree (TagFile.name);
 	TagFile.name = NULL;
 }

--- a/main/routines.c
+++ b/main/routines.c
@@ -829,8 +829,12 @@ extern FILE *tempFile (const char *const mode, char **const pName)
 	const char *const pattern = "tags.XXXXXX";
 	const char *tmpdir = NULL;
 	fileStatus *file = eStat (ExecutableProgram);
+# ifdef WIN32
+	tmpdir = getenv ("TMP");
+# else
 	if (! file->isSetuid)
 		tmpdir = getenv ("TMPDIR");
+# endif
 	if (tmpdir == NULL)
 		tmpdir = TMPDIR;
 	name = xMalloc (strlen (tmpdir) + 1 + strlen (pattern) + 1, char);
@@ -838,7 +842,13 @@ extern FILE *tempFile (const char *const mode, char **const pName)
 	fd = mkstemp (name);
 	eStatFree (file);
 #elif defined(HAVE_TEMPNAM)
-	name = tempnam (TMPDIR, "tags");
+	const char *tmpdir = NULL;
+# ifdef WIN32
+	tmpdir = getenv ("TMP");
+# endif
+	if (tmpdir == NULL)
+		tmpdir = TMPDIR;
+	name = tempnam (tmpdir, "tags");
 	if (name == NULL)
 		error (FATAL | PERROR, "cannot allocate temporary file name");
 	fd = open (name, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);

--- a/main/sort.h
+++ b/main/sort.h
@@ -17,7 +17,7 @@
 /*
 *   FUNCTION PROTOTYPES
 */
-extern void catFile (const char *const name);
+extern void catFile (FILE *fp);
 
 #ifdef EXTERNAL_SORT
 extern void externalSortTags (const boolean toStdout);


### PR DESCRIPTION
There were two problems with tempfile handling on MSYS2.

1. MinGW-w64 has mkstemp(), but it deletes a tempfile automatically when the file descriptor is closed. However u-ctags expects that the file remains.
2. tempdir was set to '/tmp', but it's not prefer for Windows. Use `TMP` environment for the temporary directory.

Related: #494