### PR TITLE
main: Don't access uninitialised buffer area in vStringNCatS

### DIFF
--- a/main/vstring.c
+++ b/main/vstring.c
@@ -139,7 +139,7 @@ extern void vStringNCatS (
 	const char *p = s;
 	size_t remain = length;
 
-	while (*p != '\0'  &&  remain > 0)
+	while (remain > 0 && *p != '\0')
 	{
 		vStringPut (string, *p);
 		--remain;


### PR DESCRIPTION
Fix #831.

The way to reproduce:

     $ echo x > a.xml
     $ valgrind --leak-check=full --track-origins=yes -v ./ctags ./a.xml
     ...
     ==28216== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
     ==28216==
     ==28216== 1 errors in context 1 of 1:
     ==28216== Conditional jump or move depends on uninitialised value(s)
     ==28216==    at 0x416C0F: vStringNCatS (vstring.c:142)
     ==28216==    by 0x416FE4: vStringNewFile (vstring.c:282)
     ==28216==    by 0x415EEE: xmlParseFILE (selectors.c:309)
     ==28216==    by 0x415EEE: selectByDTD (selectors.c:372)
     ==28216==    by 0x411239: pickLanguageBySelection (parse.c:760)
     ==28216==    by 0x411239: getSpecLanguageCommon (parse.c:860)
     ==28216==    by 0x4113E5: getPatternLanguage (parse.c:892)
     ==28216==    by 0x4113E5: getFileLanguageInternal (parse.c:936)
     ==28216==    by 0x412E1C: getFileLanguage (parse.c:987)
     ==28216==    by 0x412E1C: parseFile (parse.c:1960)
     ==28216==    by 0x40BDB4: createTagsForEntry (main.c:253)
     ==28216==    by 0x4033C7: createTagsForArgs (main.c:298)
     ==28216==    by 0x4033C7: makeTags (main.c:444)
     ==28216==    by 0x4033C7: main (main.c:546)
     ==28216==  Uninitialised value was created by a stack allocation
     ==28216==    at 0x416F3C: vStringNewFile (vstring.c:272)

The old code accesses the contents of a given buffer BEFORE checking
its valid range.

This commit changes the order: accessing the contents after checking
the range.