### PR TITLE
Use stderr for MS-DOS/Windows.

### DIFF
--- a/main/e_msoft.h
+++ b/main/e_msoft.h
@@ -9,11 +9,6 @@
 #ifndef E_MSOFT_H
 #define E_MSOFT_H
 
-/*  MS-DOS/Windows doesn't allow manipulation of standard error,
- *  so we send it to stdout instead.
- */
-#define errout  stdout
-
 #define CASE_INSENSITIVE_FILENAMES 1
 #define MANUAL_GLOBBING 1
 #define MSDOS_STYLE_PATH 1


### PR DESCRIPTION
There's no longer a reason to use stdout instead of stderr, as djgpp (if you still support DOS at all, I guess this is what you're using) provides `redir` expressly for the purpose of manipulating
standard error and `CMD.EXE` supports `2>` directly.