### PR TITLE
buildsys: make an empty repoinfo.h when building ctags from tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,7 +44,7 @@ $(REPOINFO_HEADS): $(srcdir)/.git/*
 endif
 if !BUILD_IN_GIT_REPO
 $(REPOINFO_HEADS):
-	echo 0 > $@
+	echo > $@
 endif
 
 OPTLIB2C = $(srcdir)/misc/optlib2c

--- a/main/repoinfo.c
+++ b/main/repoinfo.c
@@ -1,8 +1,12 @@
 #include "general.h"
 #include "ctags.h"
+
 #ifdef HAVE_REPOINFO_H
 #include "main/repoinfo.h"
-#else
+#endif
+
+#ifndef CTAGS_REPOINFO
 #define CTAGS_REPOINFO ((char*)0)
 #endif
+
 const char* ctags_repoinfo = CTAGS_REPOINFO;


### PR DESCRIPTION
repoinfo.h was general even when building ctags from tarball.  As
reported by @hauleth in #727, code snippet in Makefile.am made broken
repoinfo.h. This commit improves the situation.

The code snippet in Makefile.am in this commit make an empty repoinfo.h.
Instead CTAGS_REPOINFO is defined as NULL in repoinfo.c if CTAGS_REPOINFO
is not defined.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>