### PR TITLE
main: print the result of parser guessing in more detail

### DIFF
--- a/main/parse.c
+++ b/main/parse.c
@@ -720,10 +720,17 @@ static langType getSpecLanguageCommon (const char *const spec, struct getLangCtx
 	langType language;
 	parserCandidate  *candidates;
 	unsigned int n_candidates;
-
+	unsigned int i;
 	n_candidates = (*nominate)(spec, &candidates);
 
 	verbose ("		#candidates: %u\n", n_candidates);
+	if (n_candidates > 1)
+		for (i = 0; i < n_candidates; i++)
+			verbose ("			%u: %s (%s)\n",
+				 i,
+				 LanguageTable[candidates[i].lang]->name, candidates[i].spec);
+
+
 	if (n_candidates == 1)
 	{
 		language = candidates[0].lang;


### PR DESCRIPTION
e.g.

    $ ./ctags --verbose main/kind.h
    ...
    Get file language for main/kind.h
	    pattern: kind.h
		    #candidates: 2
			    0: C++ (*.h)
			    1: ObjectiveC (*.h)
    Selector: 0x415260
	    selection: C++
    ...

Signed-off-by: Masatake YAMATO <yamato@redhat.com>