### PR TITLE
verilog: Don't unget character if end-of-file was reached

### DIFF
--- a/Units/parser-verilog.r/systemverilog-github646.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-github646.d/expected.tags
@@ -1,0 +1,1 @@
+0	input.sv	/^function 0:/;"	f

--- a/Units/parser-verilog.r/systemverilog-github646.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-github646.d/input.sv
@@ -1,0 +1,1 @@
+function 0:

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -740,7 +740,7 @@ static void processPortList (int c)
 
 		deleteToken (token);
 	}
-	else
+	else if (c != EOF)
 	{
 		vUngetc (c);
 	}


### PR DESCRIPTION
Fixes #646