### PR TITLE
python: check the enablement of "member" kind in makeFunctionTag

### DIFF
--- a/Units/python-disable-member-kind.d/args.ctags
+++ b/Units/python-disable-member-kind.d/args.ctags
@@ -1,0 +1,1 @@
+--python-kinds=f

--- a/Units/python-disable-member-kind.d/input.py
+++ b/Units/python-disable-member-kind.d/input.py
@@ -1,0 +1,6 @@
+class A:
+    def m():
+        pass
+def f():
+    pass
+

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -117,8 +117,16 @@ static void makeFunctionTag (vString *const function,
 {
 	tagEntryInfo tag;
 
-	if (! PythonKinds[K_FUNCTION].enabled)
-		return;
+	if (is_class_parent)
+	{
+		if (!PythonKinds[K_MEMBER].enabled)
+			return;
+	}
+	else
+	{
+		if (!PythonKinds[K_FUNCTION].enabled)
+			return;
+	}
 
 	initTagEntry (&tag, vStringValue (function), &(PythonKinds[K_FUNCTION]));
 


### PR DESCRIPTION
In makeFunctionTag function, tags both member and function kinds are
made. If the kinds are disabled, the tags should not be made.

At the head of makeFunctionTag, the enablement of function kind is
checked but that of member is not checked. As the result, an assertion
is made failure as reported in #648 by @yevhen-m.

This commit fixes this; the enablement of "member" kind is also
checked in makeFunctionTag.

Close #648.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>