### PR TITLE
Proposal: Custom extension fields

### DIFF
--- a/Units/parser-cxx.r/bug1563476.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1563476.cpp.d/expected.tags
@@ -1,3 +1,3 @@
 g	input.cpp	/^int g() {$/;"	f	typeref:typename:int
-IntroduceBitDef	input.cpp	/^struct IntroduceBitDef< Accessor, typename$/;"	s	file:
+IntroduceBitDef	input.cpp	/^struct IntroduceBitDef< Accessor, typename$/;"	s	file:	template:<typename Accessor>
 f	input.cpp	/^ int f() { }$/;"	f	struct:IntroduceBitDef	typeref:typename:int	file:

--- a/Units/parser-cxx.r/bug872494.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/bug872494.cpp.d/args.ctags
@@ -1,3 +1,2 @@
---sort=no
---kinds-C++=*
 --c++-enable-template-info
+

--- a/Units/parser-cxx.r/bug872494.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug872494.cpp.d/expected.tags
@@ -1,5 +1,5 @@
 FooClass2	input.cpp	/^class FooClass2{};$/;"	c	file:
-TemplClass	input.cpp	/^template<> class TemplClass< char* > { int i;};$/;"	c	file:
-TemplClass	input.cpp	/^template<class T> class TemplClass { double i;};$/;"	c	file:
+TemplClass	input.cpp	/^template<> class TemplClass< char* > { int i;};$/;"	c	file:	template:<>
+TemplClass	input.cpp	/^template<class T> class TemplClass { double i;};$/;"	c	file:	template:<class T>
 i	input.cpp	/^template<> class TemplClass< char* > { int i;};$/;"	m	class:TemplClass	typeref:typename:int	file:
 i	input.cpp	/^template<class T> class TemplClass { double i;};$/;"	m	class:TemplClass	typeref:typename:double	file:

--- a/Units/parser-cxx.r/class-inheritance.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/class-inheritance.cpp.d/args.ctags
@@ -1,3 +1,5 @@
 --c++-kinds=c
 --fields=i
 --sort=no
+--c++-enable-template-info
+

--- a/Units/parser-cxx.r/class-inheritance.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/class-inheritance.cpp.d/expected.tags
@@ -1,6 +1,6 @@
 A	input.cpp	/^class A$/
 B	input.cpp	/^class B$/
-C	input.cpp	/^template<typename X,typename Y> class C$/
+C	input.cpp	/^template<typename X,typename Y> class C$/;"	template:<typename X,typename Y>
 D	input.cpp	/^class D : public A$/;"	inherits:A
 E	input.cpp	/^class E : public A, public B$/;"	inherits:A,B
 F	input.cpp	/^class F : private A, public B$/;"	inherits:A,B

--- a/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.d/args.ctags
+++ b/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.d/args.ctags
@@ -1,2 +1,4 @@
 --sort=no
 --fields=+S
+--c++-enable-template-info
+

--- a/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.d/expected.tags
+++ b/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.d/expected.tags
@@ -1,4 +1,4 @@
-c	input.cpp	/^template <int P> class c {};$/;"	c	file:
+c	input.cpp	/^template <int P> class c {};$/;"	c	file:	template:<int P>
 bVar	input.cpp	/^c< 8 > bVar;$/;"	v	typeref:typename:c<8>
 aVar	input.cpp	/^c< 1<<8 > aVar;$/;"	v	typeref:typename:c<1<<8>
 f12	input.cpp	/^template<int X> f12( c< 1<<X> & aVar) { };$/;"	f	signature:( c< 1<<X> & aVar)

--- a/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/args.ctags
@@ -1,3 +1,5 @@
 --c++-kinds=+cfl
 --fields=+SsK
 --sort=no
+--c++-enable-template-info
+

--- a/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/expected.tags
@@ -1,4 +1,4 @@
-Bar	input.cpp	/^class Bar$/;"	class	file:
+Bar	input.cpp	/^class Bar$/;"	class	file:	template:<class T>
 foo	input.cpp	/^    A foo()$/;"	function	class:Bar	typeref:typename:A	file:	signature:()
 f1	input.cpp	/^int f1()$/;"	function	typeref:typename:int	signature:()
 b	input.cpp	/^    Bar<int> b;$/;"	local	function:f1	typeref:typename:Bar<int>	file:

--- a/Units/parser-cxx.r/templates.d/args.ctags
+++ b/Units/parser-cxx.r/templates.d/args.ctags
@@ -1,3 +1,5 @@
 --sort=no
 --extra=+q
 --kinds-C++=*
+--c++-enable-template-info
+

--- a/Units/parser-cxx.r/templates.d/expected.tags
+++ b/Units/parser-cxx.r/templates.d/expected.tags
@@ -4,7 +4,7 @@ v2	input.cpp	/^zero (const T &v1, const T &v2)$/;"	z	function:zero	typeref:typen
 min	input.cpp	/^min(const T&v1, const T&v2)$/;"	f	typeref:typename:T
 v1	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:typename:const T &	file:
 v2	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:typename:const T &	file:
-Item	input.cpp	/^class Item$/;"	c	file:
+Item	input.cpp	/^class Item$/;"	c	file:	template:<class Type>
 Item	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	f	class:Item	file:
 Item::Item	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	f	class:Item	file:
 t	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	z	function:Item::Item	typeref:typename:const Type &	file:

--- a/main/entry.c
+++ b/main/entry.c
@@ -966,6 +966,30 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 					   escapeName (tag, FIELD_EXTRA));
 	}
 
+	int cfc = tag->extensionFields.customFieldCount;
+
+	if(cfc > 0)
+	{
+		// FIXME: Make this global and allocate only once!
+		vString * pBuffer = vStringNew();
+	
+		for(int i=0;i<cfc;i++)
+		{
+			vStringClear(pBuffer);
+			vStringCatSWithEscaping(pBuffer,tag->extensionFields.customValue[i]);
+		
+			length += fprintf(
+					TagFile.fp,
+					"%s\t%s:%s",
+					sep,
+					tag->extensionFields.customLabel[i],
+					vStringValue(pBuffer)
+				);
+		}
+		
+		vStringDelete(pBuffer);
+	}
+
 	return length;
 #undef sep
 }
@@ -1104,6 +1128,17 @@ static void recordTagEntryInQueue (const tagEntryInfo *const tag, tagEntryInfo* 
 	if (slot->extensionFields.typeRef[1])
 		slot->extensionFields.typeRef[1] = eStrdup (slot->extensionFields.typeRef[1]);
 
+	int cfc = slot->extensionFields.customFieldCount;
+
+	for(int i=0;i<cfc;i++)
+	{
+		Assert(slot->extensionFields.customLabel[i]);
+		Assert(slot->extensionFields.customValue[i]);
+
+		slot->extensionFields.customLabel[i] = eStrdup(slot->extensionFields.customLabel[i]);
+		slot->extensionFields.customValue[i] = eStrdup(slot->extensionFields.customValue[i]);
+	}
+
 	if (slot->sourceLanguage)
 		slot->sourceLanguage = eStrdup (slot->sourceLanguage);
 	if (slot->sourceFileName)
@@ -1135,6 +1170,14 @@ static void clearTagEntryInQueue (tagEntryInfo* slot)
 		eFree ((char *)slot->extensionFields.typeRef[0]);
 	if (slot->extensionFields.typeRef[1])
 		eFree ((char *)slot->extensionFields.typeRef[1]);
+
+	int cfc = slot->extensionFields.customFieldCount;
+
+	for(int i=0;i<cfc;i++)
+	{
+		eFree((char *)slot->extensionFields.customLabel[i]);
+		eFree((char *)slot->extensionFields.customValue[i]);
+	}
 
 	if (slot->sourceLanguage)
 		eFree ((char *)slot->sourceLanguage);

--- a/main/entry.c
+++ b/main/entry.c
@@ -973,7 +973,8 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 		// FIXME: Make this global and allocate only once!
 		vString * pBuffer = vStringNew();
 	
-		for(int i=0;i<cfc;i++)
+		int i;
+		for(i=0;i<cfc;i++)
 		{
 			vStringClear(pBuffer);
 			vStringCatSWithEscaping(pBuffer,tag->extensionFields.customValue[i]);
@@ -1130,7 +1131,8 @@ static void recordTagEntryInQueue (const tagEntryInfo *const tag, tagEntryInfo* 
 
 	int cfc = slot->extensionFields.customFieldCount;
 
-	for(int i=0;i<cfc;i++)
+	int i;
+	for(i=0;i<cfc;i++)
 	{
 		Assert(slot->extensionFields.customLabel[i]);
 		Assert(slot->extensionFields.customValue[i]);
@@ -1172,8 +1174,9 @@ static void clearTagEntryInQueue (tagEntryInfo* slot)
 		eFree ((char *)slot->extensionFields.typeRef[1]);
 
 	int cfc = slot->extensionFields.customFieldCount;
+	int i;
 
-	for(int i=0;i<cfc;i++)
+	for(i=0;i<cfc;i++)
 	{
 		eFree((char *)slot->extensionFields.customLabel[i]);
 		eFree((char *)slot->extensionFields.customValue[i]);

--- a/main/entry.h
+++ b/main/entry.h
@@ -77,6 +77,15 @@ typedef struct sTagEntryInfo {
 
 #define ROLE_INDEX_DEFINITION -1
 		int roleIndex; /* for role of reference tag */
+
+		/* Custom fields. If they are added to this structure then they are
+		assumed to be enabled: the parser has to check this */
+#define MAX_CUSTOM_EXTENSION_FIELDS 3
+
+		int customFieldCount; // number of custom fields
+		const char * customLabel[MAX_CUSTOM_EXTENSION_FIELDS];
+		const char * customValue[MAX_CUSTOM_EXTENSION_FIELDS];
+
 	} extensionFields;  /* list of extension fields*/
 
 	/* Following source* fields are used only when #line is found

--- a/main/options.c
+++ b/main/options.c
@@ -170,8 +170,9 @@ optionValues Option = {
 	.putFieldPrefix = FALSE,
 	.maxRecursionDepth = 0xffffffff,
 #ifdef DEBUG
-	0, 0        /* -D, -b */
+	0, 0,        /* -D, -b */
 #endif
+	FALSE       /* --c++-enable-template-info */
 };
 
 static OptionLoadingStage Stage = OptionLoadingStageNone;
@@ -2278,6 +2279,7 @@ static parametricOption ParametricOptions [] = {
 
 static booleanOption BooleanOptions [] = {
 	{ "append",         &Option.append,                 TRUE,  STAGE_ANY },
+	{ "c++-enable-template-info", &Option.cxxEnableTemplateInfo, TRUE, STAGE_ANY },
 	{ "file-scope",     ((boolean *)XTAG_FILE_SCOPE),   FALSE, STAGE_ANY, redirectToXtag },
 	{ "file-tags",      ((boolean *)XTAG_FILE_NAMES),   FALSE, STAGE_ANY, redirectToXtag },
 	{ "filter",         &Option.filter,                 TRUE,  STAGE_ANY },

--- a/main/options.h
+++ b/main/options.h
@@ -102,6 +102,7 @@ typedef struct sOptionValues {
 	long debugLevel;        /* -D  debugging output */
 	unsigned long breakLine;/* -b  input line at which to call lineBreak() */
 #endif
+	boolean cxxEnableTemplateInfo; /* --c++-enable-template-info */
 } optionValues;
 
 typedef enum eOptionLoadingStage {

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -732,9 +732,26 @@ boolean cxxParserParseClassStructOrUnion(
 						CXXTokenChainCondenseNoTrailingSpaces
 					);
 				tag->extensionFields.inheritance = vStringValue(
-						g_cxx.pTokenChain->pHead->pszWord
+						cxxTokenChainFirst(g_cxx.pTokenChain)->pszWord
 					);
 			}
+		}
+
+		if(g_cxx.pTemplateTokenChain && (g_cxx.pTemplateTokenChain->iCount > 0))
+		{
+			cxxTokenChainNormalizeTypeNameSpacing(g_cxx.pTemplateTokenChain);
+			cxxTokenChainCondense(
+					g_cxx.pTemplateTokenChain,
+					0
+				);
+
+			static const char * szTemplate = "template";
+
+			tag->extensionFields.customLabel[tag->extensionFields.customFieldCount] = szTemplate;
+			tag->extensionFields.customValue[tag->extensionFields.customFieldCount] = vStringValue(
+					cxxTokenChainFirst(g_cxx.pTemplateTokenChain)->pszWord
+				);
+			tag->extensionFields.customFieldCount++;
 		}
 
 		tag->isFileScope = !isInputHeaderFile();

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -21,6 +21,7 @@
 #include "debug.h"
 #include "keyword.h"
 #include "read.h"
+#include "options.h"
 
 #include <string.h>
 
@@ -737,7 +738,11 @@ boolean cxxParserParseClassStructOrUnion(
 			}
 		}
 
-		if(g_cxx.pTemplateTokenChain && (g_cxx.pTemplateTokenChain->iCount > 0))
+		if(
+				Option.cxxEnableTemplateInfo &&
+				g_cxx.pTemplateTokenChain &&
+				(g_cxx.pTemplateTokenChain->iCount > 0)
+			)
 		{
 			cxxTokenChainNormalizeTypeNameSpacing(g_cxx.pTemplateTokenChain);
 			cxxTokenChainCondense(

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -140,7 +140,7 @@ evaluate_current_token:
 				if(iTemplateLevel == 0)
 				{
 					// Non-nested > : always a terminator
-					cxxTokenChainDestroyLast(g_cxx.pTokenChain);
+					//cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 					CXX_DEBUG_LEAVE_TEXT("Found end of template");
 					return TRUE;
 				}

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -58,9 +58,10 @@ static kindOption g_aCXXKinds [] = {
 };
 
 static const char * g_aCXXAccessStrings [] = {
+	NULL,
 	"public",
+	"private",
 	"protected",
-	"private"
 };
 
 kindOption * cxxTagGetKindOptions(void)
@@ -106,22 +107,7 @@ tagEntryInfo * cxxTagBegin(enum CXXTagKind eKindId,CXXToken * pToken)
 	}
 
 	// FIXME: meaning of "is file scope" is quite debatable...
-
-	switch(cxxScopeGetAccess())
-	{
-		case CXXScopeAccessPrivate:
-			g_oCXXTag.extensionFields.access = g_aCXXAccessStrings[2];
-		break;
-		case CXXScopeAccessProtected:
-			g_oCXXTag.extensionFields.access = g_aCXXAccessStrings[1];
-		break;
-		case CXXScopeAccessPublic:
-			g_oCXXTag.extensionFields.access = g_aCXXAccessStrings[0];
-		break;
-		default:
-			// ignore
-		break;
-	}
+	g_oCXXTag.extensionFields.access = g_aCXXAccessStrings[cxxScopeGetAccess()];
 
 	return &g_oCXXTag;
 }


### PR DESCRIPTION
This is a proposal for adding custom extension fields.

It's not reasonable to add specific fields for all the possible extensions we might think of. Each parser will have its own subset instead. Each parser will be responsable of checking if the custom extension fields is enabled or not. Each parser will provide the label for the custom extension field (which is a static string anyway).

This pull also contains a sample usage of the custom extension fields: template information for classes.

Another commit in this pull enables the custom extension field with a parser specific option: --c++-enable-template-info. The advantage is that it is incredibly simple. No complicated code to add to handle parser specific parameters.

(Btw, the first two commits are an artefact of synchronizing with upstream: not sure how to get rid of them..maybe by deleting the fork and recreating it?)