### PR TITLE
Replace complex m4 builtins in configure.ac with suitable AS_TR_CPP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -568,7 +568,7 @@ AC_DEFUN([CHECK_PROTO], [
 	[],
 	[
 		AC_MSG_NOTICE([adding prototype for $1])
-		AC_DEFINE(patsubst([NEED_PROTO_NAME], [NAME], translit([$1], [[a-z]], [[A-Z]])))
+		AC_DEFINE(m4_bpatsubst([NEED_PROTO_NAME], [NAME], m4_translit([$1], [[a-z]], [[A-Z]])))
 	])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -564,12 +564,13 @@ AC_MSG_NOTICE(checking for new missing prototypes)
 
 AC_DEFUN([CHECK_PROTO], [
 	AC_EGREP_HEADER([[^A-Za-z0-9_]$1([ 	]+[A-Za-z0-9_]*)?[	 ]*\(],
-	$2,
-	,
+	[$2],
+	[],
 	[
 		AC_MSG_NOTICE([adding prototype for $1])
 		AC_DEFINE(patsubst([NEED_PROTO_NAME], [NAME], translit([$1], [[a-z]], [[A-Z]])))
-	])])
+	])
+])
 
 if test "$have_remove" = yes ; then
 	CHECK_PROTO(remove, stdio.h)

--- a/configure.ac
+++ b/configure.ac
@@ -568,7 +568,7 @@ AC_DEFUN([CHECK_PROTO], [
 	[],
 	[
 		AC_MSG_NOTICE([adding prototype for $1])
-		AC_DEFINE(m4_bpatsubst([NEED_PROTO_NAME], [NAME], m4_translit([$1], [[a-z]], [[A-Z]])))
+		AC_DEFINE(AS_TR_CPP([NEED_PROTO_$1]))
 	])
 ])
 


### PR DESCRIPTION
In configure.ac, some m4 builtins are used directory.
autoconf provides 'm4_'-prefixed alias macros for m4 builtin macros, and original non 'm4_'-prefixed macros are not recommended. Equivalent AS_TR_CPP provided by autoconf is more suitable rather than complex these m4 builtins.

AS_TR_CPP first appeared in autoconf-2.50a (2001-06-26).
autoreconf-2.59 and autoreconf-2.69 with '-Wall' report no warnings.
