### PR TITLE
Java: implement `imported' role

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -11,6 +11,7 @@ C++	h	local	local header	on
 DTS	d	undef	undefined	on
 DTS	h	system	system header	on
 DTS	h	local	local header	on
+Java	p	imported	imported package	on
 Make	I	generic	non-categorized generic role	on
 Make	I	optional	included as an optional makefile	on
 Sh	s	generic	non-categorized generic role	on
@@ -30,6 +31,7 @@ C++	h	local	local header	on
 DTS	d	undef	undefined	on
 DTS	h	system	system header	on
 DTS	h	local	local header	on
+Java	p	imported	imported package	on
 Make	I	generic	non-categorized generic role	on
 Make	I	optional	included as an optional makefile	on
 Sh	s	generic	non-categorized generic role	on

--- a/Units/parser-java.r/imported-role.d/args.ctags
+++ b/Units/parser-java.r/imported-role.d/args.ctags
@@ -1,0 +1,3 @@
+--extra=+r
+--fields=+r
+--sort=no

--- a/Units/parser-java.r/imported-role.d/expected.tags
+++ b/Units/parser-java.r/imported-role.d/expected.tags
@@ -1,0 +1,3 @@
+java.util.Map	input.java	/^import java.util.Map;$/;"	p	role:imported
+java.util.*	input.java	/^import java.util.*;$/;"	p	role:imported
+X	input.java	/^package X;$/;"	p

--- a/Units/parser-java.r/imported-role.d/input.java
+++ b/Units/parser-java.r/imported-role.d/input.java
@@ -1,0 +1,3 @@
+import java.util.Map;
+import java.util.*;
+package X;


### PR DESCRIPTION
Packages imported with keyword `import' are tagged as reference tags
with this commit. The wild-card(*) used in package specification is
recorded asis.

Example output:

    [yamato@x201]~/var/ctags-github% cat foo.java
    import java.util.Map;
    import java.util.*;

    package X;

    [yamato@x201]~/var/ctags-github% ./ctags --fields=+r --extra=+r -o - foo.java
    X	foo.java	/^package X;$/;"	p
    java.util.*	foo.java	/^import java.util.*;$/;"	p	role:imported
    java.util.Map	foo.java	/^import java.util.Map;$/;"	p	role:imported

Signed-off-by: Masatake YAMATO <yamato@redhat.com>