### PR TITLE
main: Revive const modifiers in kindOption

### DIFF
--- a/main/kind.h
+++ b/main/kind.h
@@ -29,8 +29,8 @@
 typedef struct sKindOption {
 	boolean enabled;          /* are tags for kind enabled? */
 	char  letter;               /* kind letter */
-	char* name;		  /* kind name */
-	char* description;	  /* displayed in --help output */
+	const char* name;		  /* kind name */
+	const char* description;	  /* displayed in --help output */
 } kindOption;
 
 extern void printKind (const kindOption* const kind, boolean allKindFields, boolean indent);

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -320,12 +320,12 @@ static void kindFree (void *data)
 	kind->letter = '\0';
 	if (kind->name)
 	{
-		eFree (kind->name);
+		eFree ((void *)kind->name);
 		kind->name = NULL;
 	}
 	if (kind->description)
 	{
-		eFree (kind->description);
+		eFree ((void *)kind->description);
 		kind->description = NULL;
 	}
 	eFree (kind);

--- a/main/lxcmd.c
+++ b/main/lxcmd.c
@@ -163,9 +163,9 @@ static void clearPathSet (const langType language)
 			{
 				kindOption* kind = &(p->kinds[k]);
 
-				eFree (kind->name);
+				eFree ((void *)kind->name);
 				kind->name = NULL;
-				eFree (kind->description);
+				eFree ((void *)kind->description);
 				kind->description = NULL;
 			}
 			if (p->kinds)
@@ -243,14 +243,15 @@ static boolean loadPathKind (xcmdPath *const path, char* line, char *args[])
 	kind->description = vStringDeleteUnwrap (desc);
 
 	/* TODO: This conversion should be part of protocol. */
-	kind->name = eStrdup (kind->description);
 	{
-		char *c;
-		for (c = kind->name; *c != '\0'; c++)
-		{
-			if (*c == ' ' || *c == '\t')
-				*c = '_';
-		}
+	  char *tmp = eStrdup (kind->description);
+	  char *c;
+	  for (c = tmp; *c != '\0'; c++)
+	    {
+	      if (*c == ' ' || *c == '\t')
+		*c = '_';
+	    }
+	  kind->name = tmp;
 	}
 
 	path->n_kinds += 1;


### PR DESCRIPTION
Quoted comments by @b4n from
https://github.com/universal-ctags/ctags/commit/3525c8f14fd74282810974a7791a9adcb261cb35#commitcomment-13459230

    Removal of const modifier annoys me, because we assign to string
    literals and I'm a fervent user of -Wwrite-strings, which gives me
    endless warnings like those:

    parsers/c.c:307:15: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      { TRUE,  'c', "class",      "classes"},
		   ^
    parsers/c.c:307:24: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      { TRUE,  'c', "class",      "classes"},
			    ^
    parsers/c.c:308:15: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      { TRUE,  'd', "macro",      "macro definitions"},
		   ^
    parsers/c.c:308:24: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
      { TRUE,  'd', "macro",      "macro definitions"},
			    ^
This commit revivies the const modifiers.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>