### PR TITLE
buildsys: add --enable-debugging option and disable debugging by default

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,9 @@ MAIN_HEADS += $(REGEX_HEADS)
 endif
 
 ctags_CPPFLAGS = -I. -I$(srcdir) -I$(srcdir)/main
+if ENABLE_DEBUGGING
 ctags_CPPFLAGS+= $(DEBUG_CPPFLAGS)
+endif
 ctags_CPPFLAGS+= $(FNMATCH_CPPFLAGS)
 ctags_CPPFLAGS+= $(REGCOMP_CPPFLAGS)
 ctags_CPPFLAGS+= -DHAVE_REPOINFO_H

--- a/configure.ac
+++ b/configure.ac
@@ -204,6 +204,10 @@ AC_ARG_WITH([ctags-libexecdir],
 	[AS_HELP_STRING([--with-ctags-libexecdir=DIR],
 		['universal-ctags'-specific program executables [LIBEXECDIR/ctags]])])
 
+AC_ARG_ENABLE([debugging],
+	[AS_HELP_STRING([--enable-debugging],
+		[enable debugging features])])
+
 AC_ARG_PROGRAM
 
 # Process configuration options
@@ -263,6 +267,9 @@ if test "$enable_macro_patterns" = yes ; then
 	AC_DEFINE(MACROS_USE_PATTERNS)
 	AC_MSG_NOTICE(tag file will use patterns for macros by default)
 fi
+
+AM_CONDITIONAL(ENABLE_DEBUGGING, [test "x$enable_debugging" = "xyes"])
+
 
 # Checks for programs
 # -------------------

--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -17,7 +17,7 @@ make --version
 
 ./autogen.sh
 
-./configure --enable-iconv --enable-coverage-gcov
+./configure --enable-debugging --enable-iconv --enable-coverage-gcov
 
 if [ "$TARGET" = "Unix" ]; then
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CC" = "gcc" ]; then


### PR DESCRIPTION
-DDEBUG option was passed by default.  This flag slows ctags down;
whole the buffer area of a vString object is filled with 0 every
vStringClear call.

With this commit -DDEBUG is not passed by default.  To enable it,
--enable-debugging must be passed when running configure.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>