### PR TITLE
build: allow to build ctags even if bash is not available in build en…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,12 +57,14 @@ $(REPOINFO_HEADS):
 	echo > $@
 endif
 
+if RUN_OPTLIB2C
 optlib2c_verbose = $(optlib2c_verbose_@AM_V@)
 optlib2c_verbose_ = $(optlib2c_verbose_@AM_DEFAULT_V@)
 optlib2c_verbose_0 = @echo OPTLIB2C "  $@";
 OPTLIB2C = $(srcdir)/misc/optlib2c
 %.c: %.ctags $(OPTLIB2C) Makefile
 	$(optlib2c_verbose)$(OPTLIB2C) --transform-xcmd="$(program_transform_name)" $< > $@
+endif
 dist_ctags_SOURCES = $(ALL_HEADS) $(ALL_SRCS)
 
 man_MANS = ctags.1

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,11 +1,27 @@
 #!/bin/sh
-misc/dist-test-cases > makefiles/test-cases.mak && \
-autoreconf -vfi && {
-    for i in `make -f makefiles/list-translator-input.mak`; do
-	o=${i%.ctags}.c
-	echo "optlib2c: translating $i to $o"
-	./misc/optlib2c $i > $o
-    done
+
+verify_optlib2c_requirements()
+{
+    : &&
+	which bash > /dev/null &&
+	which seq  > /dev/null
 }
+
+ctags_files=`make -f makefiles/list-translator-input.mak`
+misc/dist-test-cases > makefiles/test-cases.mak && \
+    if autoreconf -vfi; then
+	if can_run_optlib2c; then
+	    for i in ${ctags_files}; do
+		o=${i%.ctags}.c
+		echo "optlib2c: translating $i to $o"
+		./misc/optlib2c $i > $o
+	    done
+	else
+	    for i in ${ctags_files}; do
+		o=${i%.ctags}.c
+		echo "use pre-translated file: $o"
+	    done
+	fi
+    fi
 
 exit $?

--- a/configure.ac
+++ b/configure.ac
@@ -298,10 +298,11 @@ AC_PROG_LN_S
 AC_CHECK_PROG(STRIP, strip, strip, :)
 AC_SYS_LARGEFILE
 
-AC_CHECK_PROGS([BASH], [bash])
-if ! test "${BASH+set}" = "set"; then
-   AC_MSG_ERROR([bash is needed to run optlib2c translator])
-fi
+AC_CHECK_PROG([bash_found], [bash], [yes], [no])
+AC_CHECK_PROG([seq_found],  [seq],  [yes], [no])
+AM_CONDITIONAL([RUN_OPTLIB2C],
+	 [test "${bash_found}" = "yes" -a "${seq_found}" = "yes"])
+
 
 # Checks for operating environment
 # --------------------------------

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # optlib2c - a tool translating ctags option file to C
 #


### PR DESCRIPTION
…vironment

bash is needed to run optlib2c translator.
If bash is not available, use pre-translated C code for building ctags executable.

Close #794.

Using /usr/bin/env is suggested by @jockej.