### PR TITLE
Run tinst in separated builddir

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -95,7 +95,7 @@ READ_INC = readtags.h
 MANPAGE	= ctags.1
 
 AUTO_GEN   = configure config.h.in
-CONFIG_GEN = config.cache config.log config.status config.run config.h Makefile
+CONFIG_GEN = config.cache config.log config.status config.run config.h ctags.1 Makefile
 
 #
 # names for installed man pages

--- a/Makefile.in
+++ b/Makefile.in
@@ -469,8 +469,12 @@ clean-tmain:
 # Test installation
 #
 tinst:
-	rm -rf $$(pwd)/$(TINST_ROOT)
-	$(SHELL) misc/tinst $$(pwd)/$(TINST_ROOT)
+	@ \
+	\
+	builddir=$$(pwd); \
+	rm -rf $$builddir/$(TINST_ROOT); \
+	\
+	$(SHELL) $(srcdir)/misc/tinst $(srcdir) $$builddir/$(TINST_ROOT)
 
 #
 # Checking code in ctags own rules

--- a/Makefile.in
+++ b/Makefile.in
@@ -167,13 +167,6 @@ $(CTAGS_EXEC): $(OBJECTS)
 $(READ_CMD): readtags.c readtags.h
 	$(CC) -DREADTAGS_MAIN -I. -I$(srcdir) -I$(srcdir)/main $(DEFS) $(ALL_CPPFLAGS)  $(ALL_CFLAGS) $(LDFLAGS) -o $@ $(srcdir)/readtags.c
 
-ETYPEREF_OBJS = etyperef.o keyword.o routines.o strlist.o vstring.o
-etyperef$(EXEEXT): $(ETYPEREF_OBJS)
-	$(CC) $(LDFLAGS) -o $@ $(ETYPEREF_OBJS)
-
-etyperef.o: eiffel.c
-	$(CC) -DTYPE_REFERENCE_TOOL -I. -I$(srcdir) -I$(srcdir)/main $(DEFS) $(ALL_CPPFLAGS) $(ALL_CFLAGS) -o $@ -c $(srcdir)/eiffel.c
-
 $(OBJECTS): $(HEADERS) config.h Makefile
 
 # Regenerate the Makefile whenever this file (it's source) changed.  Any target
@@ -344,7 +337,6 @@ TAGS: $(CTAGS_EXEC)
 
 clean: clean-units clean-gcov clean-tmain
 	rm -f $(OBJECTS) $(CTAGS_EXEC) tags TAGS $(READ_LIB) 
-	rm -f etyperef$(EXEEXT) etyperef.$(OBJEXT)
 	rm -f $(SOURCES:.c=.gcno)
 
 mostlyclean: clean

--- a/misc/tinst
+++ b/misc/tinst
@@ -3,8 +3,8 @@ TINST_ROOT=
 
 ERROR ()
 {
-    local status="$1"
-    local msg="$2"
+    local status=$1
+    local msg=$2
     shift 2
     echo "$msg" 1>&2
     exit $status
@@ -68,25 +68,26 @@ T_existing()
 
 prepare()
 {
-    local root=$1
+    local srcdir=$1
+    local root=$2
 
 
     MSG_title "Preparing installation tests"
     
-    if ! [ -e ./configure ]; then
+    if ! [ -e ${srcdir}/configure ]; then
 	ERROR 2 "cannot find configure script"
     fi
 
-    mkdir -p "$1"
+    mkdir -p "$root"
 
-    if ! [ -d "$1" ]; then
-	ERROR 2 "failed in directory creation: $1"
+    if ! [ -d "$root" ]; then
+	ERROR 2 "failed in directory creation: $roo"
     fi
 
     rm Makefile
 
-    if ! ./configure --prefix=$1 > /dev/null; then
-	ERROR 2 "failed in running configure script $1"
+    if ! ${srcdir}/configure --prefix=$root > /dev/null; then
+	ERROR 2 "failed in running configure script $root"
     fi
 
     if ! [ -e Makefile ]; then
@@ -138,17 +139,19 @@ check()
 
 main()
 {
+    local srcdir
     local root
     local status
 
-    if [ $# = 1 ]; then
-	root=$1
-	shift
+    if [ $# = 2 ]; then
+	srcdir=$1
+	root=$2
+	shift 2
     else
 	ERROR 2 "A installation root must be given as the first argument"
     fi
     
-    prepare "${root}"
+    prepare "${srcdir}" "${root}"
 
     TINST_ROOT=${root}
     check


### PR DESCRIPTION
3 patches are included in this PR.
The 1st and 2nd are for cleaning up Makefile.in.
With the 3rd one, you can run "make tinst" in a separated builddir.