### PR TITLE
units: allow to run test cases on zsh

### DIFF
--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -17,6 +17,7 @@ UNITS=
 fuzz: TIMEOUT := $(shell timeout --version > /dev/null 2>&1 && echo 1 || echo 0)
 fuzz: $(CTAGS_TEST)
 	@ \
+	if test -n "$${ZSH_VERSION+set}"; then set -o SH_WORD_SPLIT; fi; \
 	if test x$(VG) = x1; then		\
 		VALGRIND=--with-valgrind;	\
 	fi;					\
@@ -33,6 +34,7 @@ fuzz: $(CTAGS_TEST)
 #
 noise: $(CTAGS_TEST)
 	@ \
+	if test -n "$${ZSH_VERSION+set}"; then set -o SH_WORD_SPLIT; fi; \
 	if test x$(VG) = x1; then		\
 		VALGRIND=--with-valgrind;	\
 	fi;					\
@@ -49,6 +51,7 @@ noise: $(CTAGS_TEST)
 #
 chop: $(CTAGS_TEST)
 	@ \
+	if test -n "$${ZSH_VERSION+set}"; then set -o SH_WORD_SPLIT; fi; \
 	if test x$(VG) = x1; then		\
 		VALGRIND=--with-valgrind;	\
 	fi;					\
@@ -66,6 +69,7 @@ chop: $(CTAGS_TEST)
 units: TIMEOUT := $(shell timeout --version > /dev/null 2>&1 && echo 5 || echo 0)
 units: $(CTAGS_TEST)
 	@ \
+	if test -n "$${ZSH_VERSION+set}"; then set -o SH_WORD_SPLIT; fi; \
 	if test x$(VG) = x1; then		\
 		VALGRIND=--with-valgrind;	\
 	fi;					\
@@ -97,6 +101,7 @@ clean-units:
 tmain: $(CTAGS_TEST)
 	@ \
 	\
+	if test -n "$${ZSH_VERSION+set}"; then set -o SH_WORD_SPLIT; fi; \
 	if test x$(VG) = x1; then		\
 		VALGRIND=--with-valgrind;	\
 	fi;					\

--- a/misc/units
+++ b/misc/units
@@ -17,6 +17,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+if test -n "${ZSH_VERSION+set}"; then
+    set -o SH_WORD_SPLIT
+    set +o NOMATCH
+fi
 
 #
 # Global Parameters
@@ -100,11 +104,11 @@ help_help()
 
 ERROR ()
 {
-    local status="$1"
+    local status_="$1"
     local msg="$2"
     shift 2
     echo "$msg" 1>&2
-    exit $status
+    exit $status_
 }
 
 line()
@@ -1507,14 +1511,14 @@ noise_report_line ()
 {
     local pos="$1"
     local len="$2"
-    local status="$3"
+    local status_="$3"
     local how="$4"
 
     local progress_offset=$(( pos % _NOISE_REPORT_MAX_COLUMN ))
     local nspace
 
 
-    if [ $((pos + 1)) -eq "${len}" ] || [ $status -gt 0 ]; then
+    if [ $((pos + 1)) -eq "${len}" ] || [ $status_ -gt 0 ]; then
 	nspace=0
 	while [ $nspace -lt $(( _NOISE_REPORT_MAX_COLUMN - progress_offset - 1)) ]; do
 	    printf ' '
@@ -1762,7 +1766,7 @@ tmain_run ()
 
     local r
     local a
-    local status=0
+    local status_=0
 
     local need_rearrange
 
@@ -1819,7 +1823,7 @@ tmain_run ()
 		    rm ${build_subdir}/${aspect}-actual.txt
 		else
 		    failed="${failed} ${test_name}/${aspect}-${engine}"
-		    status=1
+		    status_=1
 		fi
 	    elif [ -f ${build_subdir}/${aspect}-actual.txt ]; then
 		     rm ${build_subdir}/${aspect}-actual.txt
@@ -1846,7 +1850,7 @@ tmain_run ()
 	fi
     fi
 
-    return $status
+    return $status_
 }
 
 action_tmain ()


### PR DESCRIPTION
Allow to run units and tmain targets on zsh.
Issue reported by @tarzanek on #721.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>