### PR TITLE
Python: allow nested parenthesis in arglists

### DIFF
--- a/Units/parser-python.r/nested-parenthesis.d/args.ctags
+++ b/Units/parser-python.r/nested-parenthesis.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--fields=+S

--- a/Units/parser-python.r/nested-parenthesis.d/expected.tags
+++ b/Units/parser-python.r/nested-parenthesis.d/expected.tags
@@ -1,0 +1,5 @@
+foo	input.py	/^def foo():$/;"	f	signature:()
+bar	input.py	/^def bar():$/;"	f	signature:()
+baz	input.py	/^def baz(arg1, arg2=({()})):$/;"	f	signature:(arg1, arg2=({()}))
+gvar	input.py	/^gvar = test(())$/;"	v
+tagme	input.py	/^def tagme():$/;"	f	signature:()

--- a/Units/parser-python.r/nested-parenthesis.d/input.py
+++ b/Units/parser-python.r/nested-parenthesis.d/input.py
@@ -1,0 +1,16 @@
+# Reported by @m-novikov in #763
+def foo():
+    var = some1(some2())
+
+def bar():
+    pass
+
+def baz(arg1, arg2=({()})):
+    pass
+
+gvar = test(())
+
+
+def tagme():
+    pass
+

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -650,18 +650,28 @@ static boolean parseArglist(const char* buf, struct argParsingState *state)
 		}
 	}
 
-	current = skipUntil (start, gatherArglistCB, state->arglist);
-	switch (*current)
-	{
-	case '\0':
-		break;
-	case '(':
-		++ state->level;
-		break;
-	case ')':
-		-- state->level;
-		break;
-	}
+
+	do {
+		current = skipUntil (start, gatherArglistCB, state->arglist);
+		switch (*current)
+		{
+		case '\0':
+			break;
+		case '(':
+			++ state->level;
+			break;
+		case ')':
+			-- state->level;
+			break;
+		}
+		start = current + 1;
+	} while (
+		/* Still be in parenthesis */
+		state->level > 0
+		/* the input string is continued. */
+		&& *current && *start
+		);
+
 	return TRUE;
 }
 


### PR DESCRIPTION
Close #763 reported by @m-novikov.

Bug: any signatures that contain inside parenthesis made
python parser confused.

This commit fixes this bug.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>