### PR TITLE
C++: Avoid reporting function prototypes inside a function body

### DIFF
--- a/Units/parser-cpp.r/variables-prototypes-2.cpp.b/args.ctags
+++ b/Units/parser-cpp.r/variables-prototypes-2.cpp.b/args.ctags
@@ -1,0 +1,2 @@
+--c++-kinds=+plv
+--fields=SKn

--- a/Units/parser-cpp.r/variables-prototypes-2.cpp.b/expected.tags
+++ b/Units/parser-cpp.r/variables-prototypes-2.cpp.b/expected.tags
@@ -1,0 +1,3 @@
+listOfStrings	input.cpp	/^	List<String> listOfStrings(argv); \/\/ local$/;"	local	line:4
+main	input.cpp	/^int  main( int  argc, char ** argv )$/;"	function	line:1	signature:( int argc, char ** argv )
+sample	input.cpp	/^	String sample(argc); \/\/ local$/;"	local	line:3

--- a/Units/parser-cpp.r/variables-prototypes-2.cpp.b/input.cpp
+++ b/Units/parser-cpp.r/variables-prototypes-2.cpp.b/input.cpp
@@ -1,0 +1,11 @@
+int  main( int  argc, char ** argv )
+{
+	String sample(argc); // local
+	List<String> listOfStrings(argv); // local
+
+	foreach(String * p,listOfStrings) // NOT a prototype
+	{
+		p->dump(); // NOT a prototype
+	}
+
+}


### PR DESCRIPTION
Avoid reporting function prototypes inside a function body. This fixes cases like:

int something()
{
    foreach(...something)
    {
    }
}

in that foreach() would be reported as a prototype.

Also adds the ability to tag local variable instantiations:

int something()
{
   QString test(some,parameters);
}

