### PR TITLE
Python: fix a bug about multi-line keyword arguments

### DIFF
--- a/Units/parser-python.r/toplevel-funcall-with-keyword-args.d/expected.tags
+++ b/Units/parser-python.r/toplevel-funcall-with-keyword-args.d/expected.tags
@@ -1,0 +1,1 @@
+bar	input.py	/^def bar():$/;"	f

--- a/Units/parser-python.r/toplevel-funcall-with-keyword-args.d/input.py
+++ b/Units/parser-python.r/toplevel-funcall-with-keyword-args.d/input.py
@@ -1,0 +1,6 @@
+foo (
+	x = 1,
+	y = 2
+	)
+def bar():
+    pass


### PR DESCRIPTION
Close #765.

A bug description quoted from #765 reported by @m-novikov:

    Function calls with multi-line keyword arguments results in
    keyword arguments parsed as variables. Given:

    foo(
	    arg1=1,
	    arg2=2
    )
    def bar():
	    pass

In the example arg1 and arg2 are captured as tags.

This commit fixes this bug.

Python parser processes input file line by line.  Line may include a
tag or not. Python parser applies rules for capturing a tag to the
each input line. This commit introduces a fallback rule which calls
skipParens. As the result foo (...) in the above example are skipped.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>