### PR TITLE
C++: add missing array entry in declString

### DIFF
--- a/parsers/c.c
+++ b/parsers/c.c
@@ -769,7 +769,7 @@ static const char *declString (const declType declaration)
 {
 	static const char *const names [] = {
 		"?", "base", "class", "enum", "event", "function", "function template",
-		"ignore", "interface", "mixin", "namespace", "no mangle", "package",
+		"ignore", "interface", "mixin", "namespace", "no mangle", "package", "package ref",
 		"private", "program", "protected", "public", "struct", "task", "template",
 		"union", "using", "version", "annotation"
 	};


### PR DESCRIPTION
Add a missing entry in the declString array. Fixes debug mode runs.