### PR TITLE
docs: move the section about C++/C to the chapter for parsers

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ Proofreading and pull-requests are welcome!
 	:maxdepth: 2
 
 	news.rst
-	cxx.rst
+	parsers.rst
 	guessing.rst
 	building.rst
 	testing.rst


### PR DESCRIPTION
I forgot updating the top level toctree.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>