### PR TITLE
c-family: remove a duplicated if-conditions

### DIFF
--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3077,7 +3077,6 @@ static void tagCheck (statementInfo *const st)
 				}
 			}
 			else if (isContextualStatement (st) ||
-					st->declaration == DECL_NAMESPACE ||
 					st->declaration == DECL_VERSION ||
 					st->declaration == DECL_PROGRAM)
 			{


### PR DESCRIPTION
The condition "st->declaration == DECL_NAMESPACE" in "else if" in tagCheck
is duplicated: the same condition is also checked in isContextualStatement:

    static boolean isContextualStatement (const statementInfo *const st)
    {
	    boolean result = FALSE;
	    if (st != NULL) switch (st->declaration)
	    {
		    ...
		    case DECL_NAMESPACE:
		    ...
				result = TRUE;
	    ...
    	    return result;

Signed-off-by: Masatake YAMATO <yamato@redhat.com>