### PR TITLE
budge: make budge.ctags empty

### DIFF
--- a/misc/budge.ctags
+++ b/misc/budge.ctags
@@ -1,6 +1,3 @@
 #
 # In the future these should be preload'ed
 #
---options=ctags
---options=m4
---options=gdbinit


### PR DESCRIPTION
No extra option for running the budge script is
needed now.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>