### PR TITLE
main: omit patterns for long input lines

### DIFF
--- a/Tmain/omit-long-patterns.d/gen.sh
+++ b/Tmain/omit-long-patterns.d/gen.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+limit=96
+calls=
+
+l=$limit
+for i in $(seq $l); do
+    echo -n ' '
+done
+echo "func$l()"
+echo "{"
+echo
+echo "}"
+calls="$calls func$l"
+
+l=$(expr $limit - 1)
+for i in $(seq $l); do
+    echo -n ' '
+done
+echo "func$l()"
+echo "{"
+echo
+echo "}"
+calls="$calls func$l"
+
+l=$(expr $limit + 1)
+for i in $(seq $l); do
+    echo -n ' '
+done
+echo "func$l()"
+echo "{"
+echo
+echo "}"
+calls="$calls func$l"
+
+echo
+
+for c in $calls; do
+    echo $c
+done

--- a/Tmain/omit-long-patterns.d/input.sh
+++ b/Tmain/omit-long-patterns.d/input.sh
@@ -1,0 +1,16 @@
+                                                                                                func96()
+{
+
+}
+                                                                                               func95()
+{
+
+}
+                                                                                                 func97()
+{
+
+}
+
+func96
+func95
+func97

--- a/Tmain/omit-long-patterns.d/run.sh
+++ b/Tmain/omit-long-patterns.d/run.sh
@@ -1,0 +1,5 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+${CTAGS} -o - ./input.sh

--- a/Tmain/omit-long-patterns.d/stdout-expected.txt
+++ b/Tmain/omit-long-patterns.d/stdout-expected.txt
@@ -1,0 +1,3 @@
+func95	./input.sh	/^                                                                                               f/;"	f
+func96	./input.sh	/^                                                                                                /;"	f
+func97	./input.sh	/^                                                                                                /;"	f

--- a/Units/parser-flex.r/flex_only_mxml.mxml.d/expected.tags
+++ b/Units/parser-flex.r/flex_only_mxml.mxml.d/expected.tags
@@ -1,8 +1,8 @@
 Array.forms	input.mxml	/^	<mx:Array id="forms">$/;"	x
-Button.ls_bt_log_in_out	input.mxml	/^					<mx:Button id="ls_bt_log_in_out" x="240" y="238" label="{logInOut}" enabled="true" click="onButtonClick(event)"\/>$/;"	x
+Button.ls_bt_log_in_out	input.mxml	/^					<mx:Button id="ls_bt_log_in_out" x="240" y="238" label="{logInOut}" enabled="true" click="o/;"	x
 Form.form_login_screen	input.mxml	/^		<mx:Form label="{logInOut}" width="100%" height="100%" id="form_login_screen">$/;"	x
 HTTPService.myHTTPService	input.mxml	/^		id="myHTTPService"$/;"	x
 Label.ls_lb_welcome	input.mxml	/^					<mx:Label x="194" y="287" width="315" id="ls_lb_welcome" fontSize="16" fontWeight="bold"\/>$/;"	x
 TextInput.ls_ti_passwd	input.mxml	/^					<mx:TextInput id="ls_ti_passwd" x="240" y="206" displayAsPassword="true" text="Demo05"\/>$/;"	x
 TextInput.ls_ti_username	input.mxml	/^					<mx:TextInput id="ls_ti_username" x="240" y="174" text="admin"\/>$/;"	x
-ViewStack.viewstack1	input.mxml	/^	<mx:ViewStack x="149" y="55" id="viewstack1" width="831" height="605" change="onChangeViewStack(event);" >$/;"	x
+ViewStack.viewstack1	input.mxml	/^	<mx:ViewStack x="149" y="55" id="viewstack1" width="831" height="605" change="onChangeViewStack/;"	x

--- a/Units/perl6-bunch1.d/expected.tags
+++ b/Units/perl6-bunch1.d/expected.tags
@@ -1,9 +1,3 @@
-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
-!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
-!_TAG_PROGRAM_NAME	Universal Ctags	//
-!_TAG_PROGRAM_URL	https://github.com/universal-ctags/ctags	/official site/
-!_TAG_PROGRAM_VERSION	Development	//
 JSONPrettyActions	input.pm	/^my class JSONPrettyActions {$/;"	c
 JSONPrettyGrammar	input.pm	/^my grammar JSONPrettyGrammar {$/;"	g
 TOP	input.pm	/^    method TOP($\/) {$/;"	m
@@ -26,7 +20,7 @@ str_escape	input.pm	/^    token str_escape {$/;"	t
 string	input.pm	/^    method string($\/) {$/;"	m
 string	input.pm	/^    token string {$/;"	t
 to-json	input.pm	/^multi sub to-json(Associative:D $d, :$indent = 0, :$first = 0) {$/;"	s
-to-json	input.pm	/^multi sub to-json(Bool:D $d, :$indent = 0, :$first = 0) { (' ' x $first) ~ ($d ?? 'true' !! 'false') }$/;"	s
+to-json	input.pm	/^multi sub to-json(Bool:D $d, :$indent = 0, :$first = 0) { (' ' x $first) ~ ($d ?? 'true' !! 'fal/;"	s
 to-json	input.pm	/^multi sub to-json(Mu:D $s, :$indent = 0, :$first = 0) {$/;"	s
 to-json	input.pm	/^multi sub to-json(Mu:U $, :$indent = 0, :$first = 0) { 'null' }$/;"	s
 to-json	input.pm	/^multi sub to-json(Positional:D $d, :$indent = 0, :$first = 0) {$/;"	s

--- a/Units/review-needed.r/3526726.tex.t/expected.tags
+++ b/Units/review-needed.r/3526726.tex.t/expected.tags
@@ -23,7 +23,7 @@ How can I examine logged packets in more detail 	input.tex	/^\\subsection{How ca
 How can I protect web servers running on ports other than 80 	input.tex	/^\\subsection{How can I protect web servers running on ports other than 80?}$/;"	u	section:Rules and Alerts
 How can I run Snort on multiple interfaces simultaneously 	input.tex	/^\\subsection{How can I run Snort on multiple interfaces simultaneously?}$/;"	u	section:Configuring Snort
 How can I specify a list of ports in a rule 	input.tex	/^\\subsection{How can I specify a list of ports in a rule?}$/;"	u	section:Rules and Alerts
-How can I test Snort without having an Ethernet card or a connection to other computers 	input.tex	/^\\subsection{How can I test Snort without having an Ethernet card or a connection to other computers?  }$/;"	u	section:Getting Fancy
+How can I test Snort without having an Ethernet card or a connection to other computers 	input.tex	/^\\subsection{How can I test Snort without having an Ethernet card or a connection to other compu/;"	u	section:Getting Fancy
 How can I use Snort to log HTTP URLs or SMTP traffic 	input.tex	/^\\subsection{How can I use Snort to log HTTP URLs or SMTP traffic?}$/;"	u	section:Getting Fancy
 How do I build this BASE thing 	input.tex	/^\\subsection{How do I build this BASE thing?}$/;"	u	section:Configuring Snort
 How do I configure stream4 	input.tex	/^\\subsection{How do I configure stream4?}$/;"	u	section:Configuring Snort
@@ -48,21 +48,21 @@ How do you put Snort in debug mode 	input.tex	/^\\subsection{How do you put Snor
 How does rule ordering work 	input.tex	/^\\subsection{How does rule ordering work?}$/;"	u	section:Configuring Snort
 How long can address lists  variables  or rules be 	input.tex	/^\\subsection{How long can address lists, variables, or rules be?}$/;"	u	section:Rules and Alerts
 How to start Snort as a win32 service 	input.tex	/^\\subsection{How to start Snort as a win32 service? }$/;"	u	section:Getting Fancy
-I  m getting large amounts of $  $some alerts type$  $. What should I do  Where can I go to find out more about it 	input.tex	/^\\subsection{I'm getting large amounts of $<$some alerts type$>$. What should I do?  Where can I go to find out more about it? }$/;"	u	section:Rules and Alerts
+I  m getting large amounts of $  $some alerts type$  $. What should I do  Where can I go to find out more about it 	input.tex	/^\\subsection{I'm getting large amounts of $<$some alerts type$>$. What should I do?  Where can I/;"	u	section:Rules and Alerts
 I  m getting lots of  ICMP Ping Speedera   is this bad 	input.tex	/^\\subsection{I'm getting lots of *ICMP Ping Speedera*, is this bad?}$/;"	u	section:Problems
 I  m not seeing any interfaces listed under Win32.	input.tex	/^\\subsection{I'm not seeing any interfaces listed under Win32.}$/;"	u	section:Problems
 I  m on a switched network  can I still use Snort 	input.tex	/^\\subsection{I'm on a switched network, can I still use Snort?}$/;"	u	section:Background
 I  ve got RedHat and ....	input.tex	/^\\subsection{ I've got RedHat and ....}$/;"	u	section:Getting Started
-I am getting  snort  pid  uses obsolete  PF  _INET  SOCK  _PACKET   warnings. What  s wrong 	input.tex	/^\\subsection{I am getting `snort [pid] uses obsolete (PF\\_INET, SOCK\\_PACKET)' warnings. What's wrong?}$/;"	u	section:Problems
-I am getting too many   IIS Unicode attack detected   and  or   CGI Null Byte attack detected   false positives. How can I turn this detection off 	input.tex	/^\\subsection{I am getting too many ``IIS Unicode attack detected'' and\/or ``CGI Null Byte attack detected'' false positives.  How can I turn this detection off? }$/;"	u	section:Rules and Alerts
-I am still getting bombarded with spp  _portscan messages even though the IP that I am getting the portscan from is in my  $DNS  _SERVERs var	input.tex	/^\\subsection{I am still getting bombarded with spp\\_portscan messages even though the IP that I am getting the portscan from is in my \\$DNS\\_SERVERs var }$/;"	u	section:Problems
-I am using Snort on Windows and receive an   OpenPcap   error upon startup: ERROR: OpenPcap   device open: Error opening adapter   message. What  s wrong 	input.tex	/^\\subsection{I am using Snort on Windows and receive an ``OpenPcap() error upon startup: ERROR: OpenPcap() device open: Error opening adapter'' message. What's wrong? }$/;"	u	section:Problems
-I have one network card and two aliases  how can I force Snort to   listen   on both addresses 	input.tex	/^\\subsection{I have one network card and two aliases, how can I force Snort to ``listen'' on both addresses?}$/;"	u	section:Configuring Snort
+I am getting  snort  pid  uses obsolete  PF  _INET  SOCK  _PACKET   warnings. What  s wrong 	input.tex	/^\\subsection{I am getting `snort [pid] uses obsolete (PF\\_INET, SOCK\\_PACKET)' warnings. What'/;"	u	section:Problems
+I am getting too many   IIS Unicode attack detected   and  or   CGI Null Byte attack detected   false positives. How can I turn this detection off 	input.tex	/^\\subsection{I am getting too many ``IIS Unicode attack detected'' and\/or ``CGI Null Byte attac/;"	u	section:Rules and Alerts
+I am still getting bombarded with spp  _portscan messages even though the IP that I am getting the portscan from is in my  $DNS  _SERVERs var	input.tex	/^\\subsection{I am still getting bombarded with spp\\_portscan messages even though the IP that I/;"	u	section:Problems
+I am using Snort on Windows and receive an   OpenPcap   error upon startup: ERROR: OpenPcap   device open: Error opening adapter   message. What  s wrong 	input.tex	/^\\subsection{I am using Snort on Windows and receive an ``OpenPcap() error upon startup: ERROR: /;"	u	section:Problems
+I have one network card and two aliases  how can I force Snort to   listen   on both addresses 	input.tex	/^\\subsection{I have one network card and two aliases, how can I force Snort to ``listen'' on bot/;"	u	section:Configuring Snort
 I hear people talking about   Barnyard   . What  s that  label  barnyard	input.tex	/^\\subsection{I hear people talking about ``Barnyard''. What's that?\\label{barnyard}}$/;"	u	section:Getting Fancy
 I just downloaded a new ruleset and now Snort fails  complaining about the rules.	input.tex	/^\\subsection{I just downloaded a new ruleset and now Snort fails, complaining about the$/;"	u	section:Problems
 I think I found a bug in Snort. Now what 	input.tex	/^\\subsection{ I think I found a bug in Snort. Now what?}$/;"	u	section:Problems
 I try to start Snort and it gives an error like   ERROR: Unable to open rules file:  root  .snortrc or  root   root  .snortrc.   What can I do to fix this 	input.tex	/^\\subsection{I try to start Snort and it gives an error like ``ERROR: Unable to open$/;"	u	section:Problems
-I want to build a Snort box. Will this $  $Insert list of hardware$  $ handle $  $this much$  $ traffic 	input.tex	/^\\subsection{I want to build a Snort box.  Will this $<$Insert list of hardware$>$ handle $<$this much$>$ traffic? }$/;"	u	section:Getting Started
+I want to build a Snort box. Will this $  $Insert list of hardware$  $ handle $  $this much$  $ traffic 	input.tex	/^\\subsection{I want to build a Snort box.  Will this $<$Insert list of hardware$>$ handle $<$thi/;"	u	section:Getting Started
 IDSCenter	input.tex	/^      \\item IDS Center (Win32) \\label{IDSCenter}$/;"	l
 Is Fyodor Yarochkin the same Fyodor who wrote nmap 	input.tex	/^\\subsection{Is Fyodor Yarochkin the same Fyodor who wrote nmap?}$/;"	u	section:Background
 Is Snort vulnerable to IDS noise generators like   Stick   and   Snot   	input.tex	/^\\subsection{Is Snort vulnerable to IDS noise generators like ``Stick'' and ``Snot''?}$/;"	u	section:Background
@@ -85,7 +85,7 @@ SMB alerts aren  t working  what  s wrong 	input.tex	/^\\subsection{SMB alerts a
 Snort complains about the   react   keyword...	input.tex	/^\\subsection{Snort complains about the ``react'' keyword...}$/;"	u	section:Getting Fancy
 Snort fails to respond to a kill signal on Linux. Why 	input.tex	/^\\subsection{Snort fails to respond to a kill signal on Linux.  Why?}$/;"	u	section:Problems
 Snort is behind a firewall  ipf  pf  ipchains  ipfilter  and awfully quiet...	input.tex	/^\\subsection{Snort is behind a firewall (ipf\/pf\/ipchains\/ipfilter) and awfully quiet...}$/;"	u	section:Rules and Alerts
-Snort is dying with a  can not create file  error and I have plenty of diskspace. What  s wrong 	input.tex	/^\\subsection{Snort is dying with a `can not create file' error and I have plenty of diskspace. What's wrong?}$/;"	u	section:Problems
+Snort is dying with a  can not create file  error and I have plenty of diskspace. What  s wrong 	input.tex	/^\\subsection{Snort is dying with a `can not create file' error and I have plenty of diskspace. W/;"	u	section:Problems
 Snort is not logging to my database	input.tex	/^\\subsection{Snort is not logging to my database}$/;"	u	section:Problems
 Snort is not logging to syslog	input.tex	/^\\subsection{Snort is not logging to syslog}$/;"	u	section:Problems
 Snort says   Garbage Packet with Null Pointer discarded    Huh 	input.tex	/^\\subsection{Snort says ``Garbage Packet with Null Pointer discarded!'' Huh?}$/;"	u	section:Problems
@@ -132,8 +132,8 @@ Why does building Snort complain about missing references 	input.tex	/^\\subsect
 Why does building snort fail with errors about yylex and lex  _init 	input.tex	/^\\subsection{Why does building snort fail with errors about yylex and lex\\_init? }$/;"	u	section:Getting Started
 Why does chrooted Snort die when I send it a SIGHUP  label  chroot	input.tex	/^\\subsection{Why does chrooted Snort die when I send it a SIGHUP? \\label{chroot}}$/;"	u	section:Problems
 Why does snort report   Packet loss statistics are unavailable under Linux   	input.tex	/^\\subsection{Why does snort report ``Packet loss statistics are unavailable under Linux?''}$/;"	u	section:Problems
-Why does the  error deleting alert  message occur when attempting to delete an alert with BASE 	input.tex	/^\\subsection{Why does the `error deleting alert' message occur when attempting to delete an alert with BASE?  }$/;"	u	section:Problems
-Why does the portscan plugin log   stealth   packets even though the host is in the portscan-ignorehosts list 	input.tex	/^\\subsection{Why does the portscan plugin log ``stealth'' packets even though the host is in the portscan-ignorehosts list? }$/;"	u	section:Configuring Snort
+Why does the  error deleting alert  message occur when attempting to delete an alert with BASE 	input.tex	/^\\subsection{Why does the `error deleting alert' message occur when attempting to delete an aler/;"	u	section:Problems
+Why does the portscan plugin log   stealth   packets even though the host is in the portscan-ignorehosts list 	input.tex	/^\\subsection{Why does the portscan plugin log ``stealth'' packets even though the host is in the/;"	u	section:Configuring Snort
 Why does the program generate alerts on packets that have pass rules 	input.tex	/^\\subsection{Why does the program generate alerts on packets that have pass rules?  }$/;"	u	section:Rules and Alerts
 stealth	input.tex	/^\\subsection{How do I setup snort on a `stealth' interface? }\\label{stealth}$/;"	l
 stream4	input.tex	/^\\label{stream4}$/;"	l

--- a/Units/review-needed.r/simple.asp.t/expected.tags
+++ b/Units/review-needed.r/simple.asp.t/expected.tags
@@ -1,6 +1,6 @@
 HtmlCutout	input.asp	/^function HtmlCutout(lang, str)   'dig-out a piece of text from a multilang. string str$/;"	f
 constDecl	input.asp	/^Const constDecl = 512$/;"	d
-f_translate_9data	input.asp	/^Function f_translate_9data(id,defaulttext,data)   'lookup lang_???(id) and insert data at $0,$1,...$/;"	f
+f_translate_9data	input.asp	/^Function f_translate_9data(id,defaulttext,data)   'lookup lang_???(id) and insert data at $0,$1,/;"	f
 js_erroralert	input.asp	/^sub js_erroralert(txt)           'print inline-script to generate popup-window with txt$/;"	s
 lang_length	input.asp	/^DIM lang_length     '(htmlct.inc) num.chars to get, i.e. mid(str, lang_start, lang_length)$/;"	v
 lang_start	input.asp	/^Dim lang_start      '(htmlct.inc) char-index, use for multilanguage-strings$/;"	v

--- a/Units/review-needed.r/simple.vim.t/expected.tags
+++ b/Units/review-needed.r/simple.vim.t/expected.tags
@@ -4,7 +4,7 @@ $env_var	input.vim	/^let $env_var = 'something'$/;"	v
 <F8>	input.vim	/^nnoremap <silent> <F8> :Tlist<CR>$/;"	m
 <Leader>scdt	input.vim	/^map! <unique> <Leader>scdt <Plug>GetColumnDataType$/;"	m
 Bar	input.vim	/^fu Bar(arg)$/;"	f
-DBSetOption	input.vim	/^command! -nargs=* -complete=customlist,<SID>DB_settingsComplete DBSetOption :call s:DB_setMultipleOptions(<q-args>)$/;"	c
+DBSetOption	input.vim	/^command! -nargs=* -complete=customlist,<SID>DB_settingsComplete DBSetOption :call s:DB_setMultip/;"	c
 E	input.vim	/^function E$/;"	f
 ExtraLines	input.vim	/^            \\ ExtraLines edit<bang> <args>$/;"	c
 Foo	input.vim	/^function! Foo(arg)$/;"	f

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -151,3 +151,12 @@ To enable the option, libiconv is needed in your platform. In addition
 On windows mingw32, you must specify ``WITH_ICONV=yes`` like below::
 
 	C:\dev\ctags>mingw32-make -f mk_mingw.mak WITH_ICONV=yes
+
+Omitting the pattern for too long input line
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+No to make too large tags file, a pattern filed of tags file is omitted
+when its size goes beyond 96 bytes.
+
+An input source file with single long line causes too large tags file.
+Such input files are popular in javascript: tools for size optimizing
+generate them.

--- a/main/options.c
+++ b/main/options.c
@@ -169,6 +169,7 @@ optionValues Option = {
 	FALSE,	    /* --quiet */
 	FALSE,	    /* --_allow-xcmd-in-homedir */
 	FALSE,	    /* --_fatal-warnings */
+	.patternLengthLimit = 96,
 #ifdef DEBUG
 	0, 0        /* -D, -b */
 #endif

--- a/main/options.h
+++ b/main/options.h
@@ -103,6 +103,7 @@ typedef struct sOptionValues {
 	boolean quiet;		      /* --quiet */
 	boolean allowXcmdInHomeDir;     /* --_allow-xcmd-in-homedir */
 	boolean fatalWarnings;	/* --_fatal-warnings */
+	unsigned int patternLengthLimit; /* Not implemented yet: --patern-length-limit=N */
 #ifdef DEBUG
 	long debugLevel;        /* -D  debugging output */
 	unsigned long breakLine;/* -b  source line at which to call lineBreak() */


### PR DESCRIPTION
Too long input lines may make tags file larger.
This commits omits the length of pattern field printed to a tags file.

If a making pattern is longer than the value of Option.patternLengthLimit,
the pattern is omitted; instead of including whole the input line, the
rest of substring after nth byte of Option.patternLengthLimit is is
printed as \.\{N}. Here N is the length of the substring.

As far as testing vim accepets \.\{N} as part of a pattern.

Close #163.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>