### PR TITLE
main: fix a memory leak in language map operation

### DIFF
--- a/main/parse.c
+++ b/main/parse.c
@@ -1021,7 +1021,7 @@ static boolean removeLanguagePatternMap (const char *const pattern)
 	for (i = 0  ;  i < LanguageCount  &&  ! result ;  ++i)
 	{
 		stringList* const ptrn = LanguageTable [i]->currentPatterns;
-		if (ptrn != NULL  &&  stringListRemoveExtension (ptrn, pattern))
+		if (ptrn != NULL && stringListDeleteItemExtension (ptrn, pattern))
 		{
 			verbose (" (removed from %s)", getLanguageName (i));
 			result = TRUE;
@@ -1048,7 +1048,7 @@ extern boolean removeLanguageExtensionMap (const char *const extension)
 	for (i = 0  ;  i < LanguageCount  &&  ! result ;  ++i)
 	{
 		stringList* const exts = LanguageTable [i]->currentExtensions;
-		if (exts != NULL  &&  stringListRemoveExtension (exts, extension))
+		if (exts != NULL && stringListDeleteItemExtension (exts, extension))
 		{
 			verbose (" (removed from %s)", getLanguageName (i));
 			result = TRUE;
@@ -1585,16 +1585,12 @@ static void processLangAliasOption (const langType language,
 	}
 	else if (parameter[0] == '-')
 	{
-		vString* tmp;
 		if (lang->currentAliaes)
 		{
 			alias = parameter + 1;
-			tmp = stringListExtensionFinds(lang->currentAliaes, alias);
-			if (tmp)
+			if (stringListDeleteItemExtension (lang->currentAliaes, alias))
 			{
 				verbose ("remove alias %s from %s\n", alias, lang->name);
-				stringListRemoveExtension (lang->currentAliaes, alias);
-				vStringDelete (tmp);
 			}
 		}
 	}

--- a/main/strlist.c
+++ b/main/strlist.c
@@ -231,8 +231,8 @@ extern boolean stringListHasTest (const stringList *const current,
 	return result;
 }
 
-extern boolean stringListRemoveExtension (
-		stringList* const current, const char* const extension)
+extern boolean stringListDeleteItemExtension (stringList* const current, const char* const extension)
+
 {
 	boolean result = FALSE;
 	int where;
@@ -243,6 +243,7 @@ extern boolean stringListRemoveExtension (
 #endif
 	if (where != -1)
 	{
+		vStringDelete (current->list [where]);
 		memmove (current->list + where, current->list + where + 1,
 				(current->count - where) * sizeof (*current->list));
 		current->list [current->count - 1] = NULL;

--- a/main/strlist.h
+++ b/main/strlist.h
@@ -46,7 +46,7 @@ extern boolean stringListHas (const stringList *const current, const char *const
 extern boolean stringListHasTest (const stringList *const current,
 				  boolean (*test)(const char *s, void *userData),
 				  void *userData);
-extern boolean stringListRemoveExtension (stringList* const current, const char* const extension);
+extern boolean stringListDeleteItemExtension (stringList* const current, const char* const extension);
 extern boolean stringListExtensionMatched (const stringList* const list, const char* const extension);
 extern vString* stringListExtensionFinds (const stringList* const list, const char* const extension);
 extern boolean stringListFileMatched (const stringList* const list, const char* const str);


### PR DESCRIPTION
The leak is found in option-corpora-conflicts.d test
case with VG=1.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>