### PR TITLE
Units, C++: add a case reproducing a bug about wrong scope kind

### DIFF
--- a/Units/parser-cpp.r/namespace-and-scope.b/args.ctags
+++ b/Units/parser-cpp.r/namespace-and-scope.b/args.ctags
@@ -1,0 +1,2 @@
+--kinds-C++=*
+--fields=+K

--- a/Units/parser-cpp.r/namespace-and-scope.b/expected.tags
+++ b/Units/parser-cpp.r/namespace-and-scope.b/expected.tags
@@ -1,0 +1,3 @@
+X	input.cpp	/^namespace X {$/;"	namespace	file:
+f	input.cpp	/^	void f (void);$/;"	prototype	namespace:X	file:
+f	input.cpp	/^void X::f (void) {}$/;"	function	namespace:X

--- a/Units/parser-cpp.r/namespace-and-scope.b/input.cpp
+++ b/Units/parser-cpp.r/namespace-and-scope.b/input.cpp
@@ -1,0 +1,4 @@
+namespace X {
+	void f (void);
+};
+void X::f (void) {}


### PR DESCRIPTION
"class" is used as the kind of parent scope where "namespace" should
be used.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>