### PR TITLE
units: extend the timeout value

### DIFF
--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -66,7 +66,7 @@ chop: $(CTAGS_TEST)
 #
 # UNITS Target
 #
-units: TIMEOUT := $(shell timeout --version > /dev/null 2>&1 && echo 5 || echo 0)
+units: TIMEOUT := $(shell timeout --version > /dev/null 2>&1 && echo 10 || echo 0)
 units: $(CTAGS_TEST)
 	@ \
 	if test -n "$${ZSH_VERSION+set}"; then set -o SH_WORD_SPLIT; fi; \


### PR DESCRIPTION
These days failures are reported frequently
because of timeout.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>