### PR TITLE
Add another case to handle shift operators in template parameters

### DIFF
--- a/parsers/c.c
+++ b/parsers/c.c
@@ -1777,18 +1777,28 @@ static void skipCppTemplateParameterList (void)
 
 		if (c == '<')
 		{
-			if (roundBracketsLevel == 0)
+			int x = cppGetc ();
+			if(x != '<') 
 			{
-				if (defaultValueExpected == FALSE)
-					++angleBracketsLevel;
+				cppUngetc (x);
+				if (roundBracketsLevel == 0)
+				{
+					if (defaultValueExpected == FALSE)
+						++angleBracketsLevel;
+				}
 			}
 		}
 		else if (c == '>')
 		{
-			if (roundBracketsLevel == 0)
+			int x = cppGetc ();
+			if( x != '>') 
 			{
-				--angleBracketsLevel;
-				defaultValueExpected = FALSE;
+				cppUngetc (x);
+				if (roundBracketsLevel == 0)
+				{
+					--angleBracketsLevel;
+					defaultValueExpected = FALSE;
+				}
 			}
 		}
 		else if (c == '(')

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -1788,7 +1788,7 @@ static void skipCppTemplateParameterList (void)
 				}
 			}
 			else if(CollectingSignature)
-				vStringPut (Signature, c);
+				vStringPut (Signature, x);
 		}
 		else if (c == '>')
 		{
@@ -1803,7 +1803,7 @@ static void skipCppTemplateParameterList (void)
 				}
 			}
 			else if(CollectingSignature)
-				vStringPut (Signature, c);
+				vStringPut (Signature, x);
 		}
 		else if (c == '(')
 			roundBracketsLevel ++;

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -1787,6 +1787,8 @@ static void skipCppTemplateParameterList (void)
 						++angleBracketsLevel;
 				}
 			}
+			else if(CollectingSignature)
+				vStringPut (Signature, c);
 		}
 		else if (c == '>')
 		{
@@ -1800,6 +1802,8 @@ static void skipCppTemplateParameterList (void)
 					defaultValueExpected = FALSE;
 				}
 			}
+			else if(CollectingSignature)
+				vStringPut (Signature, c);
 		}
 		else if (c == '(')
 			roundBracketsLevel ++;


### PR DESCRIPTION
Handle this case as well:

```
template <int P> class c {};
c< 8 > bVar;
c< 1<<8 > aVar;
```