### PR TITLE
Java: add catch as a keyword

### DIFF
--- a/Units/parser-java.r/java-catch-block.d/args.ctags
+++ b/Units/parser-java.r/java-catch-block.d/args.ctags
@@ -1,0 +1,3 @@
+--fields=+K
+--java-kinds=+l
+

--- a/Units/parser-java.r/java-catch-block.d/expected.tags
+++ b/Units/parser-java.r/java-catch-block.d/expected.tags
@@ -1,0 +1,2 @@
+C	input.java	/^class C {$/;"	class
+m	input.java	/^   public void m(String a[]) {$/;"	method	class:C

--- a/Units/parser-java.r/java-catch-block.d/input.java
+++ b/Units/parser-java.r/java-catch-block.d/input.java
@@ -1,0 +1,7 @@
+// Based on code reported by @brate in #797
+class C {
+   public void m(String a[]) {
+       try {}
+       catch (Exception e) {}
+   }
+}

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -507,7 +507,7 @@ static const keywordDesc KeywordTable [] = {
      { "byte",            KEYWORD_BYTE,            { 0, 0, 0, 1, 1, 0 } },
      { "case",            KEYWORD_CASE,            { 1, 1, 1, 1, 1, 0 } },
      { "cast",            KEYWORD_CAST,            { 0, 0, 0, 1, 0, 0 } },
-     { "catch",           KEYWORD_CATCH,           { 0, 1, 1, 1, 0, 0 } },
+     { "catch",           KEYWORD_CATCH,           { 0, 1, 1, 1, 1, 0 } },
      { "cdouble",         KEYWORD_CDOUBLE,         { 0, 0, 0, 1, 0, 0 } },
      { "cent",            KEYWORD_CENT,            { 0, 0, 0, 1, 0, 0 } },
      { "cfloat",          KEYWORD_CFLOAT,          { 0, 0, 0, 1, 0, 0 } },


### PR DESCRIPTION
Close #797, a bug reported by @mrate.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>