### PR TITLE
Accept period as module name in python

### DIFF
--- a/Units/parser-python.r/python-dot-in-import.d/args.ctags
+++ b/Units/parser-python.r/python-dot-in-import.d/args.ctags
@@ -1,0 +1,3 @@
+--fields=+r
+--extra=+r
+--sort=no

--- a/Units/parser-python.r/python-dot-in-import.d/expected.tags
+++ b/Units/parser-python.r/python-dot-in-import.d/expected.tags
@@ -1,0 +1,12 @@
+A.B	input.py	/^from A.B import C as D$/;"	i	role:namespace
+C	input.py	/^from A.B import C as D$/;"	x	role:indirectly-imported
+D	input.py	/^from A.B import C as D$/;"	x
+.	input.py	/^from . import E$/;"	i	role:namespace
+E	input.py	/^from . import E$/;"	x	role:imported
+.F	input.py	/^from .F import G$/;"	i	role:namespace
+G	input.py	/^from .F import G$/;"	x	role:imported
+H.I	input.py	/^import H.I$/;"	i	role:imported
+.J.K	input.py	/^from .J.K import L$/;"	i	role:namespace
+L	input.py	/^from .J.K import L$/;"	x	role:imported
+..M.N	input.py	/^from ..M.N import O$/;"	i	role:namespace
+O	input.py	/^from ..M.N import O$/;"	x	role:imported

--- a/Units/parser-python.r/python-dot-in-import.d/input.py
+++ b/Units/parser-python.r/python-dot-in-import.d/input.py
@@ -1,0 +1,7 @@
+from A.B import C as D
+from . import E
+from .F import G
+import H.I
+
+from .J.K import L
+from ..M.N import O

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -332,7 +332,7 @@ static const char *skipUntil (const char *cp,
 }
 
 /* Skip everything up to an identifier start. */
-static const char *skipEverything (const char *cp)
+static const char *skipToNextIdentifier (const char *cp)
 {
 	return skipUntil (cp, isIdentifierFirstCharacterCB, NULL);
 }
@@ -349,7 +349,7 @@ static const char *findDefinitionOrClass (const char *cp)
 {
 	while (*cp)
 	{
-		cp = skipEverything (cp);
+		cp = skipToNextIdentifier (cp);
 		if (!strncmp(cp, "def", 3) || !strncmp(cp, "class", 5) ||
 			!strncmp(cp, "cdef", 4) || !strncmp(cp, "cpdef", 5))
 		{
@@ -427,7 +427,7 @@ static void parseImports (const char *cp, const char* from_module)
 		++cp;
 	}
 
-	cp = skipEverything (cp);
+	cp = skipToNextIdentifier (cp);
 nextLine:
 	while (*cp)
 	{
@@ -435,12 +435,12 @@ nextLine:
 		cp = skipSpace (cp);
 		if (*cp == ')')
 			found_multiline_end = TRUE;
-		cp = skipEverything (cp);
+		cp = skipToNextIdentifier (cp);
 		cp_next = parseIdentifier (cp, name_next);
 
 		if (strcmp (vStringValue (name_next), "as") == 0)
 		{
-			cp = skipEverything (cp_next);
+			cp = skipToNextIdentifier (cp_next);
 			cp = parseIdentifier (cp, name_next);
 			if (from_module)
 			{
@@ -485,7 +485,7 @@ nextLine:
 				found_multiline_end = TRUE;
 				cp++;
 			}
-			cp = skipEverything (cp);
+			cp = skipToNextIdentifier (cp);
 		}
 		else
 		{
@@ -553,9 +553,9 @@ static void parseFromModule (const char *cp, const char* dummy __unused__)
 	from_module = vStringNew ();
 	import_keyword = vStringNew ();
 
-	cp = skipEverything (cp);
+	cp = skipToNextIdentifier (cp);
 	cp = parseIdentifier (cp, from_module);
-	cp = skipEverything (cp);
+	cp = skipToNextIdentifier (cp);
 	cp = parseIdentifier (cp, import_keyword);
 
 	if (strcmp (vStringValue (import_keyword), "import") == 0
@@ -575,7 +575,7 @@ static boolean parseNamespace (const char *cp)
 {
 	void (* parse_sub) (const char *, const char *);
 
-	cp = skipEverything (cp);
+	cp = skipToNextIdentifier (cp);
 
 	if (strncmp (cp, "import", 6) == 0)
 	{


### PR DESCRIPTION
import statements including periods were not parsed well.
e.g.
```
import A.B
```
Only B was captured as a reference tag.
This commit fixes the bug.