### PR TITLE
passing parserDefinition to its parser call back function

### DIFF
--- a/main/lregex.c
+++ b/main/lregex.c
@@ -757,9 +757,11 @@ static int fileReadLineDriver(void)
 	return (readLineFromInputFile () == NULL)? EOF: 1;
 }
 
-extern void findRegexTags (void)
+extern rescanReason findRegexTags (parserDefinition *parser __unused__,
+				   const unsigned int passCount __unused__)
 {
 	findRegexTagsMainloop (fileReadLineDriver);
+	return RESCAN_NONE;
 }
 
 extern boolean hasScopeActionInRegex (const langType language)

--- a/main/parse.c
+++ b/main/parse.c
@@ -1169,7 +1169,7 @@ extern void freeParserResources (void)
 		parserDefinition* const lang = LanguageTable [i];
 
 		if (lang->finalize)
-			(lang->finalize)((langType)i, (boolean)lang->initialized);
+			(lang->finalize)(lang, (boolean)lang->initialized);
 		if (lang->fileKind != &defaultFileKind)
 		{
 			eFree (lang->fileKind);
@@ -1198,7 +1198,7 @@ static rescanReason doNothing (parserDefinition *parser __unused__,
 
 static void lazyInitialize (parserDefinition* parser)
 {
-	Assert (0 <= parser->language  &&  parser->language < (int) LanguageCount);
+	Assert (0 <= parser->id  &&  parser->id < (int) LanguageCount);
 
 	parser->parser = doNothing;
 

--- a/main/parse.c
+++ b/main/parse.c
@@ -1115,7 +1115,7 @@ static void initializeParser (langType lang)
 
 	if ((parser->initialize != NULL) && (parser->initialized == FALSE))
 	{
-		parser->initialize (lang);
+		parser->initialize (parser);
 		parser->initialized = TRUE;
 	}
 
@@ -1196,17 +1196,14 @@ static rescanReason doNothing (parserDefinition *parser __unused__,
 	return RESCAN_NONE;
 }
 
-static void lazyInitialize (langType language)
+static void lazyInitialize (parserDefinition* parser)
 {
-	parserDefinition* lang;
+	Assert (0 <= parser->language  &&  parser->language < (int) LanguageCount);
 
-	Assert (0 <= language  &&  language < (int) LanguageCount);
-	lang = LanguageTable [language];
+	parser->parser = doNothing;
 
-	lang->parser = doNothing;
-
-	if (lang->method & METHOD_REGEX)
-		lang->parser = findRegexTags;
+	if (parser->method & METHOD_REGEX)
+		parser->parser = findRegexTags;
 }
 
 /*

--- a/main/parse.h
+++ b/main/parse.h
@@ -36,6 +36,7 @@
 *   DATA DECLARATIONS
 */
 typedef int langType;
+typedef struct sParserDefinition parserDefinition;
 
 typedef enum {
 	RESCAN_NONE,   /* No rescan needed */
@@ -44,9 +45,9 @@ typedef enum {
 } rescanReason;
 
 typedef void (*createRegexTag) (const vString* const name);
-typedef void (*simpleParser) (void);
-typedef rescanReason (*rescanParser) (const unsigned int passCount);
-typedef void (*parserInitialize) (langType language);
+typedef rescanReason (* parseFunc) (parserDefinition *parser,
+				    const unsigned int passCount);
+typedef void (*parserInitialize) (parserDefinition *parser);
 
 /* Per language finalizer is called anytime when ctags exits.
    (Exceptions are a kind of options are given when invoked. Here
@@ -81,16 +82,20 @@ typedef struct sTagXpathMakeTagSpec {
 	int   kind;
 	int   role;
 	/* If make is NULL, just makeTagEntry is used instead. */
-	void (*make) (xmlNode *node,
+	void (*make) (parserDefinition * parser,
+		      xmlNode *node,
 		      const struct sTagXpathMakeTagSpec *spec,
 		      struct sTagEntryInfo *tag,
+		      const unsigned int passCount,
 		      void *userData);
 } tagXpathMakeTagSpec;
 
 typedef struct sTagXpathRecurSpec {
-	void (*enter) (xmlNode *node,
+	void (*enter) (parserDefinition * parser,
+		       xmlNode *node,
 		       const struct sTagXpathRecurSpec *spec,
 		       xmlXPathContext *ctx,
+		       const unsigned int passCount,
 		       void *userData);
 } tagXpathRecurSpec;
 
@@ -116,7 +121,7 @@ typedef struct {
 	const int id;
 } keywordTable;
 
-typedef struct {
+struct sParserDefinition {
 	/* defined by parser */
 	char* name;                    /* name of language */
 	kindOption* kinds;             /* tag kinds handled by parser */
@@ -127,8 +132,7 @@ typedef struct {
 	const char *const *aliases;    /* list of default aliases (alternative names) */
 	parserInitialize initialize;   /* initialization routine, if needed */
 	parserFinalize finalize;       /* finalize routine, if needed */
-	simpleParser parser;           /* simple parser (common case) */
-	rescanParser parser2;          /* rescanning parser (unusual case) */
+	parseFunc parser;
 	selectLanguage* selectLanguage; /* may be used to resolve conflicts */
 	unsigned int method;           /* See PARSE__... definitions above */
 	boolean useCork;
@@ -152,7 +156,7 @@ typedef struct {
 	stringList* currentPatterns;   /* current list of file name patterns */
 	stringList* currentExtensions; /* current list of extensions */
 	stringList* currentAliaes;     /* current list of aliases */
-} parserDefinition;
+};
 
 typedef parserDefinition* (parserDefinitionFunc) (void);
 
@@ -224,7 +228,8 @@ extern void freeEncodingResources (void);
 extern void installKeywordTable (const langType language);
 
 /* Regex interface */
-extern void findRegexTags (void);
+extern rescanReason findRegexTags (parserDefinition *parser,
+				   const unsigned int passCount);
 extern void findRegexTagsMainloop (int (* driver)(void));
 extern boolean matchRegex (const vString* const line, const langType language);
 extern void addLanguageRegex (const langType language, const char* const regex);
@@ -257,9 +262,12 @@ extern void useXcmdMethod (const langType language);
 extern void notifyAvailabilityXcmdMethod (const langType language);
 
 /* Xpath interface */
-extern void findXMLTags (xmlXPathContext *ctx, xmlNode *root,
-			 const tagXpathTableTable *xpathTableTable,
-			 const kindOption* const kinds, void *userData);
+extern rescanReason findXMLTags (parserDefinition *parser,
+				 xmlXPathContext *ctx, xmlNode *root,
+				 const tagXpathTableTable *xpathTableTable,
+				 const kindOption* const kinds,
+				 const unsigned int passCount,
+				 void *userData);
 extern void installTagXpathTable (const langType language);
 extern void addTagXpath (const langType language, tagXpathTable *xpathTable);
 

--- a/main/parse.h
+++ b/main/parse.h
@@ -58,7 +58,7 @@ typedef void (*parserInitialize) (parserDefinition *parser);
    whether the assoiciated initializer is invoked or not with the
    second parameter: INITIALIZED. If it is true, the initializer
    is called. */
-typedef void (*parserFinalize) (langType language, boolean initialized);
+typedef void (*parserFinalize) (parserDefinition *parser, boolean initialized);
 
 typedef const char * (*selectLanguage) (FILE *);
 

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -486,7 +486,7 @@ emit_initializer()
 	local c
 
 	cat <<EOF
-static void initialize${CTAGS_LANG_IN_C}Parser (const langType language)
+static void initialize${CTAGS_LANG_IN_C}Parser (parserDefinition *parser)
 {
 EOF
 	local i
@@ -500,13 +500,13 @@ EOF
 			fi
 			f=${CTAGS_XCMD_flags[$i]}
 			cat<<EOF
-	addLanguageXcmd (language, "$p$f");
+	addLanguageXcmd (parser->id, "$p$f");
 EOF
 		done
 	fi
 	for c in ${CTAGS_DISABLED_KINDS[@]}; do
 		cat<<EOF
-	enableRegexKind (language, '$c', FALSE);
+	enableRegexKind (parser->id, '$c', FALSE);
 EOF
 	done
 	cat<<EOF

--- a/optlib/CoffeeScript.c
+++ b/optlib/CoffeeScript.c
@@ -6,9 +6,9 @@
 #include "routines.h"
 
 
-static void initializeCoffeeScriptParser (const langType language)
+static void initializeCoffeeScriptParser (parserDefinition *parser)
 {
-	addLanguageXcmd (language, "coffeetags");
+	addLanguageXcmd (parser->id, "coffeetags");
 }
 
 extern parserDefinition* CoffeeScriptParser (void)

--- a/optlib/ctags-optlib.c
+++ b/optlib/ctags-optlib.c
@@ -6,7 +6,7 @@
 #include "routines.h"
 
 
-static void initializeCtagsParser (const langType language)
+static void initializeCtagsParser (parserDefinition *parser)
 {
 }
 

--- a/optlib/gdbinit.c
+++ b/optlib/gdbinit.c
@@ -6,10 +6,10 @@
 #include "routines.h"
 
 
-static void initializeGdbinitParser (const langType language)
+static void initializeGdbinitParser (parserDefinition *parser)
 {
-	enableRegexKind (language, 'D', FALSE);
-	enableRegexKind (language, 'l', FALSE);
+	enableRegexKind (parser->id, 'D', FALSE);
+	enableRegexKind (parser->id, 'l', FALSE);
 }
 
 extern parserDefinition* GdbinitParser (void)

--- a/optlib/m4.c
+++ b/optlib/m4.c
@@ -6,9 +6,9 @@
 #include "routines.h"
 
 
-static void initializeM4Parser (const langType language)
+static void initializeM4Parser (parserDefinition *parser)
 {
-	enableRegexKind (language, 'I', FALSE);
+	enableRegexKind (parser->id, 'I', FALSE);
 }
 
 extern parserDefinition* M4Parser (void)

--- a/parsers/ada.c
+++ b/parsers/ada.c
@@ -345,7 +345,8 @@ static adaTokenInfo *adaParse(adaParseMode mode, adaTokenInfo *parent);
 
 /* prototypes of the functions used by ctags */
 static void storeAdaTags(adaTokenInfo *token, const char *parentScope);
-static void findAdaTags(void);
+static rescanReason findAdaTags(parserDefinition *parser,
+				const unsigned int passCount);
 extern parserDefinition* AdaParser(void);
 
 static void makeSpec(adaKind *kind)
@@ -2170,7 +2171,8 @@ static void storeAdaTags(adaTokenInfo *token, const char *parentScope)
 } /* static void storeAdaTags(adaTokenInfo *token, const char *parentScope) */
 
 /* main parse function */
-static void findAdaTags(void)
+static rescanReason findAdaTags(parserDefinition *parser __unused__,
+				const unsigned int passCount __unused__)
 {
   adaTokenInfo root;
   adaTokenInfo *tmp;
@@ -2214,6 +2216,7 @@ static void findAdaTags(void)
  out:
   /* clean up tokens */
   freeAdaTokenList(&root.children);
+  return RESCAN_NONE;
 } /* static void findAdaTags(void) */
 
 /* parser definition function */

--- a/parsers/ant.c
+++ b/parsers/ant.c
@@ -25,25 +25,35 @@
 /*
 *   FUNCTION PROTOTYPES
 */
-static void antFindTagsUnderProject (xmlNode *node,
+static void antFindTagsUnderProject (parserDefinition * parser,
+				     xmlNode *node,
 				     const struct sTagXpathRecurSpec *spec,
 				     xmlXPathContext *ctx,
+				     const unsigned int passCount,
 				     void *userData);
-static void antFindTagsUnderTask (xmlNode *node,
+static void antFindTagsUnderTask (parserDefinition * parser,
+				  xmlNode *node,
 				  const struct sTagXpathRecurSpec *spec,
 				  xmlXPathContext *ctx,
+				  const unsigned int passCount,
 				  void *userData);
-static void makeTagForProjectName (xmlNode *node,
+static void makeTagForProjectName (parserDefinition * parser,
+				   xmlNode *node,
 				   const struct sTagXpathMakeTagSpec *spec,
 				   struct sTagEntryInfo *tag,
+				   const unsigned int passCount,
 				   void *userData);
-static void makeTagForTargetName (xmlNode *node,
+static void makeTagForTargetName (parserDefinition * parser,
+				  xmlNode *node,
 				  const struct sTagXpathMakeTagSpec *spec,
 				  struct sTagEntryInfo *tag,
+				  const unsigned int passCount,
 				  void *userData);
-static void makeTagWithScope (xmlNode *node,
+static void makeTagWithScope (parserDefinition * parser,
+			      xmlNode *node,
 			      const struct sTagXpathMakeTagSpec *spec,
 			      struct sTagEntryInfo *tag,
+			      const unsigned int passCount,
 			      void *userData);
 #endif
 
@@ -148,39 +158,48 @@ static const tagRegexTable const antTagRegexTable [] = {
 #ifdef HAVE_LIBXML
 
 static void
-antFindTagsUnderProject (xmlNode *node,
+antFindTagsUnderProject (parserDefinition * parser,
+			 xmlNode *node,
 			 const struct sTagXpathRecurSpec *spec,
 			 xmlXPathContext *ctx,
+			 const unsigned int passCount,
 			 void *userData)
 {
 	int corkIndex = SCOPE_NIL;
 
-	findXMLTags (ctx, node,
+	findXMLTags (parser, ctx, node,
 		     antXpathTableTable + TABLE_MAIN_NAME,
 		     AntKinds,
+		     passCount,
 		     &corkIndex);
-	findXMLTags (ctx, node,
+	findXMLTags (parser, ctx, node,
 		     antXpathTableTable + TABLE_PROJECT,
 		     AntKinds,
+		     passCount,
 		     &corkIndex);
 }
 
-static void antFindTagsUnderTask (xmlNode *node,
+static void antFindTagsUnderTask (parserDefinition * parser,
+				  xmlNode *node,
 				  const struct sTagXpathRecurSpec *spec,
 				  xmlXPathContext *ctx,
+				  const unsigned int passCount,
 				  void *userData)
 {
 	int corkIndex = *(int *)userData;
 
-	findXMLTags (ctx, node,
+	findXMLTags (parser, ctx, node,
 		     antXpathTableTable + TABLE_TARGET_NAME,
 		     AntKinds,
+		     passCount,
 		     &corkIndex);
 }
 
-static void makeTagForProjectName (xmlNode *node,
+static void makeTagForProjectName (parserDefinition * parser,
+				   xmlNode *node,
 				   const struct sTagXpathMakeTagSpec *spec,
 				   struct sTagEntryInfo *tag,
+				   const unsigned int passCount,
 				   void *userData)
 {
 	int *corkIndex = userData;
@@ -188,9 +207,11 @@ static void makeTagForProjectName (xmlNode *node,
 	*corkIndex = makeTagEntry (tag);
 }
 
-static void makeTagForTargetName (xmlNode *node,
+static void makeTagForTargetName (parserDefinition * parser,
+				  xmlNode *node,
 				  const struct sTagXpathMakeTagSpec *spec,
 				  struct sTagEntryInfo *tag,
+				  const unsigned int passCount,
 				  void *userData)
 {
 	int *corkIndex = (int *)userData;
@@ -203,9 +224,11 @@ static void makeTagForTargetName (xmlNode *node,
 	*corkIndex = makeTagEntry (tag);
 }
 
-static void makeTagWithScope (xmlNode *node,
+static void makeTagWithScope (parserDefinition * parser,
+			      xmlNode *node,
 			      const struct sTagXpathMakeTagSpec *spec,
 			      struct sTagEntryInfo *tag,
+			      const unsigned int passCount,
 			      void *userData)
 {
 	tag->extensionFields.scopeKind  = NULL;
@@ -215,12 +238,13 @@ static void makeTagWithScope (xmlNode *node,
 	makeTagEntry (tag);
 }
 
-static void
-findAntTags (void)
+static rescanReason
+findAntTags (parserDefinition * parser, const unsigned int passCount)
 {
-	findXMLTags (NULL, NULL, antXpathTableTable + TABLE_MAIN,
-		     AntKinds,
-		     NULL);
+	return findXMLTags (parser, NULL, NULL, antXpathTableTable + TABLE_MAIN,
+			    AntKinds,
+			    passCount,
+			    NULL);
 }
 #endif
 

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -252,7 +252,8 @@ static const unsigned char *readOperator (
 	return cp;
 }
 
-static void findAsmTags (void)
+static rescanReason findAsmTags(parserDefinition *parser __unused__,
+				const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	vString *operator = vStringNew ();
@@ -336,6 +337,7 @@ static void findAsmTags (void)
 	}
 	vStringDelete (name);
 	vStringDelete (operator);
+	return RESCAN_NONE;
 }
 
 static void initialize (const langType language)

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -340,9 +340,9 @@ static rescanReason findAsmTags(parserDefinition *parser __unused__,
 	return RESCAN_NONE;
 }
 
-static void initialize (const langType language)
+static void initialize (parserDefinition *parser)
 {
-	Lang_asm = language;
+	Lang_asm = parser->id;
 }
 
 extern parserDefinition* AsmParser (void)

--- a/parsers/asp.c
+++ b/parsers/asp.c
@@ -39,7 +39,8 @@ static kindOption AspKinds [] = {
 *   FUNCTION DEFINITIONS
 */
 
-static void findAspTags (void)
+static rescanReason findAspTags (parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	const unsigned char *line;
@@ -310,6 +311,7 @@ static void findAspTags (void)
 		}
 	}
 	vStringDelete (name);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* AspParser (void)

--- a/parsers/awk.c
+++ b/parsers/awk.c
@@ -34,7 +34,8 @@ static kindOption AwkKinds [] = {
 *   FUNCTION DEFINITIONS
 */
 
-static void findAwkTags (void)
+static rescanReason findAwkTags (parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	const unsigned char *line;
@@ -64,6 +65,7 @@ static void findAwkTags (void)
 		}
 	}
 	vStringDelete (name);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* AwkParser (void)

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -152,7 +152,8 @@ static void match_dot_label (char const *p)
 	}
 }
 
-static void findBasicTags (void)
+static rescanReason findBasicTags (parserDefinition *parser __unused__,
+				   const unsigned int passCount __unused__)
 {
 	const char *line;
 	const char *extension = fileExtension (getInputFileName ());
@@ -187,6 +188,7 @@ static void findBasicTags (void)
 		else
 			match_colon_label (p);
 	}
+	return RESCAN_NONE;
 }
 
 parserDefinition *BasicParser (void)
@@ -196,7 +198,7 @@ parserDefinition *BasicParser (void)
 	def->kinds = BasicKinds;
 	def->kindCount = ARRAY_SIZE (BasicKinds);
 	def->extensions = extensions;
-	def->parser = findBasicTags;
+	def->parser  = findBasicTags;
 	return def;
 }
 

--- a/parsers/beta.c
+++ b/parsers/beta.c
@@ -75,7 +75,8 @@ static void makeBetaTag (const char* const name, const betaKind kind)
 	}
 }
 
-static void findBetaTags (void)
+static rescanReason findBetaTags (parserDefinition *parser __unused__,
+				  const unsigned int passCount __unused__)
 {
 	vString *line = vStringNew ();
 	boolean incomment = FALSE;
@@ -301,6 +302,7 @@ static void findBetaTags (void)
 		inquote = FALSE;  /* This shouldn't really make a difference */
 	} while (c != EOF);
 	vStringDelete (line);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* BetaParser (void)

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3376,7 +3376,8 @@ static void createTags (const unsigned int nestLevel,
 	DebugStatement ( if (nestLevel > 0) debugParseNest (FALSE, nestLevel - 1); )
 }
 
-static rescanReason findCTags (const unsigned int passCount)
+static rescanReason findCTags (parserDefinition *parser __unused__,
+			       const unsigned int passCount)
 {
 	exception_t exception;
 	rescanReason rescan;
@@ -3487,7 +3488,7 @@ extern parserDefinition* CParser (void)
 	def->kinds      = CKinds;
 	def->kindCount  = ARRAY_SIZE (CKinds);
 	def->extensions = extensions;
-	def->parser2    = findCTags;
+	def->parser     = findCTags;
 	def->initialize = initializeCParser;
 	return def;
 }
@@ -3499,7 +3500,7 @@ extern parserDefinition* DParser (void)
 	def->kinds      = DKinds;
 	def->kindCount  = ARRAY_SIZE (DKinds);
 	def->extensions = extensions;
-	def->parser2    = findCTags;
+	def->parser     = findCTags;
 	def->initialize = initializeDParser;
 	return def;
 }
@@ -3521,7 +3522,7 @@ extern parserDefinition* CppParser (void)
 	def->kinds      = CKinds;
 	def->kindCount  = ARRAY_SIZE (CKinds);
 	def->extensions = extensions;
-	def->parser2    = findCTags;
+	def->parser     = findCTags;
 	def->initialize = initializeCppParser;
 	def->selectLanguage = selectors;
 	return def;
@@ -3536,7 +3537,7 @@ extern parserDefinition* CsharpParser (void)
 	def->kindCount  = ARRAY_SIZE (CsharpKinds);
 	def->extensions = extensions;
 	def->aliases    = aliases;
-	def->parser2    = findCTags;
+	def->parser     = findCTags;
 	def->initialize = initializeCsharpParser;
 	return def;
 }
@@ -3548,7 +3549,7 @@ extern parserDefinition* JavaParser (void)
 	def->kinds      = JavaKinds;
 	def->kindCount  = ARRAY_SIZE (JavaKinds);
 	def->extensions = extensions;
-	def->parser2    = findCTags;
+	def->parser     = findCTags;
 	def->initialize = initializeJavaParser;
 	return def;
 }
@@ -3560,7 +3561,7 @@ extern parserDefinition* VeraParser (void)
 	def->kinds      = VeraKinds;
 	def->kindCount  = ARRAY_SIZE (VeraKinds);
 	def->extensions = extensions;
-	def->parser2    = findCTags;
+	def->parser     = findCTags;
 	def->initialize = initializeVeraParser;
 	return def;
 }

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3445,40 +3445,40 @@ static void buildKeywordHash (const langType language, unsigned int idx)
 	}
 }
 
-static void initializeCParser (const langType language)
+static void initializeCParser (parserDefinition* parser)
 {
-	Lang_c = language;
-	buildKeywordHash (language, 0);
+	Lang_c = parser->id;
+	buildKeywordHash (parser->id, 0);
 }
-static void initializeCppParser (const langType language)
+static void initializeCppParser (parserDefinition* parser)
 {
-	Lang_cpp = language;
-	buildKeywordHash (language, 1);
-}
-
-static void initializeCsharpParser (const langType language)
-{
-	Lang_csharp = language;
-	buildKeywordHash (language, 2);
+	Lang_cpp = parser->id;
+	buildKeywordHash (parser->id, 1);
 }
 
-static void initializeDParser (const langType language)
+static void initializeCsharpParser (parserDefinition* parser)
 {
-	Lang_d = language;
-	buildKeywordHash (language, 3);
+	Lang_csharp = parser->id;
+	buildKeywordHash (parser->id, 2);
+}
+
+static void initializeDParser (parserDefinition* parser)
+{
+	Lang_d = parser->id;
+	buildKeywordHash (parser->id, 3);
 }
 
 
-static void initializeJavaParser (const langType language)
+static void initializeJavaParser (parserDefinition* parser)
 {
-	Lang_java = language;
-	buildKeywordHash (language, 4);
+	Lang_java = parser->id;
+	buildKeywordHash (parser->id, 4);
 }
 
-static void initializeVeraParser (const langType language)
+static void initializeVeraParser (parserDefinition* parser)
 {
-	Lang_vera = language;
-	buildKeywordHash (language, 5);
+	Lang_vera = parser->id;
+	buildKeywordHash (parser->id, 5);
 }
 
 extern parserDefinition* CParser (void)

--- a/parsers/clojure.c
+++ b/parsers/clojure.c
@@ -100,7 +100,8 @@ static void skipToSymbol (const char **p)
 		*p = *p + 1;
 }
 
-static void findClojureTags (void)
+static rescanReason findClojureTags (parserDefinition *parser __unused__,
+				     const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	const char *p;
@@ -128,6 +129,7 @@ static void findClojureTags (void)
 		}
 	}
 	vStringDelete (name);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition *ClojureParser (void)
@@ -144,7 +146,7 @@ extern parserDefinition *ClojureParser (void)
 	def->kindCount = ARRAY_SIZE (ClojureKinds);
 	def->extensions = extensions;
 	def->aliases = aliases;
-	def->parser = findClojureTags;
+	def->parser  = findClojureTags;
 	def->useCork = TRUE;
 	return def;
 }

--- a/parsers/css.c
+++ b/parsers/css.c
@@ -155,7 +155,8 @@ static cssKind classifySelector (const vString *const selector)
 	return K_SELECTOR;
 }
 
-static void findCssTags (void)
+static rescanReason findCssTags(parserDefinition *parser __unused__,
+				const unsigned int passCount __unused__)
 {
 	boolean readNextToken = TRUE;
 	tokenInfo token;
@@ -253,6 +254,7 @@ static void findCssTags (void)
 	while (token.type != TOKEN_EOF);
 
 	vStringDelete (token.string);
+	return RESCAN_NONE;
 }
 
 /* parser definition */

--- a/parsers/dbusintrospect.c
+++ b/parsers/dbusintrospect.c
@@ -33,17 +33,23 @@ static kindOption DbusIntrospectKinds [] = {
 	{ TRUE,  'p', "property",  "properties" },
 };
 
-static void dbusIntrospectFindTagsUnderInterface (xmlNode *node,
+static void dbusIntrospectFindTagsUnderInterface (parserDefinition *parser,
+						  xmlNode *node,
 						  const struct sTagXpathRecurSpec *spec,
 						  xmlXPathContext *ctx,
+						  unsigned int passCount,
 						  void *userData);
-static void makeTagForInterfaceName (xmlNode *node,
+static void makeTagForInterfaceName (parserDefinition *parser,
+xmlNode *node,
 				     const struct sTagXpathMakeTagSpec *spec,
 				     struct sTagEntryInfo *tag,
+				     unsigned int passCount,
 				     void *userData);
-static void makeTagWithScope (xmlNode *node,
+static void makeTagWithScope (parserDefinition *parser,
+			      xmlNode *node,
 			      const struct sTagXpathMakeTagSpec *spec,
 			      struct sTagEntryInfo *tag,
+			      unsigned int passCount,
 			      void *userData);
 
 
@@ -101,26 +107,32 @@ static tagXpathTableTable dbusIntrospectXpathTableTable[] = {
 	[TABLE_MAIN_NAME] = { ARRAY_AND_SIZE (dbusIntrospectXpathMainNameTable) },
 };
 
-static void dbusIntrospectFindTagsUnderInterface (xmlNode *node,
+static void dbusIntrospectFindTagsUnderInterface (parserDefinition *parser,
+						  xmlNode *node,
 						  const struct sTagXpathRecurSpec *spec,
 						  xmlXPathContext *ctx,
+						  unsigned int passCount,
 						  void *userData)
 {
 	int corkIndex = SCOPE_NIL;
 
-	findXMLTags (ctx, node,
+	findXMLTags (parser, ctx, node,
 		     dbusIntrospectXpathTableTable + TABLE_MAIN_NAME,
 		     DbusIntrospectKinds,
+		     passCount,
 		     &corkIndex);
-	findXMLTags (ctx, node,
+	findXMLTags (parser, ctx, node,
 		     dbusIntrospectXpathTableTable + TABLE_INTERFACE,
 		     DbusIntrospectKinds,
+		     passCount,
 		     &corkIndex);
 }
 
-static void makeTagWithScope (xmlNode *node,
+static void makeTagWithScope (parserDefinition *parser,
+			      xmlNode *node,
 			      const struct sTagXpathMakeTagSpec *spec,
 			      struct sTagEntryInfo *tag,
+			      unsigned int passCount,
 			      void *userData)
 {
 	tag->extensionFields.scopeKind  = NULL;
@@ -130,9 +142,11 @@ static void makeTagWithScope (xmlNode *node,
 	makeTagEntry (tag);
 }
 
-static void makeTagForInterfaceName (xmlNode *node,
+static void makeTagForInterfaceName (parserDefinition *parser,
+				     xmlNode *node,
 				     const struct sTagXpathMakeTagSpec *spec,
 				     struct sTagEntryInfo *tag,
+				     unsigned int passCount,
 				     void *userData)
 {
 	int *corkIndex = userData;
@@ -140,13 +154,14 @@ static void makeTagForInterfaceName (xmlNode *node,
 	*corkIndex = makeTagEntry (tag);
 }
 
-static void
-findDbusIntrospectTags (void)
+static rescanReason
+findDbusIntrospectTags (parserDefinition *parser, unsigned int passCount)
 {
-	findXMLTags (NULL, NULL,
-		     dbusIntrospectXpathTableTable + TABLE_MAIN,
-		     DbusIntrospectKinds,
-		     NULL);
+	return findXMLTags (parser, NULL, NULL,
+			    dbusIntrospectXpathTableTable + TABLE_MAIN,
+			    DbusIntrospectKinds,
+			    passCount,
+			    NULL);
 }
 
 extern parserDefinition*

--- a/parsers/diff.c
+++ b/parsers/diff.c
@@ -132,7 +132,8 @@ static void markTheLastTagAsDeletedFile (int scope_index)
 	e->kind = &(DiffKinds [K_DELETED_FILE]);
 }
 
-static void findDiffTags (void)
+static rescanReason findDiffTags (parserDefinition *parser __unused__,
+				  const unsigned int passCount __unused__)
 {
 	vString *filename = vStringNew ();
 	vString *hunk = vStringNew ();
@@ -199,6 +200,7 @@ static void findDiffTags (void)
 	}
 	vStringDelete (hunk);
 	vStringDelete (filename);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* DiffParser (void)

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -66,7 +66,8 @@ static const tagRegexTable const dtsTagRegexTable [] = {
 /*
 *   FUNCTION DEFINITIONS
 */
-static void runCppGetc (void)
+static rescanReason runCppGetc (parserDefinition *parser __unused__,
+				const unsigned int passCount __unused__)
 {
 	cppInit (0, FALSE, FALSE,
 		 DTSKinds + DTS_MACRO, DTS_MACRO_KIND_UNDEF_ROLE,
@@ -75,6 +76,7 @@ static void runCppGetc (void)
 	findRegexTagsMainloop (cppGetc);
 
 	cppTerminate ();
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* DTSParser (void)

--- a/parsers/eiffel.c
+++ b/parsers/eiffel.c
@@ -1048,13 +1048,15 @@ static void initialize (const langType language)
 	Lang_eiffel = language;
 }
 
-static void findEiffelTags (void)
+static rescanReason findEiffelTags(parserDefinition *parser __unused__,
+				   const unsigned int passCount __unused__)
 {
 	tokenInfo *const token = newToken ();
 
 	while (findKeyword (token, KEYWORD_class))
 		parseClass (token);
 	deleteToken (token);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* EiffelParser (void)

--- a/parsers/eiffel.c
+++ b/parsers/eiffel.c
@@ -1043,9 +1043,9 @@ static void parseClass (tokenInfo *const token)
 	         ! isType (token, TOKEN_EOF));
 }
 
-static void initialize (const langType language)
+static void initialize (parserDefinition* parser)
 {
-	Lang_eiffel = language;
+	Lang_eiffel = parser->id;
 }
 
 static rescanReason findEiffelTags(parserDefinition *parser __unused__,

--- a/parsers/erlang.c
+++ b/parsers/erlang.c
@@ -153,7 +153,8 @@ static void parseDirective (const unsigned char *cp, vString *const module)
 	vStringDelete (directive);
 }
 
-static void findErlangTags (void)
+static rescanReason findErlangTags (parserDefinition *parser __unused__,
+				    const unsigned int passCount __unused__)
 {
 	vString *const module = vStringNew ();
 	const unsigned char *line;
@@ -176,6 +177,7 @@ static void findErlangTags (void)
 			parseFunctionTag (cp, module);
 	}
 	vStringDelete (module);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition *ErlangParser (void)
@@ -185,7 +187,7 @@ extern parserDefinition *ErlangParser (void)
 	def->kinds = ErlangKinds;
 	def->kindCount = ARRAY_SIZE (ErlangKinds);
 	def->extensions = extensions;
-	def->parser = findErlangTags;
+	def->parser  = findErlangTags;
 	return def;
 }
 

--- a/parsers/falcon.c
+++ b/parsers/falcon.c
@@ -60,7 +60,8 @@ static const unsigned char *skipSpace (const unsigned char *cp)
  * Main parsing function
  */
 
-static void findFalconTags (void)
+static rescanReason findFalconTags (parserDefinition *parser __unused__,
+				    const unsigned int passCount __unused__)
 {
     vString *name = vStringNew ();
     const unsigned char *line;
@@ -132,6 +133,7 @@ static void findFalconTags (void)
         }
     }
     vStringDelete (name);
+    return RESCAN_NONE;
 }
 
 /* 

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -2371,10 +2371,10 @@ static void parseFlexFile (tokenInfo *const token)
 	} while (!isEOF (token));
 }
 
-static void initialize (const langType language)
+static void initialize (parserDefinition *parser)
 {
 	Assert (ARRAY_SIZE (FlexKinds) == FLEXTAG_COUNT);
-	Lang_js = language;
+	Lang_js = parser->id;
 }
 
 static rescanReason findFlexTags(parserDefinition *parser __unused__,

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -2377,7 +2377,8 @@ static void initialize (const langType language)
 	Lang_js = language;
 }
 
-static void findFlexTags (void)
+static rescanReason findFlexTags(parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	tokenInfo *const token = newToken ();
 	
@@ -2391,6 +2392,7 @@ static void findFlexTags (void)
 	ClassNames = NULL;
 	FunctionNames = NULL;
 	deleteToken (token);
+	return RESCAN_NONE;
 }
 
 /* Create parser definition structure */

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -2559,9 +2559,9 @@ static rescanReason findFortranTags (parserDefinition *parser __unused__,
 	return rescan;
 }
 
-static void initialize (const langType language)
+static void initialize (parserDefinition *parser)
 {
-	Lang_fortran = language;
+	Lang_fortran = parser->id;
 }
 
 extern parserDefinition* FortranParser (void)

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -2531,7 +2531,8 @@ static void parseProgramUnit (tokenInfo *const token)
 	} while (! isType (token, TOKEN_EOF));
 }
 
-static rescanReason findFortranTags (const unsigned int passCount)
+static rescanReason findFortranTags (parserDefinition *parser __unused__,
+				     const unsigned int passCount)
 {
 	tokenInfo *token;
 	rescanReason rescan;
@@ -2576,7 +2577,7 @@ extern parserDefinition* FortranParser (void)
 	def->kinds      = FortranKinds;
 	def->kindCount  = ARRAY_SIZE (FortranKinds);
 	def->extensions = extensions;
-	def->parser2    = findFortranTags;
+	def->parser     = findFortranTags;
 	def->initialize = initialize;
 	def->keywordTable = FortranKeywordTable;
 	def->keywordCount = ARRAY_SIZE (FortranKeywordTable);

--- a/parsers/glade.c
+++ b/parsers/glade.c
@@ -73,10 +73,11 @@ static tagXpathTableTable gladeXpathTableTable[] = {
 	[TABLE_MAIN] = { ARRAY_AND_SIZE(gladeXpathMainTable) },
 };
 
-static void
-findGladeTags (void)
+static rescanReason
+findGladeTags (parserDefinition *parser, unsigned int passCount)
 {
-	findXMLTags (NULL, NULL, gladeXpathTableTable + TABLE_MAIN, GladeKinds, NULL);
+	return findXMLTags (parser, NULL, NULL, gladeXpathTableTable + TABLE_MAIN, GladeKinds,
+			    passCount, NULL);
 }
 
 extern parserDefinition*

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -131,9 +131,9 @@ static boolean isIdentChar (const int c)
 		(isStartIdentChar (c) || isdigit (c));
 }
 
-static void initialize (const langType language)
+static void initialize (parserDefinition *parser)
 {
-	Lang_go = language;
+	Lang_go = parser->id;
 }
 
 static tokenInfo *newToken (void)

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -794,7 +794,8 @@ static void parseGoFile (tokenInfo *const token)
 	} while (token->type != TOKEN_EOF);
 }
 
-static void findGoTags (void)
+static rescanReason findGoTags (parserDefinition *parser __unused__,
+				const unsigned int passCount __unused__)
 {
 	tokenInfo *const token = newToken ();
 
@@ -803,6 +804,7 @@ static void findGoTags (void)
 	deleteToken (token);
 	vStringDelete (scope);
 	scope = NULL;
+	return RESCAN_NONE;
 }
 
 extern parserDefinition *GoParser (void)

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -1981,7 +1981,8 @@ static void initialize (const langType language)
 	Lang_js = language;
 }
 
-static void findJsTags (void)
+static rescanReason findJsTags (parserDefinition *parser __unused__,
+				const unsigned int passCount __unused__)
 {
 	tokenInfo *const token = newToken ();
 
@@ -1999,6 +2000,7 @@ static void findJsTags (void)
 	deleteToken (token);
 
 	Assert (NextToken == NULL);
+	return RESCAN_NONE;
 }
 
 /* Create parser definition structure */

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -1975,10 +1975,10 @@ static void parseJsFile (tokenInfo *const token)
 	} while (! isType (token, TOKEN_EOF));
 }
 
-static void initialize (const langType language)
+static void initialize (parserDefinition *parser)
 {
 	Assert (ARRAY_SIZE (JsKinds) == JSTAG_COUNT);
-	Lang_js = language;
+	Lang_js = parser->id;
 }
 
 static rescanReason findJsTags (parserDefinition *parser __unused__,

--- a/parsers/json.c
+++ b/parsers/json.c
@@ -357,7 +357,8 @@ static void parseValue (tokenInfo *const token)
 	}
 }
 
-static void findJsonTags (void)
+static rescanReason findJsonTags (parserDefinition *parser __unused__,
+				  const unsigned int passCount __unused__)
 {
 	tokenInfo *const token = newToken ();
 
@@ -372,6 +373,7 @@ static void findJsonTags (void)
 	while (token->type != TOKEN_EOF);
 
 	deleteToken (token);
+	return RESCAN_NONE;
 }
 
 static void initialize (const langType language)

--- a/parsers/json.c
+++ b/parsers/json.c
@@ -376,9 +376,9 @@ static rescanReason findJsonTags (parserDefinition *parser __unused__,
 	return RESCAN_NONE;
 }
 
-static void initialize (const langType language)
+static void initialize (parserDefinition *parser)
 {
-	Lang_json = language;
+	Lang_json = parser->id;
 }
 
 /* Create parser definition structure */

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -76,7 +76,8 @@ static void L_getit (vString *const name, const unsigned char *dbp)
 
 /* Algorithm adapted from from GNU etags.
  */
-static void findLispTags (void)
+static rescanReason findLispTags (parserDefinition *parser __unused__,
+				  const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	const unsigned char* p;
@@ -120,6 +121,7 @@ static void findLispTags (void)
 		}
 	}
 	vStringDelete (name);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* LispParser (void)
@@ -136,7 +138,7 @@ extern parserDefinition* LispParser (void)
 	def->kindCount  = ARRAY_SIZE (LispKinds);
 	def->extensions = extensions;
 	def->aliases = aliases;
-	def->parser     = findLispTags;
+	def->parser    = findLispTags;
 	return def;
 }
 

--- a/parsers/lua.c
+++ b/parsers/lua.c
@@ -126,7 +126,8 @@ static void extract_prev_token (const char *end, const char *begin_sentinel, vSt
 	}
 }
 
-static void findLuaTags (void)
+static rescanReason findLuaTags (parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	const unsigned char *line;
@@ -159,6 +160,7 @@ static void findLuaTags (void)
 		}
 	}
 	vStringDelete (name);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* LuaParser (void)

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -148,7 +148,8 @@ static void readIdentifier (const int first, vString *const id)
 	vStringTerminate (id);
 }
 
-static void findMakeTags (void)
+static rescanReason findMakeTags (parserDefinition *parser __unused__,
+				  const unsigned int passCount __unused__)
 {
 	stringList *identifiers = stringListNew ();
 	boolean newline = TRUE;
@@ -275,6 +276,7 @@ static void findMakeTags (void)
 			variable_possible = FALSE;
 	}
 	stringListDelete (identifiers);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* MakefileParser (void)

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -1073,7 +1073,8 @@ static void globalScope (vString * const ident, objcToken what)
 /*////////////////////////////////////////////////////////////////
 //// Deal with the system                                       */
 
-static void findObjcTags (void)
+static rescanReason findObjcTags (parserDefinition *parser __unused__,
+				  const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	lexingState st;
@@ -1115,6 +1116,8 @@ static void findObjcTags (void)
 	tempName = NULL;
 	prevIdent = NULL;
 	fullMethodName = NULL;
+
+	return RESCAN_NONE;
 }
 
 static void objcInitialize (const langType language)

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -1120,9 +1120,9 @@ static rescanReason findObjcTags (parserDefinition *parser __unused__,
 	return RESCAN_NONE;
 }
 
-static void objcInitialize (const langType language)
+static void objcInitialize (parserDefinition *parser)
 {
-	Lang_ObjectiveC = language;
+	Lang_ObjectiveC = parser->id;
 }
 
 extern parserDefinition *ObjcParser (void)

--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -1848,7 +1848,8 @@ static void clearStack ( void )
 		vStringDelete (stack[i].contextName);
 }
 
-static void findOcamlTags (void)
+static rescanReason findOcamlTags (parserDefinition *parser __unused__,
+				   const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	lexingState st;
@@ -1879,6 +1880,8 @@ static void findOcamlTags (void)
 	vStringDelete (lastModule);
 	vStringDelete (lastClass);
 	clearStack ();
+
+	return RESCAN_NONE;
 }
 
 static void ocamlInitialize (const langType language)

--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -1884,9 +1884,9 @@ static rescanReason findOcamlTags (parserDefinition *parser __unused__,
 	return RESCAN_NONE;
 }
 
-static void ocamlInitialize (const langType language)
+static void ocamlInitialize (parserDefinition *parser)
 {
-	Lang_Ocaml = language;
+	Lang_Ocaml = parser->id;
 
 	initOperatorTable ();
 }

--- a/parsers/pascal.c
+++ b/parsers/pascal.c
@@ -80,7 +80,8 @@ static boolean tail (const char *cp)
  * immediately following the procedure statement; if found, the tag is
  * skipped.
  */
-static void findPascalTags (void)
+static rescanReason findPascalTags (parserDefinition *parser __unused__,
+				    const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	tagEntryInfo tag;
@@ -247,6 +248,8 @@ static void findPascalTags (void)
 		}  /* while not eof */
 	}
 	vStringDelete (name);
+
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* PascalParser (void)

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -266,7 +266,9 @@ static int parseConstantsFromHashRef (const unsigned char *cp,
  * Perl support by Bart Robinson <lomew@cs.utah.edu>
  * Perl sub names: look for /^ [ \t\n]sub [ \t\n]+ [^ \t\n{ (]+/
  */
-static void findPerlTags (void)
+
+static rescanReason findPerlTags (parserDefinition *parser __unused__,
+				  const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	vString *package = NULL;
@@ -521,6 +523,7 @@ END_MAIN_WHILE:
 	vStringDelete (name);
 	if (package != NULL)
 		vStringDelete (package);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* PerlParser (void)

--- a/parsers/perl6.c
+++ b/parsers/perl6.c
@@ -287,8 +287,9 @@ next_line:
         goto next_line;
 }
 
-static void
-findPerl6Tags (void)
+static rescanReason
+findPerl6Tags (parserDefinition *parser __unused__,
+	       const unsigned int passCount __unused__)
 {
     struct p6Ctx ctx;
 
@@ -320,6 +321,7 @@ findPerl6Tags (void)
     }
 
     deinitP6Ctx(&ctx);
+    return RESCAN_NONE;
 }
 
 parserDefinition *

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -1511,14 +1511,14 @@ static rescanReason findZephirTags (parserDefinition *parser __unused__,
 	return RESCAN_NONE;
 }
 
-static void initializePhpParser (const langType language)
+static void initializePhpParser (parserDefinition *parser)
 {
-	Lang_php = language;
+	Lang_php = parser->id;
 }
 
-static void initializeZephirParser (const langType language)
+static void initializeZephirParser (parserDefinition *parser)
 {
-	Lang_zephir = language;
+	Lang_zephir = parser->id;
 }
 
 extern parserDefinition* PhpParser (void)

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -1496,14 +1496,19 @@ static void findTags (boolean startsInPhpMode)
 	deleteToken (token);
 }
 
-static void findPhpTags (void)
+
+static rescanReason findPhpTags (parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	findTags (FALSE);
+	return RESCAN_NONE;
 }
 
-static void findZephirTags (void)
+static rescanReason findZephirTags (parserDefinition *parser __unused__,
+				    const unsigned int passCount __unused__)
 {
 	findTags (TRUE);
+	return RESCAN_NONE;
 }
 
 static void initializePhpParser (const langType language)

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -987,7 +987,8 @@ static boolean matchKeyword (const char *keyword, const char *cp, const char **c
 	return FALSE;
 }
 
-static void findPythonTags (void)
+static rescanReason findPythonTags (parserDefinition *parser __unused__,
+				    const unsigned int passCount __unused__)
 {
 	vString *const continuation = vStringNew ();
 	vString *const name = vStringNew ();
@@ -1144,6 +1145,7 @@ static void findPythonTags (void)
 	vStringDelete (name);
 	vStringDelete (continuation);
 	nestingLevelsFree (nesting_levels);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition *PythonParser (void)

--- a/parsers/r.c
+++ b/parsers/r.c
@@ -53,7 +53,8 @@ static void makeRTag (const vString * const name, rKind kind)
 	makeTagEntry (&e);
 }
 
-static void createRTags (void)
+static rescanReason createRTags (parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	vString *vLine = vStringNew ();
 	vString *name = vStringNew ();
@@ -196,6 +197,8 @@ static void createRTags (void)
 
 	vStringDelete (name);
 	vStringDelete (vLine);
+
+	return RESCAN_NONE;
 }
 
 extern parserDefinition *RParser (void)

--- a/parsers/rst.c
+++ b/parsers/rst.c
@@ -154,7 +154,8 @@ static int utf8_strlen(const char *buf, int buf_len)
 
 
 /* TODO: parse overlining & underlining as distinct sections. */
-static void findRstTags (void)
+static rescanReason findRstTags (parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	fpos_t filepos;
@@ -197,6 +198,7 @@ static void findRstTags (void)
 	}
 	vStringDelete (name);
 	nestingLevelsFree(nestingLevels);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* RstParser (void)

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -377,7 +377,8 @@ static void enterUnnamedScope (void)
 	vStringDelete (name);
 }
 
-static void findRubyTags (void)
+static rescanReason findRubyTags (parserDefinition *parser __unused__,
+				  const unsigned int passCount __unused__)
 {
 	const unsigned char *line;
 	boolean inMultiLineComment = FALSE;
@@ -520,6 +521,8 @@ static void findRubyTags (void)
 		}
 	}
 	nestingLevelsFree (nesting);
+
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* RubyParser (void)

--- a/parsers/rust.c
+++ b/parsers/rust.c
@@ -957,7 +957,8 @@ static void parseBlock (lexerState *lexer, boolean delim, int kind, vString *sco
 	}
 }
 
-static void findRustTags (void)
+static rescanReason findRustTags (parserDefinition *parser __unused__,
+				  const unsigned int passCount __unused__)
 {
 	lexerState lexer;
 	vString* scope = vStringNew();
@@ -967,6 +968,7 @@ static void findRustTags (void)
 	vStringDelete(scope);
 
 	deInitLexer(&lexer);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition *RustParser (void)

--- a/parsers/scheme.c
+++ b/parsers/scheme.c
@@ -53,7 +53,8 @@ static void readIdentifier (vString *const name, const unsigned char *cp)
 	vStringTerminate (name);
 }
 
-static void findSchemeTags (void)
+static rescanReason findSchemeTags (parserDefinition *parser __unused__,
+				    const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	const unsigned char *line;
@@ -107,6 +108,7 @@ static void findSchemeTags (void)
 		}
 	}
 	vStringDelete (name);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* SchemeParser (void)

--- a/parsers/sh.c
+++ b/parsers/sh.c
@@ -99,7 +99,8 @@ static const unsigned char *skipSingleString (const unsigned char *cp)
 	return cp;
 }
 
-static void findShTags (void)
+static rescanReason findShTags (parserDefinition *parser __unused__,
+				const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	const unsigned char *line;
@@ -280,6 +281,7 @@ static void findShTags (void)
 	vStringDelete (name);
 	if (hereDocDelimiter)
 		vStringDelete (hereDocDelimiter);
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* ShParser (void)

--- a/parsers/sml.c
+++ b/parsers/sml.c
@@ -154,7 +154,8 @@ static smlKind findNextIdentifier (const unsigned char **cp)
 	return result;
 }
 
-static void findSmlTags (void)
+static rescanReason findSmlTags (parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	vString *const identifier = vStringNew ();
 	const unsigned char *line;
@@ -203,6 +204,8 @@ static void findSmlTags (void)
 		} while (cp != NULL  &&  strcmp ((const char *) cp, "") != 0);
 	}
 	vStringDelete (identifier);
+
+	return RESCAN_NONE;
 }
 
 extern parserDefinition *SmlParser (void)

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -2354,10 +2354,10 @@ static tokenType parseSqlFile (tokenInfo *const token)
 	return token->type;
 }
 
-static void initialize (const langType language)
+static void initialize (parserDefinition *parser)
 {
 	Assert (ARRAY_SIZE (SqlKinds) == SQLTAG_COUNT);
-	Lang_sql = language;
+	Lang_sql = parser->id;
 }
 
 static rescanReason findSqlTags (parserDefinition *parser __unused__,

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -2360,13 +2360,16 @@ static void initialize (const langType language)
 	Lang_sql = language;
 }
 
-static void findSqlTags (void)
+static rescanReason findSqlTags (parserDefinition *parser __unused__,
+				  const unsigned int passCount __unused__)
 {
 	tokenInfo *const token = newToken ();
 
 	while (parseSqlFile (token) != TOKEN_EOF);
 
 	deleteToken (token);
+
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* SqlParser (void)
@@ -2376,7 +2379,7 @@ extern parserDefinition* SqlParser (void)
 	def->kinds		= SqlKinds;
 	def->kindCount	= ARRAY_SIZE (SqlKinds);
 	def->extensions = extensions;
-	def->parser		= findSqlTags;
+	def->parser	= findSqlTags;
 	def->initialize = initialize;
 	def->keywordTable = SqlKeywordTable;
 	def->keywordCount = ARRAY_SIZE (SqlKeywordTable);

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -57,7 +57,8 @@ static boolean match (const unsigned char *line, const char *word)
 	return (boolean) (strncmp ((const char*) line, word, strlen (word)) == 0);
 }
 
-static void findTclTags (void)
+static rescanReason findTclTags (parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	vString *name = vStringNew ();
 	const unsigned char *line;
@@ -99,6 +100,8 @@ static void findTclTags (void)
 		}
 	}
 	vStringDelete (name);
+
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* TclParser (void)

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -547,7 +547,7 @@ static void initialize (parserDefinition *parser)
 	lastSubSubS = vStringNew();
 }
 
-static void finalize (const langType language __unused__,
+static void finalize (parserDefinition *parser __unused__,
 		      boolean initialized)
 {
 	if (initialized)

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -565,7 +565,8 @@ static void finalize (const langType language __unused__,
 	}
 }
 
-static void findTexTags (void)
+static rescanReason findTexTags (parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	tokenInfo *const token = newToken ();
 	exception_t exception;
@@ -575,6 +576,8 @@ static void findTexTags (void)
 		parseTexFile (token);
 
 	deleteToken (token);
+
+	return RESCAN_NONE;
 }
 
 /* Create parser definition structure */
@@ -588,7 +591,7 @@ extern parserDefinition* TexParser (void)
 	 */
 	def->kinds		= TexKinds;
 	def->kindCount	= ARRAY_SIZE (TexKinds);
-	def->parser		= findTexTags;
+	def->parser	= findTexTags;
 	def->initialize = initialize;
 	def->finalize   = finalize;
 	def->keywordTable =  TexKeywordTable;

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -535,10 +535,10 @@ static void parseTexFile (tokenInfo *const token)
 	} while (TRUE);
 }
 
-static void initialize (const langType language)
+static void initialize (parserDefinition *parser)
 {
 	Assert (ARRAY_SIZE (TexKinds) == TEXTAG_COUNT);
-	Lang_js = language;
+	Lang_js = parser->id;
 
 	lastPart    = vStringNew();
 	lastChapter = vStringNew();

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1097,7 +1097,8 @@ static void findTag (tokenInfo *const token)
 	}
 }
 
-static void findVerilogTags (void)
+static rescanReason findVerilogTags (parserDefinition *parser __unused__,
+				     const unsigned int passCount __unused__)
 {
 	tokenInfo *const token = newToken ();
 	int c = '\0';
@@ -1150,6 +1151,8 @@ static void findVerilogTags (void)
 	deleteToken (token);
 	pruneTokens (currentContext);
 	currentContext = NULL;
+
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* VerilogParser (void)

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -340,16 +340,16 @@ static void buildKeywordHash (const langType language, unsigned int idx)
 	}
 }
 
-static void initializeVerilog (const langType language)
+static void initializeVerilog (parserDefinition *parser)
 {
-	Lang_verilog = language;
-	buildKeywordHash (language, IDX_VERILOG);
+	Lang_verilog = parser->id;
+	buildKeywordHash (parser->id, IDX_VERILOG);
 }
 
-static void initializeSystemVerilog (const langType language)
+static void initializeSystemVerilog (parserDefinition *parser)
 {
-	Lang_systemverilog = language;
-	buildKeywordHash (language, IDX_SYSTEMVERILOG);
+	Lang_systemverilog = parser->id;
+	buildKeywordHash (parser->id, IDX_SYSTEMVERILOG);
 }
 
 static void vUngetc (int c)

--- a/parsers/vhdl.c
+++ b/parsers/vhdl.c
@@ -805,13 +805,16 @@ static tokenType parseVhdlFile (tokenInfo * const token)
 	return token->type;
 }
 
-static void findVhdlTags (void)
+static rescanReason findVhdlTags (parserDefinition *parser __unused__,
+				  const unsigned int passCount __unused__)
 {
 	tokenInfo *const token = newToken ();
 
 	while (parseVhdlFile (token) != TOKEN_EOF);
 
 	deleteToken (token);
+
+	return RESCAN_NONE;
 }
 
 extern parserDefinition *VhdlParser (void)

--- a/parsers/vhdl.c
+++ b/parsers/vhdl.c
@@ -557,9 +557,9 @@ static void makeVhdlTag (tokenInfo * const token, const vhdlKind kind)
 	}
 }
 
-static void initialize (const langType language)
+static void initialize (parserDefinition *parser)
 {
-	Lang_vhdl = language;
+	Lang_vhdl = parser->id;
 }
 
 static void parsePackage (tokenInfo * const token)

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -683,17 +683,18 @@ static void parseVimBallFile (const unsigned char *line)
 	vStringDelete (fname);
 }
 
-static void findVimTags (void)
+static rescanReason findVimTags (parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	const unsigned char *line;
 	/* TODO - change this into a structure */
 
 	line = readVimLine();
 
-    if (line == NULL)
-    {
-            return;
-    }
+	if (line == NULL)
+	{
+		return RESCAN_NONE;
+	}
 
 	if ( strncmp ((const char*) line, "UseVimball", (size_t) 10) == 0 )
 	{
@@ -703,6 +704,8 @@ static void findVimTags (void)
 	{
 		parseVimFile (line);
 	}
+
+	return RESCAN_NONE;
 }
 
 extern parserDefinition* VimParser (void)
@@ -715,7 +718,7 @@ extern parserDefinition* VimParser (void)
 	def->kindCount	= ARRAY_SIZE (VimKinds);
 	def->extensions = extensions;
 	def->patterns   = patterns;
-	def->parser		= findVimTags;
+	def->parser	= findVimTags;
 	return def;
 }
 

--- a/parsers/windres.c
+++ b/parsers/windres.c
@@ -209,7 +209,8 @@ static ResParserState parseResLine(const unsigned char *line, ResParserState sta
 	return state;
 }
 
-static void findResTags(void)
+static rescanReason findResTags (parserDefinition *parser __unused__,
+				 const unsigned int passCount __unused__)
 {
 	const unsigned char *line;
 	ResParserState state = P_STATE_NONE;
@@ -219,8 +220,10 @@ static void findResTags(void)
 	{
 		state = parseResLine(line, state);
 		if (state == P_STATE_AT_END)
-			return;
+			return RESCAN_NONE;
 	}
+
+	return RESCAN_NONE;
 }
 
 /* parser definition */
@@ -231,7 +234,7 @@ extern parserDefinition* WindResParser(void)
 	def->kinds		= ResKinds;
 	def->kindCount	= ARRAY_SIZE(ResKinds);
 	def->extensions	= extensions;
-	def->parser		= findResTags;
+	def->parser	= findResTags;
 	return def;
 }
 /* vi:set tabstop=4 shiftwidth=4 noexpandtab: */


### PR DESCRIPTION
pass parserDefinition instance to its parser callback function

In the original ctags architecture, parser callback function of
parserDefinition, the parserDefinition instance, and all the state of
parsing are separated.

This commit is initial trail for integrating them in object oriented way;
parserDefinition is considered as an object, which has the most
of all the sate of parsing as members of the object. The parser callback
is considered as a method of the object. Inheritance and Mix-In can be
introduced in the future.

My analysis of the original architecture:

```
parser callback function of parserDefinition took no argument.  If
more than two parserDefinitions share the same callback function,
isInputLanguage macro must be used to know the owner
parserDefinitions. findCTags function defined in parsers/c.c is
one of such functions. findCTags is shared in CParser, DParser,
CppParser, CsharpParser, JavaParser, and VeraParser.  In addition
all the state of parsing are stored to file local variables.
```

In a parserDefinitions there were two fields specifying the parser
callbacks: one for one path parsing, and the other for multiple path
parsing. This commit integrates the two, too.

Signed-off-by: Masatake YAMATO yamato@redhat.com
