### PR TITLE
Use relative path also with absolute filename

### DIFF
--- a/main/read.c
+++ b/main/read.c
@@ -138,7 +138,7 @@ static void setInputFileParametersCommon (inputFileInfo *finfo, vString *const f
 		else
 			vStringDelete (finfo->tagPath);
 	}
-	if (! Option.tagRelative || isAbsolutePath (vStringValue (fileName)))
+	if (! Option.tagRelative)
 		finfo->tagPath = vStringNewCopy (fileName);
 	else
 		finfo->tagPath =


### PR DESCRIPTION
I have noticed that with gutentags [1] absolute paths would be used when
only the current file gets updated via `--append /absolute/path/to/file`.

I cannot see why an absolute path should be used in that case, but have
not checked if that behavior differs from the original ctags, but it
appears to date back to 2001 [2].

This uses an absolute path only with `--tag-relative=no`.

1: https://github.com/ludovicchabant/vim-gutentags
2: https://github.com/universal-ctags/ctags/blob/568742a3708c2076e6d998246f8904629f89bbcb/read.c#L78