### PR TITLE
sh: Add support for extra Bash function identifiers

### DIFF
--- a/Units/parser-sh.r/function-identifiers-bash.d/expected.tags
+++ b/Units/parser-sh.r/function-identifiers-bash.d/expected.tags
@@ -1,0 +1,113 @@
+foo!bar	input.bash	/^function foo!bar() { echo 'foo!bar'; }$/;"	f
+foo#bar	input.bash	/^function foo#bar() { echo 'foo#bar'; }$/;"	f
+foo%bar	input.bash	/^function foo%bar() { echo 'foo%bar'; }$/;"	f
+foo*bar	input.bash	/^function foo*bar() { echo 'foo*bar'; }$/;"	f
+foo+bar	input.bash	/^function foo+bar() { echo 'foo+bar'; }$/;"	f
+foo,bar	input.bash	/^function foo,bar() { echo 'foo,bar'; }$/;"	f
+foo-bar	input.bash	/^function foo-bar() { echo 'foo-bar'; }$/;"	f
+foo.bar	input.bash	/^function foo.bar() { echo 'foo.bar'; }$/;"	f
+foo/bar	input.bash	/^function foo\/bar() { echo 'foo\/bar'; }$/;"	f
+foo0bar	input.bash	/^function foo0bar() { echo 'foo0bar'; }$/;"	f
+foo1bar	input.bash	/^function foo1bar() { echo 'foo1bar'; }$/;"	f
+foo2bar	input.bash	/^function foo2bar() { echo 'foo2bar'; }$/;"	f
+foo3bar	input.bash	/^function foo3bar() { echo 'foo3bar'; }$/;"	f
+foo4bar	input.bash	/^function foo4bar() { echo 'foo4bar'; }$/;"	f
+foo5bar	input.bash	/^function foo5bar() { echo 'foo5bar'; }$/;"	f
+foo6bar	input.bash	/^function foo6bar() { echo 'foo6bar'; }$/;"	f
+foo7bar	input.bash	/^function foo7bar() { echo 'foo7bar'; }$/;"	f
+foo8bar	input.bash	/^function foo8bar() { echo 'foo8bar'; }$/;"	f
+foo9bar	input.bash	/^function foo9bar() { echo 'foo9bar'; }$/;"	f
+foo:bar	input.bash	/^function foo:bar() { echo 'foo:bar'; }$/;"	f
+foo=bar	input.bash	/^function foo=bar() { echo 'foo=bar'; }$/;"	f
+foo?bar	input.bash	/^function foo?bar() { echo 'foo?bar'; }$/;"	f
+foo@bar	input.bash	/^function foo@bar() { echo 'foo@bar'; }$/;"	f
+fooAbar	input.bash	/^function fooAbar() { echo 'fooAbar'; }$/;"	f
+fooBbar	input.bash	/^function fooBbar() { echo 'fooBbar'; }$/;"	f
+fooCbar	input.bash	/^function fooCbar() { echo 'fooCbar'; }$/;"	f
+fooDbar	input.bash	/^function fooDbar() { echo 'fooDbar'; }$/;"	f
+fooEbar	input.bash	/^function fooEbar() { echo 'fooEbar'; }$/;"	f
+fooFbar	input.bash	/^function fooFbar() { echo 'fooFbar'; }$/;"	f
+fooGbar	input.bash	/^function fooGbar() { echo 'fooGbar'; }$/;"	f
+fooHbar	input.bash	/^function fooHbar() { echo 'fooHbar'; }$/;"	f
+fooIbar	input.bash	/^function fooIbar() { echo 'fooIbar'; }$/;"	f
+fooJbar	input.bash	/^function fooJbar() { echo 'fooJbar'; }$/;"	f
+fooKbar	input.bash	/^function fooKbar() { echo 'fooKbar'; }$/;"	f
+fooLbar	input.bash	/^function fooLbar() { echo 'fooLbar'; }$/;"	f
+fooMbar	input.bash	/^function fooMbar() { echo 'fooMbar'; }$/;"	f
+fooNbar	input.bash	/^function fooNbar() { echo 'fooNbar'; }$/;"	f
+fooObar	input.bash	/^function fooObar() { echo 'fooObar'; }$/;"	f
+fooPbar	input.bash	/^function fooPbar() { echo 'fooPbar'; }$/;"	f
+fooQbar	input.bash	/^function fooQbar() { echo 'fooQbar'; }$/;"	f
+fooRbar	input.bash	/^function fooRbar() { echo 'fooRbar'; }$/;"	f
+fooSbar	input.bash	/^function fooSbar() { echo 'fooSbar'; }$/;"	f
+fooTbar	input.bash	/^function fooTbar() { echo 'fooTbar'; }$/;"	f
+fooUbar	input.bash	/^function fooUbar() { echo 'fooUbar'; }$/;"	f
+fooVbar	input.bash	/^function fooVbar() { echo 'fooVbar'; }$/;"	f
+fooWbar	input.bash	/^function fooWbar() { echo 'fooWbar'; }$/;"	f
+fooXbar	input.bash	/^function fooXbar() { echo 'fooXbar'; }$/;"	f
+fooYbar	input.bash	/^function fooYbar() { echo 'fooYbar'; }$/;"	f
+fooZbar	input.bash	/^function fooZbar() { echo 'fooZbar'; }$/;"	f
+foo[bar	input.bash	/^function foo[bar() { echo 'foo[bar'; }$/;"	f
+foo\abar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\bbar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\fbar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\vbar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x02bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x03bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x04bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x05bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x06bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x0Ebar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x0Fbar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x10bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x11bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x12bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x13bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x14bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x15bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x16bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x17bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x18bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x19bar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x1Abar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x1Bbar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x1Cbar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x1Dbar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x1Ebar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo\x1Fbar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo]bar	input.bash	/^function foo]bar() { echo 'foo]bar'; }$/;"	f
+foo^bar	input.bash	/^function foo^bar() { echo 'foo^bar'; }$/;"	f
+foo_bar	input.bash	/^function foo_bar() { echo 'foo_bar'; }$/;"	f
+fooabar	input.bash	/^function fooabar() { echo 'fooabar'; }$/;"	f
+foobbar	input.bash	/^function foobbar() { echo 'foobbar'; }$/;"	f
+foocbar	input.bash	/^function foocbar() { echo 'foocbar'; }$/;"	f
+foodbar	input.bash	/^function foodbar() { echo 'foodbar'; }$/;"	f
+fooebar	input.bash	/^function fooebar() { echo 'fooebar'; }$/;"	f
+foofbar	input.bash	/^function foofbar() { echo 'foofbar'; }$/;"	f
+foogbar	input.bash	/^function foogbar() { echo 'foogbar'; }$/;"	f
+foohbar	input.bash	/^function foohbar() { echo 'foohbar'; }$/;"	f
+fooibar	input.bash	/^function fooibar() { echo 'fooibar'; }$/;"	f
+foojbar	input.bash	/^function foojbar() { echo 'foojbar'; }$/;"	f
+fookbar	input.bash	/^function fookbar() { echo 'fookbar'; }$/;"	f
+foolbar	input.bash	/^function foolbar() { echo 'foolbar'; }$/;"	f
+foombar	input.bash	/^function foombar() { echo 'foombar'; }$/;"	f
+foonbar	input.bash	/^function foonbar() { echo 'foonbar'; }$/;"	f
+fooobar	input.bash	/^function fooobar() { echo 'fooobar'; }$/;"	f
+foopbar	input.bash	/^function foopbar() { echo 'foopbar'; }$/;"	f
+fooqbar	input.bash	/^function fooqbar() { echo 'fooqbar'; }$/;"	f
+foorbar	input.bash	/^function foorbar() { echo 'foorbar'; }$/;"	f
+foosbar	input.bash	/^function foosbar() { echo 'foosbar'; }$/;"	f
+footbar	input.bash	/^function footbar() { echo 'footbar'; }$/;"	f
+fooubar	input.bash	/^function fooubar() { echo 'fooubar'; }$/;"	f
+foovbar	input.bash	/^function foovbar() { echo 'foovbar'; }$/;"	f
+foowbar	input.bash	/^function foowbar() { echo 'foowbar'; }$/;"	f
+fooxbar	input.bash	/^function fooxbar() { echo 'fooxbar'; }$/;"	f
+fooybar	input.bash	/^function fooybar() { echo 'fooybar'; }$/;"	f
+foozbar	input.bash	/^function foozbar() { echo 'foozbar'; }$/;"	f
+foo{bar	input.bash	/^function foo{bar() { echo 'foo{bar'; }$/;"	f
+foo}bar	input.bash	/^function foo}bar() { echo 'foo}bar'; }$/;"	f
+foo~bar	input.bash	/^function foo~bar() { echo 'foo~bar'; }$/;"	f
+foobar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foobar	input.bash	/^function foobar() { echo 'foobar'; }$/;"	f
+foo bar	input.bash	/^function foo bar() { echo 'foo bar'; }$/;"	f
+fooÿbar	input.bash	/^function fooÿbar() { echo 'fooÿbar'; }$/;"	f

--- a/Units/parser-sh.r/function-identifiers-bash.d/input.bash
+++ b/Units/parser-sh.r/function-identifiers-bash.d/input.bash
@@ -1,0 +1,398 @@
+#~ function foobar() { echo 'foobar'; }
+#~ foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+#~ function foo	bar() { echo 'foo	bar'; }
+#~ foo	bar
+
+#~ function foo
+#~ bar() { echo 'foo
+#~ bar'; }
+#~ foo
+#~ bar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+# CR would actually be allowed by bash, but let's not be crazy
+#~ function foo#~ bar() { echo 'foo#~ bar'; }
+#~ foo#~ bar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+#~ function foo bar() { echo 'foo bar'; }
+#~ foo bar
+
+function foo!bar() { echo 'foo!bar'; }
+foo!bar
+
+#~ function foo\"bar() { echo 'foo"bar'; }
+#~ foo\"bar
+
+function foo#bar() { echo 'foo#bar'; }
+foo#bar
+
+#~ function foo$bar() { echo 'foo$bar'; }
+#~ foo$bar
+
+function foo%bar() { echo 'foo%bar'; }
+foo%bar
+
+#~ function foo&bar() { echo 'foo&bar'; }
+#~ foo&bar
+
+#~ function foo\'bar() { echo "foo'bar"; }
+#~ foo\'bar
+
+#~ function foo(bar() { echo 'foo(bar'; }
+#~ foo(bar
+
+#~ function foo)bar() { echo 'foo)bar'; }
+#~ foo)bar
+
+function foo*bar() { echo 'foo*bar'; }
+foo*bar
+
+function foo+bar() { echo 'foo+bar'; }
+foo+bar
+
+function foo,bar() { echo 'foo,bar'; }
+foo,bar
+
+function foo-bar() { echo 'foo-bar'; }
+foo-bar
+
+function foo.bar() { echo 'foo.bar'; }
+foo.bar
+
+function foo/bar() { echo 'foo/bar'; }
+foo/bar
+
+function foo0bar() { echo 'foo0bar'; }
+foo0bar
+
+function foo1bar() { echo 'foo1bar'; }
+foo1bar
+
+function foo2bar() { echo 'foo2bar'; }
+foo2bar
+
+function foo3bar() { echo 'foo3bar'; }
+foo3bar
+
+function foo4bar() { echo 'foo4bar'; }
+foo4bar
+
+function foo5bar() { echo 'foo5bar'; }
+foo5bar
+
+function foo6bar() { echo 'foo6bar'; }
+foo6bar
+
+function foo7bar() { echo 'foo7bar'; }
+foo7bar
+
+function foo8bar() { echo 'foo8bar'; }
+foo8bar
+
+function foo9bar() { echo 'foo9bar'; }
+foo9bar
+
+function foo:bar() { echo 'foo:bar'; }
+foo:bar
+
+#~ function foo;bar() { echo 'foo;bar'; }
+#~ foo;bar
+
+#~ function foo<bar() { echo 'foo<bar'; }
+#~ foo<bar
+
+function foo=bar() { echo 'foo=bar'; }
+'foo=bar'
+
+#~ function foo>bar() { echo 'foo>bar'; }
+#~ foo>bar
+
+function foo?bar() { echo 'foo?bar'; }
+foo?bar
+
+function foo@bar() { echo 'foo@bar'; }
+foo@bar
+
+function fooAbar() { echo 'fooAbar'; }
+fooAbar
+
+function fooBbar() { echo 'fooBbar'; }
+fooBbar
+
+function fooCbar() { echo 'fooCbar'; }
+fooCbar
+
+function fooDbar() { echo 'fooDbar'; }
+fooDbar
+
+function fooEbar() { echo 'fooEbar'; }
+fooEbar
+
+function fooFbar() { echo 'fooFbar'; }
+fooFbar
+
+function fooGbar() { echo 'fooGbar'; }
+fooGbar
+
+function fooHbar() { echo 'fooHbar'; }
+fooHbar
+
+function fooIbar() { echo 'fooIbar'; }
+fooIbar
+
+function fooJbar() { echo 'fooJbar'; }
+fooJbar
+
+function fooKbar() { echo 'fooKbar'; }
+fooKbar
+
+function fooLbar() { echo 'fooLbar'; }
+fooLbar
+
+function fooMbar() { echo 'fooMbar'; }
+fooMbar
+
+function fooNbar() { echo 'fooNbar'; }
+fooNbar
+
+function fooObar() { echo 'fooObar'; }
+fooObar
+
+function fooPbar() { echo 'fooPbar'; }
+fooPbar
+
+function fooQbar() { echo 'fooQbar'; }
+fooQbar
+
+function fooRbar() { echo 'fooRbar'; }
+fooRbar
+
+function fooSbar() { echo 'fooSbar'; }
+fooSbar
+
+function fooTbar() { echo 'fooTbar'; }
+fooTbar
+
+function fooUbar() { echo 'fooUbar'; }
+fooUbar
+
+function fooVbar() { echo 'fooVbar'; }
+fooVbar
+
+function fooWbar() { echo 'fooWbar'; }
+fooWbar
+
+function fooXbar() { echo 'fooXbar'; }
+fooXbar
+
+function fooYbar() { echo 'fooYbar'; }
+fooYbar
+
+function fooZbar() { echo 'fooZbar'; }
+fooZbar
+
+function foo[bar() { echo 'foo[bar'; }
+'foo[bar'
+
+#~ function foo\bar() { echo 'foo\bar'; }
+#~ foo\bar
+
+function foo]bar() { echo 'foo]bar'; }
+'foo]bar'
+
+function foo^bar() { echo 'foo^bar'; }
+foo^bar
+
+function foo_bar() { echo 'foo_bar'; }
+foo_bar
+
+#~ function foo`bar() { echo 'foo`bar'; }
+#~ foo`bar
+
+function fooabar() { echo 'fooabar'; }
+fooabar
+
+function foobbar() { echo 'foobbar'; }
+foobbar
+
+function foocbar() { echo 'foocbar'; }
+foocbar
+
+function foodbar() { echo 'foodbar'; }
+foodbar
+
+function fooebar() { echo 'fooebar'; }
+fooebar
+
+function foofbar() { echo 'foofbar'; }
+foofbar
+
+function foogbar() { echo 'foogbar'; }
+foogbar
+
+function foohbar() { echo 'foohbar'; }
+foohbar
+
+function fooibar() { echo 'fooibar'; }
+fooibar
+
+function foojbar() { echo 'foojbar'; }
+foojbar
+
+function fookbar() { echo 'fookbar'; }
+fookbar
+
+function foolbar() { echo 'foolbar'; }
+foolbar
+
+function foombar() { echo 'foombar'; }
+foombar
+
+function foonbar() { echo 'foonbar'; }
+foonbar
+
+function fooobar() { echo 'fooobar'; }
+fooobar
+
+function foopbar() { echo 'foopbar'; }
+foopbar
+
+function fooqbar() { echo 'fooqbar'; }
+fooqbar
+
+function foorbar() { echo 'foorbar'; }
+foorbar
+
+function foosbar() { echo 'foosbar'; }
+foosbar
+
+function footbar() { echo 'footbar'; }
+footbar
+
+function fooubar() { echo 'fooubar'; }
+fooubar
+
+function foovbar() { echo 'foovbar'; }
+foovbar
+
+function foowbar() { echo 'foowbar'; }
+foowbar
+
+function fooxbar() { echo 'fooxbar'; }
+fooxbar
+
+function fooybar() { echo 'fooybar'; }
+fooybar
+
+function foozbar() { echo 'foozbar'; }
+foozbar
+
+function foo{bar() { echo 'foo{bar'; }
+foo{bar
+
+function foo}bar() { echo 'foo}bar'; }
+foo}bar
+
+function foo~bar() { echo 'foo~bar'; }
+foo~bar
+
+#~ function foobar() { echo 'foobar'; }
+#~ foobar
+
+# UTF-8
+
+function foobar() { echo 'foobar'; }
+foobar
+
+function foobar() { echo 'foobar'; }
+foobar
+
+# ...
+# and some printable stuff, too
+
+function foo bar() { echo 'foo bar'; }
+foo bar
+
+function fooÿbar() { echo 'fooÿbar'; }
+fooÿbar


### PR DESCRIPTION
Recognize all the crazy stuff Bash allows as function identifiers when
using the `function` keyword.