### PR TITLE
Makefile.in: copy ctags.1 from build directory

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -236,7 +236,7 @@ install-cman: $(DEST_CMAN)
 install-eman: $(DEST_EMAN)
 
 $(DEST_CMAN): $(DESTDIR)$(man1dir) $(MANPAGE) FORCE
-	- $(INSTALL_DATA) $(srcdir)/$(MANPAGE) $(DESTDIR)$@  &&  chmod 644 $(DESTDIR)$@
+	- $(INSTALL_DATA) $(MANPAGE) $(DESTDIR)$@  &&  chmod 644 $(DESTDIR)$@
 
 $(DEST_EMAN):
 	- if [ -f $(DESTDIR)$(DEST_CMAN) ]; then \


### PR DESCRIPTION
In out-of-source builds, ctags.1 is created in the build directory, not
in the directory that contains the source files.