### PR TITLE
tmain: handle transformed program name ( 3 days )

### DIFF
--- a/misc/units
+++ b/misc/units
@@ -1757,6 +1757,12 @@ tmain_run ()
     local a
     local status=0
 
+    local need_rearrange
+
+    if ! [ $(basename "${CTAGS}") = 'ctags' ]; then
+	need_rearrange=yes
+    fi
+
     basedir=$(pwd)
     for subdir in ${topdir}/*.d; do
 	if [ "${subdir}" = ${topdir}/'*.d' ]; then
@@ -1780,7 +1786,9 @@ tmain_run ()
 	r=$?
 	echo $r > ${build_subdir}/exit-actual.txt
 
-	sed -i -e 's|^ctags.exe|ctags|' ${build_subdir}/stderr-actual.txt
+	if [ -n "${need_rearrange}" ]; then
+	    sed -i -e 's|^'$(basename "${CTAGS}")':|ctags:|' ${build_subdir}/stderr-actual.txt
+	fi
 
 	if [ $r = $CODE_FOR_IGNORING_THIS_TMAIN_TEST ]; then
 	    run_result skip '/dev/null' "$(cat ${build_subdir}/stdout-actual.txt)"


### PR DESCRIPTION
The program name(ctags by default) is used as prefix in warning
messages.  So comparing expected output and actual output of stderr
can be failed when using a ctags binary is built with
--program-transform-name is used.

To avoid the failures, with this commit tmain target rearranges the
actual output; substitute "^ctags" with the transformed progoram name
before comparing.

The issue is reported by @viccuad on #568.
Close #568.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>