### PR TITLE
Refactor, C++: don't use a temporary variable to gather Signature

### DIFF
--- a/parsers/c.c
+++ b/parsers/c.c
@@ -1788,7 +1788,7 @@ static void skipCppTemplateParameterList (void)
 				}
 			}
 			else if(CollectingSignature)
-				vStringPut (Signature, x);
+				vStringPut (Signature, c);
 		}
 		else if (c == '>')
 		{
@@ -1803,7 +1803,7 @@ static void skipCppTemplateParameterList (void)
 				}
 			}
 			else if(CollectingSignature)
-				vStringPut (Signature, x);
+				vStringPut (Signature, c);
 		}
 		else if (c == '(')
 			roundBracketsLevel ++;


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>