### PR TITLE
 C: don't make a tag for switch/case label

### DIFF
--- a/Units/parser-c.r/c-label.d/input.c
+++ b/Units/parser-c.r/c-label.d/input.c
@@ -4,7 +4,10 @@ main(int argc)
   goto out;
   switch (argc)
     {
-    case 1:;
+    case 1:
+      break;
+    case A|B:
+      break;
     default:
       break;
     }

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -2752,7 +2752,8 @@ static void processColon (statementInfo *const st)
 			}
 			else if (st->parent != NULL)
 			{
-				makeTag (prev, st, FALSE, TAG_LABEL);
+				if (prevToken (st->parent, 1)->keyword != KEYWORD_SWITCH)
+					makeTag (prev, st, FALSE, TAG_LABEL);
 				reinitStatement (st, FALSE);
 			}
 		}


### PR DESCRIPTION
A switch case label containing more than two tokens,
C parser mistakenly detects it as a  goto label.

e.g.

	switch (i)
	{
		case X|Y:
		     break;

Here Y was captured as a goto label.

This commit adds an extra condition for avoiding the above case.
Only if a label candidate is not in the switch statement, c parser
makes a "goto label" kind tag for the candidate.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>