### PR TITLE
Fix build error GCC 4.4.7

### DIFF
--- a/parsers/cxx/cxx_token_chain.h
+++ b/parsers/cxx/cxx_token_chain.h
@@ -14,12 +14,12 @@
 #include "cxx_token.h"
 #include "cxx_keyword.h"
 
-typedef struct _CXXTokenChain
+struct _CXXTokenChain
 {
 	CXXToken * pHead;
 	CXXToken * pTail;
 	int iCount;
-} CXXTokenChain;
+};
 
 
 CXXTokenChain * cxxTokenChainCreate(void);


### PR DESCRIPTION
In file included from parsers/cxx/cxx.c:15:
parsers/cxx/cxx_token_chain.h:22: error: redefinition of typedef 'CXXTokenChain'
parsers/cxx/cxx_token.h:62: note: previous declaration of 'CXXTokenChain' was here