### PR TITLE
build: Refactor configure CHECK_PROTO macro.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,42 +84,6 @@ AH_TEMPLATE([__USE_FIXED_PROTOTYPES__],
 AH_TEMPLATE([NON_CONST_PUTENV_PROTOTYPE],
 	[Define this is you have a prototype for putenv() in <stdlib.h>, but
 	doesn't declare its argument as "const char *".])
-AH_TEMPLATE([NEED_PROTO_REMOVE],
-	[If you receive error or warning messages indicating that you are missing
-	a prototype for, or a type mismatch using, the following function, define
-	this label and remake.])
-AH_TEMPLATE([NEED_PROTO_UNLINK],
-	[If you receive error or warning messages indicating that you are missing
-	a prototype for, or a type mismatch using, the following function, define
-	this label and remake.])
-AH_TEMPLATE([NEED_PROTO_MALLOC],
-	[If you receive error or warning messages indicating that you are missing
-	a prototype for, or a type mismatch using, the following function, define
-	this label and remake.])
-AH_TEMPLATE([NEED_PROTO_GETENV],
-	[If you receive error or warning messages indicating that you are missing
-	a prototype for, or a type mismatch using, the following function, define
-	this label and remake.])
-AH_TEMPLATE([NEED_PROTO_FGETPOS],
-	[If you receive error or warning messages indicating that you are missing
-	a prototype for, or a type mismatch using, the following function, define
-	this label and remake.])
-AH_TEMPLATE([NEED_PROTO_STAT],
-	[If you receive error or warning messages indicating that you are missing
-	a prototype for, or a type mismatch using, the following function, define
-	this label and remake.])
-AH_TEMPLATE([NEED_PROTO_LSTAT],
-	[If you receive error or warning messages indicating that you are missing
-	a prototype for, or a type mismatch using, the following function, define
-	this label and remake.])
-AH_TEMPLATE([NEED_PROTO_TRUNCATE],
-	[If you receive error or warning messages indicating that you are missing
-	a prototype for, or a type mismatch using, the following function, define
-	this label and remake.])
-AH_TEMPLATE([NEED_PROTO_FTRUNCATE],
-	[If you receive error or warning messages indicating that you are missing
-	a prototype for, or a type mismatch using, the following function, define
-	this label and remake.])
 AH_TEMPLATE([MSDOS_STYLE_PATH],
 	[Define to 1 if your system uses MS-DOS style path.])
 
@@ -158,6 +122,8 @@ AC_DEFUN([CHECK_PROTO], [
 	[],
 	[
 		AC_MSG_NOTICE([adding prototype for $1])
+		AH_TEMPLATE(AS_TR_CPP([NEED_PROTO_$1]),
+			    [If you receive error or warning messages indicating that you are missing a prototype for, or a type mismatch using, the following function, define this label and remake.])
 		AC_DEFINE(AS_TR_CPP([NEED_PROTO_$1]))
 	])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,16 @@ const char *result_yes = "$2:$1";
 	[$4]
 ]) ])
 
+AC_DEFUN([CHECK_PROTO], [
+	AC_EGREP_HEADER([[^A-Za-z0-9_]$1([ 	]+[A-Za-z0-9_]*)?[	 ]*\(],
+	[$2],
+	[],
+	[
+		AC_MSG_NOTICE([adding prototype for $1])
+		AC_DEFINE(AS_TR_CPP([NEED_PROTO_$1]))
+	])
+])
+
 # Checks for configuration options
 # --------------------------------
 
@@ -554,16 +564,6 @@ AC_SUBST(install_libexec_targets)
 # Checks for missing prototypes
 # -----------------------------
 AC_MSG_NOTICE(checking for new missing prototypes)
-
-AC_DEFUN([CHECK_PROTO], [
-	AC_EGREP_HEADER([[^A-Za-z0-9_]$1([ 	]+[A-Za-z0-9_]*)?[	 ]*\(],
-	[$2],
-	[],
-	[
-		AC_MSG_NOTICE([adding prototype for $1])
-		AC_DEFINE(AS_TR_CPP([NEED_PROTO_$1]))
-	])
-])
 
 if test "$have_remove" = yes ; then
 	CHECK_PROTO(remove, stdio.h)

--- a/configure.ac
+++ b/configure.ac
@@ -151,6 +151,7 @@ const char *result_yes = "$2:$1";
 	[$4]
 ]) ])
 
+# CHECK_PROTO(FUNCTION, HEADER-FILE)
 AC_DEFUN([CHECK_PROTO], [
 	AC_EGREP_HEADER([[^A-Za-z0-9_]$1([ 	]+[A-Za-z0-9_]*)?[	 ]*\(],
 	[$2],


### PR DESCRIPTION
Refactoring.
As calling AH_TEMPLATE macros for NEED_PROTO_* are similar and having auto-generatable form, call AH_TEMPLATE([NEED_PROTO_*]...) from CHECK_PROTO().

Comparison:
```
$ git show $(git merge-base --fork-point master):configure.ac | wc -lc;  git show HEAD:configure.ac | wc -lc
    632   18532
    599   16907
```
reduced 33 (~5.2%) lines, 1625 (~8.8%) bytes.
