### PR TITLE
Optimize pattern generation

### DIFF
--- a/main/entry.h
+++ b/main/entry.h
@@ -50,6 +50,8 @@ typedef struct eTagFile {
 		unsigned int length;
 		unsigned int count;
 	} corkQueue;
+
+	boolean patternCacheValid;
 } tagFile;
 
 typedef struct sTagFields {

--- a/main/read.c
+++ b/main/read.c
@@ -259,6 +259,10 @@ extern boolean fileOpen (const char *const fileName, const langType language)
 		File.fp = NULL;
 	}
 
+	/* File postion is used as key for checking the availability of
+	   pattern cache in entry.h. If an input file is changed, the
+	   key is meaningless. So notifying the changing here. */
+	TagFile.patternCacheValid = FALSE;
 	File.fp = fopen (fileName, openMode);
 	if (File.fp == NULL)
 		error (WARNING | PERROR, "cannot open \"%s\"", fileName);


### PR DESCRIPTION
Making a pattern takes long time for long input line.  This commit
shortens the time. See the second commit about evaluation of my technique.