### PR TITLE
main: Don't ignore `.' extra entry when `f' is specified together

### DIFF
--- a/Units/extra-total-lines.d/args.ctags
+++ b/Units/extra-total-lines.d/args.ctags
@@ -1,3 +1,4 @@
---extra=+.
+# `f' is optional
+# There was a bug that `.' was disabled when `f' was specified together.
+--extra=+.f
 --excmd=number
-

--- a/main/parse.c
+++ b/main/parse.c
@@ -1600,7 +1600,7 @@ extern void makeFileTag (const char *const fileName)
 		tag.isFileEntry     = TRUE;
 		tag.lineNumberEntry = TRUE;
 
-		if (via_line_directive || Option.include.fileNames)
+		if (via_line_directive || (!Option.include.fileNamesWithTotalLines))
 		{
 			tag.lineNumber = 1;
 		}


### PR DESCRIPTION
I extended --extra option(.) for printing the total number of lines of
input file in c5d6954569123.

However, I injected a bug in 98392b01.  When specifying `.' with `f',
the total number of lines is not printed. This commit fixes it.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>