### PR TITLE
Fix configure use obsolete detecting macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -412,8 +412,10 @@ esac
 # MinGW has st_ino, but it doesn't work.
 if test yes != "$host_mingw"; then
 	AC_MSG_CHECKING(if struct stat contains st_ino)
-	AC_TRY_COMPILE([#include <sys/stat.h>
-					#include <stdlib.h>], [
+	AC_TRY_COMPILE([
+		#include <sys/stat.h>
+		#include <stdlib.h>
+		], [
 		struct stat st;
 		stat(".", &st);
 		if (st.st_ino > 0)
@@ -514,7 +516,8 @@ AC_TRY_RUN([
 int main(void) {
 	regex_t patbuf;
 	return (regcomp (&patbuf, "/hello/", 0) != 0);
-}],regcomp_works=yes,regcomp_works=no,AC_DEFINE(CHECK_REGCOMP))
+}
+],regcomp_works=yes,regcomp_works=no,AC_DEFINE(CHECK_REGCOMP))
 AC_MSG_RESULT($regcomp_works)
 if test yes != "$regcomp_works"; then
 	AC_DEFINE(REGCOMP_BROKEN)

--- a/configure.ac
+++ b/configure.ac
@@ -412,7 +412,7 @@ esac
 # MinGW has st_ino, but it doesn't work.
 if test yes != "$host_mingw"; then
 	AC_MSG_CHECKING(if struct stat contains st_ino)
-	AC_TRY_COMPILE([
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 		#include <sys/stat.h>
 		#include <stdlib.h>
 		], [
@@ -420,7 +420,7 @@ if test yes != "$host_mingw"; then
 		stat(".", &st);
 		if (st.st_ino > 0)
 			exit(0);
-	], have_st_ino=yes, have_st_ino=no)
+	])],[have_st_ino=yes],[have_st_ino=no])
 	AC_MSG_RESULT($have_st_ino)
 	if test yes = "$have_st_ino"; then
 		AC_DEFINE(HAVE_STAT_ST_INO)
@@ -510,14 +510,14 @@ dnl
 dnl
 AC_CHECK_FUNCS(regcomp,[
 AC_MSG_CHECKING(if regcomp works)
-AC_TRY_RUN([
+AC_RUN_IFELSE([AC_LANG_SOURCE([
 #include <sys/types.h>
 #include <regex.h>
 int main(void) {
 	regex_t patbuf;
 	return (regcomp (&patbuf, "/hello/", 0) != 0);
 }
-],regcomp_works=yes,regcomp_works=no,AC_DEFINE(CHECK_REGCOMP))
+])],[regcomp_works=yes],[regcomp_works=no],[AC_DEFINE(CHECK_REGCOMP)])
 AC_MSG_RESULT($regcomp_works)
 if test yes != "$regcomp_works"; then
 	AC_DEFINE(REGCOMP_BROKEN)


### PR DESCRIPTION
AC_TRY_COMPILE() and AC_TRY_RUN() are obsolete. Succeeding AC_COMPILE_IFELSE() and AC_RUN_IFELSE() should be used.
