### PR TITLE
Failing test for #781: triple quotes used with attrib

### DIFF
--- a/Units/parser-python.r/triple-quotes-in-class.b/expected.tags
+++ b/Units/parser-python.r/triple-quotes-in-class.b/expected.tags
@@ -1,0 +1,3 @@
+Bar	input.py	/^class Bar():$/;"	c
+Foo	input.py	/^class Foo():$/;"	c
+a	input.py	/^    a="""$/;"	v	class:Foo

--- a/Units/parser-python.r/triple-quotes-in-class.b/input.py
+++ b/Units/parser-python.r/triple-quotes-in-class.b/input.py
@@ -1,0 +1,8 @@
+class Foo():
+    a="""
+      baz
+      """
+
+
+class Bar():
+    pass


### PR DESCRIPTION
From #781:

```
% cat /tmp/t.py
class Foo():
    bar=dedent("""
               baz
               """)


class Bar():
    pass


% ctags -f - /tmp/t.py
Foo	/tmp/t.py	/^class Foo():$/;"	c	language:Python
bar	/tmp/t.py	/^    bar=dedent("""$/;"	v	language:Python	class:Foo
```

`Bar` is missing.

This is possibly related to the code at https://github.com/universal-ctags/ctags/blob/master/parsers/python.c#L1110-L1118 and/or https://github.com/universal-ctags/ctags/blob/master/parsers/python.c#L866.