### PR TITLE
units: don't remove 'r' suffix from category name when displaying the name

### DIFF
--- a/docs/units.rst
+++ b/docs/units.rst
@@ -280,7 +280,7 @@ Categories
 
 With *.r* suffix, you can put test cases under a sub directory
 of *Units*. ``Units/parser-ada.r`` is an example. If *misc/units*
-test harness, the sub directory is called a category. ``parser-ada``
+test harness, the sub directory is called a category. ``parser-ada.r``
 is the name category in the above example.
 
 

--- a/misc/units
+++ b/misc/units
@@ -892,7 +892,6 @@ action_run ()
 	[ -d "$d" ] || continue
 	category="${d##*/}"
 	build_d=${build_dir}/${category}
-	category="${category%.r}"
 	run_dir "${category}" "$d" "${build_d}"
     done
 


### PR DESCRIPTION
Just for improving the appearance of units output, I removed 'r' suffix
from categories of units test cases. This is just inconvenient when
one wants to access to a result of a failed test case.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>