### PR TITLE
Ruby: delete rspec related kinds

### DIFF
--- a/Tmain/tmain-example.d/stdout-expected.txt
+++ b/Tmain/tmain-example.d/stdout-expected.txt
@@ -2,5 +2,3 @@ c  classes
 f  methods
 m  modules
 F  singleton methods
-d  describes
-C  contexts

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -30,7 +30,7 @@
 *   DATA DECLARATIONS
 */
 typedef enum {
-	K_UNDEFINED = -1, K_CLASS, K_METHOD, K_MODULE, K_SINGLETON, K_DESCRIBE, K_CONTEXT
+	K_UNDEFINED = -1, K_CLASS, K_METHOD, K_MODULE, K_SINGLETON,
 } rubyKind;
 
 /*
@@ -41,8 +41,11 @@ static kindOption RubyKinds [] = {
 	{ TRUE, 'f', "method", "methods" },
 	{ TRUE, 'm', "module", "modules" },
 	{ TRUE, 'F', "singletonMethod", "singleton methods" },
-	{ TRUE, 'd', "describe", "describes" },
-	{ TRUE, 'C', "context", "contexts" }
+#if 0
+	/* Following two kinds are reserved. */
+	{ TRUE, 'd', "describe", "describes and contexts for Rspec" },
+	{ TRUE, 'C', "constant", "constants" },
+#endif
 };
 
 static NestingLevels* nesting = NULL;
@@ -264,10 +267,6 @@ static rubyKind parseIdentifier (
 	{
 		also_ok = "?!=";
 	}
-	else if (kind == K_DESCRIBE || kind == K_CONTEXT)
-	{
-		also_ok = " ,\".#?!='/-";
-	}
 	else
 	{
 		also_ok = "";
@@ -471,14 +470,6 @@ static void findRubyTags (void)
 				kind = K_SINGLETON;
 
 			readAndEmitTag (&cp, kind);
-		}
-		else if (canMatchKeyword (&cp, "describe"))
-		{
-			readAndEmitTag (&cp, K_DESCRIBE);
-		}
-		else if (canMatchKeyword (&cp, "context"))
-		{
-			readAndEmitTag (&cp, K_CONTEXT);
 		}
 		while (*cp != '\0')
 		{


### PR DESCRIPTION
(This is about a bug spotted in #453 by @mislav and in #11 by
 @NewAlexandria.)

Kinds C and d are for Rspec.

Parts of code related to above kinds assume a ruby string
comes after Rspec keywords (describe or context).

This is a wrong assumption. A class name can be used there.

It is nice if ctags can handle these rspec code well, but we
don't have enough resource to make it now.

So in this commit I delete rspec related code temporary. I
just reserve a kind letter 'd' for rspec for the future. 'C'
is completely deleted because (1) describe and context have
the same meaning in rspec, and (2) we would like to assign
'C' for Ruby constant as ripper-tags does.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>