### PR TITLE
main, php: add a root separator to top level items

### DIFF
--- a/Units/parser-php.r/php-full-qualified-tags.d/expected.tags
+++ b/Units/parser-php.r/php-full-qualified-tags.d/expected.tags
@@ -1,3 +1,4 @@
+\\foo	input.php	/^namespace foo;$/;"	n
 \\foo\\bar	input.php	/^class bar {$/;"	c	namespace:\\foo
 \\foo\\bar::__construct	input.php	/^    public function __construct() {$/;"	f	class:\\foo\\bar
 __construct	input.php	/^    public function __construct() {$/;"	f	class:\\foo\\bar

--- a/main/entry.c
+++ b/main/entry.c
@@ -1274,6 +1274,22 @@ extern int makeQualifiedTagEntry (const tagEntryInfo *const e)
 			sep = scopeSeparatorFor (e->kind, xk);
 			vStringCatS (fqn, sep);
 		}
+		else
+		{
+			/* This is an top level item. prepend a root separator
+			   if the kind of the item has. */
+			sep = scopeSeparatorFor (e->kind, KIND_NULL);
+			if (sep == NULL)
+			{
+				/* No root separator. The name of the
+				   oritinal tag and that of full qualified tag
+				   are the same; recording the full qualified tag
+				   is meaningless. */
+				return r;
+			}
+			else
+				vStringCatS (fqn, sep);
+		}
 		vStringCatS (fqn, e->name);
 
 		x.name = vStringValue (fqn);

--- a/main/kind.c
+++ b/main/kind.c
@@ -54,8 +54,18 @@ const char *scopeSeparatorFor (const kindOption *kind, char parentLetter)
 	scopeSeparator *table;
 	Assert (kind);
 	table = kind->separators;
+
+	/* If no table is given, use the default generic separator ".".
+	   The exception is if a root separator is looked up. In this case,
+	   return NULL to notify there is no root separator to the caller. */
+
 	if (table == NULL)
-		return ".";
+	{
+		if (parentLetter == KIND_NULL)
+			return NULL;
+		else
+			return ".";
+	}
 
 	while (table - kind->separators < kind->separatorCount)
 	{
@@ -64,5 +74,8 @@ const char *scopeSeparatorFor (const kindOption *kind, char parentLetter)
 			return table->separator;
 		table++;
 	}
-	return ".";
+	if (parentLetter == KIND_NULL)
+		return NULL;
+	else
+		return ".";
 }


### PR DESCRIPTION
makeQualifiedTagEntry() builds a full qualified tag for
a given tag. It uses scope information; put a separator
between upper item and the current item specified with
the given tag.

This commit handles the case when there is no scope information.  If
such case a root separator must be put as prefix to the current item.

e.g.

input:

    <?php
    namespace foo;
    >

the output with --extra=+q:

    \\foo	input.php	/^namespace foo;$/;"	n
    foo	input.php	/^namespace foo;$/;"	n

Signed-off-by: Masatake YAMATO <yamato@redhat.com>