### PR TITLE
Fix a lot of typos

### DIFF
--- a/Units/parser-cpp.r/bug852368.cpp.d/input.cpp
+++ b/Units/parser-cpp.r/bug852368.cpp.d/input.cpp
@@ -16,8 +16,8 @@ Summary: c/c++ unabalanced template brackets in signature
 Initial Comment:
 hi,
 
-ctags 5.5x generates unbalanced tempalte brackets in 
-the  method/function signature if a funtion parameter 
+ctags 5.5x generates unbalanced template brackets in 
+the  method/function signature if a function parameter 
 is a template.
 
 i.e.

--- a/Units/parser-fortran.r/bug726712.f90.d/input.f90
+++ b/Units/parser-fortran.r/bug726712.f90.d/input.f90
@@ -67,6 +67,6 @@
 ! end
 ! 
 ! The following subroutine is listed but cannot be selected
-! (that is, the cursor wont go there)
+! (that is, the cursor won't go there)
 ! 
 ! ----------------------------------------------------------------------

--- a/Units/parser-fortran.r/lanus.for.d/input.for
+++ b/Units/parser-fortran.r/lanus.for.d/input.for
@@ -8,7 +8,7 @@
 * 
 * I'm trying to set ctags to work with some old FORTRAN 77 programs.
 * I'm in Windows 2000, vim 6.1 and exuberant ctags 5.3.1.
-* The programs are for VAX FORTRAN 77 as of 1988. Writen with tabs and 132 columns line length.
+* The programs are for VAX FORTRAN 77 as of 1988. Written with tabs and 132 columns line length.
 * 
 * [...]
 * 

--- a/Units/parser-fortran.r/misc_types.f.d/input.f
+++ b/Units/parser-fortran.r/misc_types.f.d/input.f
@@ -12,7 +12,7 @@
 	VIRTUAL M(10,10), Y(100) 
 	VOLATILE V, Z, MAT, /INI/ 
 
-	EXTERNAL ABS ! varations of external and global
+	EXTERNAL ABS ! variations of external and global
 	CEXTERNAL ABS1 ! not supported
 	CGLOBAL ABS2 ! not supported
 	PEXTERNAL ABS3 ! not supported

--- a/Units/parser-verilog.r/verilog-sf_bug108_1.d/input.v
+++ b/Units/parser-verilog.r/verilog-sf_bug108_1.d/input.v
@@ -2,7 +2,7 @@
 //
 // Below is an example of a comment that is mis-parsed by exuberant ctags.
 // It uses the multi-line comment format, i.e. /* ... */ except that in
-// this case, the character sequence immediately preceeding the closing
+// this case, the character sequence immediately preceding the closing
 // delimiter is an asterisk. (Any even number of asterisks would have the
 // same problem.
 // The line immediately afterwards is used to demonstrate the problem.

--- a/Units/php-mode.d/input.php
+++ b/Units/php-mode.d/input.php
@@ -94,7 +94,7 @@ function g() {}
 function bug7() {}
 
 <?php
-// this WONT leave PHP mode, it's in a comment  </script>
+// this WON'T leave PHP mode, it's in a comment  </script>
 function h() {}
 ?>
 

--- a/Units/review-needed.r/3214129.vim.t/input.vim
+++ b/Units/review-needed.r/3214129.vim.t/input.vim
@@ -731,7 +731,7 @@ function! s:HGCommit(...)
     " Protect against case and backslash issues in Windows.
     let autoPattern = '\c' . messageFileName
 
-    " Ensure existance of group
+    " Ensure existence of group
     augroup HGCommit
     augroup END
 

--- a/Units/review-needed.r/3526726.tex.t/input.tex
+++ b/Units/review-needed.r/3526726.tex.t/input.tex
@@ -551,7 +551,7 @@ available.
 
 As for OS selection, use what you like. When we implement Data Acquisition
 Plugin's in Snort 2.0 this may become more of a factor, but for now I'm hearing
-about a lot of people seeing alot of success using Snort on Solaris, Linux,
+about a lot of people seeing a lot of success using Snort on Solaris, Linux,
 *BSD and Windows 2000. Personally, I develop Snort on FreeBSD and Sourcefire
 uses OpenBSD for our sensor appliance OS, but I've been hearing some good
 things about the RedHat Turbo Packet interface (which would require mods for
@@ -638,7 +638,7 @@ these steps at your OWN risk.
 \item In a command prompt, run 'ipconfig' to verify the interface does not have an IP bound to it.
 \end{enumerate}
 
-If you do not recieve an IP address listing from the interface you
+If you do not receive an IP address listing from the interface you
 modified, you are good to go.  To run snort with the specified interface,
 use the -i flag such as 'snort -v -d -p -i1'
  
@@ -683,7 +683,7 @@ hub. The idea is to use the rcv cables for the wire going to the sniffer box
 and use the xmit cables from another hub port. This will give you a link light
 and allow your sniffer to rcv only. Cannot xmit because the xmit cables are not
 connected. This has been successfully used on netgear single speed hubs. It
-wont work on dual speed hubs due to the negotiation of speed.
+won't work on dual speed hubs due to the negotiation of speed.
 
 Pin outs. They are reversed in the picture in order to prevent lines from
 crossing, and I only included the pins used.
@@ -1602,7 +1602,7 @@ were detected by snort when a communications session attempt fails.
 
 The default order that the rules are applied in is alerts first, then pass
 rules, then log rules. This ordering ensures that you don't write 50 great
-alert rules and then disable them all accidently with an errant pass rule. If
+alert rules and then disable them all accidentally with an errant pass rule. If
 you really want to change this order so that the pass rules are applied first,
 use the ``-o'' command line switch, or the ``order'' config directive.
 
@@ -2401,7 +2401,7 @@ Try this script to archive the files:
   * []#!/bin/sh
 
     # 
-    # Logfile rotation script for snort writen by jameso@elwood.net.
+    # Logfile rotation script for snort written by jameso@elwood.net.
     # 
     # This script is pretty basic. We start out by setting some vars.
     # Its job is tho rotate the days logfiles, e-mail you with what 
@@ -2416,9 +2416,9 @@ Try this script to archive the files:
     # every night, so we want to set the dirdate var the day the script
     # runs minus a day so we label the files with the correct day. We
     # Then create a dir for the days logs, move the log files into 
-    # todays dir. As soon as that is done restart snort so we don't miss
+    # today's dir. As soon as that is done restart snort so we don't miss
     # anything. Then delete any logs that are uncompressed and over a
-    # week old. Then compress out todays logs and archive them away, and
+    # week old. Then compress out today's logs and archive them away, and
     # end up by mailling out the logs to you.
     #
     # Define where you have the base of your snort install
@@ -2455,14 +2455,14 @@ Try this script to archive the files:
      olddirdate=$month-$eightday-$year
     fi
     
-    # Create the Dir for todays logs.
+    # Create the Dir for today's logs.
     if [ ! -d $weeklogs/$dirdate ]
     then
      mkdir $weeklogs/$dirdate
     fi
     
-    # Move the log files into todays log dir. This is done with
-    # a for loop right now, because I am afriad that if alot is
+    # Move the log files into today's log dir. This is done with
+    # a for loop right now, because I am afraid that if alot is
     # logged there may be to many items to move with a "mv *"
     # type command. There may a better way to do this, but I don't
     # know it yet.
@@ -2704,7 +2704,7 @@ adapter basically mediating the 10 up to 100 and vice versa.
 The bad thing about hubs that {\em don't} have this ``feature,'' is that
 in order to support 10bt devices, they throttle the entire hub speed
 down to 10bt if there is one or more 10bt only devices hooked up to it.
-I have seen this behavior (and did the bandwidth tests to proove it) on
+I have seen this behavior (and did the bandwidth tests to prove it) on
 old 3com office connect 10/100 hubs (newer ones do the 2 hubs with a switch
 thing.)  So, the point of what I am saying is, since these old hubs have
 no switching capabilities, and they don't know which port the traffic is
@@ -2750,7 +2750,7 @@ traffic (telnet,http for example).  You set up a port to mirror
 traffic from the ports that have the devices your interested in to the
 port you have your analysis device plugged into.  Without doing so,
 you don't see the unicast conversations because the traffic is getting
-"switched" accross the backplane so pc on port 1 talks to server on
+"switched" across the backplane so pc on port 1 talks to server on
 port 2 and no other ports get this traffic. If server on port 2
 broadcasts or multicasts, the information is flooded out all ports.
 (multicast can be controlled on some switches so only those ports that
@@ -2761,7 +2761,7 @@ An excellent book on the topic is Interconnections by Radia Perlman.
 (Bridges and Routers).
   
 Additional caveat: if you deal with full duplex on a switched port,
-only a tap would save you - users have succesfully used Shomiti's
+only a tap would save you - users have successfully used Shomiti's
 ones on 100MB FD ports, and used two Snort instances, capturing
 traffic on both directions. Port mirroring didn't work in that case ...
 

--- a/Units/review-needed.r/bug612019.pas.t/input.pas
+++ b/Units/review-needed.r/bug612019.pas.t/input.pas
@@ -16,7 +16,7 @@ Initial Comment:
 In attached sample there are some lines from tags file
 generated for object pascal sources.
 There are some problems with this lines.
-Generaly speaking they are parsed incorrectly.
+Generally speaking they are parsed incorrectly.
 *)
 unit a;
 

--- a/Units/review-needed.r/jsFunc_tutorial.js.t/input.js
+++ b/Units/review-needed.r/jsFunc_tutorial.js.t/input.js
@@ -122,7 +122,7 @@ var multiply=D5("*");           // created "multiply" function
 
 // test the functions
 alert("result of add="+add(10,2));            // result is 12
-alert("result of substract="+subtract(10,2)); // result is 8
+alert("result of subtract="+subtract(10,2));  // result is 8
 alert("result of multiply="+multiply(10,2));  // result is 20
 alert(add);
 

--- a/Units/review-needed.r/mode.php.t/input.php
+++ b/Units/review-needed.r/mode.php.t/input.php
@@ -94,7 +94,7 @@ function g() {}
 function bug7() {}
 
 <?php
-// this WONT leave PHP mode, it's in a comment  </script>
+// this WON'T leave PHP mode, it's in a comment  </script>
 function h() {}
 ?>
 

--- a/Units/review-needed.r/moniker.x68.t/input.x68
+++ b/Units/review-needed.r/moniker.x68.t/input.x68
@@ -23,7 +23,7 @@ START   	MOVEA.L #PROMPT1,A1             Pointer to start of prompt text
         
 *       	Get firstname
 *		=============
-        	MOVEA.L #F_NAME,A1              Pointer to store teh sentance
+        	MOVEA.L #F_NAME,A1              Pointer to store the sentence
         	MOVE.B  #READSTR,D0             Set up readstring function
         	TRAP    #15                     Get string from KB
         	MOVE.W  D1,D4                   Save length of input string to d4
@@ -38,7 +38,7 @@ START   	MOVEA.L #PROMPT1,A1             Pointer to start of prompt text
       	MOVEA.L #F_NAME,A0              Move the first char to A0
        	JSR     CHECK2                  Check if uppercase
         
-        	CMPI.B  #1,D5                   See if all the sentance is CAPS
+        	CMPI.B  #1,D5                   See if all the sentence is CAPS
         	BCS     START                   if it is'nt then re-enter                          
 
 
@@ -46,12 +46,12 @@ START   	MOVEA.L #PROMPT1,A1             Pointer to start of prompt text
 *		=======================================
 SURNAME 	MOVEA.L #PROMPT2,A1             Pointer to start of prompt text
         	MOVE.B  #PRTSTR,D0              Set up print string function
-        	MOVE.W  #(F_NAME-PROMPT2),D1    The prompt string lenght
+        	MOVE.W  #(F_NAME-PROMPT2),D1    The prompt string length
         	TRAP    #15                     Print Prompt
         
 *       	Get surname
 *		===========
-        	MOVEA.L #S_NAME,A1              Pointer to store the sentance
+        	MOVEA.L #S_NAME,A1              Pointer to store the sentence
         	MOVE.B  #READSTR,D0             Set up readstring function
         	TRAP    #15                     Get string from KB
         	MOVE.W  D1,D4                   Save length on input string
@@ -66,7 +66,7 @@ SURNAME 	MOVEA.L #PROMPT2,A1             Pointer to start of prompt text
         	MOVEA.L #S_NAME,A0              Move the first char to A0  
         	JSR     CHECK2                  Check if uppercase        
         
-        	CMPI.B  #1,D5                   See if all the sentance is CAPS
+        	CMPI.B  #1,D5                   See if all the sentence is CAPS
         	BCS     SURNAME                 if it is'nt then re-enter     
 
 *       	Move the first char for fname and prints it (Initial Bit)
@@ -78,7 +78,7 @@ INITIAL 	MOVEA.L #F_NAME,A1              Move the first char to A1
 
 PRNSURNAME	MOVEA.L #S_NAME,A1              Pointer to start of prompt text
         	MOVE.B  #0,D0                   Set up print string function
-        	MOVE.W  D3,D1                   The prompt string lenght
+        	MOVE.W  D3,D1                   The prompt string length
         	TRAP    #15                     Print Prompt
 
 QUIT    	STOP    #$2700                  Stop the prorgam
@@ -94,7 +94,7 @@ CHECK2  	CMPI.B  #'A',(A0)               Is Char > A ?
         	CMP.B   #('Z'+1),(A0)+          Check if char is < Z
         	BCC     RETURNFALSE             If it is then it must be a cap
         	SUBI.B  #1,D4                   Decrease s_name / f_name Length
-        	BNE     CHECK2                  jump if the sentance is not = 0
+        	BNE     CHECK2                  jump if the sentence is not = 0
 
 RETURNTRUE  MOVE.B  #1,D5			  Moves a one to D5 to make CAPS ture
             RTS					  Jump back to the main program

--- a/docs/semifuzz.rst
+++ b/docs/semifuzz.rst
@@ -54,4 +54,4 @@ following parameters:
 
 As the same as units target, this semi-fuzz test target also calls
 *misc/units shrink* when an test case is failed. See "*Units* test facility"
-about the shrinked result.
+about the shrunk result.

--- a/gnu_regex/regcomp.c
+++ b/gnu_regex/regcomp.c
@@ -2051,7 +2051,7 @@ peek_token_bracket (re_token_t *token, re_string_t *input, reg_syntax_t syntax)
 
 /* Entry point of the parser.
    Parse the regular expression REGEXP and return the structure tree.
-   If an error is occured, ERR is set by error code, and return NULL.
+   If an error is occurred, ERR is set by error code, and return NULL.
    This function build the following tree, from regular expression <reg_exp>:
 	   CAT
 	   / \
@@ -2567,7 +2567,7 @@ parse_dup_op (bin_tree_t *elem, re_string_t *regexp, re_dfa_t *dfa,
      Build the range expression which starts from START_ELEM, and ends
      at END_ELEM.  The result are written to MBCSET and SBCSET.
      RANGE_ALLOC is the allocated size of mbcset->range_starts, and
-     mbcset->range_ends, is a pointer argument sinse we may
+     mbcset->range_ends, is a pointer argument since we may
      update it.  */
 
 static reg_errcode_t
@@ -2834,7 +2834,7 @@ parse_bracket_exp (re_string_t *regexp, re_dfa_t *dfa, re_token_t *token,
      Build the range expression which starts from START_ELEM, and ends
      at END_ELEM.  The result are written to MBCSET and SBCSET.
      RANGE_ALLOC is the allocated size of mbcset->range_starts, and
-     mbcset->range_ends, is a pointer argument sinse we may
+     mbcset->range_ends, is a pointer argument since we may
      update it.  */
 
   auto inline reg_errcode_t
@@ -2918,7 +2918,7 @@ parse_bracket_exp (re_string_t *regexp, re_dfa_t *dfa, re_token_t *token,
      Build the collating element which is represented by NAME.
      The result are written to MBCSET and SBCSET.
      COLL_SYM_ALLOC is the allocated size of mbcset->coll_sym, is a
-     pointer argument sinse we may update it.  */
+     pointer argument since we may update it.  */
 
   auto inline reg_errcode_t
   __attribute ((always_inline))
@@ -3357,7 +3357,7 @@ parse_bracket_symbol (bracket_elem_t *elem, re_string_t *regexp,
      Build the equivalence class which is represented by NAME.
      The result are written to MBCSET and SBCSET.
      EQUIV_CLASS_ALLOC is the allocated size of mbcset->equiv_classes,
-     is a pointer argument sinse we may update it.  */
+     is a pointer argument since we may update it.  */
 
 static reg_errcode_t
 #ifdef RE_ENABLE_I18N
@@ -3453,7 +3453,7 @@ build_equiv_class (bitset_t sbcset, const unsigned char *name)
      Build the character class which is represented by NAME.
      The result are written to MBCSET and SBCSET.
      CHAR_CLASS_ALLOC is the allocated size of mbcset->char_classes,
-     is a pointer argument sinse we may update it.  */
+     is a pointer argument since we may update it.  */
 
 static reg_errcode_t
 #ifdef RE_ENABLE_I18N
@@ -3649,7 +3649,7 @@ build_charclass_op (re_dfa_t *dfa, RE_TRANSLATE_TYPE trans,
 /* This is intended for the expressions like "a{1,3}".
    Fetch a number from `input', and return the number.
    Return -1, if the number field is empty like "{,1}".
-   Return -2, If an error is occured.  */
+   Return -2, If an error is occurred.  */
 
 static int
 fetch_number (re_string_t *input, re_token_t *token, reg_syntax_t syntax)

--- a/gnu_regex/regex.c
+++ b/gnu_regex/regex.c
@@ -22,7 +22,7 @@
 #include "config.h"
 #endif
 
-/* Make sure noone compiles this code with a C++ compiler.  */
+/* Make sure no one compiles this code with a C++ compiler.  */
 #ifdef __cplusplus
 # error "This is C code, use a C compiler"
 #endif

--- a/gnu_regex/regex_internal.c
+++ b/gnu_regex/regex_internal.c
@@ -1258,7 +1258,7 @@ re_node_set_merge (re_node_set *dest, const re_node_set *src)
 
 /* Insert the new element ELEM to the re_node_set* SET.
    SET should not already have ELEM.
-   return -1 if an error is occured, return 1 otherwise.  */
+   return -1 if an error is occurred, return 1 otherwise.  */
 
 static int
 internal_function
@@ -1315,7 +1315,7 @@ re_node_set_insert (re_node_set *set, int elem)
 
 /* Insert the new element ELEM to the re_node_set* SET.
    SET should not already have any element greater than or equal to ELEM.
-   Return -1 if an error is occured, return 1 otherwise.  */
+   Return -1 if an error is occurred, return 1 otherwise.  */
 
 static int
 internal_function
@@ -1390,7 +1390,7 @@ re_node_set_remove_at (re_node_set *set, int idx)
 
 
 /* Add the token TOKEN to dfa->nodes, and return the index of the token.
-   Or return -1, if an error will be occured.  */
+   Or return -1, if an error will be occurred.  */
 
 static int
 internal_function

--- a/gnu_regex/regexec.c
+++ b/gnu_regex/regexec.c
@@ -468,7 +468,7 @@ re_search_stub (bufp, string, length, start, range, stop, regs, ret_len)
 
   rval = 0;
 
-  /* I hope we needn't fill ther regs with -1's when no match was found.  */
+  /* I hope we need not to fill the regs with -1's when no match was found.  */
   if (result != REG_NOERROR)
     rval = -1;
   else if (regs != NULL)
@@ -1065,7 +1065,7 @@ acquire_init_state_context (reg_errcode_t *err, const re_match_context_t *mctx,
    FL_LONGEST_MATCH means we want the POSIX longest matching.
    If P_MATCH_FIRST is not NULL, and the match fails, it is set to the
    next place where we may want to try matching.
-   Note that the matcher assume that the maching starts from the current
+   Note that the matcher assume that the matching starts from the current
    index of the buffer.  */
 
 static int

--- a/main/parse.h
+++ b/main/parse.h
@@ -45,7 +45,7 @@ typedef void (*parserInitialize) (langType language);
 
    The finalizer is called even when the initializer of the
    same parser is called or not. However, the finalizer can know
-   whether the assoicated initializer is invoked or not with the
+   whether the assoiciated initializer is invoked or not with the
    second parameter: INITIALIZED. If it is true, the initializer
    is called. */
 typedef void (*parserFinalize) (langType language, boolean initialized);

--- a/main/read.c
+++ b/main/read.c
@@ -276,7 +276,7 @@ extern boolean openInputFile (const char *const fileName, const langType languag
 		File.fp = NULL;
 	}
 
-	/* File postion is used as key for checking the availability of
+	/* File position is used as key for checking the availability of
 	   pattern cache in entry.h. If an input file is changed, the
 	   key is meaningless. So notifying the changing here. */
 	TagFile.patternCacheValid = FALSE;

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -32,7 +32,7 @@ endif
 #
 # Silent/verbose commands
 #
-# when V is not set the output of commands is ommited or simplified
+# when V is not set the output of commands is omited or simplified
 #
 V	 ?= 0
 

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -1351,7 +1351,7 @@ static boolean parseStatement (tokenInfo *const token, tokenInfo *const parent, 
 	if ( is_inside_class )
 		is_class = TRUE;
 	/*
-	 * var can preceed an inner function
+	 * var can precede an inner function
 	 */
 	if ( isKeyword(token, KEYWORD_var) ||
 		 isKeyword(token, KEYWORD_let) ||

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -1167,7 +1167,7 @@ static void parseDeclareANSI (tokenInfo *const token, const boolean local)
 	 *		 DECLARE varname2 datatype;
 	 *		 ...
 	 *
-	 * This differ from PL/SQL where DECLARE preceeds the BEGIN block
+	 * This differ from PL/SQL where DECLARE precedes the BEGIN block
 	 * and the DECLARE keyword is not repeated.
 	 */
 	while (isKeyword (token, KEYWORD_declare))

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -307,9 +307,9 @@ static boolean parseCommand (const unsigned char *line)
 	/* 
 	 * Found a user-defined command 
 	 *
-	 * They can have many options preceeded by a dash
+	 * They can have many options preceded by a dash
 	 * command! -nargs=+ -complete Select  :call s:DB_execSql("select " . <q-args>)
-	 * The name of the command should be the first word not preceeded by a dash
+	 * The name of the command should be the first word not preceded by a dash
 	 *
 	 */
 	const unsigned char *cp = line;
@@ -370,7 +370,7 @@ static boolean parseCommand (const unsigned char *line)
 
 	/*
 	 * Strip off any spaces and options which are part of the command.
-	 * These should preceed the command name.
+	 * These should precede the command name.
 	 */
 	do
 	{


### PR DESCRIPTION
All credit goes to the authors of codespell.
(Well except for 'sentance', which somehow isn't detected.)
However, I have verified and correct them all by myself and am now going blind -- err, I mean, I won't do the rest by hand.

Some of these corrections may need special attention, most importantly:

    # Logfile rotation script for snort writen by jameso@elwood.net.

This sounds like it was taken from a third-party script, and that script should be fixed, too.

This caused downstream bug: https://github.com/geany/geany/pull/849

These are the codespell results that look like a true positive, but were ignored by me for some reason:

    (ignored, because these are "ancient" changelogs)
	./old-docs/NEWS.exuberant:142: accomodate  ==> accommodate
	./old-docs/website/quotes.html:678: alot  ==> a lot, allot
	./old-docs/NEWS.exuberant:833: indentical  ==> identical
	./old-docs/website/tools.html:41: infinit  ==> infinite
	./old-docs/NEWS.exuberant:825: occured  ==> occurred
	./old-docs/NEWS.exuberant:784: occuring  ==> occurring
	./old-docs/FAQ:125: primarly  ==> primarily
	./old-docs/website/faq.html:223: primarly  ==> primarily
	./old-docs/website/quotes.html:33: similiar  ==> similar
	./old-docs/EXTENDING.html:253: stucture  ==> structure
	./old-docs/EXTENDING.html:285: stucture  ==> structure
	./old-docs/EXTENDING.html:344: stucture  ==> structure
	./old-docs/EXTENDING.html:375: stucture  ==> structure
	./old-docs/website/quotes.html:560: Verison  ==> Version
	./old-docs/website/quotes.html:560: WONDERFULL  ==> WONDERFUL

    (ignored, because these are variable names)
	./Units/review-needed.r/test.vhd.t/expected.tags:165: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/expected.tags:165: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:360: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:4475: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:4492: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:4502: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:4518: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:4661: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:4688: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:4700: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:4761: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:6427: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:6434: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:6448: scaleable  ==> scalable
	./Units/review-needed.r/test.vhd.t/input.vhd:6483: scaleable  ==> scalable
