### PR TITLE
Remove dctags target from all makefiles

### DIFF
--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -12,16 +12,19 @@ OBJEXT = o
 ALL_OBJS += $(REGEX_OBJS)
 ALL_OBJS += $(FNMATCH_OBJS)
 VPATH = . ./main ./parsers
+
 ifeq (yes, $(WITH_ICONV))
 DEFINES += -DHAVE_ICONV
 LIBS += -liconv
 endif
 
-ctags.exe: OPT = -O4 -Os -fexpensive-optimizations
-ctags.exe: LDFLAGS = -s
-dctags.exe: OPT = -g
-dctags.exe: DEBUG = -DDEBUG
-dctags.exe: ALL_SRCS += debug.c
+ifdef DEBUG
+DEFINES += -DDEBUG
+OPT = -g
+else
+OPT = -O4 -Os -fexpensive-optimizations
+LDFLAGS = -s
+endif
 
 .SUFFIXES: .c .o
 
@@ -45,9 +48,8 @@ V_CC_1	 =
 	$(V_CC) $(CC) -c $(OPT) $(CFLAGS) $(DEFINES) $(INCLUDES) -o $@ $<
 
 ctags: ctags.exe
-dctags: dctags.exe
 
-ctags.exe dctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS)
+ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS)
 	$(V_CC) $(CC) $(OPT) $(CFLAGS) $(LDFLAGS) $(DEFINES) $(INCLUDES) -o $@ $(ALL_OBJS) $(LIBS)
 
 readtags.exe: readtags.c
@@ -56,6 +58,5 @@ readtags.exe: readtags.c
 clean:
 	$(SILENT) echo Cleaning
 	$(SILENT) rm -f ctags.exe
-	$(SILENT) rm -f dctags.exe
 	$(SILENT) rm -f tags
 	$(SILENT) rm -f main/*.o parsers/*.o gnu_regex/*.o fnmatch/*.o

--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -14,10 +14,16 @@ REGEX_DEFINES = -DHAVE_REGCOMP -D__USE_GNU -Dbool=int -Dfalse=0 -Dtrue=1 -Dstrca
 DEFINES = -DWIN32 $(REGEX_DEFINES)
 INCLUDES = -I. -Imain -Ignu_regex -Ifnmatch
 OPT = /O2
+
 !if "$(WITH_ICONV)" == "yes"
 DEFINES = $(DEFINES) -DHAVE_ICONV
 LIBS = $(LIBS) /libpath:$(ICONV_DIR)/lib iconv.lib
 INCLUDES = $(INCLUDES) -I$(ICONV_DIR)/include
+!endif
+
+!ifdef DEBUG
+DEFINES = $(DEFINES) -DDEBUG
+OPT = $(OPT) /Zi
 !endif
 
 ctags: ctags.exe
@@ -27,10 +33,6 @@ ctags.exe: respmvc
 
 readtags.exe: readtags.c
 	cl /clr $(OPT) /Fe$@ $(DEFINES) -DREADTAGS_MAIN readtags.c /link setargv.obj
-
-# Debug version
-dctags.exe: respmvc
-	cl /Zi -DDEBUG /Fe$@ @respmvc debug.c /link setargv.obj
 
 $(REGEX_OBJS): $(REGEX_SRCS)
 	cl /c $(OPT) /Fo$@ $(INCLUDES) $(DEFINES) $(REGEX_SRCS)
@@ -45,11 +47,8 @@ respmvc: $(REGEX_OBJS) $(FNMATCH_OBJS) $(ALL_SRCS) $(REGEX_SRCS) $(FNMATCH_SRCS)
 	echo $(REGEX_SRCS) >> $@
 	echo $(FNMATCH_SRCS) >> $@
 
-mostlyclean:
+clean:
 	- del *.obj
-	- del dctags.exe
+	- del ctags.exe
 	- del respmvc
 	- del tags
-
-clean: mostlyclean
-	- del ctags.exe


### PR DESCRIPTION
maintainer.mak has been already removed with the commit
5dc45359a022626d4f5f3aa89f8d232cda69bcfc, and the dctags target has been
also removed. It is better to remove the dctags target also from
mk_mingw.mak and mk_mvc.mak.

If you want to build debug version, use the following commands:
  MinGW: make -f mk_mingw.mak DEBUG=1
  MSVC:  nmake -f mk_mvc.mak DEBUG=1