### PR TITLE
fix #629 infinite loop with fortran parser on C file

### DIFF
--- a/Units/parser-fortran.r/bug629.d/args.ctags
+++ b/Units/parser-fortran.r/bug629.d/args.ctags
@@ -1,0 +1,1 @@
+--language-force=Fortran

--- a/Units/parser-fortran.r/bug629.d/expected.tags
+++ b/Units/parser-fortran.r/bug629.d/expected.tags
@@ -1,0 +1,1 @@
+test_enumeration	input.c	/^enum test_enumeration /;"	E

--- a/Units/parser-fortran.r/bug629.d/input.c
+++ b/Units/parser-fortran.r/bug629.d/input.c
@@ -1,0 +1,5 @@
+enum test_enumeration {
+    ENUM_1 = 1,
+    ENUM_2,
+    ENUM_3
+};

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -2052,7 +2052,8 @@ static void parseEnumBlock (tokenInfo *const token)
 		makeFortranTag (name, TAG_ENUM);
 	skipToNextStatement (token);
 	ancestorPush (name);
-	while (! isKeyword (token, KEYWORD_end))
+	while (! isKeyword (token, KEYWORD_end) &&
+		   ! isType(token, TOKEN_EOF))
 	{
 		if (isTypeSpec (token))
 			parseTypeDeclarationStmt (token);


### PR DESCRIPTION
When parsing C enum, Fortran parse try to find an "end" token in
parseEnumBlock. There is no such key word at end of C enum statement and
the parser falls into infinite loop. To solve it, add an end-of-file
test when trying to find "end" token. If reach end of file, jump out of
the loop.