### PR TITLE
AppVeyor: Install dos2unix on Cygwin

### DIFF
--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -136,6 +136,7 @@ goto :eof
 :: ----------------------------------------------------------------------
 :: Using Cygwin, iconv enabled
 @echo on
+c:\cygwin\setup-x86.exe -qnNdO -R C:/cygwin -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P dos2unix
 PATH c:\cygwin\bin;%PATH%
 set CHERE_INVOKING=yes
 bash -lc ""


### PR DESCRIPTION
Some tests were skipped on Cygwin on AppVeyor because Cygwin version of
dos2unix was not installed. (Another version of dos2unix which comes
with Git is already installed but it doesn't work well when we run our
tests.)