### PR TITLE
Units, C++: fix broken test case for #807

### DIFF
--- a/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.b/expected.tags
+++ b/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.b/expected.tags
@@ -1,4 +1,4 @@
-aVar	input.cpp	/^c< 1<<8 > aVar;"	v
-bVar	input.cpp	/^c< 8 > bVar;$/;"	v
 c	input.cpp	/^template <int P> class c {};$/;"	c	file:
-func    input.cpp	/^template<int X> func( c< 1<<X> & aVar) {$/;"  f	signature:( c< 1<<X> & aVar)
+bVar	input.cpp	/^c< 8 > bVar;$/;"	v
+aVar	input.cpp	/^c< 1<<8 > aVar;$/;"	v
+f12	input.cpp	/^template<int X> f12( c< 1<<X> & aVar) { };$/;"	f	signature:( c< 1<<X> & aVar)

--- a/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.b/input.cpp
+++ b/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.b/input.cpp
@@ -1,4 +1,3 @@
-int main (int c) {};
 template <int P> class c {};
 c< 8 > bVar;
 c< 1<<8 > aVar;


### PR DESCRIPTION
The order of lines and patterns were broken.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>