### PR TITLE
appveyor: Use preinstalled MSYS2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,6 @@
 version: 1.0.{build}
 
 environment:
-  global:
-    MSYS2_BASEVER: 20150512
-
   matrix:
     - compiler: msbuild
       CONFIGURATION: Release

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -106,8 +106,8 @@ goto :eof
 PATH C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%
 set CHERE_INVOKING=yes
 :: Install and update necessary packages
-bash -lc "for i in {1..3}; do update-core && break || sleep 15; done"
-bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-{gcc,libiconv} automake autoconf make dos2unix && break || sleep 15; done"
+rem bash -lc "for i in {1..3}; do update-core && break || sleep 15; done"
+rem bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-{gcc,libiconv} automake autoconf make dos2unix && break || sleep 15; done"
 
 bash -lc "autoreconf -vfi"
 :: Patching configure.

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -103,15 +103,10 @@ goto :eof
 :: ----------------------------------------------------------------------
 :: Using MSYS2, iconv enabled
 @echo on
-:: Install MSYS2
-appveyor DownloadFile "http://kent.dl.sourceforge.net/project/msys2/Base/%MSYS2_ARCH%/msys2-base-%MSYS2_ARCH%-%MSYS2_BASEVER%.tar.xz" -FileName "msys2.tar.xz"
-c:\cygwin\bin\xz -dc msys2.tar.xz | c:\cygwin\bin\tar xf -
-
-PATH %APPVEYOR_BUILD_FOLDER%\%MSYS2_DIR%\%MSYSTEM%\bin;%APPVEYOR_BUILD_FOLDER%\%MSYS2_DIR%\usr\bin;%PATH%
+PATH C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%
 set CHERE_INVOKING=yes
-bash -lc ""
 :: Install and update necessary packages
-bash -lc "for i in {1..3}; do pacman --noconfirm --needed -Sy bash pacman pacman-mirrors msys2-runtime && break || sleep 15; done"
+bash -lc "for i in {1..3}; do update-core && break || sleep 15; done"
 bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-{gcc,libiconv} automake autoconf make dos2unix && break || sleep 15; done"
 
 bash -lc "autoreconf -vfi"


### PR DESCRIPTION
Now MSYS2 is preinstalled on AppVeyor. Use preinstalled version.