### PR TITLE
configure.ac: Remove redundant $TMPDIR environment variable test.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -299,8 +299,6 @@ if test -n "$enable_tmpdir"; then
 	tmpdir="$enable_tmpdir"
 elif test -n "$TMPDIR"; then
 	tmpdir="$TMPDIR"
-elif test -n "$TMPDIR"; then
-	tmpdir="$TMPDIR"
 elif test -n "$TMP"; then
 	tmpdir="$TMP"
 elif test -n "$TEMP"; then


### PR DESCRIPTION
Redundant TMPDIR environment variable tests are exists in configure.ac.
