### PR TITLE
appveyor: show diff output of failure test cases

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -383,6 +383,9 @@ UNITS=
 ifdef TRAVIS
 SHOW_DIFF_OUTPUT=--show-diff-output
 endif
+ifdef APPVEYOR
+SHOW_DIFF_OUTPUT=--show-diff-output
+endif
 
 .PHONY: check units fuzz noise tmain tinst clean-units clean-tmain clean-gcov run-gcov codecheck roundtrip help
 check: tmain units

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -125,7 +125,7 @@ c:\cygwin\bin\file ctags.exe
 :: Check if it works
 .\ctags --version || exit 1
 :: Run tests
-bash -lc "make check"
+bash -lc "make check APPVEYOR=1"
 
 @echo off
 goto :eof
@@ -155,7 +155,7 @@ c:\cygwin\bin\file ctags.exe
 :: Check if it works
 .\ctags --version || exit 1
 :: Run tests
-bash -lc "make check"
+bash -lc "make check APPVEYOR=1"
 
 @echo off
 goto :eof


### PR DESCRIPTION
Instead of referring an environment variable APPVEYOR described in http://www.appveyor.com/docs/environment-variables, I define it in appveyor.bat explicitly as same as we defined TRAVIS
in misc/travis-check.sh.
