### PR TITLE
readtags: implement $, generic extension field accessor

### DIFF
--- a/Tmain/readtags-qualifier.d/run.sh
+++ b/Tmain/readtags-qualifier.d/run.sh
@@ -26,4 +26,6 @@ echo ';; (and (eq? $kind "member") (substr? $name "."))' &&
 ${V} ${READTAGS} -e -t output.tags -Q '(and (eq? $kind "member") (substr? $name "."))' -l &&
 echo ';; (and (member "Foo" $inherits) (eq? $kind "class"))' &&
 ${V} ${READTAGS}  -e -t output.tags -Q '(and (member "Foo" $inherits) (eq? $kind "class"))' -l &&
+echo ';; (not ($ "signature"))' &&
+${V} ${READTAGS}  -e -t output.tags -Q '(not ($ "signature"))' -l &&
 :

--- a/Tmain/readtags-qualifier.d/stdout-expected.txt
+++ b/Tmain/readtags-qualifier.d/stdout-expected.txt
@@ -21,3 +21,11 @@ Foo.aw	base.py	/^    def aw ():$/;"	kind:member	language:Python	scope:class:Foo	
 ;; (and (member "Foo" $inherits) (eq? $kind "class"))
 Bar	base.py	/^class Bar (Foo):$/;"	kind:class	language:Python	inherits:Foo	access:public
 Baz	base.py	/^class Baz (Foo): $/;"	kind:class	language:Python	inherits:Foo	access:public
+;; (not ($ "signature"))
+A	base.py	/^    class A:$/;"	kind:class	language:Python	scope:class:Foo	inherits:	access:public
+B	base.py	/^    class B:$/;"	kind:class	language:Python	scope:class:Bar	inherits:	access:public
+Bar	base.py	/^class Bar (Foo):$/;"	kind:class	language:Python	inherits:Foo	access:public
+Baz	base.py	/^class Baz (Foo): $/;"	kind:class	language:Python	inherits:Foo	access:public
+C	base.py	/^    class C:$/;"	kind:class	language:Python	scope:class:Baz	inherits:	access:public
+Foo	base.py	/^class Foo:$/;"	kind:class	language:Python	inherits:	access:public
+base.py	base.py	28;"	kind:file	language:Python

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -436,6 +436,7 @@ rejection: readtags doesn't print it.
 		suffix?
 		substr?
 		 member
+		      $
 		  $name
 		 $input
 		$access
@@ -469,6 +470,12 @@ language; see the other documents.
 prefix?, suffix?, and substr? may be only available in this
 implementation. All of them takes two strings. The first one
 is called target.
+
+The exception in above name convention is `$` operator.
+`$` is generic accessor for accessing to extension fields.
+`$` takes one argument: the name of an extension field.
+It returns the value of field as a string if a value
+is given, or `#f`.
 
 ::
 

--- a/dsl/qualifier.c
+++ b/dsl/qualifier.c
@@ -56,6 +56,7 @@ static EsObject* builtin_prefix (EsObject *args, tagEntry *entry);
 static EsObject* builtin_suffix (EsObject *args, tagEntry *entry);
 static EsObject* builtin_substr (EsObject *args, tagEntry *entry);
 static EsObject* builtin_member (EsObject *args, tagEntry *entry);
+static EsObject* builtin_entry_ref (EsObject *args, tagEntry *entry);
 
 
 static EsObject* value_name (EsObject *args, tagEntry *entry);
@@ -98,6 +99,8 @@ struct sCode {
 	  .helpstr = "(substr? TARGET<string> SUBSTR<string>) -> <boolean>" },
 	{ "member",  builtin_member, NULL, CHECK_ARITY, 2,
 	  .helpstr = "(member ELEMENT LIST) -> #f|<list>'" },
+	{ "$",       builtin_entry_ref, NULL, CHECK_ARITY, 1,
+	  .helpstr = "($ NAME) -> #f|<string>'" },
 
 	{ "$name",           value_name,           NULL, MEMORABLE, 0UL,},
 	{ "$input",          value_input,          NULL, MEMORABLE, 0UL,
@@ -460,6 +463,20 @@ static EsObject* entry_xget_string (tagEntry *entry, const char* name)
 	else
 		return es_false;
 }
+
+static EsObject* builtin_entry_ref (EsObject *args, tagEntry *entry)
+{
+	EsObject *key = es_car(args);
+
+	if (es_error_p (key))
+		return key;
+	else if (! es_string_p (key))
+		throw (WRONG_TYPE_ARGUMENT,
+		       es_symbol_intern ("$"));
+	else
+		return entry_xget_string (entry, es_string_get (key));
+}
+
 
 static EsObject* value_name (EsObject *args, tagEntry *entry)
 {


### PR DESCRIPTION
To handle the tags file in which uncommon fields are used, this commit introduces generic field accessor.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>