### PR TITLE
build: Add '--with-ctags-{data,sysconf,libexec}dir' configure options

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -26,11 +26,11 @@ libdir	= @libdir@
 incdir	= @includedir@
 mandir	= @mandir@
 datadir = @datadir@
-pkgdatadir = @datadir@/@PACKAGE_NAME@
+pkgdatadir = @pkgdatadir@
 sysconfdir = @sysconfdir@
-pkgsysconfdir = @sysconfdir@/@PACKAGE_NAME@
+pkgsysconfdir = @pkgsysconfdir@
 libexecdir = @libexecdir@
-pkglibexecdir = @libexecdir@/@PACKAGE_NAME@
+pkglibexecdir = @pkglibexecdir@
 SLINK	= @LN_S@
 STRIP	= @STRIP@
 ifdef SPARSE

--- a/configure.ac
+++ b/configure.ac
@@ -201,10 +201,52 @@ AC_ARG_ENABLE(tmpdir,
 		[default directory for temporary files [ARG=/tmp]])],
 	tmpdir_specified=yes)
 
+AC_ARG_WITH([ctags-datadir],
+	[AS_HELP_STRING([--with-ctags-datadir=DIR],
+		['universal-ctags'-specific read-only architecture-independent data [DATADIR/ctags]])])
+
+AC_ARG_WITH([ctags-sysconfdir],
+	[AS_HELP_STRING([--with-ctags-sysconfdir=DIR],
+		['universal-ctags'-specific read-only single-machine data [SYSCONFDIR/ctags]])])
+
+AC_ARG_WITH([ctags-libexecdir],
+	[AS_HELP_STRING([--with-ctags-libexecdir=DIR],
+		['universal-ctags'-specific program executables [LIBEXECDIR/ctags]])])
+
 AC_ARG_PROGRAM
 
 # Process configuration options
 # -----------------------------
+
+case "${with_ctags_datadir+set}"-"$with_ctags_datadir" in #(
+"set"-"yes") ctags_datadir="${datadir}/ctags"	   ;; #(
+"set"-"no")  ctags_datadir="${datadir}"		   ;; #(
+"set"-*)     ctags_datadir="${with_ctags_datadir}" ;; #(
+*)	     ctags_datadir="${datadir}/ctags"	   ;;
+esac
+
+case "${with_ctags_sysconfdir+set}"-"$with_ctags_sysconfdir" in #(
+"set"-"yes") ctags_sysconfdir="${sysconfdir}/ctags"	 ;; #(
+"set"-"no")  ctags_sysconfdir="${sysconfdir}"		 ;; #(
+"set"-*)     ctags_sysconfdir="${with_ctags_sysconfdir}" ;; #(
+*)	     ctags_sysconfdir="${sysconfdir}/ctags"	 ;;
+esac
+
+case "${with_ctags_libexecdir+set}"-"$with_ctags_libexecdir" in #(
+"set"-"yes") ctags_libexecdir="${libexecdir}/ctags"	 ;; #(
+"set"-"no")  ctags_libexecdir="${libexecdir}"		 ;; #(
+"set"-*)     ctags_libexecdir="${with_ctags_libexecdir}" ;; #(
+*)	     ctags_libexecdir="${libexecdir}/ctags"	 ;;
+esac
+
+pkgdatadir="${ctags_datadir}"
+pkgsysconfdir="${ctags_sysconfdir}"
+pkglibexecdir="${ctags_libexecdir}"
+
+AC_SUBST([pkgdatadir])
+AC_SUBST([pkgsysconfdir])
+AC_SUBST([pkglibexecdir])
+
 
 install_targets="install-ctags install-data install-libexec"
 AC_MSG_CHECKING(whether to install link to etags)


### PR DESCRIPTION
Add '--with-ctags-datadir', '--with-ctags-sysconfdir', and '--with-ctags-libexecdir' configure options to control universal-ctags specific installation directories.

fix #580.
