### PR TITLE
c++: Fix parsing of C++11 raw string literals

### DIFF
--- a/Units/parser-cpp.r/cxx11-raw-strings.d/expected.tags
+++ b/Units/parser-cpp.r/cxx11-raw-strings.d/expected.tags
@@ -2,9 +2,21 @@ FOUR	input.cpp	/^#define FOUR /;"	d	file:
 memb1	input.cpp	/^struct typ1 { int memb1; };$/;"	m	struct:typ1	file:
 memb2	input.cpp	/^struct typ2 { int memb2; };$/;"	m	struct:typ2	file:
 memb3	input.cpp	/^struct typ3 { int memb3; };$/;"	m	struct:typ3	file:
+memb4	input.cpp	/^struct typ4 { int memb4; };$/;"	m	struct:typ4	file:
+memb5	input.cpp	/^struct typ5 { int memb5; };$/;"	m	struct:typ5	file:
+memb6	input.cpp	/^struct typ6 { int memb6; };$/;"	m	struct:typ6	file:
+memb7	input.cpp	/^struct typ7 { int memb7; };$/;"	m	struct:typ7	file:
 str1	input.cpp	/^static const char* str1 = R"blah($/;"	v	file:
 str2	input.cpp	/^static const char* str2 = R"blah($/;"	v	file:
 str3	input.cpp	/^static const char* str3 = FOUR"f(iv)e";$/;"	v	file:
+str4	input.cpp	/^static const char* str4 = LR"blah(";int bug4;)blah";$/;"	v	file:
+str5	input.cpp	/^static const char* str5 = u8R"blah(";int bug5;)blah";$/;"	v	file:
+str6	input.cpp	/^static const char* str6 = uR"blah(";int bug6;)blah";$/;"	v	file:
+str7	input.cpp	/^static const char* str7 = UR"blah(";int bug7;)blah";$/;"	v	file:
 typ1	input.cpp	/^struct typ1 { int memb1; };$/;"	s	file:
 typ2	input.cpp	/^struct typ2 { int memb2; };$/;"	s	file:
 typ3	input.cpp	/^struct typ3 { int memb3; };$/;"	s	file:
+typ4	input.cpp	/^struct typ4 { int memb4; };$/;"	s	file:
+typ5	input.cpp	/^struct typ5 { int memb5; };$/;"	s	file:
+typ6	input.cpp	/^struct typ6 { int memb6; };$/;"	s	file:
+typ7	input.cpp	/^struct typ7 { int memb7; };$/;"	s	file:

--- a/Units/parser-cpp.r/cxx11-raw-strings.d/expected.tags
+++ b/Units/parser-cpp.r/cxx11-raw-strings.d/expected.tags
@@ -1,0 +1,10 @@
+FOUR	input.cpp	/^#define FOUR /;"	d	file:
+memb1	input.cpp	/^struct typ1 { int memb1; };$/;"	m	struct:typ1	file:
+memb2	input.cpp	/^struct typ2 { int memb2; };$/;"	m	struct:typ2	file:
+memb3	input.cpp	/^struct typ3 { int memb3; };$/;"	m	struct:typ3	file:
+str1	input.cpp	/^static const char* str1 = R"blah($/;"	v	file:
+str2	input.cpp	/^static const char* str2 = R"blah($/;"	v	file:
+str3	input.cpp	/^static const char* str3 = FOUR"f(iv)e";$/;"	v	file:
+typ1	input.cpp	/^struct typ1 { int memb1; };$/;"	s	file:
+typ2	input.cpp	/^struct typ2 { int memb2; };$/;"	s	file:
+typ3	input.cpp	/^struct typ3 { int memb3; };$/;"	s	file:

--- a/Units/parser-cpp.r/cxx11-raw-strings.d/input.cpp
+++ b/Units/parser-cpp.r/cxx11-raw-strings.d/input.cpp
@@ -19,3 +19,16 @@ struct typ2 { int memb2; };
 static const char* str3 = FOUR"f(iv)e";
 
 struct typ3 { int memb3; };
+
+/* check for prefixes */
+static const char* str4 = LR"blah(";int bug4;)blah";
+struct typ4 { int memb4; };
+
+static const char* str5 = u8R"blah(";int bug5;)blah";
+struct typ5 { int memb5; };
+
+static const char* str6 = uR"blah(";int bug6;)blah";
+struct typ6 { int memb6; };
+
+static const char* str7 = UR"blah(";int bug7;)blah";
+struct typ7 { int memb7; };

--- a/Units/parser-cpp.r/cxx11-raw-strings.d/input.cpp
+++ b/Units/parser-cpp.r/cxx11-raw-strings.d/input.cpp
@@ -1,0 +1,21 @@
+
+static const char* str1 = R"blah(
+lots
+of text
+)blah";
+
+struct typ1 { int memb1; };
+
+static const char* str2 = R"blah(
+lots
+of text including a quote"
+)blah";
+
+struct typ2 { int memb2; };
+
+/* check we don't get confused by string concatenation */
+#define FOUR "four"
+
+static const char* str3 = FOUR"f(iv)e";
+
+struct typ3 { int memb3; };

--- a/main/get.c
+++ b/main/get.c
@@ -928,10 +928,7 @@ process:
 					 * 	"xxx(raw)xxx";
 					 *
 					 * which is perfectly valid (yet probably very unlikely). */
-					const unsigned char *base = (unsigned char *) vStringValue (File.line);
-					int prev = '\n';
-					if (File.currentLine - File.ungetchIdx - 2 >= base)
-						prev = (int) *(File.currentLine - File.ungetchIdx - 2);
+					int prev = getNthPrevCFromInputFile (1, 0);
 
 					if (! isident (prev))
 					{

--- a/main/get.c
+++ b/main/get.c
@@ -928,9 +928,9 @@ process:
 					 * 	"xxx(raw)xxx";
 					 *
 					 * which is perfectly valid (yet probably very unlikely). */
-					int prev = getNthPrevCFromInputFile (1, 0);
-					int prev2 = getNthPrevCFromInputFile (2, 0);
-					int prev3 = getNthPrevCFromInputFile (3, 0);
+					int prev = getNthPrevCFromInputFile (1, '\0');
+					int prev2 = getNthPrevCFromInputFile (2, '\0');
+					int prev3 = getNthPrevCFromInputFile (3, '\0');
 
 					if (! isident (prev) ||
 					    (! isident (prev2) && (prev == 'L' || prev == 'u' || prev == 'U')) ||

--- a/main/get.c
+++ b/main/get.c
@@ -66,6 +66,7 @@ typedef struct sCppState {
 	int		ungetch, ungetch2;   /* ungotten characters, if any */
 	boolean resolveRequired;     /* must resolve if/else/elif/endif branch */
 	boolean hasAtLiteralStrings; /* supports @"c:\" strings */
+	boolean hasCxxRawLiteralStrings; /* supports R"xxx(...)xxx" strings */
 	boolean hasSingleQuoteLiteralNumbers; /* supports vera number literals:
 						 'h..., 'o..., 'd..., and 'b... */
 	const kindOption  *defineMacroKind;
@@ -95,6 +96,7 @@ static cppState Cpp = {
 	'\0', '\0',  /* ungetch characters */
 	FALSE,       /* resolveRequired */
 	FALSE,       /* hasAtLiteralStrings */
+	FALSE,       /* hasCxxRawLiteralStrings */
 	FALSE,	     /* hasSingleQuoteLiteralNumbers */
 	NULL,	     /* defineMacroKind */
 	.macroUndefRoleIndex   = ROLE_INDEX_DEFINITION,
@@ -125,6 +127,7 @@ extern unsigned int getDirectiveNestLevel (void)
 }
 
 extern void cppInit (const boolean state, const boolean hasAtLiteralStrings,
+		     const boolean hasCxxRawLiteralStrings,
 		     const boolean hasSingleQuoteLiteralNumbers,
 		     const struct sKindOption *defineMacroKind,
 		     int macroUndefRoleIndex,
@@ -137,6 +140,7 @@ extern void cppInit (const boolean state, const boolean hasAtLiteralStrings,
 	Cpp.ungetch2        = '\0';
 	Cpp.resolveRequired = FALSE;
 	Cpp.hasAtLiteralStrings = hasAtLiteralStrings;
+	Cpp.hasCxxRawLiteralStrings = hasCxxRawLiteralStrings;
 	Cpp.hasSingleQuoteLiteralNumbers = hasSingleQuoteLiteralNumbers;
 	Cpp.defineMacroKind  = defineMacroKind;
 	Cpp.macroUndefRoleIndex = macroUndefRoleIndex;
@@ -650,6 +654,56 @@ static int skipToEndOfString (boolean ignoreBackslash)
 	return STRING_SYMBOL;  /* symbolic representation of string */
 }
 
+
+static int isCxxRawLiteralDelimiterChar (int c)
+{
+	return (c != ' ' && c != '\f' && c != '\n' && c != '\r' && c != '\t' && c != '\v' &&
+	        c != '(' && c != ')' && c != '\\');
+}
+
+static int skipToEndOfCxxRawLiteralString (void)
+{
+	int c = getcFromInputFile ();
+
+	if (c != '(' && ! isCxxRawLiteralDelimiterChar (c))
+	{
+		ungetcToInputFile (c);
+		c = skipToEndOfString (FALSE);
+	}
+	else
+	{
+		char delim[16];
+		unsigned int delimLen = 0;
+		boolean collectDelim = TRUE;
+
+		do
+		{
+			if (collectDelim)
+			{
+				if (isCxxRawLiteralDelimiterChar (c) &&
+				    delimLen < (sizeof delim / sizeof *delim))
+					delim[delimLen++] = c;
+				else
+					collectDelim = FALSE;
+			}
+			else if (c == ')')
+			{
+				unsigned int i = 0;
+
+				while ((c = getcFromInputFile ()) != EOF && i < delimLen && delim[i] == c)
+					i++;
+				if (i == delimLen && c == DOUBLE_QUOTE)
+					break;
+				else
+					ungetcToInputFile (c);
+			}
+		}
+		while ((c = getcFromInputFile ()) != EOF);
+		c = STRING_SYMBOL;
+	}
+	return c;
+}
+
 /*  Skips to the end of the three (possibly four) 'c' sequence, returning a
  *  special character to symbolically represent a generic character.
  *  Also detects Vera numbers that include a base specifier (ie. 'b1010).
@@ -854,6 +908,43 @@ process:
 					}
 					else
 						ungetcToInputFile (next);
+				}
+				else if (c == 'R' && Cpp.hasCxxRawLiteralStrings)
+				{
+					/* OMG!11 HACK!!11  Get the previous character.
+					 *
+					 * We need to know whether the previous character was an identifier or not,
+					 * because "R" has to be on its own, not part of an identifier.  This allows
+					 * for constructs like:
+					 *
+					 * 	#define FOUR "4"
+					 * 	const char *p = FOUR"5";
+					 *
+					 * which is not a raw literal, but a preprocessor concatenation.
+					 *
+					 * FIXME: handle
+					 *
+					 * 	const char *p = R\
+					 * 	"xxx(raw)xxx";
+					 *
+					 * which is perfectly valid (yet probably very unlikely). */
+					const unsigned char *base = (unsigned char *) vStringValue (File.line);
+					int prev = '\n';
+					if (File.currentLine - File.ungetchIdx - 2 >= base)
+						prev = (int) *(File.currentLine - File.ungetchIdx - 2);
+
+					if (! isident (prev))
+					{
+						int next = getcFromInputFile ();
+						if (next != DOUBLE_QUOTE)
+							ungetcToInputFile (next);
+						else
+						{
+							Cpp.directive.accept = FALSE;
+							c = skipToEndOfCxxRawLiteralString ();
+							break;
+						}
+					}
 				}
 			enter:
 				Cpp.directive.accept = FALSE;

--- a/main/get.c
+++ b/main/get.c
@@ -929,8 +929,12 @@ process:
 					 *
 					 * which is perfectly valid (yet probably very unlikely). */
 					int prev = getNthPrevCFromInputFile (1, 0);
+					int prev2 = getNthPrevCFromInputFile (2, 0);
+					int prev3 = getNthPrevCFromInputFile (3, 0);
 
-					if (! isident (prev))
+					if (! isident (prev) ||
+					    (! isident (prev2) && (prev == 'L' || prev == 'u' || prev == 'U')) ||
+					    (! isident (prev3) && (prev2 == 'u' && prev == '8')))
 					{
 						int next = getcFromInputFile ();
 						if (next != DOUBLE_QUOTE)

--- a/main/get.h
+++ b/main/get.h
@@ -62,6 +62,7 @@ extern unsigned int getDirectiveNestLevel (void);
 
 extern void cppInit (const boolean state,
 		     const boolean hasAtLiteralStrings,
+		     const boolean hasCxxRawLiteralStrings,
 		     const boolean hasSingleQuoteLiteralNumbers,
 		     const struct sKindOption *defineMacroKind,
 		     int macroUndefRoleIndex,

--- a/main/read.c
+++ b/main/read.c
@@ -511,6 +511,18 @@ extern int getcFromInputFile (void)
 	return c;
 }
 
+/* returns the nth previous character (0 meaning current), or def if nth cannot
+ * be accessed.  Note that this can't access previous line data. */
+extern int getNthPrevCFromInputFile (unsigned int nth, int def)
+{
+	const unsigned char *base = (unsigned char *) vStringValue (File.line);
+
+	if (File.currentLine - File.ungetchIdx - 1 - nth >= base)
+		return (int) *(File.currentLine - File.ungetchIdx - 1 - nth);
+	else
+		return def;
+}
+
 extern int skipToCharacterInInputFile (int c)
 {
 	int d;

--- a/main/read.c
+++ b/main/read.c
@@ -516,9 +516,10 @@ extern int getcFromInputFile (void)
 extern int getNthPrevCFromInputFile (unsigned int nth, int def)
 {
 	const unsigned char *base = (unsigned char *) vStringValue (File.line);
+	const unsigned int offset = File.ungetchIdx + 1 + nth;
 
-	if (File.currentLine - File.ungetchIdx - 1 - nth >= base)
-		return (int) *(File.currentLine - File.ungetchIdx - 1 - nth);
+	if (File.currentLine != NULL && File.currentLine >= base + offset)
+		return (int) *(File.currentLine - offset);
 	else
 		return def;
 }

--- a/main/read.h
+++ b/main/read.h
@@ -132,6 +132,7 @@ extern void                 freeInputFileResources (void);
 extern boolean              openInputFile (const char *const fileName, const langType language);
 extern void                 closeInputFile (void);
 extern int                  getcFromInputFile (void);
+extern int                  getNthPrevCFromInputFile (unsigned int nth, int def);
 extern int                  skipToCharacterInInputFile (int c);
 extern void                 ungetcToInputFile (int c);
 extern const unsigned char *readLineFromInputFile (void);

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3407,7 +3407,8 @@ static rescanReason findCTags (const unsigned int passCount)
 		role_for_header_local = VR_HEADER_LOCAL;
 	}
 
-	cppInit ((boolean) (passCount > 1), isInputLanguage (Lang_csharp), isInputLanguage(Lang_vera),
+	cppInit ((boolean) (passCount > 1), isInputLanguage (Lang_csharp), isInputLanguage(Lang_cpp),
+		 isInputLanguage(Lang_vera),
 		 kind_for_define, role_for_macro_undef,
 		 kind_for_header, role_for_header_system, role_for_header_local);
 

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -68,7 +68,7 @@ static const tagRegexTable const dtsTagRegexTable [] = {
 */
 static void runCppGetc (void)
 {
-	cppInit (0, FALSE, FALSE,
+	cppInit (0, FALSE, FALSE, FALSE,
 		 DTSKinds + DTS_MACRO, DTS_MACRO_KIND_UNDEF_ROLE,
 		 DTSKinds + DTS_HEADER, DTS_HEADER_KIND_SYSTEM_ROLE, DTS_HEADER_KIND_LOCAL_ROLE);
 


### PR DESCRIPTION
See http://en.cppreference.com/w/cpp/language/string_literal

---

This contains a pretty ugly hack to fetch the previous character, in
order not to get fooled by string concatenation hidden behind a macro,
like in `FOUR"five"`, which is not a raw string literal but simply the
identifier `FOUR` followed by the string `"five"`.

While this may sound uncommon, it is not and lead to complaints [2][3]
when Scintilla [1] broke this when they introduced C++11 raw string
literal support themselves.

The implementation here still contains a bug with line continuations: a
raw literal of the form:

```c
const char *str = R\
"xxx(...)xxx";
```

is not properly recognized as such, although it's perfectly valid (yet
probably very uncommon).  For the record, Scintilla has also suffers
from this but nobody complained about it yet.

[1] http://scintilla.org/
[2] https://sourceforge.net/p/scintilla/bugs/1207/
[3] https://sourceforge.net/p/scintilla/bugs/1454/