### PR TITLE
main: remove unused parameter from renderRole function

### DIFF
--- a/main/field.c
+++ b/main/field.c
@@ -383,7 +383,7 @@ static const char *renderFieldRole (const tagEntryInfo *const tag, vString* b)
 	{
 		Assert (rindex < tag->kind->nRoles);
 		role  = & (tag->kind->roles [rindex]);
-		return renderRole (role, tag, b);
+		return renderRole (role, b);
 	}
 
 	return vStringValue (b);

--- a/main/kind.c
+++ b/main/kind.c
@@ -21,8 +21,7 @@ extern void printRole (const roleDesc* const role)
 		printf ("%s\t%s\t%s\n", role->name, role->description, role->enabled? "on": "off");
 }
 
-extern const char *renderRole (const roleDesc* const role,
-			       const tagEntryInfo *const tag __unused__, vString* b)
+extern const char *renderRole (const roleDesc* const role, vString* b)
 {
 	vStringCatS (b, role->name);
 	return vStringValue (b);

--- a/main/kind.h
+++ b/main/kind.h
@@ -19,10 +19,8 @@ typedef struct sRoleDesc {
 	const char* description;	  /* displayed in --help output */
 } roleDesc;
 
-struct sTagEntryInfo;
-typedef struct sTagEntryInfo tagEntryInfo;
 extern void printRole (const roleDesc* const role); /* for --help */
-extern const char *renderRole (const roleDesc* const role, const tagEntryInfo *const tag, vString* b);
+extern const char *renderRole (const roleDesc* const role, vString* b);
 
 /*
  * Predefined kinds


### PR DESCRIPTION
To avoid circular header file inclusion, tagEntryInfo was defined in
multiple headers. The one of definition is needed in a parameter of
prototype declaration of renderRole function. However, the parameter
is not used in the function now.

This commit removes both the parameter and the one of tagEntryInfo type
info definition.

This is needed to build ctags on RHEL5.11.
Close #699.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>