### PR TITLE
Regex with scope

### DIFF
--- a/Units/dts-simple.d/expected.tags
+++ b/Units/dts-simple.d/expected.tags
@@ -1,4 +1,4 @@
-0x00	input.dts	/^    phandle = <0x00>    $/;"	p
+0x00	input.dts	/^    phandle = <0x00>    $/;"	p	label:label
 bar	input.dts	/^#define bar /;"	d	file:
 foo.dtsi	input.dts	/^#include "foo.dtsi"/;"	h
 label	input.dts	/^label: test {$/;"	l

--- a/Units/regex-with-scope.d/args.ctags
+++ b/Units/regex-with-scope.d/args.ctags
@@ -4,9 +4,11 @@
 --langdef=foo
     --map-foo=+.foo
     --regex-foo=/^#.*//{exclusive}
-    --regex-foo=/^[[:blank:]]*define[[:blank:]]+([[:alnum:]_]+):/\1/d,definition/{scope=push}
+    --regex-foo=/^[[:blank:]]*define[[:blank:]]+([[:alnum:]_]+)[[:blank:]]*\{/\1/d,definition/{scope=push}
+    --regex-foo=/^[[:blank:]]*\{/_/d,definition/{scope=push}{placeholder}
     --regex-foo=/^[[:blank:]]*package[[:blank:]]+([[:alnum:]_]+)/\1/p,package/{scope=push}
     --regex-foo=/^[[:blank:]]*end[[:blank:]]*$//{scope=pop}{exclusive}
+    --regex-foo=/^[[:blank:]]*\}[[:blank:]]*$//{scope=pop}{exclusive}
     --regex-foo=/^[[:blank:]]*ns[[:blank:]]+([[:alnum:]_]+)/\1/n,namespace/{scope=set}
     --regex-foo=/^[[:blank:]]*var[[:blank:]]+([[:alnum:]_]+)/\1/v,var/{scope=ref}
     --regex-foo=/^[[:blank:]]*global//{scope=clear}{exclusive}

--- a/Units/regex-with-scope.d/args.ctags
+++ b/Units/regex-with-scope.d/args.ctags
@@ -1,0 +1,12 @@
+# To check the output easier
+--sort=no
+
+--langdef=foo
+    --map-foo=+.foo
+    --regex-foo=/^#.*//{exclusive}
+    --regex-foo=/^[[:blank:]]*define[[:blank:]]+([[:alnum:]_]+):/\1/d,definition/{scope=push}
+    --regex-foo=/^[[:blank:]]*package[[:blank:]]+([[:alnum:]_]+)/\1/p,package/{scope=push}
+    --regex-foo=/^[[:blank:]]*end[[:blank:]]*$//{scope=pop}{exclusive}
+    --regex-foo=/^[[:blank:]]*ns[[:blank:]]+([[:alnum:]_]+)/\1/n,namespace/{scope=set}
+    --regex-foo=/^[[:blank:]]*var[[:blank:]]+([[:alnum:]_]+)/\1/v,var/{scope=ref}
+    --regex-foo=/^[[:blank:]]*global//{scope=clear}{exclusive}

--- a/Units/regex-with-scope.d/expected.tags
+++ b/Units/regex-with-scope.d/expected.tags
@@ -1,21 +1,21 @@
 NS1	input.foo	/^ns NS1$/;"	n
 x	input.foo	/^define x {$/;"	d	namespace:NS1
-y	input.foo	/^	define y {$/;"	d	definition:x
-v_y_0	input.foo	/^	       var v_y_0$/;"	v	definition:y
-v_y_1	input.foo	/^	       var v_y_1$/;"	v	definition:y
-z	input.foo	/^	define z {$/;"	d	definition:x
-v_z_0	input.foo	/^	       var v_z_0$/;"	v	definition:z
-v_z_1	input.foo	/^	       var v_z_1$/;"	v	definition:z
-a	input.foo	/^	       define a {$/;"	d	definition:z
+y	input.foo	/^	define y {$/;"	d	definition:NS1.x
+v_y_0	input.foo	/^	       var v_y_0$/;"	v	definition:NS1.x.y
+v_y_1	input.foo	/^	       var v_y_1$/;"	v	definition:NS1.x.y
+z	input.foo	/^	define z {$/;"	d	definition:NS1.x
+v_z_0	input.foo	/^	       var v_z_0$/;"	v	definition:NS1.x.z
+v_z_1	input.foo	/^	       var v_z_1$/;"	v	definition:NS1.x.z
+a	input.foo	/^	       define a {$/;"	d	definition:NS1.x.z
 NS2	input.foo	/^ns NS2$/;"	n
 p	input.foo	/^define p {$/;"	d	namespace:NS2
-q	input.foo	/^   define q {$/;"	d	definition:p
+q	input.foo	/^   define q {$/;"	d	definition:NS2.p
 v_g1	input.foo	/^var v_g1$/;"	v
 d_g	input.foo	/^define d_g {$/;"	d
 v_l	input.foo	/^       var v_l$/;"	v	definition:d_g
 NS3	input.foo	/^ns NS3$/;"	n
 PACKAGE	input.foo	/^package PACKAGE$/;"	p	namespace:NS3
-p	input.foo	/^define p {$/;"	d	package:PACKAGE
-q	input.foo	/^   define q {$/;"	d	definition:p
-L	input.foo	/^		var L$/;"	v	definition:q
+p	input.foo	/^define p {$/;"	d	package:NS3.PACKAGE
+q	input.foo	/^   define q {$/;"	d	definition:NS3.PACKAGE.p
+L	input.foo	/^		var L$/;"	v	definition:NS3.PACKAGE.p.q
 v_g2	input.foo	/^var v_g2$/;"	v	namespace:NS3

--- a/Units/regex-with-scope.d/expected.tags
+++ b/Units/regex-with-scope.d/expected.tags
@@ -1,20 +1,21 @@
 NS1	input.foo	/^ns NS1$/;"	n
-x	input.foo	/^define x:$/;"	d	namespace:NS1
-y	input.foo	/^	define y:$/;"	d	definition:x
+x	input.foo	/^define x {$/;"	d	namespace:NS1
+y	input.foo	/^	define y {$/;"	d	definition:x
 v_y_0	input.foo	/^	       var v_y_0$/;"	v	definition:y
 v_y_1	input.foo	/^	       var v_y_1$/;"	v	definition:y
-z	input.foo	/^	define z:$/;"	d	definition:x
+z	input.foo	/^	define z {$/;"	d	definition:x
 v_z_0	input.foo	/^	       var v_z_0$/;"	v	definition:z
 v_z_1	input.foo	/^	       var v_z_1$/;"	v	definition:z
-a	input.foo	/^	       define a:$/;"	d	definition:z
+a	input.foo	/^	       define a {$/;"	d	definition:z
 NS2	input.foo	/^ns NS2$/;"	n
-p	input.foo	/^define p:$/;"	d	namespace:NS2
-q	input.foo	/^   define q:$/;"	d	definition:p
+p	input.foo	/^define p {$/;"	d	namespace:NS2
+q	input.foo	/^   define q {$/;"	d	definition:p
 v_g1	input.foo	/^var v_g1$/;"	v
-d_g	input.foo	/^define d_g:$/;"	d
+d_g	input.foo	/^define d_g {$/;"	d
 v_l	input.foo	/^       var v_l$/;"	v	definition:d_g
 NS3	input.foo	/^ns NS3$/;"	n
 PACKAGE	input.foo	/^package PACKAGE$/;"	p	namespace:NS3
-p	input.foo	/^define p:$/;"	d	package:PACKAGE
-q	input.foo	/^   define q:$/;"	d	definition:p
+p	input.foo	/^define p {$/;"	d	package:PACKAGE
+q	input.foo	/^   define q {$/;"	d	definition:p
+L	input.foo	/^		var L$/;"	v	definition:q
 v_g2	input.foo	/^var v_g2$/;"	v	namespace:NS3

--- a/Units/regex-with-scope.d/expected.tags
+++ b/Units/regex-with-scope.d/expected.tags
@@ -1,0 +1,20 @@
+NS1	input.foo	/^ns NS1$/;"	n
+x	input.foo	/^define x:$/;"	d	namespace:NS1
+y	input.foo	/^	define y:$/;"	d	definition:x
+v_y_0	input.foo	/^	       var v_y_0$/;"	v	definition:y
+v_y_1	input.foo	/^	       var v_y_1$/;"	v	definition:y
+z	input.foo	/^	define z:$/;"	d	definition:x
+v_z_0	input.foo	/^	       var v_z_0$/;"	v	definition:z
+v_z_1	input.foo	/^	       var v_z_1$/;"	v	definition:z
+a	input.foo	/^	       define a:$/;"	d	definition:z
+NS2	input.foo	/^ns NS2$/;"	n
+p	input.foo	/^define p:$/;"	d	namespace:NS2
+q	input.foo	/^   define q:$/;"	d	definition:p
+v_g1	input.foo	/^var v_g1$/;"	v
+d_g	input.foo	/^define d_g:$/;"	d
+v_l	input.foo	/^       var v_l$/;"	v	definition:d_g
+NS3	input.foo	/^ns NS3$/;"	n
+PACKAGE	input.foo	/^package PACKAGE$/;"	p	namespace:NS3
+p	input.foo	/^define p:$/;"	d	package:PACKAGE
+q	input.foo	/^   define q:$/;"	d	definition:p
+v_g2	input.foo	/^var v_g2$/;"	v	namespace:NS3

--- a/Units/regex-with-scope.d/input.foo
+++ b/Units/regex-with-scope.d/input.foo
@@ -1,0 +1,41 @@
+ns NS1
+define x:
+	define y:
+	       var v_y_0
+	       var v_y_1
+	end
+	define z:
+	       var v_z_0
+	       var v_z_1
+	       define a:
+	       end
+	end
+end
+
+ns NS2
+define p:
+   define q:
+	  print
+   end
+end
+
+global
+var v_g1
+define d_g:
+       var v_l
+end
+
+ns NS3
+package PACKAGE
+define p:
+   define q:
+	  print
+   end
+
+# end of define
+end
+
+# end of package
+end
+
+var v_g2

--- a/Units/regex-with-scope.d/input.foo
+++ b/Units/regex-with-scope.d/input.foo
@@ -1,39 +1,42 @@
 ns NS1
-define x:
-	define y:
+define x {
+	define y {
 	       var v_y_0
 	       var v_y_1
-	end
-	define z:
+	}
+	define z {
 	       var v_z_0
 	       var v_z_1
-	       define a:
-	       end
-	end
-end
+	       define a {
+	       }
+	}
+}
 
 ns NS2
-define p:
-   define q:
+define p {
+   define q {
 	  print
-   end
-end
+   }
+}
 
 global
 var v_g1
-define d_g:
+define d_g {
        var v_l
-end
+}
 
 ns NS3
 package PACKAGE
-define p:
-   define q:
+define p {
+   define q {
 	  print
-   end
+	  {
+		var L
+	  }
+   }
 
 # end of define
-end
+}
 
 # end of package
 end

--- a/main/entry.c
+++ b/main/entry.c
@@ -791,6 +791,40 @@ static int writeEtagsEntry (const tagEntryInfo *const tag)
 	return length;
 }
 
+static char* getFullQualifiedScopeNameFromCorkQueue (const tagEntryInfo * inner_scope)
+{
+
+	const tagEntryInfo *scope = inner_scope;
+	stringList *queue = stringListNew ();
+	vString *v;
+	vString *n;
+	unsigned int c;
+
+	while (scope)
+	{
+		if (!scope->placeholder)
+		{
+			v = vStringNewInit ((char *)scope->name);
+			stringListAdd (queue, v);
+		}
+		scope =  getEntryInCorkQueue (scope->extensionFields.scopeIndex);
+	}
+
+	n = vStringNew ();
+	while ((c = stringListCount (queue)) > 0)
+	{
+		v = stringListLast (queue);
+		vStringCat (n, v);
+		vStringDelete (v);
+		stringListRemoveLast (queue);
+		if (c != 1)
+			vStringPut (n, '.');
+	}
+	stringListDelete (queue);
+
+	return vStringDeleteUnwrap (n);
+}
+
 static int addExtensionFields (const tagEntryInfo *const tag)
 {
 	const char* const kindKey = Option.extensionFields.kindKey ? "kind:" : "";
@@ -825,10 +859,14 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 			 && TagFile.corkQueue.count > 0)
 		{
 			const tagEntryInfo * scope;
+			char *full_qualified_scope_name;
 
 			scope = getEntryInCorkQueue (tag->extensionFields.scopeIndex);
+			full_qualified_scope_name = getFullQualifiedScopeNameFromCorkQueue(scope);
+			Assert (full_qualified_scope_name);
 			length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
-					   scope->kind->name, scope->name);
+					   scope->kind->name, full_qualified_scope_name);
+			eFree (full_qualified_scope_name);
 		}
 	}
 

--- a/main/entry.c
+++ b/main/entry.c
@@ -1075,7 +1075,10 @@ extern void uncorkTagFile(void)
 
 extern tagEntryInfo *getEntryInCorkQueue   (unsigned int n)
 {
-	return TagFile.corkQueue.queue + n;
+	if ((SCOPE_NIL < n) && (n < TagFile.corkQueue.count))
+		return TagFile.corkQueue.queue + n;
+	else
+		return NULL;
 }
 
 extern size_t        countEntryInCorkQueue (void)

--- a/main/entry.c
+++ b/main/entry.c
@@ -1024,6 +1024,9 @@ static void writeTagEntry (const tagEntryInfo *const tag)
 {
 	int length = 0;
 
+	if (tag->placeholder)
+		return;
+
 	DebugStatement ( debugEntry (tag); )
 	if (Option.xref)
 		length = writeXrefEntry (tag);

--- a/main/entry.h
+++ b/main/entry.h
@@ -93,6 +93,10 @@ typedef struct sTagEntryInfo {
 		const char* typeRef [2];  /* e.g., "struct" and struct name */
 
 	} extensionFields;  /* list of extension fields*/
+
+	boolean placeholder;	/* This is just a part of scope context.
+				   Put this entry to cork queue but
+				   don't print it to tags file. */
 } tagEntryInfo;
 
 /*

--- a/main/flags.c
+++ b/main/flags.c
@@ -73,3 +73,32 @@ void flagsEval (const char* flags, flagDefinition* defs, unsigned int ndefs, voi
 				defs[j].shortProc(flags[i], data);
 	}
 }
+
+void  flagPrintHelp (flagDefinition* def, unsigned int ndefs)
+{
+
+	unsigned int i;
+	const char *longStr;
+	const char *description;
+	const char *paramName;
+	char shortChar[3];
+	for ( i = 0; i < ndefs; ++i )
+	{
+		longStr = def[i].longStr? def[i].longStr: "";
+		description = def[i].description? def[i].description: "";
+		paramName = def[i].paramName;
+
+		if (def[i].shortChar == '\0')
+			strcpy (shortChar, "\\0");
+		else
+		{
+			shortChar[0] = def[i].shortChar;
+			shortChar[1] = '\0';
+		}
+
+		if (paramName)
+			printf ("%s\t%s=%s\t%s\n", shortChar, longStr, paramName, description);
+		else
+			printf ("%s\t%s\t%s\n", shortChar, longStr, description);
+	}
+}

--- a/main/flags.c
+++ b/main/flags.c
@@ -20,15 +20,17 @@
 #include "vstring.h"
 #include "routines.h"
 
-void flagsEval (const char* flags, flagDefinition* defs, unsigned int ndefs, void* data)
+void flagsEval (const char* flags_original, flagDefinition* defs, unsigned int ndefs, void* data)
 {
 	unsigned int i, j;
+	char *flags;
 
-	if (!flags)
+	if (!flags_original)
 		return;
 	if (!defs)
 		return;
 
+	flags = eStrdup (flags_original);
 	for (i = 0 ; flags [i] != '\0' ; ++i)
 	{
 		if (flags [i] == LONG_FLAGS_OPEN)
@@ -72,6 +74,7 @@ void flagsEval (const char* flags, flagDefinition* defs, unsigned int ndefs, voi
 			if (flags[i] == defs[j].shortChar)
 				defs[j].shortProc(flags[i], data);
 	}
+	eFree (flags);
 }
 
 void  flagPrintHelp (flagDefinition* def, unsigned int ndefs)

--- a/main/flags.h
+++ b/main/flags.h
@@ -19,9 +19,11 @@ typedef struct {
 	const char *longStr;
 	void (* shortProc) (char c,  void *data);
 	void (* longProc)  (const char* const s, const char* const param, void *data);
-  /* TODO: handler for help message */
+	const char *paramName;
+	const char *description;
 } flagDefinition;
 
 extern void flagsEval (const char* flags, flagDefinition* defs, unsigned int ndefs, void* data);
+extern void flagPrintHelp (flagDefinition* def, unsigned int ndefs);
 
 #endif	/* _FLAGS_H */

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -709,6 +709,15 @@ static regexPattern *addTagRegexInternal (
 				eFree (description);
 		}
 	}
+
+	if (*name == '\0')
+	{
+		if (rptr->exclusive)
+			rptr->ignore = TRUE;
+		else
+			error (WARNING, "%s: regexp missing name pattern", regex);
+	}
+
 	return rptr;
 }
 
@@ -753,15 +762,7 @@ extern void addLanguageRegex (
 		char *name, *kinds, *flags;
 		if (parseTagRegex (regex_pat, &name, &kinds, &flags))
 		{
-			regexPattern * r;
-			r = addTagRegexInternal (language, regex_pat, name, kinds, flags);
-			if (*name == '\0')
-			{
-				if (r->exclusive)
-					r->ignore = TRUE;
-				else
-					error (WARNING, "%s: regexp missing name pattern", regex);
-			}
+			addTagRegexInternal (language, regex_pat, name, kinds, flags);
 			eFree (regex_pat);
 		}
 	}

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -253,7 +253,8 @@ static void pre_ptrn_flag_exclusive_long (const char* const s __unused__, const 
 }
 
 static flagDefinition prePtrnFlagDef[] = {
-	{ 'x',  "exclusive", pre_ptrn_flag_exclusive_short, pre_ptrn_flag_exclusive_long },
+	{ 'x',  "exclusive", pre_ptrn_flag_exclusive_short, pre_ptrn_flag_exclusive_long ,
+	  NULL, "skip testing the other patterns if a line is matched to this pattern"},
 };
 
 static kindOption *kindNew ()
@@ -412,17 +413,21 @@ static void regex_flag_icase_long (const char* s __unused__, const char* const u
 }
 
 
+static flagDefinition regexFlagDefs[] = {
+	{ 'b', "basic",  regex_flag_basic_short,  regex_flag_basic_long,
+	  NULL, "interpreted as a Posix basic regular expression."},
+	{ 'e', "extend", regex_flag_extend_short, regex_flag_extend_long,
+	  NULL, "interpreted as a Posix extended regular expression (default)"},
+	{ 'i', "icase",  regex_flag_icase_short,  regex_flag_icase_long,
+	  NULL, "applied in a case-insensitive manner"},
+};
+
 static regex_t* compileRegex (const char* const regexp, const char* const flags)
 {
 	int cflags = REG_EXTENDED | REG_NEWLINE;
 	regex_t *result = NULL;
 	int errcode;
 
-	flagDefinition regexFlagDefs[] = {
-		{ 'b', "basic",  regex_flag_basic_short,  regex_flag_basic_long  },
-		{ 'e', "extend", regex_flag_extend_short, regex_flag_extend_long },
-		{ 'i', "icase",  regex_flag_icase_short,  regex_flag_icase_long  },
-	};
 	flagsEval (flags,
 		   regexFlagDefs,
 		   COUNT(regexFlagDefs),
@@ -916,6 +921,14 @@ extern void printRegexKinds (const langType language __unused__,
 		const char* const langName = getLanguageName (language);
 		printRegexKindsInPatternSet (set, langName, allKindFields, indent);
 	}
+#endif
+}
+
+extern void printRegexFlags (void)
+{
+#ifdef HAVE_REGEX
+	flagPrintHelp (regexFlagDefs,  COUNT (regexFlagDefs));
+	flagPrintHelp (prePtrnFlagDef, COUNT (prePtrnFlagDef));
 #endif
 }
 

--- a/main/options.c
+++ b/main/options.c
@@ -324,6 +324,8 @@ static optionDescription LongOptionDescription [] = {
  {1,"       Output list of supported languages."},
  {1,"  --list-maps=[language|all]"},
  {1,"       Output list of language mappings."},
+ {1,"  --list-regex-flags"},
+ {1,"       Output list of flags which can be used in a regex parser definition."},
  {1,"  --map-<LANG>=[+]map"},
  {1,"       Set or add(+) a map for <LANG>."},
  {1,"       Unlike --langmap a pattern or an extension can be specified at once."},
@@ -1672,6 +1674,14 @@ static void processListLanguagesOption (
 	exit (0);
 }
 
+static void processListRegexFlagsOptions (
+		const char *const option __unused__,
+		const char *const parameter __unused__)
+{
+	printRegexFlags ();
+	exit (0);
+}
+
 
 static void freeSearchPathList (searchPathList** pathList)
 {
@@ -2146,6 +2156,7 @@ static parametricOption ParametricOptions [] = {
 	{ "_list-kinds-full",       processListKindsOption,         TRUE,   STAGE_ANY },
 	{ "list-languages",         processListLanguagesOption,     TRUE,   STAGE_ANY },
 	{ "list-maps",              processListMapsOption,          TRUE,   STAGE_ANY },
+	{ "list-regex-flags",       processListRegexFlagsOptions,   TRUE,   STAGE_ANY },
 	{ "options",                processOptionFile,              FALSE,  STAGE_ANY },
 	{ "sort",                   processSortOption,              TRUE,   STAGE_ANY },
 	{ "version",                processVersionOption,           TRUE,   STAGE_ANY },

--- a/main/parse.c
+++ b/main/parse.c
@@ -1204,6 +1204,8 @@ static void initializeParser (parserDefinition *const parser, langType lang)
 	{
 		parser->initialize (lang);
 		parser->initialize = NULL;
+		if (hasScopeActionInRegex (lang))
+			parser->useCork = TRUE;
 	}
 
 	Assert (parser->fileKind != KIND_NULL);
@@ -1307,7 +1309,11 @@ static void lazyInitialize (langType language)
 	lang->parser = doNothing;
 
 	if (lang->method & (METHOD_NOT_CRAFTED|METHOD_REGEX))
+	{
+		if (hasScopeActionInRegex (language))
+			lang->useCork = TRUE;
 		lang->parser = findRegexTags;
+	}
 
 }
 #endif

--- a/main/parse.c
+++ b/main/parse.c
@@ -1198,18 +1198,23 @@ static boolean doesParserUseKind (const parserDefinition *const parser, char let
 	return FALSE;
 }
 
+static void initializeParser (parserDefinition *const parser, langType lang)
+{
+	if (parser->initialize != NULL)
+	{
+		parser->initialize (lang);
+		parser->initialize = NULL;
+	}
+
+	Assert (parser->fileKind != KIND_NULL);
+	Assert (!doesParserUseKind (parser, parser->fileKind->letter));
+}
+
 static void initializeParsers (void)
 {
 	unsigned int i;
 	for (i = 0  ;  i < LanguageCount  ;  ++i)
-	{
-		if (LanguageTable [i]->initialize != NULL)
-			(LanguageTable [i]->initialize) ((langType) i);
-
-		Assert (LanguageTable [i]->fileKind != NULL);
-		Assert (!doesParserUseKind (LanguageTable [i],
-					    LanguageTable [i]->fileKind->letter));
-	}
+		initializeParser (LanguageTable [i], i);
 }
 
 extern void initializeParsing (void)
@@ -1827,23 +1832,19 @@ static rescanReason createTagsForFile (
 	Assert (0 <= language  &&  language < (int) LanguageCount);
 	if (fileOpen (fileName, language))
 	{
-		const parserDefinition* const lang = LanguageTable [language];
+		parserDefinition *const lang = LanguageTable [language];
+
+		initializeParser (lang, language);
+
+		Assert (lang->parser || lang->parser2);
 
 		if (LanguageTable [language]->useCork)
 			corkTagFile();
 
-	  retry:
 		if (lang->parser != NULL)
 			lang->parser ();
 		else if (lang->parser2 != NULL)
 			rescan = lang->parser2 (passCount);
-		else if (lang->initialize != NULL)
-		{
-			parserInitialize init = lang->initialize;
-			init(language);
-			Assert (lang->parser || lang->parser2);
-			goto retry;
-		}
 
 		makeFileTag (fileName);
 

--- a/main/parse.h
+++ b/main/parse.h
@@ -168,6 +168,7 @@ extern void printRegexKinds (const langType language, boolean allKindFields, boo
 extern void freeRegexResources (void);
 extern boolean checkRegex (void);
 extern void useRegexMethod (const langType language);
+extern void printRegexFlags (void);
 
 #ifdef HAVE_COPROC
 extern boolean invokeXcmd (const char* const fileName, const langType language);

--- a/main/parse.h
+++ b/main/parse.h
@@ -169,6 +169,7 @@ extern void freeRegexResources (void);
 extern boolean checkRegex (void);
 extern void useRegexMethod (const langType language);
 extern void printRegexFlags (void);
+extern boolean hasScopeActionInRegex (const langType language);
 
 #ifdef HAVE_COPROC
 extern boolean invokeXcmd (const char* const fileName, const langType language);

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -31,11 +31,25 @@ static void installDTSRegex (const langType language)
 {
 	/* phandle = <0x00> */
 	addTagRegex (language,
-		"^[ \t]*phandle[ \t]+=[ \t]+<(0x[a-fA-F0-9]+)>", "\\1", "p,phandler,phandlers", NULL);
+		     "^[ \t]*phandle[ \t]+=[ \t]+<(0x[a-fA-F0-9]+)>", "\\1",
+		     "p,phandler,phandlers",
+		     "{scope=ref}");
 
 	/* label: */
 	addTagRegex (language,
-		"^[ \t]*([a-zA-Z][a-zA-Z0-9_]*)[ \t]*:", "\\1", "l,label,labels", NULL);
+		     "^[ \t]*([a-zA-Z][a-zA-Z0-9_]*)[ \t]*:", "\\1",
+		     "l,label,labels",
+		     "{scope=push}{exclusive}");
+
+	/* extras for tracking scopes  */
+	addTagRegex (language,
+		     "^[ \t]*([a-zA-Z][a-zA-Z0-9_]*)[ \t]*\\{", "",
+		     "",
+		     "{scope=push}{placeholder}{exclusive}");
+	addTagRegex (language,
+		     "^[ \t]*\\};", "",
+		     "",
+		     "{scope=pop}{exclusive}");
 }
 
 static void runCppGetc (void)


### PR DESCRIPTION
Introduce scope long flag to allow a regex based parser attaching scope information to tags.
e.g.

```
    $ cat /tmp/input.pp
    class foo {
	include bar
    }

    $ cat /tmp/pp.ctags
    --langdef=pp
	    --map-pp=+.pp
	    --regex-pp=/^class[[:blank:]]*([[:alnum:]]+)[[[:blank:]]]*\{/\1/c,class,classes/{scope=push}
	    --regex-pp=/^[[:blank:]]*include[[:blank:]]*([[:alnum:]]+).*/\1/i,include,includes/{scope=ref}
	    --regex-pp=/^[[:blank:]]*\}.*//{scope=pop}{exclusive}

    $ ~/var/ctags/ctags --options=/tmp/pp.ctags -o - /tmp/input.pp
    bar	/tmp/input.pp	/^    include bar$/;"	i	class:foo
    foo	/tmp/input.pp	/^class foo {$/;"	c
```