### PR TITLE
main: Introduce an option to add "UCTAGS" as prefix to field names

### DIFF
--- a/Tmain/list-fields-with-prefix.d/run.sh
+++ b/Tmain/list-fields-with-prefix.d/run.sh
@@ -1,0 +1,4 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+CTAGS=$1
+$CTAGS --quiet --options=NONE --put-field-prefix --list-fields | grep UCTAGS

--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -1,0 +1,2 @@
+r	UCTAGSrole	role	format-char	off
+Z	UCTAGSscope	Include the "scope:" key in scope field(use s)	NONE	off

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -186,6 +186,28 @@ Following extra tag entries are newly introduced.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``--list-extras``, ``--list-features`` and ``--list-fields`` are added.
 
+``--put-field-prefix`` options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some fields are newly introduced in universal-ctags. We will introduce more
+in the future. Other tags generators may also introduce for their own fields.
+
+In such situation there is concern about confliction of field names;
+mixing tags files generated from multiple tags generator including
+universal-ctags is difficult. ``--put-field-prefix`` provides a
+workaround for the use case. When ``--put-field-prefix`` is given,
+ctags puts "UCTAGS" as prefix for newly introduced field.
+
+.. code-block:: console
+
+    $ cat /tmp/foo.h
+    #include <stdio.h>
+    $ ./ctags -o - --extra=+r --fields=+r /tmp/foo.h
+    stdio.h	/tmp/foo.h	/^#include <stdio.h>/;"	h	role:system
+    $ ./ctags --put-field-prefix -o - --extra=+r --fields=+r /tmp/foo.h
+    stdio.h	/tmp/foo.h	/^#include <stdio.h>/;"	h	UCTAGSrole:system
+
+In this example, ``role`` is prefixed.
 
 
 Changes in tags file format

--- a/main/ctags.h
+++ b/main/ctags.h
@@ -28,6 +28,8 @@
  * Constant
  */
 extern const char* ctags_repoinfo;
+#define CTAGS_FIELD_PREFIX "UCTAGS"
+
 
 #endif	/* CTAGS_MAIN_CTAGS_H */
 

--- a/main/entry.c
+++ b/main/entry.c
@@ -828,13 +828,13 @@ static char* getFullQualifiedScopeNameFromCorkQueue (const tagEntryInfo * inner_
 static int addExtensionFields (const tagEntryInfo *const tag)
 {
 	const char* const kindKey = getFieldDesc (FIELD_KIND_KEY)->enabled
-		?getFieldDesc (FIELD_KIND_KEY)->name
+		?getFieldName (FIELD_KIND_KEY)
 		:"";
 	const char* const kindFmt = getFieldDesc (FIELD_KIND_KEY)->enabled
 		?"%s\t%s:%s"
 		:"%s\t%s%s";
 	const char* const scopeKey = getFieldDesc (FIELD_SCOPE_KEY)->enabled
-		?getFieldDesc (FIELD_SCOPE_KEY)->name
+		?getFieldName (FIELD_SCOPE_KEY)
 		:"";
 	const char* const scopeFmt = getFieldDesc (FIELD_SCOPE_KEY)->enabled
 		?"%s\t%s:%s:%s"
@@ -859,12 +859,12 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 
 	if (getFieldDesc (FIELD_LINE_NUMBER)->enabled)
 		length += fprintf (TagFile.fp, "%s\t%s:%ld", sep,
-				   getFieldDesc (FIELD_LINE_NUMBER)->name,
+				   getFieldName (FIELD_LINE_NUMBER),
 				   tag->lineNumber);
 
 	if (getFieldDesc (FIELD_LANGUAGE)->enabled  &&  tag->language != NULL)
 		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
-				   getFieldDesc (FIELD_LANGUAGE)->name,
+				   getFieldName (FIELD_LANGUAGE),
 				   escapeName (tag, FIELD_LANGUAGE));
 
 	if (getFieldDesc (FIELD_SCOPE)->enabled)
@@ -897,39 +897,39 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 			tag->extensionFields.typeRef [0] != NULL  &&
 			tag->extensionFields.typeRef [1] != NULL)
 		length += fprintf (TagFile.fp, "%s\t%s:%s:%s", sep,
-				   getFieldDesc (FIELD_TYPE_REF)->name,
+				   getFieldName (FIELD_TYPE_REF),
 				   tag->extensionFields.typeRef [0],
 				   escapeName (tag, FIELD_TYPE_REF));
 
 	if (getFieldDesc (FIELD_FILE_SCOPE)->enabled &&  tag->isFileScope)
 		length += fprintf (TagFile.fp, "%s\t%s:", sep,
-				   getFieldDesc (FIELD_FILE_SCOPE)->name);
+				   getFieldName (FIELD_FILE_SCOPE));
 
 	if (getFieldDesc (FIELD_INHERITANCE)->enabled &&
 			tag->extensionFields.inheritance != NULL)
 		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
-				   getFieldDesc (FIELD_INHERITANCE)->name,
+				   getFieldName (FIELD_INHERITANCE),
 				   escapeName (tag, FIELD_INHERITANCE));
 
 	if (getFieldDesc (FIELD_ACCESS)->enabled &&  tag->extensionFields.access != NULL)
 		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
-				   getFieldDesc (FIELD_ACCESS)->name,
+				   getFieldName (FIELD_ACCESS),
 				   tag->extensionFields.access);
 
 	if (getFieldDesc (FIELD_IMPLEMENTATION)->enabled &&
 			tag->extensionFields.implementation != NULL)
 		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
-				   getFieldDesc (FIELD_IMPLEMENTATION)->name,
+				   getFieldName (FIELD_IMPLEMENTATION),
 				   tag->extensionFields.implementation);
 
 	if (getFieldDesc (FIELD_SIGNATURE)->enabled &&
 			tag->extensionFields.signature != NULL)
 		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
-				   getFieldDesc (FIELD_SIGNATURE)->name,
+				   getFieldName (FIELD_SIGNATURE),
 				   escapeName (tag, FIELD_SIGNATURE));
 	if (getFieldDesc (FIELD_ROLE)->enabled && tag->extensionFields.roleIndex != ROLE_INDEX_DEFINITION)
 		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
-				   getFieldDesc (FIELD_ROLE)->name,
+				   getFieldName (FIELD_ROLE),
 				   escapeName (tag, FIELD_ROLE));
 
 	return length;

--- a/main/field.h
+++ b/main/field.h
@@ -53,11 +53,13 @@ typedef struct sFieldDesc {
 	const char* description;  /* displayed in --help output */
 	renderEscaped renderEscaped;
 	vString *buffer;
+	const char* nameWithPrefix;
 } fieldDesc;
 
 extern fieldDesc* getFieldDesc(fieldType type);
 extern fieldType getFieldTypeForOption (char letter);
 extern const char* renderFieldEscaped (fieldDesc *fdesc, const tagEntryInfo *tag);
+extern const char* getFieldName(fieldType type);
 extern void printFields (void);
 
 #endif	/* CTAGS_MAIN_FIELD_H */

--- a/main/options.c
+++ b/main/options.c
@@ -166,6 +166,7 @@ optionValues Option = {
 	FALSE,	    /* --_allow-xcmd-in-homedir */
 	FALSE,	    /* --_fatal-warnings */
 	.patternLengthLimit = 96,
+	.putFieldPrefix = FALSE,
 #ifdef DEBUG
 	0, 0        /* -D, -b */
 #endif
@@ -319,6 +320,8 @@ static optionDescription LongOptionDescription [] = {
 #endif
  {0,"  --print-language"},
  {0,"       Don't make tags file but just print the guessed language name for input file."},
+ {0,"  --put-field-prefix"},
+ {0,"       Put \"" CTAGS_FIELD_PREFIX "\" as prefix for the name of fields newly introduced in universal-ctags."},
  {1,"  --quiet=[yes|no]"},
  {0,"       Don't print NOTICE class messages [no]."},
  {1,"  --recurse=[yes|no]"},
@@ -2125,6 +2128,7 @@ static booleanOption BooleanOptions [] = {
 	{ "if0",            &Option.if0,                    FALSE, STAGE_ANY },
 	{ "line-directives",&Option.lineDirectives,         FALSE, STAGE_ANY },
 	{ "links",          &Option.followLinks,            FALSE, STAGE_ANY },
+	{ "put-field-prefix", &Option.putFieldPrefix,       FALSE, STAGE_ANY },
 	{ "print-language", &Option.printLanguage,          TRUE,  STAGE_ANY },
 	{ "quiet",          &Option.quiet,                  FALSE, STAGE_ANY },
 #ifdef RECURSE_SUPPORTED

--- a/main/options.h
+++ b/main/options.h
@@ -96,6 +96,7 @@ typedef struct sOptionValues {
 	boolean allowXcmdInHomeDir;     /* --_allow-xcmd-in-homedir */
 	boolean fatalWarnings;	/* --_fatal-warnings */
 	unsigned int patternLengthLimit; /* Not implemented yet: --patern-length-limit=N */
+	boolean putFieldPrefix;		 /* --put-field-prefix */
 #ifdef DEBUG
 	long debugLevel;        /* -D  debugging output */
 	unsigned long breakLine;/* -b  input line at which to call lineBreak() */


### PR DESCRIPTION
We want to add more fields to tags output.

e.g. "returnType:" of a function declaration,
"decorator:" or "annotation:" attached to a name.

In other hand there are many tags generators. .e.g.  coffeetags and
ripper-tags. The authors of these tools may want to add the
generator(and its target language) own new fields to the output.

There is concern about confliction of field names.

For providing a workaround of the confliction, this
commit introduce --put-field-prefix option.

When --put-field-prefix is given, "UCTAGS" is prefixed to the name of
all fields newly introduced in universal ctags.

Example output(--list-fields):

    [yamato@x201]~/var/ctags-github% ./ctags --put-field-prefix --list-fields | grep UC
    r	UCTAGSrole	role	format-char	off
    Z	UCTAGSscope	Include the "scope:" key in scope field(use s)	NONE	off
    [yamato@x201]~/var/ctags-github% ./ctags --list-fields | grep '^[rZ]'
    r	role	role	format-char	off
    Z	scope	Include the "scope:" key in scope field(use s)	NONE	off

Example output(--extra=+r --fields=+r):

    [yamato@x201]~/var/ctags-github% cat /tmp/foo.h
    #include <stdio.h>
    [yamato@x201]~/var/ctags-github% ./ctags -o - --extra=+r --fields=+r /tmp/foo.h
    stdio.h	/tmp/foo.h	/^#include <stdio.h>/;"	h	role:system
    [yamato@x201]~/var/ctags-github% ./ctags --put-field-prefix -o - --extra=+r --fields=+r /tmp/foo.h
    stdio.h	/tmp/foo.h	/^#include <stdio.h>/;"	h	UCTAGSrole:system

Signed-off-by: Masatake YAMATO <yamato@redhat.com>