### PR TITLE
main: embed the information whether -DDEBUG was given or not to --version output

### DIFF
--- a/main/options.c
+++ b/main/options.c
@@ -1207,6 +1207,14 @@ static void printProgramIdentification (void)
 	printf ("  Compiled: %s, %s\n", __DATE__, __TIME__);
 	printf ("  URL: %s\n", PROGRAM_URL);
 
+	printf ("  DEBUG: %s\n",
+#ifdef DEBUG
+		"YES"
+#else
+		"NO"
+#endif		
+		);
+
 	printFeatureList ();
 }
 


### PR DESCRIPTION
Example output

    % ./ctags --version
    ./ctags --version
    Universal Ctags Development(7b40b46), Copyright (C) 2015 Universal Ctags Team
    Universal Ctags is derived from Exuberant Ctags.
    Exuberant Ctags 5.8, Copyright (C) 1996-2009 Darren Hiebert
      Compiled: Oct 29 2015, 13:56:35
      URL: https://ctags.io/
      DEBUG: YES
      Optional compiled features: +wildcards, +regex, +debug, +option-directory, +coproc

Signed-off-by: Masatake YAMATO <yamato@redhat.com>