### PR TITLE
Fixing of license & copyright headers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,5 +1,6 @@
 #	This source code is released for free distribution under the terms
-#	of the GNU General Public License version 2.
+#	of the GNU General Public License version 2 or (at your option) any
+#	later version.
 #
 # Makefile for UNIX-like platforms.
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,3 +1,6 @@
+#	This source code is released for free distribution under the terms
+#	of the GNU General Public License version 2.
+#
 # Makefile for UNIX-like platforms.
 
 # These are the names of the installed programs, in case you wish to change

--- a/Tmain/alias-for-unknown-language.d/run.sh
+++ b/Tmain/alias-for-unknown-language.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE --alias-nosuchlang=Z

--- a/Tmain/corpus-for-unknown-language.d/run.sh
+++ b/Tmain/corpus-for-unknown-language.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE --corpus-nosuchlang=Z:data

--- a/Tmain/define-own-file-kind.d/run.sh
+++ b/Tmain/define-own-file-kind.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE --langdef=foo'{fileKind=c}' --list-file-kind | grep ^foo

--- a/Tmain/dot-ctags-with-indentation.d/run.sh
+++ b/Tmain/dot-ctags-with-indentation.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --options=NONE --options=./args.ctags --_force-quit=0

--- a/Tmain/enable-kind-postfix-with-wildcard.d/run.sh
+++ b/Tmain/enable-kind-postfix-with-wildcard.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 ${CTAGS} --quiet --options=NONE '--*-kinds=*' --list-kinds | grep '\[off\]'
 

--- a/Tmain/enable-kind-postfix.d/run.sh
+++ b/Tmain/enable-kind-postfix.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 ${CTAGS} --quiet --options=NONE --c-kinds=+l-f --list-kinds=C | grep '^[fl]'
 

--- a/Tmain/enable-kind-prefix-with-wildcard.d/run.sh
+++ b/Tmain/enable-kind-prefix-with-wildcard.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 ${CTAGS} --quiet --options=NONE '--kinds-*=*' --list-kinds | grep '\[off\]'
 

--- a/Tmain/enable-kind-prefix.d/run.sh
+++ b/Tmain/enable-kind-prefix.d/run.sh
@@ -1,2 +1,5 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 ${CTAGS} --quiet --options=NONE --kinds-c=+l-f --list-kinds=C | grep '^[fl]'

--- a/Tmain/input-encoding-option.d/run.sh
+++ b/Tmain/input-encoding-option.d/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-# Copyright: 2015 Masatake YAMATO
-#            2015 Yasuhiro MATSUMOTO
+# Copyright: 2015 Yasuhiro MATSUMOTO
 # License: GPL-2
 
 CTAGS=$1

--- a/Tmain/input-encoding-option.d/run.sh
+++ b/Tmain/input-encoding-option.d/run.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 # Copyright: 2015 Masatake YAMATO
-#            2015 Yasuhiro MATSUMOTO
 # License: GPL-2
 
 CTAGS=$1

--- a/Tmain/input-encoding-option.d/run.sh
+++ b/Tmain/input-encoding-option.d/run.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 BUILDDIR=$4
 

--- a/Tmain/input-encoding-option.d/run.sh
+++ b/Tmain/input-encoding-option.d/run.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 # Copyright: 2015 Masatake YAMATO
+#            2015 Yasuhiro MATSUMOTO
 # License: GPL-2
 
 CTAGS=$1

--- a/Tmain/invalid-encoding-option.d/run.sh
+++ b/Tmain/invalid-encoding-option.d/run.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 if ${CTAGS} --quiet --options=NONE --list-features | grep -q multibyte ; then

--- a/Tmain/langmap-option-including-patterns.d/run.sh
+++ b/Tmain/langmap-option-including-patterns.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 : &&

--- a/Tmain/langmap-option.d/run.sh
+++ b/Tmain/langmap-option.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 : &&

--- a/Tmain/list-file-kind.d/run.sh
+++ b/Tmain/list-file-kind.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 $1 --quiet --options=NONE --list-file-kind=Ruby \

--- a/Tmain/list-kind-full.d/run.sh
+++ b/Tmain/list-kind-full.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE --_list-kinds-full=C

--- a/Tmain/load-dot-ctags-twice.d/run.sh
+++ b/Tmain/load-dot-ctags-twice.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 # TODO: --quiet

--- a/Tmain/lregex-accept-reserved-kind.d/run.sh
+++ b/Tmain/lregex-accept-reserved-kind.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE -o - --langdef=foo'{fileKind=!}' --regex-foo=/a/\0/F/ run.sh

--- a/Tmain/lregex-list-kind-full.d/run.sh
+++ b/Tmain/lregex-list-kind-full.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE -o - \

--- a/Tmain/lregex-list-kinds.d/run.sh
+++ b/Tmain/lregex-list-kinds.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE -o - \

--- a/Tmain/lregex-reject-reserved-kind.d/run.sh
+++ b/Tmain/lregex-reject-reserved-kind.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE -o - --langdef=foo --regex-foo=/a/\0/F/ run.sh

--- a/Tmain/lxcmd-accept-reserved-kind.d/foo.sh
+++ b/Tmain/lxcmd-accept-reserved-kind.d/foo.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo 'v  variable'
 echo 'F  function'
 echo 'm  macro'

--- a/Tmain/lxcmd-accept-reserved-kind.d/run.sh
+++ b/Tmain/lxcmd-accept-reserved-kind.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 . ../utils.sh

--- a/Tmain/lxcmd-backend-not-found.d/foo.sh
+++ b/Tmain/lxcmd-backend-not-found.d/foo.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 exit 127

--- a/Tmain/lxcmd-backend-not-found.d/run.sh
+++ b/Tmain/lxcmd-backend-not-found.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 . ../utils.sh

--- a/Tmain/lxcmd-backend-premature-death.d/foo.sh
+++ b/Tmain/lxcmd-backend-premature-death.d/foo.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 exit 1

--- a/Tmain/lxcmd-backend-premature-death.d/run.sh
+++ b/Tmain/lxcmd-backend-premature-death.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 . ../utils.sh

--- a/Tmain/lxcmd-broken-kind.d/foo0.sh
+++ b/Tmain/lxcmd-broken-kind.d/foo0.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo 'a'
 exit 0

--- a/Tmain/lxcmd-broken-kind.d/foo1.sh
+++ b/Tmain/lxcmd-broken-kind.d/foo1.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo 'b '
 exit 0

--- a/Tmain/lxcmd-broken-kind.d/foo2.sh
+++ b/Tmain/lxcmd-broken-kind.d/foo2.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo 'cd'
 exit 0

--- a/Tmain/lxcmd-broken-kind.d/foo3.sh
+++ b/Tmain/lxcmd-broken-kind.d/foo3.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo 'e[off]'
 exit 0

--- a/Tmain/lxcmd-broken-kind.d/foo4.sh
+++ b/Tmain/lxcmd-broken-kind.d/foo4.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo 'f [off]'
 exit 0

--- a/Tmain/lxcmd-broken-kind.d/foo5.sh
+++ b/Tmain/lxcmd-broken-kind.d/foo5.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo 'g  [off]'
 exit 0

--- a/Tmain/lxcmd-broken-kind.d/foo6.sh
+++ b/Tmain/lxcmd-broken-kind.d/foo6.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo 'h  i[off]'
 exit 0

--- a/Tmain/lxcmd-broken-kind.d/foo7.sh
+++ b/Tmain/lxcmd-broken-kind.d/foo7.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo 'j  kl[off]'
 exit 0

--- a/Tmain/lxcmd-broken-kind.d/foo8.sh
+++ b/Tmain/lxcmd-broken-kind.d/foo8.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo ' m desc'
 exit 0

--- a/Tmain/lxcmd-broken-kind.d/run.sh
+++ b/Tmain/lxcmd-broken-kind.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 . ../utils.sh

--- a/Tmain/lxcmd-disabled-kind.d/foo.sh
+++ b/Tmain/lxcmd-disabled-kind.d/foo.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo 'a b [off]'
 echo 'c  d [off]'
 echo 'e f  [off]'

--- a/Tmain/lxcmd-disabled-kind.d/run.sh
+++ b/Tmain/lxcmd-disabled-kind.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 . ../utils.sh

--- a/Tmain/lxcmd-exit-status-override.d/foo.sh
+++ b/Tmain/lxcmd-exit-status-override.d/foo.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 exit 42

--- a/Tmain/lxcmd-exit-status-override.d/run.sh
+++ b/Tmain/lxcmd-exit-status-override.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 . ../utils.sh

--- a/Tmain/lxcmd-list-kinds-full.d/foo.sh
+++ b/Tmain/lxcmd-list-kinds-full.d/foo.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo "a  aa"
 echo "b  bb"
 echo "c  a b c"

--- a/Tmain/lxcmd-list-kinds-full.d/run.sh
+++ b/Tmain/lxcmd-list-kinds-full.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 . ../utils.sh

--- a/Tmain/lxcmd-list-kinds.d/foo.sh
+++ b/Tmain/lxcmd-list-kinds.d/foo.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo "a  aa"
 echo "b  bb"

--- a/Tmain/lxcmd-list-kinds.d/run.sh
+++ b/Tmain/lxcmd-list-kinds.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 . ../utils.sh

--- a/Tmain/lxcmd-reject-reserved-kind.d/foo.sh
+++ b/Tmain/lxcmd-reject-reserved-kind.d/foo.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 echo 'v  variable'
 echo 'F  function'
 echo 'm  macro'

--- a/Tmain/lxcmd-reject-reserved-kind.d/run.sh
+++ b/Tmain/lxcmd-reject-reserved-kind.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 . ../utils.sh

--- a/Tmain/lxcmd-reject-specifying-in-dot-ctags.d/run.sh
+++ b/Tmain/lxcmd-reject-specifying-in-dot-ctags.d/run.sh
@@ -1,2 +1,5 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 ${CTAGS} --quiet --_force-quit=2

--- a/Tmain/map-for-unknown-language.d/run.sh
+++ b/Tmain/map-for-unknown-language.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE --map-nosuchlang=.Z

--- a/Tmain/map-lang-option.d/run.sh
+++ b/Tmain/map-lang-option.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 : &&

--- a/Tmain/no-input-encoding-option.d/run.sh
+++ b/Tmain/no-input-encoding-option.d/run.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 if ${CTAGS} --quiet --options=NONE --list-features | grep -q multibyte ; then

--- a/Tmain/option-echo-and-force-quit.d/run.sh
+++ b/Tmain/option-echo-and-force-quit.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 # --quiet cannot be used in this test case.

--- a/Tmain/output-encoding-option.d/run.sh
+++ b/Tmain/output-encoding-option.d/run.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
-# Copyright: 2015 Masatake YAMATO
-#            2015 Yasuhiro MATSUMOTO
+# Copyright: 2015 Yasuhiro MATSUMOTO
 # License: GPL-2
 
 CTAGS=$1

--- a/Tmain/output-encoding-option.d/run.sh
+++ b/Tmain/output-encoding-option.d/run.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # Copyright: 2015 Masatake YAMATO
+#            2015 Yasuhiro MATSUMOTO
 # License: GPL-2
 
 CTAGS=$1

--- a/Tmain/output-encoding-option.d/run.sh
+++ b/Tmain/output-encoding-option.d/run.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 BUILDDIR=$4
 

--- a/Tmain/regex-for-unknown-language.d/run.sh
+++ b/Tmain/regex-for-unknown-language.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE --regex-nosuchlang=/a/

--- a/Tmain/selector-dont-select-disabled-lang.d/run.sh
+++ b/Tmain/selector-dont-select-disabled-lang.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE --languages=-ObjectiveC --print-language input.h

--- a/Tmain/sorted-help-message.d/run.sh
+++ b/Tmain/sorted-help-message.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 if ! [ "$(basename $SHELL)" = "bash" ]; then

--- a/Tmain/tmain-example.d/run.sh
+++ b/Tmain/tmain-example.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 DATADIR=$2
 LIBEXECDIR=$3

--- a/Tmain/tmain-skip-example.d/run.sh
+++ b/Tmain/tmain-skip-example.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 if ${CTAGS} --list-features | grep -q afasdfasfasfsa; then
     echo
 else

--- a/Tmain/xcmd-dont-run-setgid-executable.d/run.sh
+++ b/Tmain/xcmd-dont-run-setgid-executable.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 . ../utils.sh

--- a/Tmain/xcmd-dont-run-setuid-executable.d/run.sh
+++ b/Tmain/xcmd-dont-run-setuid-executable.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 . ../utils.sh

--- a/Tmain/xcmd-for-unknown-language.d/run.sh
+++ b/Tmain/xcmd-for-unknown-language.d/run.sh
@@ -1,3 +1,6 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
 CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE --xcmd-nosuchlang=./run.sh

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,8 @@
 #	Copyright (c) 2009, Darren Hiebert
 #
 #	This source code is released for free distribution under the terms
-#	of the GNU General Public License version 2.
+#	of the GNU General Public License version 2 or (at your option) any
+#	later version.
 
 #	Process this file with autoconf to produce a configure script.
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #	Copyright (c) 2009, Darren Hiebert
 #
 #	This source code is released for free distribution under the terms
-#	of the GNU General Public License.
+#	of the GNU General Public License version 2.
 
 #	Process this file with autoconf to produce a configure script.
 

--- a/ctags.spec
+++ b/ctags.spec
@@ -2,7 +2,7 @@ Summary: Exuberant Ctags - a multi-language source code indexing tool
 Name: ctags
 Version: @VERSION@
 Release: 1
-License: GPL
+License: GPLv2
 Group: Development/Tools
 Source: http://prdownloads.sourceforge.net/ctags/ctags-%{version}.tar.gz
 URL: http://ctags.sourceforge.net

--- a/main/args.c
+++ b/main/args.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1999-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for reading command line arguments.
 */

--- a/main/args.c
+++ b/main/args.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1999-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for reading command line arguments.
 */

--- a/main/args.h
+++ b/main/args.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1999-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Defines external interface to command line argument reading.
 */

--- a/main/args.h
+++ b/main/args.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1999-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Defines external interface to command line argument reading.
 */

--- a/main/ctags.h
+++ b/main/ctags.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Program definitions
 */

--- a/main/ctags.h
+++ b/main/ctags.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Program definitions
 */

--- a/main/debug.c
+++ b/main/debug.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains debugging functions.
 */

--- a/main/debug.c
+++ b/main/debug.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains debugging functions.
 */

--- a/main/debug.h
+++ b/main/debug.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   External interface to debug.c
 */

--- a/main/debug.h
+++ b/main/debug.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   External interface to debug.c
 */

--- a/main/e_msoft.h
+++ b/main/e_msoft.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 2002-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Configures ctags for Microsoft environment.
 */

--- a/main/e_msoft.h
+++ b/main/e_msoft.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 2002-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Configures ctags for Microsoft environment.
 */

--- a/main/entry.c
+++ b/main/entry.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for creating tag entries.
 */

--- a/main/entry.c
+++ b/main/entry.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for creating tag entries.
 */

--- a/main/entry.h
+++ b/main/entry.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   External interface to entry.c
 */

--- a/main/entry.h
+++ b/main/entry.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   External interface to entry.c
 */

--- a/main/flags.c
+++ b/main/flags.c
@@ -3,7 +3,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions to process command line options.
 */

--- a/main/flags.c
+++ b/main/flags.c
@@ -3,7 +3,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions to process command line options.
 */

--- a/main/flags.h
+++ b/main/flags.h
@@ -4,7 +4,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Defines external interface to option processing.
 */

--- a/main/flags.h
+++ b/main/flags.h
@@ -4,7 +4,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Defines external interface to option processing.
 */

--- a/main/general.h
+++ b/main/general.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Provides the general (non-ctags-specific) environment assumed by all.
 */

--- a/main/general.h
+++ b/main/general.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Provides the general (non-ctags-specific) environment assumed by all.
 */

--- a/main/get.c
+++ b/main/get.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains the high level source read functions (preprocessor
 *   directives are handled within this level).

--- a/main/get.c
+++ b/main/get.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains the high level source read functions (preprocessor
 *   directives are handled within this level).

--- a/main/get.h
+++ b/main/get.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   External interface to get.c
 */

--- a/main/get.h
+++ b/main/get.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   External interface to get.c
 */

--- a/main/htable.c
+++ b/main/htable.c
@@ -4,7 +4,7 @@
 *   Copyright (c) 2014, Masatake YAMATO
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Defines hashtable
 */

--- a/main/htable.c
+++ b/main/htable.c
@@ -4,7 +4,7 @@
 *   Copyright (c) 2014, Masatake YAMATO
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Defines hashtable
 */

--- a/main/htable.h
+++ b/main/htable.h
@@ -4,7 +4,7 @@
 *   Copyright (c) 2014, Masatake YAMATO
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Defines hashtable
 */

--- a/main/htable.h
+++ b/main/htable.h
@@ -4,7 +4,7 @@
 *   Copyright (c) 2014, Masatake YAMATO
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Defines hashtable
 */

--- a/main/keyword.c
+++ b/main/keyword.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Manages a keyword hash.
 */

--- a/main/keyword.c
+++ b/main/keyword.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Manages a keyword hash.
 */

--- a/main/keyword.h
+++ b/main/keyword.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   External interface to keyword.c
 */

--- a/main/keyword.h
+++ b/main/keyword.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   External interface to keyword.c
 */

--- a/main/kind.h
+++ b/main/kind.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 */
 #ifndef _KIND_H

--- a/main/kind.h
+++ b/main/kind.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 */
 #ifndef _KIND_H

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for applying regular expression matching.
 *

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for applying regular expression matching.
 *

--- a/main/lxcmd.c
+++ b/main/lxcmd.c
@@ -5,7 +5,7 @@
 *   Copyright (c) 2014, Masatake YAMATO
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for invoking external command.
 *   Half of codes are derived from lregex.c.

--- a/main/lxcmd.c
+++ b/main/lxcmd.c
@@ -5,7 +5,7 @@
 *   Copyright (c) 2014, Masatake YAMATO
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for invoking external command.
 *   Half of codes are derived from lregex.c.

--- a/main/main.c
+++ b/main/main.c
@@ -5,8 +5,9 @@
 *           http://ctags.sourceforge.net
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2. It is provided on an as-is basis and no
-*   responsibility is accepted for its failure to perform as expected.
+*   GNU General Public License version 2 or (at your option) any later version.
+*   It is provided on an as-is basis and no responsibility is accepted for its
+*   failure to perform as expected.
 *
 *   This is a reimplementation of the ctags (1) program. It is an attempt to
 *   provide a fully featured ctags program which is free of the limitations

--- a/main/main.c
+++ b/main/main.c
@@ -5,7 +5,7 @@
 *           http://ctags.sourceforge.net
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License. It is provided on an as-is basis and no
+*   GNU General Public License version 2. It is provided on an as-is basis and no
 *   responsibility is accepted for its failure to perform as expected.
 *
 *   This is a reimplementation of the ctags (1) program. It is an attempt to

--- a/main/main.h
+++ b/main/main.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   External interface to main.c
 */

--- a/main/main.h
+++ b/main/main.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   External interface to main.c
 */

--- a/main/mbcs.c
+++ b/main/mbcs.c
@@ -4,7 +4,7 @@
 *   Copyright (c) 2015, vim-jp
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for checking multibyte character set.
 */

--- a/main/mbcs.c
+++ b/main/mbcs.c
@@ -4,7 +4,7 @@
 *   Copyright (c) 2015, vim-jp
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for checking multibyte character set.
 */

--- a/main/mbcs.h
+++ b/main/mbcs.h
@@ -4,7 +4,7 @@
 *   Copyright (c) 2015, vim-jp
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for checking multibyte character set.
 */

--- a/main/mbcs.h
+++ b/main/mbcs.h
@@ -4,7 +4,7 @@
 *   Copyright (c) 2015, vim-jp
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for checking multibyte character set.
 */

--- a/main/nestlevel.c
+++ b/main/nestlevel.c
@@ -3,7 +3,7 @@
 *   Copyright 2009-2011 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Defines external interface to scope nesting levels for tags.
 */

--- a/main/nestlevel.c
+++ b/main/nestlevel.c
@@ -3,7 +3,7 @@
 *   Copyright 2009-2011 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Defines external interface to scope nesting levels for tags.
 */

--- a/main/nestlevel.h
+++ b/main/nestlevel.h
@@ -3,7 +3,7 @@
 *   Copyright 2009-2011 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Defines external interface to scope nesting levels for tags.
 */

--- a/main/nestlevel.h
+++ b/main/nestlevel.h
@@ -3,7 +3,7 @@
 *   Copyright 2009-2011 Nick Treleaven <nick(dot)treleaven(at)btinternet(dot)com>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Defines external interface to scope nesting levels for tags.
 */

--- a/main/options.c
+++ b/main/options.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions to process command line options.
 */

--- a/main/options.c
+++ b/main/options.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions to process command line options.
 */
@@ -389,7 +389,7 @@ static optionDescription LongOptionDescription [] = {
 static const char* const License1 =
 "This program is free software; you can redistribute it and/or\n"
 "modify it under the terms of the GNU General Public License\n"
-"as published by the Free Software Foundation; either version 2\n"
+"as published by the Free Software Foundation; either version 2 or (at your option) any later version.n"
 "of the License, or (at your option) any later version.\n"
 "\n";
 static const char* const License2 =

--- a/main/options.c
+++ b/main/options.c
@@ -389,7 +389,7 @@ static optionDescription LongOptionDescription [] = {
 static const char* const License1 =
 "This program is free software; you can redistribute it and/or\n"
 "modify it under the terms of the GNU General Public License\n"
-"as published by the Free Software Foundation; either version 2 or (at your option) any later version.n"
+"as published by the Free Software Foundation; either version 2"
 "of the License, or (at your option) any later version.\n"
 "\n";
 static const char* const License2 =

--- a/main/options.h
+++ b/main/options.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Defines external interface to option processing.
 */

--- a/main/options.h
+++ b/main/options.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Defines external interface to option processing.
 */

--- a/main/parse.c
+++ b/main/parse.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for managing source languages and
 *   dispatching files to the appropriate language parser.

--- a/main/parse.c
+++ b/main/parse.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for managing source languages and
 *   dispatching files to the appropriate language parser.

--- a/main/parse.h
+++ b/main/parse.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Private definitions for parsing support.
 */

--- a/main/parse.h
+++ b/main/parse.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Private definitions for parsing support.
 */

--- a/main/parsers.h
+++ b/main/parsers.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   External interface to all language parsing modules.
 *

--- a/main/parsers.h
+++ b/main/parsers.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   External interface to all language parsing modules.
 *

--- a/main/pcoproc.c
+++ b/main/pcoproc.c
@@ -4,7 +4,7 @@
 *   Copyright (c) 2014, Masatake YAMATO
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   replaces popen/pclose
 */

--- a/main/pcoproc.c
+++ b/main/pcoproc.c
@@ -4,7 +4,7 @@
 *   Copyright (c) 2014, Masatake YAMATO
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   replaces popen/pclose
 */

--- a/main/pcoproc.h
+++ b/main/pcoproc.h
@@ -4,7 +4,7 @@
 *   Copyright (c) 2014, Masatake YAMATO
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   replaces popen/pclose
 */

--- a/main/pcoproc.h
+++ b/main/pcoproc.h
@@ -4,7 +4,7 @@
 *   Copyright (c) 2014, Masatake YAMATO
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   replaces popen/pclose
 */

--- a/main/read.c
+++ b/main/read.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains low level source and tag file read functions (newline
 *   conversion for source files are performed at this level).

--- a/main/read.c
+++ b/main/read.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains low level source and tag file read functions (newline
 *   conversion for source files are performed at this level).

--- a/main/read.h
+++ b/main/read.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   External interface to read.c
 */

--- a/main/read.h
+++ b/main/read.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   External interface to read.c
 */

--- a/main/routines.c
+++ b/main/routines.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2002-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains a lose assortment of shared functions.
 */

--- a/main/routines.c
+++ b/main/routines.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2002-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains a lose assortment of shared functions.
 */

--- a/main/routines.h
+++ b/main/routines.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   External interface to routines.c
 */

--- a/main/routines.h
+++ b/main/routines.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   External interface to routines.c
 */

--- a/main/selectors.c
+++ b/main/selectors.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2015, Dmitri Tikhonov
  *
  * This source code is released for free distribution under the terms of the
- * GNU General Public License version 2.
+ * GNU General Public License version 2 or (at your option) any later version.
  *
  * selectors.c -- routines for selecting a language
  */

--- a/main/selectors.c
+++ b/main/selectors.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2015, Masatake Yamato
- *               2015, Dmitri Tikhonov
+ * Copyright (c) 2015, Dmitri Tikhonov
  *
  * This source code is released for free distribution under the terms of the
  * GNU General Public License version 2.

--- a/main/selectors.c
+++ b/main/selectors.c
@@ -1,4 +1,10 @@
 /*
+ * Copyright (c) 2015, Masatake Yamato
+ *               2015, Dmitri Tikhonov
+ *
+ * This source code is released for free distribution under the terms of the
+ * GNU General Public License version 2.
+ *
  * selectors.c -- routines for selecting a language
  */
 

--- a/main/selectors.h
+++ b/main/selectors.h
@@ -1,4 +1,10 @@
 /*
+ * Copyright (c) 2015, Masatake Yamato
+ *               2015, Dmitri Tikhonov
+ *
+ * This source code is released for free distribution under the terms of the
+ * GNU General Public License version 2.
+ *
  * selectors.h
  */
 

--- a/main/selectors.h
+++ b/main/selectors.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2015, Masatake Yamato
- *               2015, Dmitri Tikhonov
+ * Copyright (c) 2015, Dmitri Tikhonov
  *
  * This source code is released for free distribution under the terms of the
  * GNU General Public License version 2.

--- a/main/selectors.h
+++ b/main/selectors.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2015, Dmitri Tikhonov
  *
  * This source code is released for free distribution under the terms of the
- * GNU General Public License version 2.
+ * GNU General Public License version 2 or (at your option) any later version.
  *
  * selectors.h
  */

--- a/main/sort.c
+++ b/main/sort.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions to sort the tag entries.
 */

--- a/main/sort.c
+++ b/main/sort.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions to sort the tag entries.
 */

--- a/main/sort.h
+++ b/main/sort.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   External interface to sort.c
 */

--- a/main/sort.h
+++ b/main/sort.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   External interface to sort.c
 */

--- a/main/strlist.c
+++ b/main/strlist.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1999-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions managing resizable string lists.
 */

--- a/main/strlist.c
+++ b/main/strlist.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1999-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions managing resizable string lists.
 */

--- a/main/strlist.h
+++ b/main/strlist.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1999-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Defines external interface to resizable string lists.
 */

--- a/main/strlist.h
+++ b/main/strlist.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1999-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Defines external interface to resizable string lists.
 */

--- a/main/tg.c
+++ b/main/tg.c
@@ -6,8 +6,9 @@
  *  Author: Masatake YAMATO <yamato@redhat.com>
  *
  *  This source code is released for free distribution under the terms of the
- *  GNU General Public License version 2. It is provided on an as-is basis and no
- *  responsibility is accepted for its failure to perform as expected.
+ *  GNU General Public License version 2 or (at your option) any later version. 
+ *  It is provided on an as-is basis and no responsibility is accepted for its
+ *  failure to perform as expected.
  *
  */
 

--- a/main/tg.c
+++ b/main/tg.c
@@ -6,7 +6,7 @@
  *  Author: Masatake YAMATO <yamato@redhat.com>
  *
  *  This source code is released for free distribution under the terms of the
- *  GNU General Public License. It is provided on an as-is basis and no
+ *  GNU General Public License version 2. It is provided on an as-is basis and no
  *  responsibility is accepted for its failure to perform as expected.
  *
  */

--- a/main/tg.h
+++ b/main/tg.h
@@ -6,8 +6,9 @@
  *  Author: Masatake YAMATO <yamato@redhat.com>
  *
  *  This source code is released for free distribution under the terms of the
- *  GNU General Public License version 2. It is provided on an as-is basis and no
- *  responsibility is accepted for its failure to perform as expected.
+ *  GNU General Public License version 2 or (at your option) any later version.
+ *  It is provided on an as-is basis and no responsibility is accepted for its
+ *  failure to perform as expected.
  *
  */
 #ifndef _TG_H

--- a/main/tg.h
+++ b/main/tg.h
@@ -6,7 +6,7 @@
  *  Author: Masatake YAMATO <yamato@redhat.com>
  *
  *  This source code is released for free distribution under the terms of the
- *  GNU General Public License. It is provided on an as-is basis and no
+ *  GNU General Public License version 2. It is provided on an as-is basis and no
  *  responsibility is accepted for its failure to perform as expected.
  *
  */

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions supporting resizeable strings.
 */

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions supporting resizeable strings.
 */

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   Provides the external interface for resizeable strings.
 */

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   Provides the external interface for resizeable strings.
 */

--- a/maintainer.mak
+++ b/maintainer.mak
@@ -1,5 +1,8 @@
 #	Copyright (c) 1996-2009, Darren Hiebert
 #
+#	This source code is released for free distribution under the terms
+#	of the GNU General Public License version 2.
+#
 #	Development makefile for Universal Ctags. Also used to build releases.
 #	Requires GNU make.
 

--- a/maintainer.mak
+++ b/maintainer.mak
@@ -1,7 +1,8 @@
 #	Copyright (c) 1996-2009, Darren Hiebert
 #
 #	This source code is released for free distribution under the terms
-#	of the GNU General Public License version 2.
+#	of the GNU General Public License version 2 or (at your option) any
+#	later version.
 #
 #	Development makefile for Universal Ctags. Also used to build releases.
 #	Requires GNU make.

--- a/misc/badinput.c
+++ b/misc/badinput.c
@@ -4,7 +4,7 @@
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 3 of the License, or
+   the Free Software Foundation; either version 2 of the License, or
    (at your option) any later version.
 
    This program is distributed in the hope that it will be useful,

--- a/misc/budge
+++ b/misc/budge
@@ -4,7 +4,7 @@
 #
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation; either version 3 of the License, or
+#   the Free Software Foundation; either version 2 of the License, or
 #   (at your option) any later version.
 #
 #   This program is distributed in the hope that it will be useful,

--- a/misc/budge
+++ b/misc/budge
@@ -1,4 +1,20 @@
 #!/bin/sh
+#
+#   Copyright (C) 2014 Masatake YAMATO
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
 # ----------------------------------------------------------------------------------------
 # Show the ratio of the number of files handled by ctags to the number of all files of ctags source directory.
 # -----------------------------------------------------------------------------------------

--- a/misc/src-check
+++ b/misc/src-check
@@ -1,4 +1,19 @@
 #!/bin/sh
+#
+#   Copyright (C) 2014 Masatake YAMATO
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 check_include_general_h_first()
 {

--- a/misc/src-check
+++ b/misc/src-check
@@ -4,7 +4,7 @@
 #
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation; either version 3 of the License, or
+#   the Free Software Foundation; either version 2 of the License, or
 #   (at your option) any later version.
 #
 #   This program is distributed in the hope that it will be useful,

--- a/misc/tinst
+++ b/misc/tinst
@@ -4,7 +4,7 @@
 #
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation; either version 3 of the License, or
+#   the Free Software Foundation; either version 2 of the License, or
 #   (at your option) any later version.
 #
 #   This program is distributed in the hope that it will be useful,

--- a/misc/tinst
+++ b/misc/tinst
@@ -1,4 +1,20 @@
 #!/bin/sh
+#
+#   Copyright (C) 2014 Masatake YAMATO
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 TINST_ROOT=
 
 ERROR ()

--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -2,7 +2,7 @@
 #
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
-#   the Free Software Foundation; either version 3 of the License, or
+#   the Free Software Foundation; either version 2 of the License, or
 #   (at your option) any later version.
 #
 #   This program is distributed in the hope that it will be useful,

--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -1,4 +1,19 @@
 #!/bin/sh -e
+#
+#   Copyright (C) 2014 Masatake YAMATO
+#
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 autoreconf -f -i -v
 ./configure --enable-iconv

--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -1,7 +1,5 @@
 #!/bin/sh -e
 #
-#   Copyright (C) 2014 Masatake YAMATO
-#
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
 #   the Free Software Foundation; either version 3 of the License, or

--- a/misc/units
+++ b/misc/units
@@ -6,7 +6,7 @@
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
+# the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful,

--- a/mkinstalldirs
+++ b/mkinstalldirs
@@ -1,8 +1,9 @@
 #! /bin/sh
 # mkinstalldirs --- make directory hierarchy
+#
 # Author: Noah Friedman <friedman@prep.ai.mit.edu>
 # Created: 1993-05-16
-# Public domain
+# License: Public domain
 
 errstatus=0
 

--- a/parsers/ada.c
+++ b/parsers/ada.c
@@ -3,6 +3,7 @@
  * Version:       0.6
  * Date:          October 26, 2006
  * Author:        A. Aaron Cornelius (ADotAaronDotCorneliusAtgmailDotcom)
+ * License:       GPL-2
  *
  * Installation:
  * You must have the Exuberant Ctags source to install this parser.  Once you

--- a/parsers/ant.c
+++ b/parsers/ant.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2008, David Fishburn
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for Ant language files.
 */

--- a/parsers/ant.c
+++ b/parsers/ant.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2008, David Fishburn
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for Ant language files.
 */

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for assembly language
 *   files.

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for assembly language
 *   files.

--- a/parsers/asp.c
+++ b/parsers/asp.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000, Patrick Dehne <patrick@steidle.net>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for the ASP (Active
 *   Server Pages) web page scripting language.

--- a/parsers/asp.c
+++ b/parsers/asp.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000, Patrick Dehne <patrick@steidle.net>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for the ASP (Active
 *   Server Pages) web page scripting language.

--- a/parsers/awk.c
+++ b/parsers/awk.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for AWK functions.
 */

--- a/parsers/awk.c
+++ b/parsers/awk.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for AWK functions.
 */

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -4,7 +4,7 @@
  *   Copyright (c) 2000-2006, Darren Hiebert, Elias Pschernig
  *
  *   This source code is released for free distribution under the terms of the
- *   GNU General Public License version 2.
+ *   GNU General Public License version 2 or (at your option) any later version.
  *
  *   This module contains functions for generating tags for BlitzBasic
  *   (BlitzMax), PureBasic and FreeBasic language files. For now, this is kept

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -4,7 +4,7 @@
  *   Copyright (c) 2000-2006, Darren Hiebert, Elias Pschernig
  *
  *   This source code is released for free distribution under the terms of the
- *   GNU General Public License.
+ *   GNU General Public License version 2.
  *
  *   This module contains functions for generating tags for BlitzBasic
  *   (BlitzMax), PureBasic and FreeBasic language files. For now, this is kept

--- a/parsers/beta.c
+++ b/parsers/beta.c
@@ -4,7 +4,7 @@
 *   Written by Erik Corry <corry@mjolner.dk>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for BETA language
 *   files.

--- a/parsers/beta.c
+++ b/parsers/beta.c
@@ -4,7 +4,7 @@
 *   Written by Erik Corry <corry@mjolner.dk>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for BETA language
 *   files.

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for parsing and scanning C, C++, C#, D and Java
 *   source files.

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1996-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for parsing and scanning C, C++, C#, D and Java
 *   source files.

--- a/parsers/clojure.c
+++ b/parsers/clojure.c
@@ -2,7 +2,7 @@
  *   Copyright (c) 2015, Miloslav Nenadál <nenadalm@gmail.com>
  *
  *   This source code is released for free distribution under the terms of the
- *   GNU General Public License.
+ *   GNU General Public License version 2.
  *
  *   This module contains code for generating tags for the Clojure language.
  */

--- a/parsers/clojure.c
+++ b/parsers/clojure.c
@@ -2,7 +2,7 @@
  *   Copyright (c) 2015, Miloslav Nenadál <nenadalm@gmail.com>
  *
  *   This source code is released for free distribution under the terms of the
- *   GNU General Public License version 2.
+ *   GNU General Public License version 2 or (at your option) any later version.
  *
  *   This module contains code for generating tags for the Clojure language.
  */

--- a/parsers/cobol.c
+++ b/parsers/cobol.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for COBOL language
 *   files.

--- a/parsers/cobol.c
+++ b/parsers/cobol.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for COBOL language
 *   files.

--- a/parsers/css.c
+++ b/parsers/css.c
@@ -2,6 +2,7 @@
  * css.c
  * Token-based parser for CSS definitions
  * Author - Colomban Wendling <colomban@geany.org>
+ * License GPL-2
  **************************************************************************/
 #include "general.h"
 

--- a/parsers/diff.c
+++ b/parsers/diff.c
@@ -3,7 +3,7 @@
 *   Copyright (c) 2000-2001, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for diff files (based on Sh parser).
 */

--- a/parsers/diff.c
+++ b/parsers/diff.c
@@ -3,7 +3,7 @@
 *   Copyright (c) 2000-2001, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for diff files (based on Sh parser).
 */

--- a/parsers/dosbatch.c
+++ b/parsers/dosbatch.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2009, David Fishburn
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for DOS Batch language files.
 */

--- a/parsers/dosbatch.c
+++ b/parsers/dosbatch.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2009, David Fishburn
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for DOS Batch language files.
 */

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2015, André Rivotti Casimiro <andre.r.casimiro@gmail.com>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for YACC language files.
 */

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2015, André Rivotti Casimiro <andre.r.casimiro@gmail.com>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for YACC language files.
 */

--- a/parsers/eiffel.c
+++ b/parsers/eiffel.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for Eiffel language
 *   files.

--- a/parsers/eiffel.c
+++ b/parsers/eiffel.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for Eiffel language
 *   files.

--- a/parsers/erlang.c
+++ b/parsers/erlang.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2003, Brent Fulgham <bfulgham@debian.org>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for Erlang language
 *   files.  Some of the parsing constructs are based on the Emacs 'etags'

--- a/parsers/erlang.c
+++ b/parsers/erlang.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2003, Brent Fulgham <bfulgham@debian.org>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for Erlang language
 *   files.  Some of the parsing constructs are based on the Emacs 'etags'

--- a/parsers/falcon.c
+++ b/parsers/falcon.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2011, 2012 Steven Oliver <oliver.steven@gmail.com>
  * 
  * This source code is released for free distribution under the terms of the
- * GNU General Public License version 2.
+ * GNU General Public License version 2 or (at your option) any later version.
  * 
  * This module contains functions for generating tags for Falcon language
  * files.

--- a/parsers/falcon.c
+++ b/parsers/falcon.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2011, 2012 Steven Oliver <oliver.steven@gmail.com>
  * 
  * This source code is released for free distribution under the terms of the
- * GNU General Public License.
+ * GNU General Public License version 2.
  * 
  * This module contains functions for generating tags for Falcon language
  * files.

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -4,7 +4,7 @@
  *	 Copyright (c) 2008, David Fishburn
  *
  *	 This source code is released for free distribution under the terms of the
- *	 GNU General Public License version 2.
+ *	 GNU General Public License version 2 or (at your option) any later version.
  *
  *	 This module contains functions for generating tags for Adobe languages.
  *	 There are a number of different ones, but this will begin with:

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -4,7 +4,7 @@
  *	 Copyright (c) 2008, David Fishburn
  *
  *	 This source code is released for free distribution under the terms of the
- *	 GNU General Public License.
+ *	 GNU General Public License version 2.
  *
  *	 This module contains functions for generating tags for Adobe languages.
  *	 There are a number of different ones, but this will begin with:

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for Fortran language
 *   files.

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 1998-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for Fortran language
 *   files.

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -1,6 +1,6 @@
 /*
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   INCLUDE FILES
 */

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -1,4 +1,7 @@
 /*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2.
+*
 *   INCLUDE FILES
 */
 #include "general.h"        /* must always come first */

--- a/parsers/html.c
+++ b/parsers/html.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for HTML language
 *   files.

--- a/parsers/html.c
+++ b/parsers/html.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for HTML language
 *   files.

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -2,7 +2,7 @@
  *	 Copyright (c) 2003, Darren Hiebert
  *
  *	 This source code is released for free distribution under the terms of the
- *	 GNU General Public License.
+ *	 GNU General Public License version 2.
  *
  *	 This module contains functions for generating tags for JavaScript language
  *	 files.

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -2,7 +2,7 @@
  *	 Copyright (c) 2003, Darren Hiebert
  *
  *	 This source code is released for free distribution under the terms of the
- *	 GNU General Public License version 2.
+ *	 GNU General Public License version 2 or (at your option) any later version.
  *
  *	 This module contains functions for generating tags for JavaScript language
  *	 files.

--- a/parsers/json.c
+++ b/parsers/json.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2014, Colomban Wendling <colomban@geany.org>
  *
  * This source code is released for free distribution under the terms of the
- * GNU General Public License version 2.
+ * GNU General Public License version 2 or (at your option) any later version.
  */
 /*
  * This module contains functions for generating tags for JSON files.

--- a/parsers/json.c
+++ b/parsers/json.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2014, Colomban Wendling <colomban@geany.org>
  *
  * This source code is released for free distribution under the terms of the
- * GNU General Public License.
+ * GNU General Public License version 2.
  */
 /*
  * This module contains functions for generating tags for JSON files.

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for LISP files.
 */

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for LISP files.
 */

--- a/parsers/lua.c
+++ b/parsers/lua.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2001, Max Ischenko <mfi@ukr.net>.
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for Lua language.
 */

--- a/parsers/lua.c
+++ b/parsers/lua.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2001, Max Ischenko <mfi@ukr.net>.
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for Lua language.
 */

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2005, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for makefiles.
 */

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2005, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for makefiles.
 */

--- a/parsers/matlab.c
+++ b/parsers/matlab.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2008, David Fishburn
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for MATLAB language files.
 */

--- a/parsers/matlab.c
+++ b/parsers/matlab.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2008, David Fishburn
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for MATLAB language files.
 */

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -3,7 +3,7 @@
 *   Copyright (c) 2010, Vincent Berthoux
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for Objective C
 *   language files.

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -3,7 +3,7 @@
 *   Copyright (c) 2010, Vincent Berthoux
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for Objective C
 *   language files.

--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2009, Vincent Berthoux
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for Objective Caml
 *   language files.

--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2009, Vincent Berthoux
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for Objective Caml
 *   language files.

--- a/parsers/pascal.c
+++ b/parsers/pascal.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2001-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for the Pascal language,
 *   including some extensions for Object Pascal.

--- a/parsers/pascal.c
+++ b/parsers/pascal.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2001-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for the Pascal language,
 *   including some extensions for Object Pascal.

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for PERL language
 *   files.

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for PERL language
 *   files.

--- a/parsers/perl6.c
+++ b/parsers/perl6.c
@@ -9,7 +9,7 @@
  *   - generate fully-qualified tags.
  *
  * This source code is released for free distribution under the terms of
- * the GNU General Public License.
+ * the GNU General Public License version 2.
  */
 
 #include "general.h"    /* must always come first */

--- a/parsers/perl6.c
+++ b/parsers/perl6.c
@@ -9,7 +9,7 @@
  *   - generate fully-qualified tags.
  *
  * This source code is released for free distribution under the terms of
- * the GNU General Public License version 2.
+ * the GNU General Public License version 2 or (at your option) any later version.
  */
 
 #include "general.h"    /* must always come first */

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2013, Colomban Wendling <ban@herbesfolles.org>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains code for generating tags for the PHP scripting
 *   language.

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2013, Colomban Wendling <ban@herbesfolles.org>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains code for generating tags for the PHP scripting
 *   language.

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for Python language
 *   files.

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for Python language
 *   files.

--- a/parsers/r.c
+++ b/parsers/r.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2003-2004, Ascher Stefan <stievie@utanet.at>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for R language files.
 *   R is a programming language for statistical computing.

--- a/parsers/r.c
+++ b/parsers/r.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2003-2004, Ascher Stefan <stievie@utanet.at>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for R language files.
 *   R is a programming language for statistical computing.

--- a/parsers/rexx.c
+++ b/parsers/rexx.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2001-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for the REXX language
 *   (http://www.rexxla.org, http://www2.hursley.ibm.com/rexx).

--- a/parsers/rexx.c
+++ b/parsers/rexx.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2001-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for the REXX language
 *   (http://www.rexxla.org, http://www2.hursley.ibm.com/rexx).

--- a/parsers/rst.c
+++ b/parsers/rst.c
@@ -3,7 +3,7 @@
 *   Copyright (c) 2007-2011, Nick Treleaven
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for reStructuredText (reST) files.
 */

--- a/parsers/rst.c
+++ b/parsers/rst.c
@@ -3,7 +3,7 @@
 *   Copyright (c) 2007-2011, Nick Treleaven
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for reStructuredText (reST) files.
 */

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -6,7 +6,7 @@
 *   Copyright (c) 2004 Elliott Hughes <enh@acm.org>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for Ruby language
 *   files.

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -6,7 +6,7 @@
 *   Copyright (c) 2004 Elliott Hughes <enh@acm.org>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for Ruby language
 *   files.

--- a/parsers/rust.c
+++ b/parsers/rust.c
@@ -1,7 +1,7 @@
 /*
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for Rust files.
 */

--- a/parsers/rust.c
+++ b/parsers/rust.c
@@ -1,7 +1,7 @@
 /*
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for Rust files.
 */

--- a/parsers/scheme.c
+++ b/parsers/scheme.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for Scheme language
 *   files.

--- a/parsers/scheme.c
+++ b/parsers/scheme.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for Scheme language
 *   files.

--- a/parsers/sh.c
+++ b/parsers/sh.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for scripts for the
 *   Bourne shell (and its derivatives, the Korn and Z shells).

--- a/parsers/sh.c
+++ b/parsers/sh.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2002, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for scripts for the
 *   Bourne shell (and its derivatives, the Korn and Z shells).

--- a/parsers/slang.c
+++ b/parsers/slang.c
@@ -4,7 +4,7 @@
  *   Author: Francesc Rocher <f.rocher@computer.org>.
  *
  *   This source code is released for free distribution under the terms of the
- *   GNU General Public License version 2.
+ *   GNU General Public License version 2 or (at your option) any later version.
  *
  *   This module contains functions for generating tags for S-Lang files.
  */

--- a/parsers/slang.c
+++ b/parsers/slang.c
@@ -4,7 +4,7 @@
  *   Author: Francesc Rocher <f.rocher@computer.org>.
  *
  *   This source code is released for free distribution under the terms of the
- *   GNU General Public License.
+ *   GNU General Public License version 2.
  *
  *   This module contains functions for generating tags for S-Lang files.
  */

--- a/parsers/sml.c
+++ b/parsers/sml.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2002, Venkatesh Prasad Ranganath and Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for SML language files.
 */

--- a/parsers/sml.c
+++ b/parsers/sml.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2002, Venkatesh Prasad Ranganath and Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for SML language files.
 */

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -2,7 +2,7 @@
  *	Copyright (c) 2002-2003, Darren Hiebert
  *
  *	This source code is released for free distribution under the terms of the
- *	GNU General Public License.
+ *	GNU General Public License version 2.
  *
  *	This module contains functions for generating tags for PL/SQL language
  *	files.

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -2,7 +2,7 @@
  *	Copyright (c) 2002-2003, Darren Hiebert
  *
  *	This source code is released for free distribution under the terms of the
- *	GNU General Public License version 2.
+ *	GNU General Public License version 2 or (at your option) any later version.
  *
  *	This module contains functions for generating tags for PL/SQL language
  *	files.

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for TCL scripts.
 */

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2000-2003, Darren Hiebert
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for TCL scripts.
 */

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -5,7 +5,7 @@
  *	 Copyright (c) 2012, Jan Larres
  *
  *	 This source code is released for free distribution under the terms of the
- *	 GNU General Public License version 2.
+ *	 GNU General Public License version 2 or (at your option) any later version.
  *
  *	 This module contains functions for generating tags for TeX language files.
  *

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -5,7 +5,7 @@
  *	 Copyright (c) 2012, Jan Larres
  *
  *	 This source code is released for free distribution under the terms of the
- *	 GNU General Public License.
+ *	 GNU General Public License version 2.
  *
  *	 This module contains functions for generating tags for TeX language files.
  *

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2003, Darren Hiebert
 * 
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 * 
 *   This module contains functions for generating tags for the Verilog HDL
 *   (Hardware Description Language).

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2003, Darren Hiebert
 * 
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 * 
 *   This module contains functions for generating tags for the Verilog HDL
 *   (Hardware Description Language).

--- a/parsers/vhdl.c
+++ b/parsers/vhdl.c
@@ -4,7 +4,7 @@
 *   Copyright (c) 2008, Nicolas Vincent
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for VHDL files.
 */

--- a/parsers/vhdl.c
+++ b/parsers/vhdl.c
@@ -4,7 +4,7 @@
 *   Copyright (c) 2008, Nicolas Vincent
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for VHDL files.
 */

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -2,7 +2,7 @@
 *	Copyright (c) 2000-2003, Darren Hiebert
 *
 *	This source code is released for free distribution under the terms of the
-*	GNU General Public License version 2.
+*	GNU General Public License version 2 or (at your option) any later version.
 *
 *	Thanks are due to Jay Glanville for significant improvements.
 *

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -2,7 +2,7 @@
 *	Copyright (c) 2000-2003, Darren Hiebert
 *
 *	This source code is released for free distribution under the terms of the
-*	GNU General Public License.
+*	GNU General Public License version 2.
 *
 *	Thanks are due to Jay Glanville for significant improvements.
 *

--- a/parsers/windres.c
+++ b/parsers/windres.c
@@ -4,7 +4,7 @@
  *	Copyright (c) 2013, Frank Fesevur <ffes(at)users.sourceforge.net>
  *
  *	This source code is released for free distribution under the terms of the
- *	GNU General Public License version 2.
+ *	GNU General Public License version 2 or (at your option) any later version.
  *
  *	This module contains functions for generating tags for Windows Resource files.
  */

--- a/parsers/windres.c
+++ b/parsers/windres.c
@@ -4,7 +4,7 @@
  *	Copyright (c) 2013, Frank Fesevur <ffes(at)users.sourceforge.net>
  *
  *	This source code is released for free distribution under the terms of the
- *	GNU General Public License.
+ *	GNU General Public License version 2.
  *
  *	This module contains functions for generating tags for Windows Resource files.
  */

--- a/parsers/yacc.c
+++ b/parsers/yacc.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2001-2002, Nick Hibma <n_hibma@van-laarhoven.org>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License version 2.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for YACC language files.
 */

--- a/parsers/yacc.c
+++ b/parsers/yacc.c
@@ -2,7 +2,7 @@
 *   Copyright (c) 2001-2002, Nick Hibma <n_hibma@van-laarhoven.org>
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2.
 *
 *   This module contains functions for generating tags for YACC language files.
 */

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -1,8 +1,9 @@
+@echo off
+:: Batch file for building/testing ctags on AppVeyor
+::
 :: Copyright: 2015 K. Takata
 :: License: GPL-2
 
-@echo off
-:: Batch file for building/testing ctags on AppVeyor
 
 cd %APPVEYOR_BUILD_FOLDER%
 if /I "%1"=="test" (

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -1,3 +1,6 @@
+:: Copyright: 2015 K. Takata
+:: License: GPL-2
+
 @echo off
 :: Batch file for building/testing ctags on AppVeyor
 


### PR DESCRIPTION
This pull request mostly adds "version 2." to the license already stated in the headers, and adds some missing headers and copyright info.

I have left the copyright holders out for files that weren't mostly done by 1 or 2 persons (one can use git blame to obtains those always).

Also, I have added some license info with the GPL-2 to select files that didn't have a header or license info at all (given that the previous work was GPL-2, exuberant-ctags).