### PR TITLE
Chop test

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -418,6 +418,20 @@ noise: $(CTAGS_TEST)
 	$(SHELL) $${c} $(srcdir)/Units
 
 #
+# CHOP Target
+#
+chop: $(CTAGS_TEST)
+	@ \
+	c="$(srcdir)/misc/units chop \
+		--ctags=$(CTAGS_TEST) \
+		--languages=$(LANGUAGES) \
+		--datadir=$(srcdir)/data \
+		--libexecdir=$(srcdir)/libexec \
+		$(VALGRIND) --run-shrink \
+		--with-timeout=$(TIMEOUT)"; \
+	$(SHELL) $${c} $(srcdir)/Units
+
+#
 # UNITS Target
 #
 units: TIMEOUT := $(shell timeout --version > /dev/null 2>&1 && echo 5 || echo 0)
@@ -511,6 +525,7 @@ help:
 	@echo "make tmain                        - Run ctags main functionality test cases"
 	@echo "make fuzz                         - Verify that all parsers are able to properly process each available test unit"
 	@echo "make noise                        - Veirfy the behavior of parsers for broken input: a character injected or removed randomly"
+	@echo "make chop                         - Veirfy the behavior of parsers for broken input: randomly truncated"
 	@echo
 	@echo "Arguments that can be used in testing targets:"
 	@echo "VG=1                              - Run test cases with Valgrind memory profiler"

--- a/Makefile.in
+++ b/Makefile.in
@@ -375,9 +375,6 @@ CTAGS_TEST = ./$(CTAGS_EXEC)
 ifdef VG
 VALGRIND=--with-valgrind
 endif
-ifdef SHRINK
-RUN_SHRINK=--run-shrink
-endif
 TIMEOUT=
 LANGUAGES=
 CATEGORIES=
@@ -402,7 +399,7 @@ fuzz: $(CTAGS_TEST)
 		--languages=$(LANGUAGES) \
 		--datadir=$(srcdir)/data \
 		--libexecdir=$(srcdir)/libexec \
-		$(VALGRIND) $(RUN_SHRINK) \
+		$(VALGRIND) --run-shrink \
 		--with-timeout=$(TIMEOUT)"; \
 	$(SHELL) $${c} $(srcdir)/Units
 
@@ -416,7 +413,7 @@ noise: $(CTAGS_TEST)
 		--languages=$(LANGUAGES) \
 		--datadir=$(srcdir)/data \
 		--libexecdir=$(srcdir)/libexec \
-		$(VALGRIND) $(RUN_SHRINK) \
+		$(VALGRIND) --run-shrink \
 		--with-timeout=$(TIMEOUT)"; \
 	$(SHELL) $${c} $(srcdir)/Units
 
@@ -436,7 +433,7 @@ units: $(CTAGS_TEST)
 		--units=$(UNITS) \
 		--datadir=$(srcdir)/data \
 		--libexecdir=$(srcdir)/libexec \
-		$(VALGRIND) $(RUN_SHRINK) \
+		$(VALGRIND) --run-shrink \
 		--with-timeout=$(TIMEOUT) \
 		$(SHOW_DIFF_OUTPUT)"; \
 	 $(SHELL) $${c} $(srcdir)/Units $${builddir}/Units

--- a/Makefile.in
+++ b/Makefile.in
@@ -513,7 +513,7 @@ help:
 	@echo "make units                        - Run parser unit test cases"
 	@echo "make tmain                        - Run ctags main functionality test cases"
 	@echo "make fuzz                         - Verify that all parsers are able to properly process each available test unit"
-	@echo "make noise                        - TODO"
+	@echo "make noise                        - Veirfy the behavior of parsers for broken input: a character injected or removed randomly"
 	@echo
 	@echo "Arguments that can be used in testing targets:"
 	@echo "VG=1                              - Run test cases with Valgrind memory profiler"

--- a/docs/chop.rst
+++ b/docs/chop.rst
@@ -1,0 +1,20 @@
+Chop testing
+---------------------------------------------------------------------
+
+:Maintainer: Masatake YAMATO <yamato@redhat.com>
+
+----
+After reviving many bug reports, we recognized some of them spot
+unexpected EOF. The chop target is developed based on this recognition.
+
+The chop target generates many input files from an existing input file
+under *Units* by truncating the existing input file at variety file
+position.
+
+::
+
+   $ make chop  LANGUAGES=LANG1[,LANG2,...]
+
+It takes a long time, especially with ``VG=1``, so this cannot be run
+under Travis CI. However, it is a good idea to run it locally.
+

--- a/docs/semifuzz.rst
+++ b/docs/semifuzz.rst
@@ -50,12 +50,6 @@ following parameters:
 		The valgrind report is recorded at
 		``Units/\*/VALGRIND-${language}.tmp``.
 
-	``SHRINK=1``
-
-		If exit status is non-zero, run ``units shrink`` to
-		minimize the bad input. Using bisection algorithm,
-		*misc/units shrink* tries to make the shortest input
-		which makes ctags exit with non-zero status.
-		The result is reported to ``Units/\*/SHRINK-${language}.tmp``.
-		This is very useful for debugging.
-
+As the same as units target, this semi-fuzz test target also calls
+*misc/units shrink* when an test case is failed. See "*Units* test facility"
+about the shrinked result.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -10,6 +10,8 @@ ctags in limited resources.
 `Semi fuzz(Fuzz) testing <semifuzz.rst>`_
 
 `Noise testing <noise.rst>`_
+
+`Chop testing <chop.rst>`_
 	     
 `Tmain: a facility for testing main part <tmain.rst>`_
 

--- a/docs/units.rst
+++ b/docs/units.rst
@@ -284,11 +284,11 @@ is the name category in the above example.
 Finding minimal bad input
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If ``SHRINK=1`` is given as argument for make, the input causing
-``FAILED`` result is passed to *misc/units shrink*.  *misc/units
-shrink* tries to make the shortest input which makes ctags exits with
-non-zero status.  The result is reported to
-``Units/\*/SHRINK-${language}.tmp``.  Maybe useful to debug.
+When a test case is failed, the input causing ``FAILED`` result is
+passed to *misc/units shrink*.  *misc/units shrink* tries to make the
+shortest input which makes ctags exits with non-zero status.  The
+result is reported to ``Units/\*/SHRINK-${language}.tmp``.  Maybe
+useful to debug.
 
 Acknowledgments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/misc/units
+++ b/misc/units
@@ -87,6 +87,8 @@ Usage:
 
 	$(help_tmain)
 
+	$(help_chop)
+
 	$(help_clean_tmain)
 EOF
 }
@@ -2017,6 +2019,161 @@ EOF
 
 }
 
+help_chop ()
+{
+cat <<EOF
+$0 noise [OPTIONS] UNITS-DIR
+	   OPTIONS:
+		--ctags CTAGS: ctags exectuable file for testing
+		--datadir DATADIR: data directory
+		--languages PARSER1[,PARSER2,...]: run only PARSER* related cases
+		--libexecdir LIBEXECDIR: libexec directory
+		--quiet: don't print dots as passed test cases.
+		--with-timeout DURATION: run a test case under timeout
+					 command with SECOND.
+					 0 means no timeout.
+					 default is 1.
+		--with-valgrind: run a test case under valgrind
+			       If this option given, DURATION is changed to
+			       DURATION := DURATION * ${_VG_TIMEOUT_FACTOR}
+EOF
+}
+
+action_chop ()
+{
+    action_fuzz_common chop_lang "$@"
+}
+
+chop_lang ()
+{
+    local lang="$1"
+    local dir="$2"
+    shift 2
+    local f
+    local r
+    printf '%-60s\n' "Fuzzing by chopping input (${lang})"
+    line '-'
+
+    r=0
+    for f in $(find "${dir}" -type f -name 'input.*'); do
+	if ! chop_lang_file "${lang}" "${f}"; then
+	    r=1
+	    break
+	fi
+    done
+    echo
+    return $r
+}
+
+chop_lang_file ()
+{
+    local lang="$1"
+    local input="$2"
+    shift 2
+
+    local r
+    local cmdline
+    local cmdline_for_shirking
+    local len=$(stat -c %s "${input}")
+
+    local guessed_lang
+    guessed_lang=$( ${_CMDLINE_FOR_SHRINKING} --print-language "${input}" 2>/dev/null | sed -n 's/^.*: //p')
+    if [ "${lang}" !=  "${guessed_lang}" ]; then
+	return 0
+    fi
+
+    i=0
+    echo "Testing cases derived from: ${input}"
+    line '.' --no-newline
+
+    r=0
+    while [ "$i" -lt "$len" ]; do
+	if chop_lang_file_chopspec "${input}" "${len}" "$i" "${lang}"; then
+	    i=$(( i + 1 ))
+	else
+	    r=1
+	    break
+	fi
+    done
+    echo
+    return $r
+}
+
+chop()
+{
+    local input=$1
+    local pos=$2
+
+    dd if=$input bs=1 count=$pos
+}
+
+chop_lang_file_chopspec()
+{
+    local input="$1"
+    local len="$2"
+    local pos="$3"
+    local lang="$4"
+    shift 4
+
+    local dir="${input%/*}"
+    local ochopped=$(printf "%s/CHOP-INPUT-%s.tmp" "${dir}" "$pos")
+    local ocmdline=$(printf "%s/CHOP-CMDLINE-%s.tmp" "${dir}" "$pos")
+    local ovalgrind=$(printf "%s/CHOP-VALGRIND-%s.tmp" "${dir}" "$pos")
+    local oshrink=$(printf "%s/CHOP-SHRINK-%s.tmp" "${dir}" "$pos")
+
+    local cmdline
+    local cmdline_for_shirking
+    local progress_offset
+    local r
+
+    rm -f "${ocmdline}" "${ovalgrind}" "${ochopped}" "${oshrink}"
+
+    if [ "${WITH_VALGRIND}" = 'yes' ]; then
+	cmdline=$( printf "${_CMDLINE} --language-force=${lang} ${ochopped}" "${ovalgrind}" )
+    else
+	cmdline="${_CMDLINE} --language-force=${lang} ${ochopped}"
+    fi
+    cmdline_for_shirking="${_CMDLINE_FOR_SHRINKING} --language-force=${lang} %s"
+
+    chop "${input}" "${pos}" > "$ochopped"  2> /dev/null
+
+    progress_offset=$(( pos % _NOISE_REPORT_MAX_COLUMN ))
+    if [ "${progress_offset}" -eq 0 ]; then
+	[ $pos -gt 0 ] && printf " %d/%d" "$pos" "${len}"
+	echo
+    fi
+
+    echo "${cmdline}" > "${ocmdline}"
+    ( exec 2>&-; ${cmdline} 2> /dev/null > /dev/null )
+    r=$?
+    case $r in
+	0)
+	    printf 'o'
+	    noise_report_line "${pos}" "${len}" "${r}" ""
+	    rm "${ochopped}"
+	    rm -f "${ovalgrind}" "${ocmdline}"
+	    ;;
+	${_TIMEOUT_EXIT})
+	    printf "T"
+	    noise_report_line "${pos}" "${len}" "${r}" ""
+	    printf '\n%-20s\n' "[timeout $lang]" "$ochopped"
+	    [ "${RUN_SHRINK}" = 'yes' ] && fuzz_shrink "${cmdline_for_shirking}" "${ochopped}" "${oshrink}" "${lang}"
+	    ;;
+	${_VALGRIND_EXIT})
+	    printf "V"
+	    noise_report_line "${pos}" "${len}" "${r}" ""
+	    printf '\n%-20s %s\n' "[valgrind-error $lang]" "$ochopped"
+	    ;;
+	*)
+	    printf "!"
+	    noise_report_line "${pos}" "${len}" "${r}" ""
+	    printf '\n%-20s %s\n' "[unexpected-status($r) $lang]" "$ochopped"
+	    [ "${RUN_SHRINK}" = 'yes' ] && fuzz_shrink "${cmdline_for_shirking}" "${ochopped}" "${oshrink}" "${lang}"
+	    ;;
+    esac
+    return $r
+}
+
 # * Avoid issues between sed and the locale settings by overriding it using
 #   LC_ALL, which takes precedence over all other locale configurations:
 #   https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html
@@ -2071,6 +2228,10 @@ main ()
 	    ;;
 	shrink)
 	    action_shrink "$@"
+	    return $?
+	    ;;
+	chop)
+	    action_chop "$@"
 	    return $?
 	    ;;
 	*)

--- a/misc/units
+++ b/misc/units
@@ -1657,7 +1657,7 @@ noise_lang_file ()
 	done
     done
     echo
-    return 0;
+    return 0
 }
 
 noise_lang ()


### PR DESCRIPTION
Close #633.

After reviving many bug reports, we recognized some of them spot
unexpected EOF. The chop target is developed based on this recognition.

The chop target generates many input files from an existing input file
under *Units* by truncating the existing input file at variety file
position.

You can try the target with:

    $ make chop