### PR TITLE
SQL: handle unexpected tokens in declare block

### DIFF
--- a/Units/parser-sql.r/sql_pgSQL_empty_decl.d/expected.tags
+++ b/Units/parser-sql.r/sql_pgSQL_empty_decl.d/expected.tags
@@ -1,0 +1,2 @@
+X	input.sql	/^CREATE FUNCTION X RETURNS void AS $\$$/;"	f
+Y	input.sql	/^CREATE OR REPLACE FUNCTION Y(i integer) RETURNS integer AS $\$$/;"	f

--- a/Units/parser-sql.r/sql_pgSQL_empty_decl.d/input.sql
+++ b/Units/parser-sql.r/sql_pgSQL_empty_decl.d/input.sql
@@ -1,0 +1,14 @@
+CREATE FUNCTION X RETURNS void AS $$
+BEGIN
+	IF 0 = 0 THEN
+	   ;
+	 END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Taken from https://www.postgresql.jp/document/9.2/html/sql-createfunction.html
+CREATE OR REPLACE FUNCTION Y(i integer) RETURNS integer AS $$
+        BEGIN
+                RETURN i + 1;
+        END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
The original code expects a semicolon in a declare block.  However,
as a test case shows, a block can have a token other than a semicolon
at least in pgSQL.

This commit adds an additional rule to stop finding the semicolon for
handling the situation. When 'begin' or 'end' is found, the sql parsr
stops finding the semicolon and exits from declare block handling.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>