### PR TITLE
Verilog/improvements

### DIFF
--- a/Units/verilog-sv-basic.d/args.ctags
+++ b/Units/verilog-sv-basic.d/args.ctags
@@ -1,1 +1,2 @@
 --extra=+q
+--systemverilog-kinds=+Q

--- a/Units/verilog-sv-basic.d/expected.tags
+++ b/Units/verilog-sv-basic.d/expected.tags
@@ -11,20 +11,20 @@ STATE4	input.sv	/^           STATE4 = 4'h5    ,$/;"	c	module:mod
 STATE5	input.sv	/^           STATE5 = 4'h6    ,$/;"	c	module:mod
 STATE6	input.sv	/^           STATE6 = 4'h7    ,$/;"	c	module:mod
 STATE7	input.sv	/^           STATE7 = 4'h8;$/;"	c	module:mod
-a	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	function:test.extern_func
+a	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	prototype:test.extern_func
 a	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
 a	input.sv	/^    input wire a,$/;"	p	module:mod
 a	input.sv	/^    reg a;$/;"	r	class:test
 add	input.sv	/^task add ($/;"	t	module:mod
 array	input.sv	/^    for (gencnt = 0; gencnt < PARAM1; gencnt = gencnt + 1) begin: array$/;"	b	module:mod
 b	input.sv	/^    b,c,$/;"	p	module:mod
-b	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	function:test.extern_func
+b	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	prototype:test.extern_func
 b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
 b	input.sv	/^    logic b;$/;"	r	class:test
 c	input.sv	/^    b,c,$/;"	p	module:mod
 d	input.sv	/^    d ,$/;"	p	module:mod
 e	input.sv	/^    output wire e ,$/;"	p	module:mod
-extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	f	class:test
+extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	Q	class:test
 f	input.sv	/^    output reg f,$/;"	p	module:mod
 g	input.sv	/^    inout wire g$/;"	p	module:mod
 gencnt	input.sv	/^genvar gencnt;$/;"	r	module:mod
@@ -72,9 +72,9 @@ temp	input.sv	/^    reg temp;$/;"	r	function:mod.mult
 test	input.sv	/^class test;$/;"	C
 test.a	input.sv	/^    reg a;$/;"	r	class:test
 test.b	input.sv	/^    logic b;$/;"	r	class:test
-test.extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	f	class:test
-test.extern_func.a	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	function:test.extern_func
-test.extern_func.b	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	function:test.extern_func
+test.extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	Q	class:test
+test.extern_func.a	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	prototype:test.extern_func
+test.extern_func.b	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	prototype:test.extern_func
 test.mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:test
 test.mult.a	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
 test.mult.b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult

--- a/Units/verilog-sv-basic.d/expected.tags
+++ b/Units/verilog-sv-basic.d/expected.tags
@@ -22,6 +22,7 @@ b	input.sv	/^    extern virtual function void extern_func (input bit a, input b)
 b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
 b	input.sv	/^    logic b;$/;"	r	class:test
 c	input.sv	/^    b,c,$/;"	p	module:mod
+c	input.sv	/^    bit [1:0] c[3] = '{0, 0, 0};$/;"	r	class:test
 d	input.sv	/^    d ,$/;"	p	module:mod
 e	input.sv	/^    output wire e ,$/;"	p	module:mod
 extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	Q	class:test
@@ -72,6 +73,7 @@ temp	input.sv	/^    reg temp;$/;"	r	function:mod.mult
 test	input.sv	/^class test;$/;"	C
 test.a	input.sv	/^    reg a;$/;"	r	class:test
 test.b	input.sv	/^    logic b;$/;"	r	class:test
+test.c	input.sv	/^    bit [1:0] c[3] = '{0, 0, 0};$/;"	r	class:test
 test.extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	Q	class:test
 test.extern_func.a	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	prototype:test.extern_func
 test.extern_func.b	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	prototype:test.extern_func

--- a/Units/verilog-sv-basic.d/expected.tags
+++ b/Units/verilog-sv-basic.d/expected.tags
@@ -61,9 +61,13 @@ mod.mult.temp	input.sv	/^    reg temp;$/;"	r	function:mod.mult
 mod.mult.x	input.sv	/^    input x,$/;"	p	function:mod.mult
 mod.mult.y	input.sv	/^    input y);$/;"	p	function:mod.mult
 mod.mynet	input.sv	/^wire [PARAM1-1:0] mynet;$/;"	n	module:mod
+mod.ref_test	input.sv	/^function ref_test ($/;"	f	module:mod
+mod.ref_test.tref1	input.sv	/^    ref tref1,$/;"	p	function:mod.ref_test
+mod.ref_test.tref2	input.sv	/^    ref wire tref2,$/;"	p	function:mod.ref_test
 mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:test
 mult	input.sv	/^function mult ($/;"	f	module:mod
 mynet	input.sv	/^wire [PARAM1-1:0] mynet;$/;"	n	module:mod
+ref_test	input.sv	/^function ref_test ($/;"	f	module:mod
 temp	input.sv	/^    reg temp;$/;"	r	function:mod.mult
 test	input.sv	/^class test;$/;"	C
 test.a	input.sv	/^    reg a;$/;"	r	class:test
@@ -74,6 +78,8 @@ test.extern_func.b	input.sv	/^    extern virtual function void extern_func (inpu
 test.mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:test
 test.mult.a	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
 test.mult.b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
+tref1	input.sv	/^    ref tref1,$/;"	p	function:mod.ref_test
+tref2	input.sv	/^    ref wire tref2,$/;"	p	function:mod.ref_test
 x	input.sv	/^    input x, y$/;"	p	task:mod.add
 x	input.sv	/^    input x,$/;"	p	function:mod.mult
 y	input.sv	/^    input x, y$/;"	p	task:mod.add

--- a/Units/verilog-sv-basic.d/input.sv
+++ b/Units/verilog-sv-basic.d/input.sv
@@ -63,6 +63,12 @@ function mult (
     return temp;
 endfunction
 
+function ref_test (
+    ref tref1,
+    ref wire tref2,
+    );
+endfunction
+
 wire [PARAM1-1:0] mynet;
 
 genvar gencnt;

--- a/Units/verilog-sv-basic.d/input.sv
+++ b/Units/verilog-sv-basic.d/input.sv
@@ -8,6 +8,8 @@
 class test;
     reg a;
     logic b;
+    bit [1:0] c[3] = '{0, 0, 0};
+
     function mult (a, input b = 0);
         return a * b;
     endfunction : mult

--- a/Units/verilog-sv-class.d/args.ctags
+++ b/Units/verilog-sv-class.d/args.ctags
@@ -1,2 +1,3 @@
 --extra=+q
+--systemverilog-kinds=+Q
 --fields=+i

--- a/Units/verilog-sv-class.d/expected.tags
+++ b/Units/verilog-sv-class.d/expected.tags
@@ -16,6 +16,12 @@ b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
 b	input.sv	/^    logic b;$/;"	r	class:test
 b	input.sv	/^virtual function myfunc (a, b);$/;"	p	function:paramtest3.myfunc
 c	input.sv	/^    logic c;$/;"	r	class:supertest
+c	input.sv	/^extern virtual function test ext_func (c, d);$/;"	p	prototype:paramtest3.ext_func
+c	input.sv	/^function test paramtest3::ext_func (c, d);$/;"	p	function:paramtest3.ext_func
+d	input.sv	/^extern virtual function test ext_func (c, d);$/;"	p	prototype:paramtest3.ext_func
+d	input.sv	/^function test paramtest3::ext_func (c, d);$/;"	p	function:paramtest3.ext_func
+ext_func	input.sv	/^extern virtual function test ext_func (c, d);$/;"	Q	class:paramtest3
+ext_func	input.sv	/^function test paramtest3::ext_func (c, d);$/;"	f	class:paramtest3
 extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	Q	class:test
 mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:supertest
 mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:test
@@ -27,6 +33,12 @@ paramtest2.BASE	input.sv	/^  type BASE=supertest #(test)$/;"	c	class:paramtest2
 paramtest3	input.sv	/^class paramtest3 #(type BASE=supertest, type BASE2=paramtest);$/;"	C
 paramtest3.BASE	input.sv	/^class paramtest3 #(type BASE=supertest, type BASE2=paramtest);$/;"	c	class:paramtest3
 paramtest3.BASE2	input.sv	/^class paramtest3 #(type BASE=supertest, type BASE2=paramtest);$/;"	c	class:paramtest3
+paramtest3.ext_func	input.sv	/^extern virtual function test ext_func (c, d);$/;"	Q	class:paramtest3
+paramtest3.ext_func	input.sv	/^function test paramtest3::ext_func (c, d);$/;"	f	class:paramtest3
+paramtest3.ext_func.c	input.sv	/^extern virtual function test ext_func (c, d);$/;"	p	prototype:paramtest3.ext_func
+paramtest3.ext_func.c	input.sv	/^function test paramtest3::ext_func (c, d);$/;"	p	function:paramtest3.ext_func
+paramtest3.ext_func.d	input.sv	/^extern virtual function test ext_func (c, d);$/;"	p	prototype:paramtest3.ext_func
+paramtest3.ext_func.d	input.sv	/^function test paramtest3::ext_func (c, d);$/;"	p	function:paramtest3.ext_func
 paramtest3.myfunc	input.sv	/^virtual function myfunc (a, b);$/;"	f	class:paramtest3
 paramtest3.myfunc.a	input.sv	/^virtual function myfunc (a, b);$/;"	p	function:paramtest3.myfunc
 paramtest3.myfunc.b	input.sv	/^virtual function myfunc (a, b);$/;"	p	function:paramtest3.myfunc

--- a/Units/verilog-sv-class.d/expected.tags
+++ b/Units/verilog-sv-class.d/expected.tags
@@ -23,6 +23,7 @@ d	input.sv	/^function test paramtest3::ext_func (c, d);$/;"	p	function:paramtest
 ext_func	input.sv	/^extern virtual function test ext_func (c, d);$/;"	Q	class:paramtest3
 ext_func	input.sv	/^function test paramtest3::ext_func (c, d);$/;"	f	class:paramtest3
 extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	Q	class:test
+fwrd_ref	input.sv	/^    extern virtual function bit fwrd_ref;$/;"	Q	class:supertest
 mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:supertest
 mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:test
 myfunc	input.sv	/^virtual function myfunc (a, b);$/;"	f	class:paramtest3
@@ -44,6 +45,7 @@ paramtest3.myfunc.a	input.sv	/^virtual function myfunc (a, b);$/;"	p	function:pa
 paramtest3.myfunc.b	input.sv	/^virtual function myfunc (a, b);$/;"	p	function:paramtest3.myfunc
 supertest	input.sv	/^class supertest extends test;$/;"	C	inherits:test
 supertest.c	input.sv	/^    logic c;$/;"	r	class:supertest
+supertest.fwrd_ref	input.sv	/^    extern virtual function bit fwrd_ref;$/;"	Q	class:supertest
 supertest.mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:supertest
 supertest.mult.a	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:supertest.mult
 supertest.mult.b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:supertest.mult

--- a/Units/verilog-sv-class.d/expected.tags
+++ b/Units/verilog-sv-class.d/expected.tags
@@ -1,5 +1,7 @@
 BASE	input.sv	/^  type BASE=supertest #(test)$/;"	c	class:paramtest2
 BASE	input.sv	/^class paramtest #(type BASE=supertest #(test)) extends BASE;$/;"	c	class:paramtest
+BASE	input.sv	/^class paramtest3 #(type BASE=supertest, type BASE2=paramtest);$/;"	c	class:paramtest3
+BASE2	input.sv	/^class paramtest3 #(type BASE=supertest, type BASE2=paramtest);$/;"	c	class:paramtest3
 DEFINE	input.sv	/^`define DEFINE$/;"	c
 DEF_VALUE	input.sv	/^`define DEF_VALUE   1'd100$/;"	c
 DEF_WITH_EQ	input.sv	/^`define DEF_WITH_EQ = 1'd100$/;"	c
@@ -7,18 +9,27 @@ a	input.sv	/^    extern virtual function void extern_func (input bit a, input b)
 a	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:supertest.mult
 a	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
 a	input.sv	/^    reg a;$/;"	r	class:test
+a	input.sv	/^virtual function myfunc (a, b);$/;"	p	function:paramtest3.myfunc
 b	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	prototype:test.extern_func
 b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:supertest.mult
 b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
 b	input.sv	/^    logic b;$/;"	r	class:test
+b	input.sv	/^virtual function myfunc (a, b);$/;"	p	function:paramtest3.myfunc
 c	input.sv	/^    logic c;$/;"	r	class:supertest
 extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	Q	class:test
 mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:supertest
 mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:test
-paramtest	input.sv	/^class paramtest #(type BASE=supertest #(test)) extends BASE;$/;"	C	inherits:BASE
+myfunc	input.sv	/^virtual function myfunc (a, b);$/;"	f	class:paramtest3
+paramtest	input.sv	/^class paramtest #(type BASE=supertest #(test)) extends BASE;$/;"	C
 paramtest.BASE	input.sv	/^class paramtest #(type BASE=supertest #(test)) extends BASE;$/;"	c	class:paramtest
 paramtest2	input.sv	/^class paramtest2 #($/;"	C
 paramtest2.BASE	input.sv	/^  type BASE=supertest #(test)$/;"	c	class:paramtest2
+paramtest3	input.sv	/^class paramtest3 #(type BASE=supertest, type BASE2=paramtest);$/;"	C
+paramtest3.BASE	input.sv	/^class paramtest3 #(type BASE=supertest, type BASE2=paramtest);$/;"	c	class:paramtest3
+paramtest3.BASE2	input.sv	/^class paramtest3 #(type BASE=supertest, type BASE2=paramtest);$/;"	c	class:paramtest3
+paramtest3.myfunc	input.sv	/^virtual function myfunc (a, b);$/;"	f	class:paramtest3
+paramtest3.myfunc.a	input.sv	/^virtual function myfunc (a, b);$/;"	p	function:paramtest3.myfunc
+paramtest3.myfunc.b	input.sv	/^virtual function myfunc (a, b);$/;"	p	function:paramtest3.myfunc
 supertest	input.sv	/^class supertest extends test;$/;"	C	inherits:test
 supertest.c	input.sv	/^    logic c;$/;"	r	class:supertest
 supertest.mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:supertest

--- a/Units/verilog-sv-class.d/expected.tags
+++ b/Units/verilog-sv-class.d/expected.tags
@@ -3,16 +3,16 @@ BASE	input.sv	/^class paramtest #(type BASE=supertest #(test)) extends BASE;$/;"
 DEFINE	input.sv	/^`define DEFINE$/;"	c
 DEF_VALUE	input.sv	/^`define DEF_VALUE   1'd100$/;"	c
 DEF_WITH_EQ	input.sv	/^`define DEF_WITH_EQ = 1'd100$/;"	c
-a	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	function:test.extern_func
+a	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	prototype:test.extern_func
 a	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:supertest.mult
 a	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
 a	input.sv	/^    reg a;$/;"	r	class:test
-b	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	function:test.extern_func
+b	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	prototype:test.extern_func
 b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:supertest.mult
 b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
 b	input.sv	/^    logic b;$/;"	r	class:test
 c	input.sv	/^    logic c;$/;"	r	class:supertest
-extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	f	class:test
+extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	Q	class:test
 mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:supertest
 mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:test
 paramtest	input.sv	/^class paramtest #(type BASE=supertest #(test)) extends BASE;$/;"	C	inherits:BASE
@@ -27,9 +27,9 @@ supertest.mult.b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:s
 test	input.sv	/^class test;$/;"	C
 test.a	input.sv	/^    reg a;$/;"	r	class:test
 test.b	input.sv	/^    logic b;$/;"	r	class:test
-test.extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	f	class:test
-test.extern_func.a	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	function:test.extern_func
-test.extern_func.b	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	function:test.extern_func
+test.extern_func	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	Q	class:test
+test.extern_func.a	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	prototype:test.extern_func
+test.extern_func.b	input.sv	/^    extern virtual function void extern_func (input bit a, input b);$/;"	p	prototype:test.extern_func
 test.mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:test
 test.mult.a	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult
 test.mult.b	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult

--- a/Units/verilog-sv-class.d/input.sv
+++ b/Units/verilog-sv-class.d/input.sv
@@ -30,3 +30,10 @@ class paramtest2 #(
   type BASE=supertest #(test)
 ) extends BASE;
 endclass : paramtest2
+
+class paramtest3 #(type BASE=supertest, type BASE2=paramtest);
+
+virtual function myfunc (a, b);
+endfunction
+
+endclass : paramtest3

--- a/Units/verilog-sv-class.d/input.sv
+++ b/Units/verilog-sv-class.d/input.sv
@@ -36,4 +36,9 @@ class paramtest3 #(type BASE=supertest, type BASE2=paramtest);
 virtual function myfunc (a, b);
 endfunction
 
+extern virtual function test ext_func (c, d);
+
 endclass : paramtest3
+
+function test paramtest3::ext_func (c, d);
+endfunction

--- a/Units/verilog-sv-class.d/input.sv
+++ b/Units/verilog-sv-class.d/input.sv
@@ -18,6 +18,7 @@ endclass : test
 
 class supertest extends test;
     logic c;
+    extern virtual function bit fwrd_ref;
     function mult (a, input b = 0);
         return a * b * 2;
     endfunction : mult

--- a/Units/verilog-sv-interface.d/args.ctags
+++ b/Units/verilog-sv-interface.d/args.ctags
@@ -1,1 +1,2 @@
 --extra=+q
+--systemverilog-kinds=+Q

--- a/Units/verilog-sv-interface.d/expected.tags
+++ b/Units/verilog-sv-interface.d/expected.tags
@@ -3,7 +3,7 @@ b	input.sv	/^logic a, b, c, d;$/;"	r	interface:intf
 c	input.sv	/^logic a, b, c, d;$/;"	r	interface:intf
 d	input.sv	/^logic a, b, c, d;$/;"	r	interface:intf
 e	input.sv	/^logic [11:0] e;$/;"	r	interface:intf
-external_interface	input.sv	/^extern interface external_interface;$/;"	I
+external_interface	input.sv	/^extern interface external_interface;$/;"	Q
 in1	input.sv	/^    input in1,$/;"	p	interface:intf
 in2	input.sv	/^    input [11:0] in2,$/;"	p	interface:intf
 intf	input.sv	/^interface intf ($/;"	I

--- a/Units/verilog-sv-package.d/args.ctags
+++ b/Units/verilog-sv-package.d/args.ctags
@@ -1,1 +1,2 @@
 --extra=+q
+--systemverilog-kinds=+Q

--- a/Units/verilog-sv-program.d/args.ctags
+++ b/Units/verilog-sv-program.d/args.ctags
@@ -1,1 +1,2 @@
 --extra=+q
+--systemverilog-kinds=+Q

--- a/Units/verilog-sv-program.d/expected.tags
+++ b/Units/verilog-sv-program.d/expected.tags
@@ -1,5 +1,5 @@
 count	input.sv	/^    byte count;$/;"	r	block:prog.stop
-external_program	input.sv	/^extern program external_program;$/;"	P
+external_program	input.sv	/^extern program external_program;$/;"	Q
 i	input.sv	/^    longint i;$/;"	r	block:prog.start
 in1	input.sv	/^    input in1,$/;"	p	program:prog
 in2	input.sv	/^    input [11:0] in2,$/;"	p	program:prog

--- a/Units/verilog-sv-qualifiers.d/args.ctags
+++ b/Units/verilog-sv-qualifiers.d/args.ctags
@@ -1,1 +1,2 @@
 --extra=+q
+--systemverilog-kinds=+Q

--- a/Units/verilog-sv-qualifiers.d/expected.tags
+++ b/Units/verilog-sv-qualifiers.d/expected.tags
@@ -1,70 +1,70 @@
-ext_func	input.sv	/^extern function ext_func (x, y);$/;"	f
-ext_func.x	input.sv	/^extern function ext_func (x, y);$/;"	p	function:ext_func
-ext_func.y	input.sv	/^extern function ext_func (x, y);$/;"	p	function:ext_func
-ext_local_func	input.sv	/^extern local function ext_local_func (x, y);$/;"	f
-ext_local_func.x	input.sv	/^extern local function ext_local_func (x, y);$/;"	p	function:ext_local_func
-ext_local_func.y	input.sv	/^extern local function ext_local_func (x, y);$/;"	p	function:ext_local_func
-ext_local_task	input.sv	/^extern local task ext_local_task (x, y);$/;"	t
-ext_local_task.x	input.sv	/^extern local task ext_local_task (x, y);$/;"	p	task:ext_local_task
-ext_local_task.y	input.sv	/^extern local task ext_local_task (x, y);$/;"	p	task:ext_local_task
-ext_protected_func	input.sv	/^extern protected function ext_protected_func (x, y);$/;"	f
-ext_protected_func.x	input.sv	/^extern protected function ext_protected_func (x, y);$/;"	p	function:ext_protected_func
-ext_protected_func.y	input.sv	/^extern protected function ext_protected_func (x, y);$/;"	p	function:ext_protected_func
-ext_protected_task	input.sv	/^extern protected task ext_protected_task (x, y);$/;"	t
-ext_protected_task.x	input.sv	/^extern protected task ext_protected_task (x, y);$/;"	p	task:ext_protected_task
-ext_protected_task.y	input.sv	/^extern protected task ext_protected_task (x, y);$/;"	p	task:ext_protected_task
-ext_pure_virt_func	input.sv	/^extern pure virtual function ext_pure_virt_func (x);$/;"	f
-ext_pure_virt_func.x	input.sv	/^extern pure virtual function ext_pure_virt_func (x);$/;"	p	function:ext_pure_virt_func
-ext_pure_virt_task	input.sv	/^extern pure virtual task ext_pure_virt_task (x);$/;"	t
-ext_pure_virt_task.x	input.sv	/^extern pure virtual task ext_pure_virt_task (x);$/;"	p	task:ext_pure_virt_task
-ext_static_func	input.sv	/^extern static function ext_static_func (x, y);$/;"	f
-ext_static_func.x	input.sv	/^extern static function ext_static_func (x, y);$/;"	p	function:ext_static_func
-ext_static_func.y	input.sv	/^extern static function ext_static_func (x, y);$/;"	p	function:ext_static_func
-ext_static_task	input.sv	/^extern static task ext_static_task (x, y);$/;"	t
-ext_static_task.x	input.sv	/^extern static task ext_static_task (x, y);$/;"	p	task:ext_static_task
-ext_static_task.y	input.sv	/^extern static task ext_static_task (x, y);$/;"	p	task:ext_static_task
-ext_task	input.sv	/^extern task ext_task (x, y);$/;"	t
-ext_task.x	input.sv	/^extern task ext_task (x, y);$/;"	p	task:ext_task
-ext_task.y	input.sv	/^extern task ext_task (x, y);$/;"	p	task:ext_task
-pure_virt_func	input.sv	/^pure virtual function pure_virt_func (x);$/;"	f
-pure_virt_func.x	input.sv	/^pure virtual function pure_virt_func (x);$/;"	p	function:pure_virt_func
-pure_virt_local_func	input.sv	/^pure virtual local function pure_virt_local_func (x);$/;"	f
-pure_virt_local_func.x	input.sv	/^pure virtual local function pure_virt_local_func (x);$/;"	p	function:pure_virt_local_func
-pure_virt_local_task	input.sv	/^pure virtual local task pure_virt_local_task (x);$/;"	t
-pure_virt_local_task.x	input.sv	/^pure virtual local task pure_virt_local_task (x);$/;"	p	task:pure_virt_local_task
-pure_virt_protected_func	input.sv	/^pure virtual protected function pure_virt_protected_func (x);$/;"	f
-pure_virt_protected_func.x	input.sv	/^pure virtual protected function pure_virt_protected_func (x);$/;"	p	function:pure_virt_protected_func
-pure_virt_protected_task	input.sv	/^pure virtual protected task pure_virt_protected_task (x);$/;"	t
-pure_virt_protected_task.x	input.sv	/^pure virtual protected task pure_virt_protected_task (x);$/;"	p	task:pure_virt_protected_task
-pure_virt_static_func	input.sv	/^pure virtual static function pure_virt_static_func (x);$/;"	f
-pure_virt_static_func.x	input.sv	/^pure virtual static function pure_virt_static_func (x);$/;"	p	function:pure_virt_static_func
-pure_virt_static_task	input.sv	/^pure virtual static task pure_virt_static_task (x);$/;"	t
-pure_virt_static_task.x	input.sv	/^pure virtual static task pure_virt_static_task (x);$/;"	p	task:pure_virt_static_task
-pure_virt_task	input.sv	/^pure virtual task pure_virt_task (x);$/;"	t
-pure_virt_task.x	input.sv	/^pure virtual task pure_virt_task (x);$/;"	p	task:pure_virt_task
-x	input.sv	/^extern function ext_func (x, y);$/;"	p	function:ext_func
-x	input.sv	/^extern local function ext_local_func (x, y);$/;"	p	function:ext_local_func
-x	input.sv	/^extern local task ext_local_task (x, y);$/;"	p	task:ext_local_task
-x	input.sv	/^extern protected function ext_protected_func (x, y);$/;"	p	function:ext_protected_func
-x	input.sv	/^extern protected task ext_protected_task (x, y);$/;"	p	task:ext_protected_task
-x	input.sv	/^extern pure virtual function ext_pure_virt_func (x);$/;"	p	function:ext_pure_virt_func
-x	input.sv	/^extern pure virtual task ext_pure_virt_task (x);$/;"	p	task:ext_pure_virt_task
-x	input.sv	/^extern static function ext_static_func (x, y);$/;"	p	function:ext_static_func
-x	input.sv	/^extern static task ext_static_task (x, y);$/;"	p	task:ext_static_task
-x	input.sv	/^extern task ext_task (x, y);$/;"	p	task:ext_task
-x	input.sv	/^pure virtual function pure_virt_func (x);$/;"	p	function:pure_virt_func
-x	input.sv	/^pure virtual local function pure_virt_local_func (x);$/;"	p	function:pure_virt_local_func
-x	input.sv	/^pure virtual local task pure_virt_local_task (x);$/;"	p	task:pure_virt_local_task
-x	input.sv	/^pure virtual protected function pure_virt_protected_func (x);$/;"	p	function:pure_virt_protected_func
-x	input.sv	/^pure virtual protected task pure_virt_protected_task (x);$/;"	p	task:pure_virt_protected_task
-x	input.sv	/^pure virtual static function pure_virt_static_func (x);$/;"	p	function:pure_virt_static_func
-x	input.sv	/^pure virtual static task pure_virt_static_task (x);$/;"	p	task:pure_virt_static_task
-x	input.sv	/^pure virtual task pure_virt_task (x);$/;"	p	task:pure_virt_task
-y	input.sv	/^extern function ext_func (x, y);$/;"	p	function:ext_func
-y	input.sv	/^extern local function ext_local_func (x, y);$/;"	p	function:ext_local_func
-y	input.sv	/^extern local task ext_local_task (x, y);$/;"	p	task:ext_local_task
-y	input.sv	/^extern protected function ext_protected_func (x, y);$/;"	p	function:ext_protected_func
-y	input.sv	/^extern protected task ext_protected_task (x, y);$/;"	p	task:ext_protected_task
-y	input.sv	/^extern static function ext_static_func (x, y);$/;"	p	function:ext_static_func
-y	input.sv	/^extern static task ext_static_task (x, y);$/;"	p	task:ext_static_task
-y	input.sv	/^extern task ext_task (x, y);$/;"	p	task:ext_task
+ext_func	input.sv	/^extern function ext_func (x, y);$/;"	Q
+ext_func.x	input.sv	/^extern function ext_func (x, y);$/;"	p	prototype:ext_func
+ext_func.y	input.sv	/^extern function ext_func (x, y);$/;"	p	prototype:ext_func
+ext_local_func	input.sv	/^extern local function ext_local_func (x, y);$/;"	Q
+ext_local_func.x	input.sv	/^extern local function ext_local_func (x, y);$/;"	p	prototype:ext_local_func
+ext_local_func.y	input.sv	/^extern local function ext_local_func (x, y);$/;"	p	prototype:ext_local_func
+ext_local_task	input.sv	/^extern local task ext_local_task (x, y);$/;"	Q
+ext_local_task.x	input.sv	/^extern local task ext_local_task (x, y);$/;"	p	prototype:ext_local_task
+ext_local_task.y	input.sv	/^extern local task ext_local_task (x, y);$/;"	p	prototype:ext_local_task
+ext_protected_func	input.sv	/^extern protected function ext_protected_func (x, y);$/;"	Q
+ext_protected_func.x	input.sv	/^extern protected function ext_protected_func (x, y);$/;"	p	prototype:ext_protected_func
+ext_protected_func.y	input.sv	/^extern protected function ext_protected_func (x, y);$/;"	p	prototype:ext_protected_func
+ext_protected_task	input.sv	/^extern protected task ext_protected_task (x, y);$/;"	Q
+ext_protected_task.x	input.sv	/^extern protected task ext_protected_task (x, y);$/;"	p	prototype:ext_protected_task
+ext_protected_task.y	input.sv	/^extern protected task ext_protected_task (x, y);$/;"	p	prototype:ext_protected_task
+ext_pure_virt_func	input.sv	/^extern pure virtual function ext_pure_virt_func (x);$/;"	Q
+ext_pure_virt_func.x	input.sv	/^extern pure virtual function ext_pure_virt_func (x);$/;"	p	prototype:ext_pure_virt_func
+ext_pure_virt_task	input.sv	/^extern pure virtual task ext_pure_virt_task (x);$/;"	Q
+ext_pure_virt_task.x	input.sv	/^extern pure virtual task ext_pure_virt_task (x);$/;"	p	prototype:ext_pure_virt_task
+ext_static_func	input.sv	/^extern static function ext_static_func (x, y);$/;"	Q
+ext_static_func.x	input.sv	/^extern static function ext_static_func (x, y);$/;"	p	prototype:ext_static_func
+ext_static_func.y	input.sv	/^extern static function ext_static_func (x, y);$/;"	p	prototype:ext_static_func
+ext_static_task	input.sv	/^extern static task ext_static_task (x, y);$/;"	Q
+ext_static_task.x	input.sv	/^extern static task ext_static_task (x, y);$/;"	p	prototype:ext_static_task
+ext_static_task.y	input.sv	/^extern static task ext_static_task (x, y);$/;"	p	prototype:ext_static_task
+ext_task	input.sv	/^extern task ext_task (x, y);$/;"	Q
+ext_task.x	input.sv	/^extern task ext_task (x, y);$/;"	p	prototype:ext_task
+ext_task.y	input.sv	/^extern task ext_task (x, y);$/;"	p	prototype:ext_task
+pure_virt_func	input.sv	/^pure virtual function pure_virt_func (x);$/;"	Q
+pure_virt_func.x	input.sv	/^pure virtual function pure_virt_func (x);$/;"	p	prototype:pure_virt_func
+pure_virt_local_func	input.sv	/^pure virtual local function pure_virt_local_func (x);$/;"	Q
+pure_virt_local_func.x	input.sv	/^pure virtual local function pure_virt_local_func (x);$/;"	p	prototype:pure_virt_local_func
+pure_virt_local_task	input.sv	/^pure virtual local task pure_virt_local_task (x);$/;"	Q
+pure_virt_local_task.x	input.sv	/^pure virtual local task pure_virt_local_task (x);$/;"	p	prototype:pure_virt_local_task
+pure_virt_protected_func	input.sv	/^pure virtual protected function pure_virt_protected_func (x);$/;"	Q
+pure_virt_protected_func.x	input.sv	/^pure virtual protected function pure_virt_protected_func (x);$/;"	p	prototype:pure_virt_protected_func
+pure_virt_protected_task	input.sv	/^pure virtual protected task pure_virt_protected_task (x);$/;"	Q
+pure_virt_protected_task.x	input.sv	/^pure virtual protected task pure_virt_protected_task (x);$/;"	p	prototype:pure_virt_protected_task
+pure_virt_static_func	input.sv	/^pure virtual static function pure_virt_static_func (x);$/;"	Q
+pure_virt_static_func.x	input.sv	/^pure virtual static function pure_virt_static_func (x);$/;"	p	prototype:pure_virt_static_func
+pure_virt_static_task	input.sv	/^pure virtual static task pure_virt_static_task (x);$/;"	Q
+pure_virt_static_task.x	input.sv	/^pure virtual static task pure_virt_static_task (x);$/;"	p	prototype:pure_virt_static_task
+pure_virt_task	input.sv	/^pure virtual task pure_virt_task (x);$/;"	Q
+pure_virt_task.x	input.sv	/^pure virtual task pure_virt_task (x);$/;"	p	prototype:pure_virt_task
+x	input.sv	/^extern function ext_func (x, y);$/;"	p	prototype:ext_func
+x	input.sv	/^extern local function ext_local_func (x, y);$/;"	p	prototype:ext_local_func
+x	input.sv	/^extern local task ext_local_task (x, y);$/;"	p	prototype:ext_local_task
+x	input.sv	/^extern protected function ext_protected_func (x, y);$/;"	p	prototype:ext_protected_func
+x	input.sv	/^extern protected task ext_protected_task (x, y);$/;"	p	prototype:ext_protected_task
+x	input.sv	/^extern pure virtual function ext_pure_virt_func (x);$/;"	p	prototype:ext_pure_virt_func
+x	input.sv	/^extern pure virtual task ext_pure_virt_task (x);$/;"	p	prototype:ext_pure_virt_task
+x	input.sv	/^extern static function ext_static_func (x, y);$/;"	p	prototype:ext_static_func
+x	input.sv	/^extern static task ext_static_task (x, y);$/;"	p	prototype:ext_static_task
+x	input.sv	/^extern task ext_task (x, y);$/;"	p	prototype:ext_task
+x	input.sv	/^pure virtual function pure_virt_func (x);$/;"	p	prototype:pure_virt_func
+x	input.sv	/^pure virtual local function pure_virt_local_func (x);$/;"	p	prototype:pure_virt_local_func
+x	input.sv	/^pure virtual local task pure_virt_local_task (x);$/;"	p	prototype:pure_virt_local_task
+x	input.sv	/^pure virtual protected function pure_virt_protected_func (x);$/;"	p	prototype:pure_virt_protected_func
+x	input.sv	/^pure virtual protected task pure_virt_protected_task (x);$/;"	p	prototype:pure_virt_protected_task
+x	input.sv	/^pure virtual static function pure_virt_static_func (x);$/;"	p	prototype:pure_virt_static_func
+x	input.sv	/^pure virtual static task pure_virt_static_task (x);$/;"	p	prototype:pure_virt_static_task
+x	input.sv	/^pure virtual task pure_virt_task (x);$/;"	p	prototype:pure_virt_task
+y	input.sv	/^extern function ext_func (x, y);$/;"	p	prototype:ext_func
+y	input.sv	/^extern local function ext_local_func (x, y);$/;"	p	prototype:ext_local_func
+y	input.sv	/^extern local task ext_local_task (x, y);$/;"	p	prototype:ext_local_task
+y	input.sv	/^extern protected function ext_protected_func (x, y);$/;"	p	prototype:ext_protected_func
+y	input.sv	/^extern protected task ext_protected_task (x, y);$/;"	p	prototype:ext_protected_task
+y	input.sv	/^extern static function ext_static_func (x, y);$/;"	p	prototype:ext_static_func
+y	input.sv	/^extern static task ext_static_task (x, y);$/;"	p	prototype:ext_static_task
+y	input.sv	/^extern task ext_task (x, y);$/;"	p	prototype:ext_task

--- a/Units/verilog-sv-typedef.d/args.ctags
+++ b/Units/verilog-sv-typedef.d/args.ctags
@@ -1,1 +1,2 @@
 --extra=+q
+--systemverilog-kinds=+Q

--- a/Units/verilog-sv-typedef.d/expected.tags
+++ b/Units/verilog-sv-typedef.d/expected.tags
@@ -1,6 +1,6 @@
 myType	input.sv	/^} myType;$/;"	T
 myType2	input.sv	/^typedef classname#(paramvalue) myType2;$/;"	T
-type_class	input.sv	/^typedef class type_class;$/;"	T
+type_class	input.sv	/^typedef class type_class;$/;"	Q
 type_enum	input.sv	/^typedef enum type_enum;$/;"	T
 type_interface_class	input.sv	/^typedef interface class type_interface_class;$/;"	T
 type_struct	input.sv	/^typedef struct type_struct;$/;"	T

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -862,10 +862,9 @@ static void processClass (tokenInfo *const token)
 					}
 				}
 			} while (c != ')' && c != EOF);
-			c = vGetc ();
+			c = skipWhite (vGetc ());
 			parameters = popToken (parameters);
 		}
-		c = skipWhite (vGetc ());
 	}
 
 	/* Search for inheritance information */

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -985,6 +985,12 @@ static void tagNameList (tokenInfo* token, int c)
 		if (c == '=')
 		{
 			c = skipWhite (vGetc ());
+			if (c == '\'')
+			{
+				c = skipWhite (vGetc ());
+				if (c != '{')
+					vUngetc (c);
+			}
 			if (c == '{')
 				skipPastMatch ("{}");
 			else

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -740,6 +740,10 @@ static void processPortList (int c)
 
 		deleteToken (token);
 	}
+	else
+	{
+		vUngetc (c);
+	}
 }
 
 static void processFunction (tokenInfo *const token)

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -176,6 +176,7 @@ static const keywordAssoc KeywordTable [] = {
 	{ "package",   K_PACKAGE,   { 1, 0 } },
 	{ "program",   K_PROGRAM,   { 1, 0 } },
 	{ "property",  K_PROPERTY,  { 1, 0 } },
+	{ "ref",       K_PORT,      { 1, 0 } },
 	{ "shortint",  K_REGISTER,  { 1, 0 } },
 	{ "shortreal", K_REGISTER,  { 1, 0 } },
 	{ "static",    K_IGNORE,    { 1, 0 } },

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -59,6 +59,7 @@ typedef enum {
 	K_MODPORT,
 	K_PACKAGE,
 	K_PROGRAM,
+	K_PROTOTYPE,
 	K_PROPERTY,
 	K_TYPEDEF
 } verilogKind;
@@ -79,7 +80,7 @@ typedef struct sTokenInfo {
 	verilogKind         lastKind;      /* Kind of last found tag */
 	vString*            blockName;     /* Current block name */
 	vString*            inheritance;   /* Class inheritance */
-	boolean             singleStat;    /* Single statement (ends at next semi-colon) */
+	boolean             prototype;     /* Is only a prototype */
 } tokenInfo;
 
 /*
@@ -118,6 +119,7 @@ static kindOption SystemVerilogKinds [] = {
  { TRUE, 'M', "modport",   "modports" },
  { TRUE, 'K', "package",   "packages" },
  { TRUE, 'P', "program",   "programs" },
+ { FALSE,'Q', "prototype", "prototypes" },
  { TRUE, 'R', "property",  "properties" },
  { TRUE, 'T', "typedef",   "type declarations" }
 };
@@ -176,6 +178,7 @@ static const keywordAssoc KeywordTable [] = {
 	{ "package",   K_PACKAGE,   { 1, 0 } },
 	{ "program",   K_PROGRAM,   { 1, 0 } },
 	{ "property",  K_PROPERTY,  { 1, 0 } },
+	{ "pure",      K_IGNORE,    { 1, 0 } },
 	{ "ref",       K_PORT,      { 1, 0 } },
 	{ "shortint",  K_REGISTER,  { 1, 0 } },
 	{ "shortreal", K_REGISTER,  { 1, 0 } },
@@ -245,10 +248,10 @@ static short hasSimplePortList (tokenInfo const* token)
 	}
 }
 
-static short isSingleStatement (tokenInfo const* token)
+static short isPrototype (tokenInfo const* token)
 {
 	if (strcmp (vStringValue (token->name), "extern")  == 0 ||
-        strcmp (vStringValue (token->name), "virtual") == 0 )
+        strcmp (vStringValue (token->name), "pure") == 0 )
 	{
 		return TRUE;
 	} else {
@@ -268,7 +271,7 @@ static tokenInfo *newToken (void)
 	token->lastKind = K_UNDEFINED;
 	token->blockName = vStringNew ();
 	token->inheritance = vStringNew ();
-	token->singleStat = FALSE;
+	token->prototype = FALSE;
 	return token;
 }
 
@@ -545,9 +548,20 @@ static void dropContext (tokenInfo *const token)
 static void createTag (tokenInfo *const token)
 {
 	tagEntryInfo tag;
+	verilogKind kind;
+
+	/* Determine if kind is prototype */
+	if (currentContext->prototype)
+	{
+		kind = K_PROTOTYPE;
+	}
+	else
+	{
+		kind = token->kind;
+	}
 
 	/* Do nothing it tag name is empty or tag kind is disabled */
-	if (vStringLength (token->name) == 0 || ! kindEnabled (token->kind))
+	if (vStringLength (token->name) == 0 || ! kindEnabled (kind))
 	{
 		return;
 	}
@@ -560,13 +574,13 @@ static void createTag (tokenInfo *const token)
 			getSourceLanguageName (),
 			token->filePosition,
 			getSourceFileTagPath (),
-			kindFromKind (token->kind)
+			kindFromKind (kind)
 			);
-	verbose ("Adding tag %s (kind %d)", vStringValue (token->name), token->kind);
+	verbose ("Adding tag %s (kind %d)", vStringValue (token->name), kind);
 	if (currentContext->kind != K_UNDEFINED)
 	{
 		verbose (" to context %s\n", vStringValue (currentContext->name));
-		currentContext->lastKind = token->kind;
+		currentContext->lastKind = kind;
 		tag.extensionFields.scopeKind = kindFromKind (currentContext->kind);
 		tag.extensionFields.scopeName = vStringValue (currentContext->name);
 	}
@@ -597,7 +611,7 @@ static void createTag (tokenInfo *const token)
 		tokenInfo *newScope = newToken ();
 
 		vStringCopy (newScope->name, token->name);
-		newScope->kind = token->kind;
+		newScope->kind = kind;
 		createContext (newScope);
 	}
 
@@ -751,7 +765,19 @@ static void processTypedef (tokenInfo *const token)
 	/*Note: At the moment, only identifies typedef name and not its contents */
 	int c;
 
-	/* Get identifiers */
+	/* Get typedef type */
+	c = skipWhite (vGetc ());
+	if (isIdentifierCharacter (c))
+	{
+		readIdentifier (token, c);
+		/* A typedef class is just a prototype */
+		if (strcmp (vStringValue (token->name), "class") == 0)
+		{
+			currentContext->prototype = TRUE;
+		}
+	}
+
+	/* Skip remaining identifiers */
 	c = skipWhite (vGetc ());
 	while (isIdentifierCharacter (c))
 	{
@@ -780,16 +806,19 @@ static void processTypedef (tokenInfo *const token)
 		if (c == '(')
 		{
 			skipPastMatch ("()");
+			c = skipWhite (vGetc ());
 		}
-		c = skipWhite (vGetc ());
 	}
 
-	/* Read new typedef identifier */
+	/* Read typedef name */
 	if (isIdentifierCharacter (c))
 	{
 		readIdentifier (token, c);
 	}
-
+	else
+	{
+		vUngetc (c);
+	}
 	/* Use last identifier to create tag */
 	createTag (token);
 }
@@ -948,6 +977,8 @@ static void tagNameList (tokenInfo* token, int c)
 
 static void findTag (tokenInfo *const token)
 {
+	verbose ("Checking token %s of kind %d\n", vStringValue (token->name), token->kind);
+
 	if (currentContext->kind != K_UNDEFINED)
 	{
 		/* Drop context, but only if an end token is found */
@@ -996,9 +1027,9 @@ static void findTag (tokenInfo *const token)
 	{
 		processClass (token);
 	}
-	else if (token->kind == K_IGNORE && isSingleStatement (token))
+	else if (token->kind == K_IGNORE && isPrototype (token))
 	{
-		currentContext->singleStat = TRUE;
+		currentContext->prototype = TRUE;
 	}
 	else if (isVariable (token))
 	{
@@ -1059,14 +1090,19 @@ static void findVerilogTags (void)
 					skipPastMatch ("()");
 				}
 				break;
-			/* Drop context on single statements, which don't have an end
+			/* Drop context on prototypes because they don't have an end
 			 * statement */
 			case ';':
-				if (currentContext->scope && currentContext->scope->singleStat)
+				if (currentContext->scope && currentContext->scope->prototype)
 				{
 					verbose ("Dropping context %s\n", vStringValue (currentContext->name));
 					currentContext = popToken (currentContext);
-					currentContext->singleStat = FALSE;
+					currentContext->prototype = FALSE;
+				}
+				/* Prototypes end at the end of statement */
+				if (currentContext->prototype)
+				{
+					currentContext->prototype = FALSE;
 				}
 				break;
 			default :


### PR DESCRIPTION
Various improvements and fixes to the Verilog parser.
Major updates:
1. Add support for prototype like function/task declaration, which adds a new kind Q that is disabled by default.
2. Parse class scoped declarations that contain the code implementation of the above prototypes.

This simplifies code navigation because, by default, only the function/task declarations that contain the implementation code are output to the tags file.