### PR TITLE
build: Add missing main/tg.h to MAIN_HEADERS in source.mak

### DIFF
--- a/source.mak
+++ b/source.mak
@@ -27,6 +27,7 @@ MAIN_HEADERS =				\
 	$(MAIN_DIR)/selectors.h		\
 	$(MAIN_DIR)/sort.h		\
 	$(MAIN_DIR)/strlist.h		\
+	$(MAIN_DIR)/tg.h		\
 	$(MAIN_DIR)/vstring.h
 
 PARSER_HEADERS =


### PR DESCRIPTION
Header file main/tg.h is missing in source.mak.
