### PR TITLE
main: don't make a tag for an empty string even if AllowNullTag is TRUE

### DIFF
--- a/Tmain/allow-null-tag.d/stdout-expected.txt
+++ b/Tmain/allow-null-tag.d/stdout-expected.txt
@@ -1,2 +1,1 @@
-	input.json	/^[{"":1}]$/;"	n	object:0
 0	input.json	/^[{"":1}]$/;"	o

--- a/main/entry.c
+++ b/main/entry.c
@@ -1152,9 +1152,11 @@ extern int makeTagEntry (const tagEntryInfo *const tag)
 	Assert (tag->name != NULL && strchr (tag->name, '\t') == NULL);
 	Assert (getSourceLanguageFileKind() == tag->kind || isSourceLanguageKindEnabled (tag->kind->letter));
 
-	if (tag->name [0] == '\0' && (!getSourceLanguageAllowNullTag()) && (!tag->placeholder))
+	if (tag->name [0] == '\0' && (!tag->placeholder))
 	{
-		error (WARNING, "ignoring null tag in %s(line: %lu)", vStringValue (File.name), tag->lineNumber);
+		if (!getSourceLanguageAllowNullTag())
+			error (WARNING, "ignoring null tag in %s(line: %lu)",
+			       vStringValue (File.name), tag->lineNumber);
 		goto out;
 	}
 


### PR DESCRIPTION
Revisit #492, #590.

As suggested by @b4n in #590, a tag for an empty string is not useful.
With this commit ctags doesn't record such tags even if AllowNullTag is TRUE.

In other word, AllowNullTag field just controls  the warning about
the tags for empty strings; ctags doesn't warn if it is TRUE.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>