### PR TITLE
units: Add dos2unix checking when running on MSYS2

### DIFF
--- a/misc/units
+++ b/misc/units
@@ -784,7 +784,7 @@ action_run ()
     [ -d "${LIBEXECDIR}" ] || ERROR 1 "no such directory: ${LIBEXECDIR}"
     : ${WITH_TIMEOUT:=0}
     [ "$WITH_TIMEOUT" = 0 ] || check_availability timeout
-    [ "WITH_VALGRIND" = 'yes' ]  && check_availability valgrind
+    [ "$WITH_VALGRIND" = 'yes' ] && check_availability valgrind
     check_availability grep
     check_availability diff
 
@@ -1334,7 +1334,7 @@ action_fuzz_common ()
     [ -d "${LIBEXECDIR}" ] || ERROR 1 "no such directory: ${LIBEXECDIR}"
     : ${WITH_TIMEOUT:=2}
     [ "$WITH_TIMEOUT" = 0 ] || check_availability timeout
-    [ "WITH_VALGRIND" = 'yes' ]  && check_availability valgrind
+    [ "$WITH_VALGRIND" = 'yes' ] && check_availability valgrind
     check_availability find
 
     cmdline="${CTAGS} --options=NONE --\*-kinds=\* --fields=\* --libexec-dir=${LIBEXECDIR} --data-dir=${DATADIR}"

--- a/misc/units
+++ b/misc/units
@@ -785,6 +785,7 @@ action_run ()
     : ${WITH_TIMEOUT:=0}
     [ "$WITH_TIMEOUT" = 0 ] || check_availability timeout
     [ "$WITH_VALGRIND" = 'yes' ] && check_availability valgrind
+    [ "$MSYSTEM" != '' ] && check_availability dos2unix
     check_availability grep
     check_availability diff
 


### PR DESCRIPTION
Also fixes valgrind checking.

See: https://github.com/universal-ctags/ctags/issues/494#issuecomment-133634328
Note: When running on MSYS2, `MSYSTEM` is set to "MSYS", "MINGW32" or "MINGW64".