### PR TITLE
Fix union syntax errors in parser files.

### DIFF
--- a/parsers/ant.c
+++ b/parsers/ant.c
@@ -75,52 +75,58 @@ enum antXpathTable {
 static tagXpathTable antXpathMainTable [] = {
 	{ "///project",
 	  LXPATH_TABLE_DO_RECUR,
-	  .recurSpec = {
+      { .recurSpec= {
 			antFindTagsUnderProject
-		}
+        }
+      }
 	},
 };
 
 static tagXpathTable antXpathProjectTable [] = {
 	{ "target",
 	  LXPATH_TABLE_DO_RECUR,
-	  .recurSpec = {
+      { .recurSpec= {
 			antFindTagsUnderTask
 		}
+      }
 	},
 	{ "property/@name",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_PROPERTY, ROLE_INDEX_DEFINITION,
 			makeTagWithScope,
 		}
+      }
 	},
 	{ "import/@file",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_IMPORT, R_IMPORT_GENERIC,
 			makeTagWithScope,
 		}
+      }
 	},
 };
 
 static tagXpathTable antXpathMainNameTable [] = {
 	{ "@name",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_PROJECT, ROLE_INDEX_DEFINITION,
 			makeTagForProjectName,
 		}
+      }
 	},
 };
 
 static tagXpathTable antXpathTargetNameTable [] = {
 	{ "@name",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_TARGET, ROLE_INDEX_DEFINITION,
 			makeTagForTargetName,
 		}
+      }
 	},
 };
 

--- a/parsers/dbusintrospect.c
+++ b/parsers/dbusintrospect.c
@@ -50,24 +50,27 @@ static void makeTagWithScope (xmlNode *node,
 static tagXpathTable dbusIntrospectXpathInterfaceTable [] = {
 	{ "//method/@name",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_METHOD,    ROLE_INDEX_DEFINITION,
 			makeTagWithScope,
 		}
+      }
 	},
 	{ "//signal/@name",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_SIGNAL,    ROLE_INDEX_DEFINITION,
 			makeTagWithScope,
 		}
+      }
 	},
 	{ "//property/@name",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_PROPERTY,  ROLE_INDEX_DEFINITION,
 			makeTagWithScope
 		}
+      }
 	},
 
 };
@@ -75,19 +78,21 @@ static tagXpathTable dbusIntrospectXpathInterfaceTable [] = {
 static tagXpathTable dbusIntrospectXpathMainTable [] = {
 	{ "///interface",
 	  LXPATH_TABLE_DO_RECUR,
-	  .recurSpec = {
+      { .recurSpec = {
 			dbusIntrospectFindTagsUnderInterface
 		}
+      }
 	},
 };
 
 static tagXpathTable dbusIntrospectXpathMainNameTable [] = {
 	{ "@name",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_INTERFACE, ROLE_INDEX_DEFINITION,
 			makeTagForInterfaceName,
 		}
+      }
 	},
 };
 

--- a/parsers/glade.c
+++ b/parsers/glade.c
@@ -50,18 +50,21 @@ static kindOption GladeKinds [] = {
 static tagXpathTable gladeXpathMainTable[] = {
 	{ "///glade-interface//widget//@id",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_ID,    ROLE_INDEX_DEFINITION }
+      }
 	},
 	{ "///glade-interface//widget//@class",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_CLASS, R_CLASS_WIDGET }
+      }
 	},
 	{ "///glade-interface//signal//@handler",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_HANDLER, R_HANDLER_HANDLER }
+      }
 	},
 };
 

--- a/parsers/maven2.c
+++ b/parsers/maven2.c
@@ -77,37 +77,42 @@ static void makeTagForProperties (xmlNode *node,
 static tagXpathTable maven2XpathMainTable[] = {
 	{ "/*[local-name()='project']/*[local-name()='groupId']",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_GROUP_ID,  ROLE_INDEX_DEFINITION,
 			makeTagWithScope
 		}
+      }
 	},
 	{ "/*[local-name()='project']/*[local-name()='parent']/*[local-name()='groupId']",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_GROUP_ID,  R_GROUP_ID_PARENT,
 			makeTagWithScope
 		}
+      }
 	},
 	{ "/*[local-name()='project']/*[local-name()='artifactId']",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_ARTIFACT_ID,  ROLE_INDEX_DEFINITION,
 			makeTagWithScope
 		}
+      }
 	},
 	{ "/*[local-name()='project']/*[local-name()='parent']/*[local-name()='artifactId']",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+      { .makeTagSpec = {
 			K_ARTIFACT_ID,  R_ARTIFACT_ID_PARENT,
 			makeTagWithScope
 		}
+      }
 	},
 	{ "/*[local-name()='project']/*[local-name()='properties']/*",
 	  LXPATH_TABLE_DO_RECUR,
-	  .recurSpec = {
+      { .recurSpec = {
 			makeTagForProperties
 		}
+      }
 	},
 };
 


### PR DESCRIPTION
Missing curly braces when initializing union members in tagXpathTable structs:
 - recurSpec
 - makeTagSpec

Fix for #798