### PR TITLE
Tmain: add --quiet --options=NONE to the command line of run.sh of extra-field.d

### DIFF
--- a/Tmain/extra-field.d/run.sh
+++ b/Tmain/extra-field.d/run.sh
@@ -3,5 +3,6 @@
 
 CTAGS=$1
 
-${CTAGS} --fields=+Er --extra=+qr. -o - input.cpp | sed -e 's|[^	]*\(input.cpp\)|\1|'
+${CTAGS} --quiet --options=NONE --fields=+Er --extra=+qr. -o - input.cpp \
+    | sed -e 's|[^	]*\(input.cpp\)|\1|'
 


### PR DESCRIPTION
Close #866.

To make the test output independent from the environment where
the test is run, --quiet --options=NONE is added.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>