### PR TITLE
PHP: parse `use` aliases

### DIFF
--- a/Units/parser-php.r/php-use.d/expected.tags
+++ b/Units/parser-php.r/php-use.d/expected.tags
@@ -1,0 +1,23 @@
+CONST	input.php	/^    const CONST = 1;$/;"	d	class:\\NS\\Cls
+Cls	input.php	/^  class Cls implements Iface {$/;"	c	namespace:\\NS
+Cls	input.php	/^  class Cls implements NSIface {$/;"	c	namespace:\\NS2
+Cls	input.php	/^  use NS\\Cls;$/;"	a	typeref:unknown:NS\\Cls
+Cls2	input.php	/^  use NS2\\Cls as Cls2;$/;"	a	typeref:unknown:NS2\\Cls
+FOO	input.php	/^  const FOO = 1;$/;"	d	namespace:\\NS
+FOO	input.php	/^  use const NS\\FOO;$/;"	a	namespace:\\NS2	typeref:define:NS\\FOO
+Iface	input.php	/^  interface Iface extends NSIface {$/;"	i	namespace:\\NS2
+Iface	input.php	/^  interface Iface {$/;"	i	namespace:\\NS
+MYCONST	input.php	/^  use const NS\\FOO as MYCONST;$/;"	a	typeref:define:NS\\FOO
+NS	input.php	/^namespace NS {$/;"	n
+NS2	input.php	/^namespace NS2 {$/;"	n
+NSCls	input.php	/^  use NS\\Iface as NSIface, NS\\Cls as NSCls;$/;"	a	namespace:\\NS2	typeref:unknown:NS\\Cls
+NSIface	input.php	/^  use NS\\Iface as NSIface, NS\\Cls as NSCls;$/;"	a	namespace:\\NS2	typeref:unknown:NS\\Iface
+SomeAliasedNS	input.php	/^  use NS as SomeAliasedNS;$/;"	a	typeref:unknown:NS
+cls	input.php	/^  $cls = new Cls2;$/;"	v
+cls	input.php	/^  $cls = new Cls;$/;"	v
+foo	input.php	/^    private $foo = FOO;$/;"	v	class:\\NS2\\Cls
+hello	input.php	/^    public function hello() {$/;"	f	class:\\NS2\\Cls
+hello	input.php	/^    public function hello() {$/;"	f	class:\\NS\\Cls
+hello	input.php	/^    public function hello();$/;"	f	interface:\\NS\\Iface
+test	input.php	/^  function test() {$/;"	f	namespace:\\NS
+test	input.php	/^  use function NS\\test;$/;"	a	typeref:function:NS\\test

--- a/Units/parser-php.r/php-use.d/expected.tags
+++ b/Units/parser-php.r/php-use.d/expected.tags
@@ -1,17 +1,29 @@
 CONST	input.php	/^    const CONST = 1;$/;"	d	class:\\NS\\Cls
+ClassFour	input.php	/^  use NS2\\{NS30 as NameSpaceTreePointO, NS31\\Cls4 as ClassFour};$/;"	a	typeref:unknown:NS2\\NS31\\Cls4
 Cls	input.php	/^  class Cls implements Iface {$/;"	c	namespace:\\NS
 Cls	input.php	/^  class Cls implements NSIface {$/;"	c	namespace:\\NS2
 Cls	input.php	/^  use NS\\Cls;$/;"	a	typeref:unknown:NS\\Cls
 Cls2	input.php	/^  use NS2\\Cls as Cls2;$/;"	a	typeref:unknown:NS2\\Cls
+Cls3	input.php	/^  class Cls3 {}$/;"	c	namespace:\\NS2\\NS30
+Cls4	input.php	/^  class Cls4 {}$/;"	c	namespace:\\NS2\\NS31
+Cls4	input.php	/^  use NS2\\{NS30, NS31\\Cls4};$/;"	a	typeref:unknown:NS2\\NS31\\Cls4
 FOO	input.php	/^  const FOO = 1;$/;"	d	namespace:\\NS
 FOO	input.php	/^  use const NS\\FOO;$/;"	a	namespace:\\NS2	typeref:define:NS\\FOO
 Iface	input.php	/^  interface Iface extends NSIface {$/;"	i	namespace:\\NS2
 Iface	input.php	/^  interface Iface {$/;"	i	namespace:\\NS
+Iface	input.php	/^  use NS2\\{Cls as NS2Cls, Iface};$/;"	a	typeref:unknown:NS2\\Iface
 MYCONST	input.php	/^  use const NS\\FOO as MYCONST;$/;"	a	typeref:define:NS\\FOO
 NS	input.php	/^namespace NS {$/;"	n
 NS2	input.php	/^namespace NS2 {$/;"	n
+NS2Cls	input.php	/^  use NS2\\{Cls as NS2Cls, Iface};$/;"	a	typeref:unknown:NS2\\Cls
+NS2\\NS30	input.php	/^namespace NS2\\NS30 {$/;"	n
+NS2\\NS30\\NS301	input.php	/^namespace NS2\\NS30\\NS301 {}$/;"	n
+NS2\\NS30\\NS302	input.php	/^namespace NS2\\NS30\\NS302 {}$/;"	n
+NS2\\NS31	input.php	/^namespace NS2\\NS31 {$/;"	n
+NS30	input.php	/^  use NS2\\{NS30, NS31\\Cls4};$/;"	a	typeref:unknown:NS2\\NS30
 NSCls	input.php	/^  use NS\\Iface as NSIface, NS\\Cls as NSCls;$/;"	a	namespace:\\NS2	typeref:unknown:NS\\Cls
 NSIface	input.php	/^  use NS\\Iface as NSIface, NS\\Cls as NSCls;$/;"	a	namespace:\\NS2	typeref:unknown:NS\\Iface
+NameSpaceTreePointO	input.php	/^  use NS2\\{NS30 as NameSpaceTreePointO, NS31\\Cls4 as ClassFour};$/;"	a	typeref:unknown:NS2\\NS30
 SomeAliasedNS	input.php	/^  use NS as SomeAliasedNS;$/;"	a	typeref:unknown:NS
 cls	input.php	/^  $cls = new Cls2;$/;"	v
 cls	input.php	/^  $cls = new Cls;$/;"	v

--- a/Units/parser-php.r/php-use.d/input.php
+++ b/Units/parser-php.r/php-use.d/input.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace NS {
+  const FOO = 1;
+  
+  interface Iface {
+    public function hello();
+  }
+  
+  class Cls implements Iface {
+    const CONST = 1;
+    
+    public function hello() {
+      echo "hi\n";
+    }
+  }
+    
+  function test() {
+    echo "test\n";
+  }
+}
+
+namespace NS2 {
+  use NS\Iface as NSIface, NS\Cls as NSCls;
+  use const NS\FOO;
+  
+  interface Iface extends NSIface {
+    
+  }
+  
+  class Cls implements NSIface {
+    private $foo = FOO;
+    
+    public function hello() {
+      echo "hello ",$this->foo,"\n";
+    }
+  }
+}
+
+namespace {
+  use NS as SomeAliasedNS;
+  use NS\Cls;
+  use NS2\Cls as Cls2;
+  use const NS\FOO as MYCONST;
+  use function NS\test;
+  
+  $cls = new Cls;
+  echo $cls::CONST, "\n";
+  echo MYCONST, "\n";
+  
+  $cls->hello();
+  
+  test();
+  
+  $cls = new Cls2;
+  $cls->hello();
+}

--- a/Units/parser-php.r/php-use.d/input.php
+++ b/Units/parser-php.r/php-use.d/input.php
@@ -37,12 +37,26 @@ namespace NS2 {
   }
 }
 
+namespace NS2\NS30 {
+  class Cls3 {}
+}
+
+namespace NS2\NS31 {
+  class Cls4 {}
+}
+
+namespace NS2\NS30\NS301 {}
+namespace NS2\NS30\NS302 {}
+
 namespace {
   use NS as SomeAliasedNS;
   use NS\Cls;
   use NS2\Cls as Cls2;
   use const NS\FOO as MYCONST;
   use function NS\test;
+  use NS2\{Cls as NS2Cls, Iface};
+  use NS2\{NS30, NS31\Cls4};
+  use NS2\{NS30 as NameSpaceTreePointO, NS31\Cls4 as ClassFour};
   
   $cls = new Cls;
   echo $cls::CONST, "\n";
@@ -54,4 +68,7 @@ namespace {
   
   $cls = new Cls2;
   $cls->hello();
+  
+  new ClassFour;
+  new NameSpaceTreePointO\Cls3;
 }


### PR DESCRIPTION
Fixes #847.

As it's similar to a C typedef, report the source type in `typeRef[1]`.  `typeRef[0]` is filled sensibly when possible, but most generally not, because it's impossible to know whether it'll be a class, interface or namespace.  In that case, `unknown` is used instead.