### PR TITLE
Fix broken program transformation in optlib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,9 +48,12 @@ $(REPOINFO_HEADS):
 	echo > $@
 endif
 
+optlib2c_verbose = $(optlib2c_verbose_@AM_V@)
+optlib2c_verbose_ = $(optlib2c_verbose_@AM_DEFAULT_V@)
+optlib2c_verbose_0 = @echo OPTLIB2C "  $@";
 OPTLIB2C = $(srcdir)/misc/optlib2c
 %.c: %.ctags $(OPTLIB2C) Makefile
-	$(OPTLIB2C) --transform-xcmd="$(program_transform_name)" $< > $@
+	$(optlib2c_verbose)$(OPTLIB2C) --transform-xcmd="$(program_transform_name)" $< > $@
 dist_ctags_SOURCES = $(ALL_HEADS) $(ALL_SRCS)
 
 man_MANS = ctags.1

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,7 @@ $(REPOINFO_HEADS):
 endif
 
 OPTLIB2C = $(srcdir)/misc/optlib2c
-.ctags.c: $(OPTLIB2C)
+%.c: %.ctags $(OPTLIB2C)
 	$(OPTLIB2C) $< > $@
 dist_ctags_SOURCES = $(ALL_HEADS) $(ALL_SRCS)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,8 +49,8 @@ $(REPOINFO_HEADS):
 endif
 
 OPTLIB2C = $(srcdir)/misc/optlib2c
-%.c: %.ctags $(OPTLIB2C)
-	$(OPTLIB2C) $< > $@
+%.c: %.ctags $(OPTLIB2C) Makefile
+	$(OPTLIB2C) --transform-xcmd="$(program_transform_name)" $< > $@
 dist_ctags_SOURCES = $(ALL_HEADS) $(ALL_SRCS)
 
 man_MANS = ctags.1

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -18,6 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+declare OPTLIB2C_TRANSFORM_XCMD
 
 declare CTAGS_LANG
 declare CTAGS_LANG_IN_C
@@ -86,7 +87,7 @@ print_help()
 	echo "Usage:"
 
 	echo "	$0 --help"
-	echo "	$0 FILE.ctags > FILE.c"
+	echo "	$0 [--transform-xcmd=PROGRAM_TRANSFORM_NAME] FILE.ctags > FILE.c"
 
 	exit $status
 }
@@ -455,6 +456,31 @@ EOF
 	echo
 }
 
+transform_xcmd()
+{
+	local p=$1
+	local transform=$2
+
+	local pd
+	local pb
+	local pb_transformed
+
+	pd=$(dirname "$p")
+	pb=$(basename "$p")
+	pb_transformed=$(sed -e "${transform}" <<< "${pb}")
+
+	# If no directory component is given in $p,
+	# dirname command prints '.'. This '.' should not be
+	# in ${p_transformed}.
+	if [[ "${p:0:1}" != '.' ]] && [[ ${pd} == '.' ]]; then
+		pd=
+	else
+		pd="${pd}"/
+	fi
+
+	echo "${pd}${pb_transformed}"
+}
+
 emit_initializer()
 {
 	local c
@@ -469,6 +495,9 @@ EOF
 	if [ ${#CTAGS_XCMD_PATH[@]} -gt 0 ]; then
 		for i in $(seq 0 $(( ${#CTAGS_XCMD_PATH[@]} - 1))); do
 			p=${CTAGS_XCMD_PATH[$i]}
+			if [[ -n "${OPTLIB2C_TRANSFORM_XCMD}" ]]; then
+				p=$(transform_xcmd "$p" "${OPTLIB2C_TRANSFORM_XCMD}")
+			fi
 			f=${CTAGS_XCMD_flags[$i]}
 			cat<<EOF
 	addLanguageXcmd (language, "$p$f");
@@ -668,18 +697,25 @@ main()
 {
 	local optlib
 
-	case $1 in
-		(-h|--help)
-			print_help 0
-			;;
-		(-*)
-			error "unrecongnized option: $1"
-			;;
-		(*)
-			optlib=$1
-			shift
-			;;
-	esac
+	while (( $# > 0 )); do
+		case $1 in
+			(-h|--help)
+				print_help 0
+				;;
+			(--transform-xcmd=*)
+				OPTLIB2C_TRANSFORM_XCMD=${1/--transform-xcmd=/}
+				shift
+				;;
+			(-*)
+				error "unrecongnized option: $1"
+				;;
+			(*)
+				optlib=$1
+				shift
+				break
+				;;
+		esac
+	done
 
 	if (( $# > 0 )); then
 		error "Too many argument: $@"

--- a/optlib/CoffeeScript.c
+++ b/optlib/CoffeeScript.c
@@ -8,7 +8,7 @@
 
 static void initializeCoffeeScriptParser (const langType language)
 {
-	addLanguageXcmd (language, "coffeetags");
+	addLanguageXcmd (language, "excoffeetags");
 }
 
 extern parserDefinition* CoffeeScriptParser (void)


### PR DESCRIPTION
See c5dc92b.
Close #753.

An issue about program transformation is reported in #753.
I didn't considered that the name of xcmd drivers are also transformed.
Instead of changing Makefile.am as proposed in #753 by @jonthn, I fixed optlib2c.
