### PR TITLE
Add the MIO library

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -1243,7 +1243,7 @@ static void writeTagEntry (const tagEntryInfo *const tag)
 
 	++TagFile.numTags.added;
 	rememberMaxLengths (strlen (tag->name), (size_t) length);
-	DebugStatement ( fflush (TagFile.fp); )
+	DebugStatement ( mio_flush (TagFile.fp); )
 
 	abort_if_ferror (TagFile.fp);
 }

--- a/main/entry.c
+++ b/main/entry.c
@@ -78,12 +78,12 @@
 typedef struct eTagFile {
 	char *name;
 	char *directory;
-	FILE *fp;
+	MIO *fp;
 	struct sNumTags { unsigned long added, prev; } numTags;
 	struct sMax { size_t line, tag; } max;
 	struct sEtags {
 		char *name;
-		FILE *fp;
+		MIO *fp;
 		size_t byteCount;
 	} etags;
 	vString *vLine;
@@ -152,9 +152,9 @@ extern const char *tagFileName (void)
 *   Pseudo tag support
 */
 
-static void abort_if_ferror(FILE *const fp)
+static void abort_if_ferror(MIO *const fp)
 {
-	if (ferror (fp))
+	if (mio_error (fp))
 		error (FATAL | PERROR, "cannot write tag file");
 }
 
@@ -175,10 +175,10 @@ extern void writePseudoTag (const struct sPtagDesc *desc,
 	const int length = parserName
 
 #define OPT(X) ((X)?(X):"")
-	  ? fprintf (TagFile.fp, "%s%s%s%s\t%s\t%s\n",
+	  ? mio_printf (TagFile.fp, "%s%s%s%s\t%s\t%s\n",
 		     PSEUDO_TAG_PREFIX, desc->name, PSEUDO_TAG_SEPARATOR, parserName,
 		     OPT(fileName), OPT(pattern))
-	  : fprintf (TagFile.fp, "%s%s\t%s\t/%s/\n",
+	  : mio_printf (TagFile.fp, "%s%s\t%s\t/%s/\n",
 		     PSEUDO_TAG_PREFIX, desc->name,
 		     OPT(fileName), OPT(pattern));
 #undef OPT
@@ -243,7 +243,7 @@ extern void makeFileTag (const char *const fileName)
 }
 
 static void updateSortedFlag (
-		const char *const line, FILE *const fp, fpos_t startOfLine)
+		const char *const line, MIO *const fp, MIOPos startOfLine)
 {
 	const char *const tab = strchr (line, '\t');
 
@@ -253,28 +253,28 @@ static void updateSortedFlag (
 
 		if (line [boolOffset] == '0'  ||  line [boolOffset] == '1')
 		{
-			fpos_t nextLine;
+			MIOPos nextLine;
 
-			if (fgetpos (fp, &nextLine) == -1 || fsetpos (fp, &startOfLine) == -1)
+			if (mio_getpos (fp, &nextLine) == -1 || mio_getpos (fp, &startOfLine) == -1)
 				error (WARNING, "Failed to update 'sorted' pseudo-tag");
 			else
 			{
-				fpos_t flagLocation;
+				MIOPos flagLocation;
 				int c, d;
 
 				do
-					c = fgetc (fp);
+					c = mio_getc (fp);
 				while (c != '\t'  &&  c != '\n');
-				fgetpos (fp, &flagLocation);
-				d = fgetc (fp);
+				mio_getpos (fp, &flagLocation);
+				d = mio_getc (fp);
 				if (c == '\t'  &&  (d == '0'  ||  d == '1')  &&
 					d != (int) Option.sorted)
 				{
-					fsetpos (fp, &flagLocation);
-					fputc (Option.sorted == SO_FOLDSORTED ? '2' :
-						(Option.sorted == SO_SORTED ? '1' : '0'), fp);
+					mio_setpos (fp, &flagLocation);
+					mio_putc (fp, Option.sorted == SO_FOLDSORTED ? '2' :
+						(Option.sorted == SO_SORTED ? '1' : '0'));
 				}
-				fsetpos (fp, &nextLine);
+				mio_setpos (fp, &nextLine);
 			}
 		}
 	}
@@ -283,12 +283,12 @@ static void updateSortedFlag (
 /*  Look through all line beginning with "!_TAG_FILE", and update those which
  *  require it.
  */
-static long unsigned int updatePseudoTags (FILE *const fp)
+static long unsigned int updatePseudoTags (MIO *const fp)
 {
 	enum { maxEntryLength = 20 };
 	char entry [maxEntryLength + 1];
 	unsigned long linesRead = 0;
-	fpos_t startOfLine;
+	MIOPos startOfLine;
 	size_t entryLength;
 	const char *line;
 
@@ -296,7 +296,7 @@ static long unsigned int updatePseudoTags (FILE *const fp)
 	entryLength = strlen (entry);
 	Assert (entryLength < maxEntryLength);
 
-	fgetpos (fp, &startOfLine);
+	mio_getpos (fp, &startOfLine);
 	line = readLineRaw (TagFile.vLine, fp);
 	while (line != NULL  &&  line [0] == entry [0])
 	{
@@ -311,7 +311,7 @@ static long unsigned int updatePseudoTags (FILE *const fp)
 				if (strcmp (classType, "_SORTED") == 0)
 					updateSortedFlag (line, fp, startOfLine);
 			}
-			fgetpos (fp, &startOfLine);
+			mio_getpos (fp, &startOfLine);
 		}
 		line = readLineRaw (TagFile.vLine, fp);
 	}
@@ -395,7 +395,7 @@ static boolean isEtagsLine (const char *const line)
 static boolean isTagFile (const char *const filename)
 {
 	boolean ok = FALSE;  /* we assume not unless confirmed */
-	FILE *const fp = fopen (filename, "rb");
+	MIO *const fp = mio_new_file (filename, "rb");
 
 	if (fp == NULL  &&  errno == ENOENT)
 		ok = TRUE;
@@ -407,7 +407,7 @@ static boolean isTagFile (const char *const filename)
 			ok = TRUE;
 		else
 			ok = (boolean) (isCtagsLine (line) || isEtagsLine (line));
-		fclose (fp);
+		mio_free (fp);
 	}
 	return ok;
 }
@@ -444,25 +444,25 @@ extern void openTagFile (void)
 		if (Option.etags)
 		{
 			if (Option.append  &&  fileExists)
-				TagFile.fp = fopen (TagFile.name, "a+b");
+				TagFile.fp = mio_new_file (TagFile.name, "a+b");
 			else
-				TagFile.fp = fopen (TagFile.name, "w+b");
+				TagFile.fp = mio_new_file (TagFile.name, "w+b");
 		}
 		else
 		{
 			if (Option.append  &&  fileExists)
 			{
-				TagFile.fp = fopen (TagFile.name, "r+");
+				TagFile.fp = mio_new_file (TagFile.name, "r+");
 				if (TagFile.fp != NULL)
 				{
 					TagFile.numTags.prev = updatePseudoTags (TagFile.fp);
-					fclose (TagFile.fp);
-					TagFile.fp = fopen (TagFile.name, "a+");
+					mio_free (TagFile.fp);
+					TagFile.fp = mio_new_file (TagFile.name, "a+");
 				}
 			}
 			else
 			{
-				TagFile.fp = fopen (TagFile.name, "w");
+				TagFile.fp = mio_new_file (TagFile.name, "w");
 				if (TagFile.fp != NULL && isXtagEnabled (XTAG_PSEUDO_TAGS))
 					addCommonPseudoTags ();
 			}
@@ -478,7 +478,7 @@ extern void openTagFile (void)
 
 #ifdef USE_REPLACEMENT_TRUNCATE
 
-static void copyBytes (FILE* const fromFp, FILE* const toFp, const long size)
+static void copyBytes (MIO* const fromFp, MIO* const toFp, const long size)
 {
 	enum { BufferSize = 1000 };
 	long toRead, numRead;
@@ -488,8 +488,8 @@ static void copyBytes (FILE* const fromFp, FILE* const toFp, const long size)
 	{
 		toRead = (0 < remaining && remaining < BufferSize) ?
 					remaining : (long) BufferSize;
-		numRead = fread (buffer, (size_t) 1, (size_t) toRead, fromFp);
-		if (fwrite (buffer, (size_t)1, (size_t)numRead, toFp) < (size_t)numRead)
+		numRead = mio_read (fromFp, buffer, (size_t) 1, (size_t) toRead);
+		if (mio_write (toFp, buffer, (size_t)1, (size_t)numRead) < (size_t)numRead)
 			error (FATAL | PERROR, "cannot complete write");
 		if (remaining > 0)
 			remaining -= numRead;
@@ -499,20 +499,20 @@ static void copyBytes (FILE* const fromFp, FILE* const toFp, const long size)
 
 static void copyFile (const char *const from, const char *const to, const long size)
 {
-	FILE* const fromFp = fopen (from, "rb");
+	MIO* const fromFp = mio_new_file (from, "rb");
 	if (fromFp == NULL)
 		error (FATAL | PERROR, "cannot open file to copy");
 	else
 	{
-		FILE* const toFp = fopen (to, "wb");
+		MIO* const toFp = mio_new_file (to, "wb");
 		if (toFp == NULL)
 			error (FATAL | PERROR, "cannot open copy destination");
 		else
 		{
 			copyBytes (fromFp, toFp, size);
-			fclose (toFp);
+			mio_free (toFp);
 		}
-		fclose (fromFp);
+		mio_free (fromFp);
 	}
 }
 
@@ -521,8 +521,8 @@ static void copyFile (const char *const from, const char *const to, const long s
 static int replacementTruncate (const char *const name, const long size)
 {
 	char *tempName = NULL;
-	FILE *fp = tempFile ("w", &tempName);
-	fclose (fp);
+	MIO *fp = tempFile ("w", &tempName);
+	mio_free (fp);
 	copyFile (name, tempName, size);
 	copyFile (tempName, name, WHOLE_FILE);
 	remove (tempName);
@@ -536,18 +536,18 @@ static int replacementTruncate (const char *const name, const long size)
 #ifndef EXTERNAL_SORT
 static void internalSortTagFile (void)
 {
-	FILE *fp;
+	MIO *fp;
 
 	/*  Open/Prepare the tag file and place its lines into allocated buffers.
 	 */
 	if (TagsToStdout)
 	{
 		fp = TagFile.fp;
-		fseek (fp, 0, SEEK_SET);
+		mio_seek (fp, 0, SEEK_SET);
 	}
 	else
 	{
-		fp = fopen (tagFileName (), "r");
+		fp = mio_new_file (tagFileName (), "r");
 		if (fp == NULL)
 			failedSort (fp, NULL);
 	}
@@ -557,7 +557,7 @@ static void internalSortTagFile (void)
 			  TagFile.numTags.added + TagFile.numTags.prev);
 
 	if (! TagsToStdout)
-		fclose (fp);
+		mio_free (fp);
 }
 #endif
 
@@ -610,7 +610,7 @@ static void resizeTagFile (const long newSize)
 		fprintf (stderr, "Cannot shorten tag file: errno = %d\n", errno);
 }
 
-static void writeEtagsIncludes (FILE *const fp)
+static void writeEtagsIncludes (MIO *const fp)
 {
 	if (Option.etagsInclude)
 	{
@@ -618,7 +618,7 @@ static void writeEtagsIncludes (FILE *const fp)
 		for (i = 0  ;  i < stringListCount (Option.etagsInclude)  ;  ++i)
 		{
 			vString *item = stringListItem (Option.etagsInclude, i);
-			fprintf (fp, "\f\n%s,include\n", vStringValue (item));
+			mio_printf (fp, "\f\n%s,include\n", vStringValue (item));
 		}
 	}
 }
@@ -629,14 +629,14 @@ extern void closeTagFile (const boolean resize)
 
 	if (Option.etags)
 		writeEtagsIncludes (TagFile.fp);
-	fflush (TagFile.fp);
+	mio_flush (TagFile.fp);
 	abort_if_ferror (TagFile.fp);
-	desiredSize = ftell (TagFile.fp);
-	fseek (TagFile.fp, 0L, SEEK_END);
-	size = ftell (TagFile.fp);
+	desiredSize = mio_tell (TagFile.fp);
+	mio_seek (TagFile.fp, 0L, SEEK_END);
+	size = mio_tell (TagFile.fp);
 	if (! TagsToStdout)
 		/* The tag file should be closed before resizing. */
-		if (fclose (TagFile.fp) != 0)
+		if (mio_free (TagFile.fp) != 0)
 			error (FATAL | PERROR, "cannot close tag file");
 
 	if (resize  &&  desiredSize < size)
@@ -649,7 +649,7 @@ extern void closeTagFile (const boolean resize)
 	sortTagFile ();
 	if (TagsToStdout)
 	{
-		if (fclose (TagFile.fp) != 0)
+		if (mio_free (TagFile.fp) != 0)
 			error (FATAL | PERROR, "cannot close tag file");
 		remove (tagFileName ());  /* remove temporary file */
 	}
@@ -667,15 +667,15 @@ extern void endEtagsFile (const char *const filename)
 {
 	const char *line;
 
-	fprintf (TagFile.fp, "\f\n%s,%ld\n", filename, (long) TagFile.etags.byteCount);
+	mio_printf (TagFile.fp, "\f\n%s,%ld\n", filename, (long) TagFile.etags.byteCount);
 	abort_if_ferror (TagFile.fp);
 
 	if (TagFile.etags.fp != NULL)
 	{
-		rewind (TagFile.etags.fp);
+		mio_rewind (TagFile.etags.fp);
 		while ((line = readLineRaw (TagFile.vLine, TagFile.etags.fp)) != NULL)
-			fputs (line, TagFile.fp);
-		fclose (TagFile.etags.fp);
+			mio_puts (TagFile.fp, line);
+		mio_free (TagFile.etags.fp);
 		remove (TagFile.etags.name);
 		eFree (TagFile.etags.name);
 		TagFile.etags.fp = NULL;
@@ -745,18 +745,18 @@ static int vstring_puts (const char* s, void *data)
 
 static int file_putc (char c, void *data)
 {
-	FILE *fp = data;
-	putc (c, fp);
+	MIO *fp = data;
+	mio_putc (fp, c);
 	return 1;
 }
 
 static int file_puts (const char* s, void *data)
 {
-	FILE *fp = data;
-	return fputs (s, fp);
+	MIO *fp = data;
+	return mio_puts (fp, s);
 }
 
-static boolean isPosSet(fpos_t pos)
+static boolean isPosSet(MIOPos pos)
 {
 	char * p = (char *)&pos;
 	boolean r = FALSE;
@@ -813,7 +813,7 @@ static int writeXrefEntry (const tagEntryInfo *const tag)
 		}
 	}
 
-	fputc ('\n', TagFile.fp);
+	mio_putc (TagFile.fp, '\n');
 	length++;
 
 	return length;
@@ -841,7 +841,7 @@ static int writeEtagsEntry (const tagEntryInfo *const tag)
 	int length;
 
 	if (tag->isFileEntry)
-		length = fprintf (TagFile.etags.fp, "\177%s\001%lu,0\n",
+		length = mio_printf (TagFile.etags.fp, "\177%s\001%lu,0\n",
 				tag->name, tag->lineNumber);
 	else
 	{
@@ -856,7 +856,7 @@ static int writeEtagsEntry (const tagEntryInfo *const tag)
 		else
 			line [strlen (line) - 1] = '\0';
 
-		length = fprintf (TagFile.etags.fp, "%s\177%s\001%lu,%ld\n", line,
+		length = mio_printf (TagFile.etags.fp, "%s\177%s\001%lu,%ld\n", line,
 				tag->name, tag->lineNumber, seekValue);
 	}
 	TagFile.etags.byteCount += length;
@@ -929,21 +929,21 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 
 	if (tag->kind->name != NULL && (getFieldDesc (FIELD_KIND_LONG)->enabled  ||
 		 (getFieldDesc (FIELD_KIND)->enabled  && tag->kind == '\0')))
-		length += fprintf (TagFile.fp, kindFmt, sep, kindKey, tag->kind->name);
+		length += mio_printf (TagFile.fp, kindFmt, sep, kindKey, tag->kind->name);
 	else if (tag->kind != '\0'  && (getFieldDesc (FIELD_KIND)->enabled ||
 			(getFieldDesc (FIELD_KIND_LONG)->enabled &&  tag->kind->name == NULL)))
 	{
 		char str[2] = {tag->kind->letter, '\0'};
-		length += fprintf (TagFile.fp, kindFmt, sep, kindKey, str);
+		length += mio_printf (TagFile.fp, kindFmt, sep, kindKey, str);
 	}
 
 	if (getFieldDesc (FIELD_LINE_NUMBER)->enabled)
-		length += fprintf (TagFile.fp, "%s\t%s:%ld", sep,
+		length += mio_printf (TagFile.fp, "%s\t%s:%ld", sep,
 				   getFieldName (FIELD_LINE_NUMBER),
 				   tag->lineNumber);
 
 	if (getFieldDesc (FIELD_LANGUAGE)->enabled  &&  tag->language != NULL)
-		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
+		length += mio_printf (TagFile.fp, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_LANGUAGE),
 				   escapeName (tag, FIELD_LANGUAGE));
 
@@ -951,7 +951,7 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 	{
 		if (tag->extensionFields.scopeKind != NULL  &&
 		    tag->extensionFields.scopeName != NULL)
-			length += fprintf (TagFile.fp, scopeFmt, sep,
+			length += mio_printf (TagFile.fp, scopeFmt, sep,
 					   scopeKey,
 					   tag->extensionFields.scopeKind->name,
 					   escapeName (tag, FIELD_SCOPE));
@@ -964,7 +964,7 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 			scope = getEntryInCorkQueue (tag->extensionFields.scopeIndex);
 			full_qualified_scope_name = getFullQualifiedScopeNameFromCorkQueue(scope);
 			Assert (full_qualified_scope_name);
-			length += fprintf (TagFile.fp, scopeFmt, sep,
+			length += mio_printf (TagFile.fp, scopeFmt, sep,
 					   scopeKey,
 					   scope->kind->name, full_qualified_scope_name);
 
@@ -976,39 +976,39 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 	if (getFieldDesc (FIELD_TYPE_REF)->enabled &&
 			tag->extensionFields.typeRef [0] != NULL  &&
 			tag->extensionFields.typeRef [1] != NULL)
-		length += fprintf (TagFile.fp, "%s\t%s:%s:%s", sep,
+		length += mio_printf (TagFile.fp, "%s\t%s:%s:%s", sep,
 				   getFieldName (FIELD_TYPE_REF),
 				   tag->extensionFields.typeRef [0],
 				   escapeName (tag, FIELD_TYPE_REF));
 
 	if (getFieldDesc (FIELD_FILE_SCOPE)->enabled &&  tag->isFileScope)
-		length += fprintf (TagFile.fp, "%s\t%s:", sep,
+		length += mio_printf (TagFile.fp, "%s\t%s:", sep,
 				   getFieldName (FIELD_FILE_SCOPE));
 
 	if (getFieldDesc (FIELD_INHERITANCE)->enabled &&
 			tag->extensionFields.inheritance != NULL)
-		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
+		length += mio_printf (TagFile.fp, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_INHERITANCE),
 				   escapeName (tag, FIELD_INHERITANCE));
 
 	if (getFieldDesc (FIELD_ACCESS)->enabled &&  tag->extensionFields.access != NULL)
-		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
+		length += mio_printf (TagFile.fp, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_ACCESS),
 				   tag->extensionFields.access);
 
 	if (getFieldDesc (FIELD_IMPLEMENTATION)->enabled &&
 			tag->extensionFields.implementation != NULL)
-		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
+		length += mio_printf (TagFile.fp, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_IMPLEMENTATION),
 				   tag->extensionFields.implementation);
 
 	if (getFieldDesc (FIELD_SIGNATURE)->enabled &&
 			tag->extensionFields.signature != NULL)
-		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
+		length += mio_printf (TagFile.fp, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_SIGNATURE),
 				   escapeName (tag, FIELD_SIGNATURE));
 	if (getFieldDesc (FIELD_ROLE)->enabled && tag->extensionFields.roleIndex != ROLE_INDEX_DEFINITION)
-		length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
+		length += mio_printf (TagFile.fp, "%s\t%s:%s", sep,
 				   getFieldName (FIELD_ROLE),
 				   escapeName (tag, FIELD_ROLE));
 
@@ -1016,7 +1016,7 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 	{
 		const char *value = escapeName (tag, FIELD_EXTRA);
 		if (value)
-			length += fprintf (TagFile.fp, "%s\t%s:%s", sep,
+			length += mio_printf (TagFile.fp, "%s\t%s:%s", sep,
 					   getFieldName (FIELD_EXTRA),
 					   escapeName (tag, FIELD_EXTRA));
 	}
@@ -1043,10 +1043,10 @@ static int   makePatternStringCommon (const tagEntryInfo *const tag,
 	void * o_output;
 
 	static vString *cached_pattern;
-	static fpos_t   cached_location;
+	static MIOPos   cached_location;
 	if (TagFile.patternCacheValid
 	    && (! tag->truncateLine)
-	    && (memcmp (&tag->filePosition, &cached_location, sizeof(fpos_t)) == 0))
+	    && (memcmp (&tag->filePosition, &cached_location, sizeof(MIOPos)) == 0))
 		return puts_func (vStringValue (cached_pattern), output);
 
 	line = readLineFromBypass (TagFile.vLine, tag->filePosition, NULL);
@@ -1105,28 +1105,28 @@ static int writePatternEntry (const tagEntryInfo *const tag)
 static int writeLineNumberEntry (const tagEntryInfo *const tag)
 {
 	if (Option.lineDirectives)
-		return fprintf (TagFile.fp, "%s", escapeName (tag, FIELD_LINE_NUMBER));
+		return mio_printf (TagFile.fp, "%s", escapeName (tag, FIELD_LINE_NUMBER));
 	else
-		return fprintf (TagFile.fp, "%lu", tag->lineNumber);
+		return mio_printf (TagFile.fp, "%lu", tag->lineNumber);
 }
 
 static int writeCtagsEntry (const tagEntryInfo *const tag)
 {
-	int length = fprintf (TagFile.fp, "%s\t%s\t",
+	int length = mio_printf (TagFile.fp, "%s\t%s\t",
 			      escapeName (tag, FIELD_NAME),
 			      escapeName (tag, FIELD_INPUT_FILE));
 
 	if (tag->lineNumberEntry)
 		length += writeLineNumberEntry (tag);
 	else if (tag->pattern)
-		length += fprintf(TagFile.fp, "%s", tag->pattern);
+		length += mio_printf(TagFile.fp, "%s", tag->pattern);
 	else
 		length += writePatternEntry (tag);
 
 	if (includeExtensionFlags ())
 		length += addExtensionFields (tag);
 
-	length += fprintf (TagFile.fp, "\n");
+	length += mio_printf (TagFile.fp, "\n");
 
 	return length;
 }
@@ -1409,7 +1409,7 @@ extern void initRefTagEntry (tagEntryInfo *const e, const char *const name,
 extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 			      unsigned long lineNumber,
 			      const char* language,
-			      fpos_t      filePosition,
+			      MIOPos      filePosition,
 			      const char *inputFileName,
 			      const kindOption *kind,
 			      int roleIndex,
@@ -1489,14 +1489,14 @@ extern void invalidatePatternCache(void)
 	TagFile.patternCacheValid = FALSE;
 }
 
-extern void tagFilePosition (fpos_t *p)
+extern void tagFilePosition (MIOPos *p)
 {
-	fgetpos (TagFile.fp, p);
+	mio_getpos (TagFile.fp, p);
 }
 
-extern void setTagFilePosition (fpos_t *p)
+extern void setTagFilePosition (MIOPos *p)
 {
-	fsetpos (TagFile.fp, p);
+	mio_setpos (TagFile.fp, p);
 }
 
 extern const char* getTagFileDirectory (void)

--- a/main/entry.h
+++ b/main/entry.h
@@ -19,6 +19,7 @@
 #include "kind.h"
 #include "vstring.h"
 #include "xtag.h"
+#include "mio.h"
 
 /*
 *   MACROS
@@ -49,7 +50,7 @@ typedef struct sTagEntryInfo {
 	unsigned long lineNumber;     /* line number of tag */
 	const char* pattern;	      /* pattern for locating input line
 				       * (may be NULL if not present) *//*  */
-	fpos_t      filePosition;     /* file position of line containing tag */
+	MIOPos      filePosition;     /* file position of line containing tag */
 	const char* language;         /* language of input file */
 	const char *inputFileName;   /* name of input file */
 	const char *name;             /* name of the tag */
@@ -109,7 +110,7 @@ extern void initRefTagEntry (tagEntryInfo *const e, const char *const name,
 extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 			      unsigned long lineNumber,
 			      const char* language,
-			      fpos_t      filePosition,
+			      MIOPos      filePosition,
 			      const char *inputFileName,
 			      const kindOption *kind,
 			      int roleIndex,
@@ -123,8 +124,8 @@ extern void setNumTagsAdded (unsigned long nadded);
 extern unsigned long numTagsTotal(void);
 extern unsigned long maxTagsLine(void);
 extern void invalidatePatternCache(void);
-extern void tagFilePosition (fpos_t *p);
-extern void setTagFilePosition (fpos_t *p);
+extern void tagFilePosition (MIOPos *p);
+extern void setTagFilePosition (MIOPos *p);
 extern const char* getTagFileDirectory (void);
 
 /* Getting line associated with tag */

--- a/main/fmt.c
+++ b/main/fmt.c
@@ -27,28 +27,28 @@ typedef union uFmtSpec {
 
 struct sFmtElement {
 	union uFmtSpec spec;
-	int (* printer) (fmtSpec*, FILE* fp, const tagEntryInfo *);
+	int (* printer) (fmtSpec*, MIO* fp, const tagEntryInfo *);
 	struct sFmtElement *next;
 };
 
-static int printLiteral (fmtSpec* fspec, FILE* fp, const tagEntryInfo * tag __unused__)
+static int printLiteral (fmtSpec* fspec, MIO* fp, const tagEntryInfo * tag __unused__)
 {
-	return fputs (fspec->const_str, fp);
+	return mio_puts (fp, fspec->const_str);
 }
 
-static int printTagField (fmtSpec* fspec, FILE* fp, const tagEntryInfo * tag)
+static int printTagField (fmtSpec* fspec, MIO* fp, const tagEntryInfo * tag)
 {
 	int i;
 	int width = fspec->field.width;
 	const char* str = renderFieldEscaped (fspec->field.desc, tag);
 
 	if (width < 0)
-		i = fprintf (fp, "%-*s", -1 * width, str);
+		i = mio_printf (fp, "%-*s", -1 * width, str);
 	else if (width > 0)
-		i = fprintf (fp, "%*s", width, str);
+		i = mio_printf (fp, "%*s", width, str);
 	else
 	{
-		fputs (str, fp);
+		mio_puts (fp, str);
 		i = strlen (str);
 	}
 	return i;
@@ -188,7 +188,7 @@ extern fmtElement *fmtNew (const char*  fmtString)
 	return code;
 }
 
-extern int fmtPrint   (fmtElement * fmtelts, FILE* fp, const tagEntryInfo *tag)
+extern int fmtPrint   (fmtElement * fmtelts, MIO* fp, const tagEntryInfo *tag)
 {
 	fmtElement *f = fmtelts;
 	int i = 0;

--- a/main/fmt.h
+++ b/main/fmt.h
@@ -15,11 +15,12 @@
 
 #include "general.h"
 #include "entry.h"
+#include "mio.h"
 #include <stdio.h>
 
 typedef struct sFmtElement fmtElement;
 extern fmtElement *fmtNew     (const char* fmtString);
-extern int         fmtPrint   (fmtElement * fmtelts, FILE* fp, const tagEntryInfo *tag);
+extern int         fmtPrint   (fmtElement * fmtelts, MIO* fp, const tagEntryInfo *tag);
 extern void        fmtDelete  (fmtElement * fmtelts);
 
 #endif	/* FMT_H */

--- a/main/general.h
+++ b/main/general.h
@@ -78,10 +78,6 @@ typedef bool boolean;
 typedef enum { FALSE, TRUE } boolean;
 #endif
 
-#if ! defined (HAVE_FGETPOS) && ! defined (fpos_t)
-# define fpos_t long
-#endif
-
 /*
 *   FUNCTION PROTOTYPES
 */

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -548,7 +548,7 @@ static void processLanguageRegex (const langType language,
 	else
 	{
 		const char* regexfile = parameter + 1;
-		FILE* const fp = fopen (regexfile, "r");
+		MIO* const fp = mio_new_file (regexfile, "r");
 		if (fp == NULL)
 			error (WARNING | PERROR, "%s", regexfile);
 		else
@@ -556,7 +556,7 @@ static void processLanguageRegex (const langType language,
 			vString* const regex = vStringNew ();
 			while (readLineRaw (regex, fp))
 				addLanguageRegex (language, vStringValue (regex));
-			fclose (fp);
+			mio_free (fp);
 			vStringDelete (regex);
 		}
 	}

--- a/main/lxcmd.c
+++ b/main/lxcmd.c
@@ -1037,7 +1037,7 @@ static boolean makePseudoTagEntryFromTagEntry (tagEntry* entry)
 static boolean makeTagEntryFromTagEntry (xcmdPath* path, tagEntry* entry)
 {
 	tagEntryInfo tag;
-	fpos_t      filePosition;
+	MIOPos      filePosition;
 
 	if (hasPseudoTagPrefix (entry->name))
 	{

--- a/main/mio.c
+++ b/main/mio.c
@@ -18,7 +18,10 @@
  *
  */
 
+#include "general.h"  /* must always come first */
+
 #include "mio.h"
+#include "routines.h"
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -93,14 +96,14 @@ MIO *mio_new_file_full (const char *filename,
 	/* we need to create the MIO object first, because we may not be able to close
 	 * the opened file if the user passed NULL as the close function, which means
 	 * that everything must succeed if we've opened the file successfully */
-	mio = malloc (sizeof *mio);
+	mio = xMalloc (1, MIO);
 	if (mio)
 	{
 		FILE *fp = open_func (filename, mode);
 
 		if (! fp)
 		{
-			free (mio);
+			eFree (mio);
 			mio = NULL;
 		}
 		else
@@ -160,7 +163,7 @@ MIO *mio_new_fp (FILE *fp, MIOFCloseFunc close_func)
 	if (!fp)
 		return NULL;
 
-	mio = malloc (sizeof *mio);
+	mio = xMalloc (1, MIO);
 	if (mio)
 	{
 		mio->type = MIO_TYPE_FILE;
@@ -214,7 +217,7 @@ MIO *mio_new_memory (unsigned char *data,
 {
 	MIO *mio;
 
-	mio = malloc (sizeof *mio);
+	mio = xMalloc (1, MIO);
 	if (mio)
 	{
 		mio->type = MIO_TYPE_MEMORY;
@@ -319,7 +322,7 @@ int mio_free (MIO *mio)
 			mio->impl.mem.error = FALSE;
 		}
 
-		free (mio);
+		eFree (mio);
 	}
 
 	return rv;

--- a/main/mio.c
+++ b/main/mio.c
@@ -1,0 +1,1063 @@
+/*
+ *  MIO, an I/O abstraction layer replicating C file I/O API.
+ *  Copyright (C) 2010  Colomban Wendling <ban@herbesfolles.org>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "mio.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <limits.h>
+
+/* minimal reallocation chunk size */
+#define MIO_CHUNK_SIZE 4096
+
+#define MAX(a, b)  (((a) > (b)) ? (a) : (b))
+
+
+/**
+ * SECTION:mio
+ * @short_description: The MIO object
+ * @include: mio/mio.h
+ *
+ * The #MIO object replicates the C file I/O API with support of both standard
+ * file based operations and in-memory operations. Its goal is to ease the port
+ * of an application that uses C file I/O API to perform in-memory operations.
+ *
+ * A #MIO object is created using mio_new_file() or mio_new_memory(), depending
+ * on whether you want file or in-memory operations, and destroyed using
+ * mio_free(). There is also some other convenient API to create file-based
+ * #MIO objects for more complex cases, such as mio_new_file_full() and
+ * mio_new_fp().
+ *
+ * Once the #MIO object is created, you can perform standard I/O operations on
+ * it transparently without the need to care about the effective underlying
+ * operations.
+ *
+ * The I/O API is almost exactly a replication of the standard C file I/O API
+ * with the significant difference that the first parameter is always the #MIO
+ * object to work on.
+ */
+
+
+/**
+ * mio_new_file_full:
+ * @filename: Filename to open, passed as-is to @open_func as the first argument
+ * @mode: Mode in which open the file, passed as-is to @open_func as the second
+ *        argument
+ * @open_func: A function with the fopen() semantic to use to open the file
+ * @close_func: A function with the fclose() semantic to close the file when
+ *              the #MIO object is destroyed, or %NULL not to close the #FILE
+ *              object
+ *
+ * Creates a new #MIO object working on a file, from a filename and an opening
+ * function. See also mio_new_file().
+ *
+ * This function is generally overkill and mio_new_file() should often be used
+ * instead, but it allows to specify a custom function to open a file, as well
+ * as a close function. The former is useful e.g. if you need to wrap fopen()
+ * for some reason (like filename encoding conversion for example), and the
+ * latter allows you both to match your custom open function and to choose
+ * whether the underlying #FILE object should or not be closed when mio_free()
+ * is called on the returned object.
+ *
+ * Free-function: mio_free()
+ *
+ * Returns: A new #MIO on success, or %NULL on failure.
+ */
+MIO *mio_new_file_full (const char *filename,
+						const char *mode,
+						MIOFOpenFunc open_func,
+						MIOFCloseFunc close_func)
+{
+	MIO *mio;
+
+	/* we need to create the MIO object first, because we may not be able to close
+	 * the opened file if the user passed NULL as the close function, which means
+	 * that everything must succeed if we've opened the file successfully */
+	mio = malloc (sizeof *mio);
+	if (mio)
+	{
+		FILE *fp = open_func (filename, mode);
+
+		if (! fp)
+		{
+			free (mio);
+			mio = NULL;
+		}
+		else
+		{
+			mio->type = MIO_TYPE_FILE;
+			mio->impl.file.fp = fp;
+			mio->impl.file.close_func = close_func;
+		}
+	}
+
+	return mio;
+}
+
+/**
+ * mio_new_file:
+ * @filename: Filename to open, same as the fopen()'s first argument
+ * @mode: Mode in which open the file, fopen()'s second argument
+ *
+ * Creates a new #MIO object working on a file from a filename; wrapping
+ * fopen().
+ * This function simply calls mio_new_file_full() with the libc's fopen() and
+ * fclose() functions.
+ *
+ * Free-function: mio_free()
+ *
+ * Returns: A new #MIO on success, or %NULL on failure.
+ */
+MIO *mio_new_file (const char *filename, const char *mode)
+{
+	return mio_new_file_full (filename, mode, fopen, fclose);
+}
+
+/**
+ * mio_new_fp:
+ * @fp: An opened #FILE object
+ * @close_func: (allow-none): Function used to close @fp when the #MIO object
+ *              gets destroyed, or %NULL not to close the #FILE object
+ *
+ * Creates a new #MIO object working on a file, from an already opened #FILE
+ * object.
+ *
+ * <example>
+ * <title>Typical use of this function</title>
+ * <programlisting>
+ * MIO *mio = mio_new_fp (fp, fclose);
+ * </programlisting>
+ * </example>
+ *
+ * Free-function: mio_free()
+ *
+ * Returns: A new #MIO on success or %NULL on failure.
+ */
+MIO *mio_new_fp (FILE *fp, MIOFCloseFunc close_func)
+{
+	MIO *mio;
+
+	if (!fp)
+		return NULL;
+
+	mio = malloc (sizeof *mio);
+	if (mio)
+	{
+		mio->type = MIO_TYPE_FILE;
+		mio->impl.file.fp = fp;
+		mio->impl.file.close_func = close_func;
+	}
+
+	return mio;
+}
+
+/**
+ * mio_new_memory:
+ * @data: Initial data (may be %NULL)
+ * @size: Length of @data in bytes
+ * @realloc_func: A function with the realloc() semantic used to grow the
+ *                buffer, or %NULL to disable buffer growing
+ * @free_func: A function with the free() semantic to destroy the data together
+ *             with the object, or %NULL not to destroy the data
+ *
+ * Creates a new #MIO object working on memory.
+ *
+ * To allow the buffer to grow, you must provide a @realloc_func, otherwise
+ * trying to write after the end of the current data will fail.
+ *
+ * If you want the buffer to be freed together with the #MIO object, you must
+ * give a @free_func; otherwise the data will still live after #MIO object
+ * termination.
+ *
+ * <example>
+ * <title>Basic creation of a non-growable, freeable #MIO object</title>
+ * <programlisting>
+ * MIO *mio = mio_new_memory (data, size, NULL, g_free);
+ * </programlisting>
+ * </example>
+ *
+ * <example>
+ * <title>Basic creation of an empty growable and freeable #MIO object</title>
+ * <programlisting>
+ * MIO *mio = mio_new_memory (NULL, 0, g_try_realloc, g_free);
+ * </programlisting>
+ * </example>
+ *
+ * Free-function: mio_free()
+ *
+ * Returns: A new #MIO on success, or %NULL on failure.
+ */
+MIO *mio_new_memory (unsigned char *data,
+					 size_t size,
+					 MIOReallocFunc realloc_func,
+					 MIODestroyNotify free_func)
+{
+	MIO *mio;
+
+	mio = malloc (sizeof *mio);
+	if (mio)
+	{
+		mio->type = MIO_TYPE_MEMORY;
+		mio->impl.mem.buf = data;
+		mio->impl.mem.ungetch = EOF;
+		mio->impl.mem.pos = 0;
+		mio->impl.mem.size = size;
+		mio->impl.mem.allocated_size = size;
+		mio->impl.mem.realloc_func = realloc_func;
+		mio->impl.mem.free_func = free_func;
+		mio->impl.mem.eof = FALSE;
+		mio->impl.mem.error = FALSE;
+	}
+
+	return mio;
+}
+
+/**
+ * mio_file_get_fp:
+ * @mio: A #MIO object
+ *
+ * Gets the underlying #FILE object associated with a #MIO file stream.
+ *
+ * <warning><para>The returned object may become invalid after a call to
+ * mio_free() if the stream was configured to close the file when
+ * destroyed.</para></warning>
+ *
+ * Returns: The underlying #FILE object of the given stream, or %NULL if the
+ *          stream is not a file stream.
+ */
+FILE *mio_file_get_fp (MIO *mio)
+{
+	FILE *fp = NULL;
+
+	if (mio->type == MIO_TYPE_FILE)
+		fp = mio->impl.file.fp;
+
+	return fp;
+}
+
+/**
+ * mio_memory_get_data:
+ * @mio: A #MIO object
+ * @size: (allow-none) (out): Return location for the length of the returned
+ *        memory, or %NULL
+ *
+ * Gets the underlying memory buffer associated with a #MIO memory stream.
+ *
+ * <warning><para>The returned pointer and size may become invalid after a
+ * successful write on the stream or after a call to mio_free() if the stream
+ * was configured to free the memory when destroyed.</para></warning>
+ *
+ * Returns: The memory buffer of the given #MIO stream, or %NULL if the stream
+ *          is not a memory stream.
+ */
+unsigned char *mio_memory_get_data (MIO *mio, size_t *size)
+{
+	unsigned char *ptr = NULL;
+
+	if (mio->type == MIO_TYPE_MEMORY)
+	{
+		ptr = mio->impl.mem.buf;
+		if (size)
+			*size = mio->impl.mem.size;
+	}
+
+	return ptr;
+}
+
+/**
+ * mio_free:
+ * @mio: A #MIO object
+ *
+ * Destroys a #MIO object.
+ *
+ * Returns: Error code obtained from the registered MIOFCloseFunc or 0 on success.
+ */
+int mio_free (MIO *mio)
+{
+	int rv = 0;
+
+	if (mio)
+	{
+		if (mio->type == MIO_TYPE_FILE)
+		{
+			if (mio->impl.file.close_func)
+				rv = mio->impl.file.close_func (mio->impl.file.fp);
+			mio->impl.file.close_func = NULL;
+			mio->impl.file.fp = NULL;
+		}
+		else
+		{
+			if (mio->impl.mem.free_func)
+				mio->impl.mem.free_func (mio->impl.mem.buf);
+			mio->impl.mem.buf = NULL;
+			mio->impl.mem.pos = 0;
+			mio->impl.mem.size = 0;
+			mio->impl.mem.allocated_size = 0;
+			mio->impl.mem.realloc_func = NULL;
+			mio->impl.mem.free_func = NULL;
+			mio->impl.mem.eof = FALSE;
+			mio->impl.mem.error = FALSE;
+		}
+
+		free (mio);
+	}
+
+	return rv;
+}
+
+/**
+ * mio_read:
+ * @mio: A #MIO object
+ * @ptr: Pointer to the memory to fill with the read data
+ * @size: Size of each block to read
+ * @nmemb: Number o blocks to read
+ *
+ * Reads raw data from a #MIO stream. This function behave the same as fread().
+ *
+ * Returns: The number of actually read blocks. If an error occurs or if the
+ *          end of the stream is reached, the return value may be smaller than
+ *          the requested block count, or even 0. This function doesn't
+ *          distinguish between end-of-stream and an error, you should then use
+ *          mio_eof() and mio_error() to determine which occurred.
+ */
+size_t mio_read (MIO *mio,
+				 void *ptr_,
+				 size_t size,
+				 size_t nmemb)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return fread (ptr_, size, nmemb, mio->impl.file.fp);
+	else
+	{
+		size_t n_read = 0;
+
+		if (size != 0 && nmemb != 0)
+		{
+			size_t size_avail = mio->impl.mem.size - mio->impl.mem.pos;
+			size_t copy_bytes = size * nmemb;
+			unsigned char *ptr = ptr_;
+
+			if (size_avail < copy_bytes)
+				copy_bytes = size_avail;
+
+			if (copy_bytes > 0)
+			{
+				n_read = copy_bytes / size;
+
+				if (mio->impl.mem.ungetch != EOF)
+				{
+					*ptr = (unsigned char) mio->impl.mem.ungetch;
+					mio->impl.mem.ungetch = EOF;
+					copy_bytes--;
+					mio->impl.mem.pos++;
+					ptr++;
+				}
+
+				memcpy (ptr, &mio->impl.mem.buf[mio->impl.mem.pos], copy_bytes);
+				mio->impl.mem.pos += copy_bytes;
+			}
+			if (mio->impl.mem.pos >= mio->impl.mem.size)
+				mio->impl.mem.eof = TRUE;
+		}
+
+		return n_read;
+	}
+}
+
+/*
+ * mem_try_resize:
+ * @mio: A #MIO object of the type %MIO_TYPE_MEMORY
+ * @new_size: Requested new size
+ *
+ * Tries to resize the underlying buffer of an in-memory #MIO object.
+ * This supports both growing and shrinking.
+ *
+ * Returns: %TRUE on success, %FALSE otherwise.
+ */
+static int mem_try_resize (MIO *mio, size_t new_size)
+{
+	int success = FALSE;
+
+	if (mio->impl.mem.realloc_func)
+	{
+		if (new_size == ULONG_MAX)
+		{
+#ifdef EOVERFLOW
+			errno = EOVERFLOW;
+#endif
+		}
+		else
+		{
+			if (new_size > mio->impl.mem.size)
+			{
+				if (new_size <= mio->impl.mem.allocated_size)
+				{
+					mio->impl.mem.size = new_size;
+					success = TRUE;
+				}
+				else
+				{
+					size_t newsize;
+					unsigned char *newbuf;
+
+					newsize = MAX (mio->impl.mem.allocated_size + MIO_CHUNK_SIZE,
+								   new_size);
+					newbuf = mio->impl.mem.realloc_func (mio->impl.mem.buf, newsize);
+					if (newbuf)
+					{
+						mio->impl.mem.buf = newbuf;
+						mio->impl.mem.allocated_size = newsize;
+						mio->impl.mem.size = new_size;
+						success = TRUE;
+					}
+				}
+			}
+			else
+			{
+				unsigned char *newbuf;
+
+				newbuf = mio->impl.mem.realloc_func (mio->impl.mem.buf, new_size);
+				if (newbuf || new_size == 0)
+				{
+					mio->impl.mem.buf = newbuf;
+					mio->impl.mem.allocated_size = new_size;
+					mio->impl.mem.size = new_size;
+					success = TRUE;
+				}
+			}
+		}
+	}
+
+	return success;
+}
+
+/*
+ * mem_try_ensure_space:
+ * @mio: A #MIO object
+ * @n: Requested size from the current (cursor) position
+ *
+ * Tries to ensure there is enough space for @n bytes to be written from the
+ * current cursor position.
+ *
+ * Returns: %TRUE if there is enough space, %FALSE otherwise.
+ */
+static int mem_try_ensure_space (MIO *mio, size_t n)
+{
+	int success = TRUE;
+
+	if (mio->impl.mem.pos + n > mio->impl.mem.size)
+		success = mem_try_resize (mio, mio->impl.mem.pos + n);
+
+	return success;
+}
+
+/**
+ * mio_write:
+ * @mio: A #MIO object
+ * @ptr: Pointer to the memory to write on the stream
+ * @size: Size of each block to write
+ * @nmemb: Number of block to write
+ *
+ * Writes raw data to a #MIO stream. This function behaves the same as fwrite().
+ *
+ * Returns: The number of blocks actually written to the stream. This might be
+ *          smaller than the requested count if a write error occurs.
+ */
+size_t mio_write (MIO *mio,
+				  const void *ptr,
+				  size_t size,
+				  size_t nmemb)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return fwrite (ptr, size, nmemb, mio->impl.file.fp);
+	else
+	{
+		size_t n_written = 0;
+
+		if (size != 0 && nmemb != 0)
+		{
+			if (mem_try_ensure_space (mio, size * nmemb))
+			{
+				memcpy (&mio->impl.mem.buf[mio->impl.mem.pos], ptr, size * nmemb);
+				mio->impl.mem.pos += size * nmemb;
+				n_written = nmemb;
+			}
+		}
+
+		return n_written;
+	}
+}
+
+/**
+ * mio_putc:
+ * @mio: A #MIO object
+ * @c: The character to write
+ *
+ * Writes a character to a #MIO stream. This function behaves the same as
+ * fputc().
+ *
+ * Returns: The written wharacter, or %EOF on error.
+ */
+int mio_putc (MIO *mio, int c)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return fputc (c, mio->impl.file.fp);
+	else
+	{
+		int rv = EOF;
+
+		if (mem_try_ensure_space (mio, 1))
+		{
+			mio->impl.mem.buf[mio->impl.mem.pos] = (unsigned char)c;
+			mio->impl.mem.pos++;
+			rv = (int)((unsigned char)c);
+		}
+
+		return rv;
+	}
+}
+
+/**
+ * mio_puts:
+ * @mio: A #MIO object
+ * @s: The string to write
+ *
+ * Writes a string to a #MIO object. This function behaves the same as fputs().
+ *
+ * Returns: A non-negative integer on success or %EOF on failure.
+ */
+int mio_puts (MIO *mio, const char *s)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return fputs (s, mio->impl.file.fp);
+	else
+	{
+		int rv = EOF;
+		size_t len;
+
+		len = strlen (s);
+		if (mem_try_ensure_space (mio, len))
+		{
+			memcpy (&mio->impl.mem.buf[mio->impl.mem.pos], s, len);
+			mio->impl.mem.pos += len;
+			rv = 1;
+		}
+
+		return rv;
+	}
+}
+
+/**
+ * mio_vprintf:
+ * @mio: A #MIO object
+ * @format: A printf fomrat string
+ * @ap: The variadic argument list for the format
+ *
+ * Writes a formatted string into a #MIO stream. This function behaves the same
+ * as vfprintf().
+ *
+ * Returns: The number of bytes written in the stream, or a negative value on
+ *          failure.
+ */
+int mio_vprintf (MIO *mio, const char *format, va_list ap)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return vfprintf (mio->impl.file.fp, format, ap);
+	else
+	{
+		int rv = -1;
+		size_t n;
+		size_t old_pos;
+		size_t old_size;
+		va_list ap_copy;
+		char c;
+
+		old_pos = mio->impl.mem.pos;
+		old_size = mio->impl.mem.size;
+		va_copy (ap_copy, ap);
+		/* compute the size we will need into the buffer */
+		n = vsnprintf (&c, 1, format, ap_copy);
+		va_end (ap_copy);
+		if (mem_try_ensure_space (mio, n))
+		{
+			unsigned char c;
+
+			/* backup character at n+1 that will be overwritten by a \0 ... */
+			c = mio->impl.mem.buf[mio->impl.mem.pos + (n - 1)];
+			rv = vsprintf ((char *)&mio->impl.mem.buf[mio->impl.mem.pos], format, ap);
+			/* ...and restore it */
+			mio->impl.mem.buf[mio->impl.mem.pos + (n - 1)] = c;
+			if (rv >= 0 && (size_t)rv == (n - 1))
+			{
+				/* re-compute the actual size since we might have allocated one byte
+				 * more than needed */
+				mio->impl.mem.size = MAX (old_size, old_pos + (unsigned int)rv);
+				mio->impl.mem.pos += (unsigned int)rv;
+			}
+			else
+			{
+				mio->impl.mem.size = old_size;
+				rv = -1;
+			}
+		}
+
+		return rv;
+	}
+}
+
+/**
+ * mio_printf:
+ * @mio: A #MIO object
+ * @format: A print format string
+ * @...: Arguments of the format
+ *
+ * Writes a formatted string to a #MIO stream. This function behaves the same as
+ * fprintf().
+ *
+ * Returns: The number of bytes written to the stream, or a negative value on
+ *          failure.
+ */
+int mio_printf (MIO *mio, const char *format, ...)
+{
+	int rv;
+	va_list ap;
+
+	va_start (ap, format);
+	rv = mio_vprintf (mio, format, ap);
+	va_end (ap);
+
+	return rv;
+}
+
+/**
+ * mio_getc:
+ * @mio: A #MIO object
+ *
+ * Gets the current character from a #MIO stream. This function behaves the same
+ * as fgetc().
+ *
+ * Returns: The read character as a #int, or %EOF on error.
+ */
+int mio_getc (MIO *mio)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return fgetc (mio->impl.file.fp);
+	else
+	{
+		int rv = EOF;
+
+		if (mio->impl.mem.ungetch != EOF)
+		{
+			rv = mio->impl.mem.ungetch;
+			mio->impl.mem.ungetch = EOF;
+			mio->impl.mem.pos++;
+		}
+		else if (mio->impl.mem.pos < mio->impl.mem.size)
+		{
+			rv = mio->impl.mem.buf[mio->impl.mem.pos];
+			mio->impl.mem.pos++;
+		}
+		else
+			mio->impl.mem.eof = TRUE;
+
+		return rv;
+	}
+}
+
+/**
+ * mio_ungetc:
+ * @mio: A #MIO object
+ * @ch: Character to put back in the stream
+ *
+ * Puts a character back in a #MIO stream. This function behaves the sames as
+ * ungetc().
+ *
+ * <warning><para>It is only guaranteed that one character can be but back at a
+ * time, even if the implementation may allow more.</para></warning>
+ * <warning><para>Using this function while the stream cursor is at offset 0 is
+ * not guaranteed to function properly. As the C99 standard says, it is "an
+ * obsolescent feature".</para></warning>
+ *
+ * Returns: The character put back, or %EOF on error.
+ */
+int mio_ungetc (MIO *mio, int ch)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return ungetc (ch, mio->impl.file.fp);
+	else
+	{
+		int rv = EOF;
+
+		if (ch != EOF && mio->impl.mem.ungetch == EOF)
+		{
+			rv = mio->impl.mem.ungetch = ch;
+			mio->impl.mem.pos--;
+			mio->impl.mem.eof = FALSE;
+		}
+
+		return rv;
+	}
+}
+
+/**
+ * mio_gets:
+ * @mio: A #MIO object
+ * @s: A string to fill with the read data
+ * @size: The maximum number of bytes to read
+ *
+ * Reads a string from a #MIO stream, stopping after the first new-line
+ * character or at the end of the stream. This function behaves the same as
+ * fgets().
+ *
+ * Returns: @s on success, %NULL otherwise.
+ */
+char *mio_gets (MIO *mio, char *s, size_t size)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return fgets (s, (int)size, mio->impl.file.fp);
+	else
+	{
+		char *rv = NULL;
+
+		if (size > 0)
+		{
+			size_t i = 0;
+
+			if (mio->impl.mem.ungetch != EOF)
+			{
+				s[i] = (char)mio->impl.mem.ungetch;
+				mio->impl.mem.ungetch = EOF;
+				mio->impl.mem.pos++;
+				i++;
+			}
+			for (; mio->impl.mem.pos < mio->impl.mem.size && i < (size - 1); i++)
+			{
+				s[i] = (char)mio->impl.mem.buf[mio->impl.mem.pos];
+				mio->impl.mem.pos++;
+				if (s[i] == '\n')
+				{
+					i++;
+					break;
+				}
+			}
+			if (i > 0)
+			{
+				s[i] = 0;
+				rv = s;
+			}
+			if (mio->impl.mem.pos >= mio->impl.mem.size)
+				mio->impl.mem.eof = TRUE;
+		}
+
+		return rv;
+	}
+}
+
+/**
+ * mio_clearerr:
+ * @mio: A #MIO object
+ *
+ * Clears the error and end-of-stream indicators of a #MIO stream. This function
+ * behaves the same as clearerr().
+ */
+void mio_clearerr (MIO *mio)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		clearerr (mio->impl.file.fp);
+	else
+	{
+		mio->impl.mem.error = FALSE;
+		mio->impl.mem.eof = FALSE;
+	}
+}
+
+/**
+ * mio_eof:
+ * @mio: A #MIO object
+ *
+ * Checks whether the end-of-stream indicator of a #MIO stream is set. This
+ * function behaves the same as feof().
+ *
+ * Returns: A non-null value if the stream reached its end, 0 otherwise.
+ */
+int mio_eof (MIO *mio)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return feof (mio->impl.file.fp);
+	else
+		return mio->impl.mem.eof != FALSE;
+}
+
+/**
+ * mio_error:
+ * @mio: A #MIO object
+ *
+ * Checks whether the error indicator of a #MIO stream is set. This function
+ * behaves the same as ferror().
+ *
+ * Returns: A non-null value if the stream have an error set, 0 otherwise.
+ */
+int mio_error (MIO *mio)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return ferror (mio->impl.file.fp);
+	else
+		return mio->impl.mem.error != FALSE;
+}
+
+/**
+ * mio_seek:
+ * @mio: A #MIO object
+ * @offset: Offset of the new place, from @whence
+ * @whence: Move origin. SEEK_SET moves relative to the start of the stream,
+ *          SEEK_CUR from the current position and SEEK_SET from the end of the
+ *          stream.
+ *
+ * Sets the curosr position on a #MIO stream. This functions behaves the same as
+ * fseek(). See also mio_tell() and mio_setpos().
+ *
+ * Returns: 0 on success, -1 otherwise, in which case errno should be set to
+ *          indicate the error.
+ */
+int mio_seek (MIO *mio, long offset, int whence)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return fseek (mio->impl.file.fp, offset, whence);
+	else
+	{
+		/* FIXME: should we support seeking out of bounds like lseek() seems to do? */
+		int rv = -1;
+
+		switch (whence)
+		{
+			case SEEK_SET:
+				if (offset < 0 || (size_t)offset > mio->impl.mem.size)
+					errno = EINVAL;
+				else
+				{
+					mio->impl.mem.pos = (size_t)offset;
+					rv = 0;
+				}
+				break;
+
+			case SEEK_CUR:
+				if ((offset < 0 && (size_t)-offset > mio->impl.mem.pos) ||
+					mio->impl.mem.pos + (size_t)offset > mio->impl.mem.size)
+				{
+					errno = EINVAL;
+				}
+				else
+				{
+					mio->impl.mem.pos = (size_t)(mio->impl.mem.pos + offset);
+					rv = 0;
+				}
+				break;
+
+			case SEEK_END:
+				if (offset > 0 || (size_t)-offset > mio->impl.mem.size)
+					errno = EINVAL;
+				else
+				{
+					mio->impl.mem.pos = mio->impl.mem.size - (size_t)-offset;
+					rv = 0;
+				}
+				break;
+
+			default:
+				errno = EINVAL;
+		}
+		if (rv == 0)
+		{
+			mio->impl.mem.eof = FALSE;
+			mio->impl.mem.ungetch = EOF;
+		}
+
+		return rv;
+	}
+}
+
+/**
+ * mio_tell:
+ * @mio: A #MIO object
+ *
+ * Gets the current cursor position of a #MIO stream. This function behaves the
+ * same as ftell().
+ *
+ * Returns: The current offset from the start of the stream, or -1 or error, in
+ *          which case errno is set to indicate the error.
+ */
+long mio_tell (MIO *mio)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return ftell (mio->impl.file.fp);
+	else
+	{
+		long rv = -1;
+
+		if (mio->impl.mem.pos > LONG_MAX)
+		{
+#ifdef EOVERFLOW
+			errno = EOVERFLOW;
+#endif
+		}
+		else
+			rv = (long)mio->impl.mem.pos;
+
+		return rv;
+	}
+}
+
+/**
+ * mio_rewind:
+ * @mio: A #MIO object
+ *
+ * Resets the cursor position to 0, and also the end-of-stream and the error
+ * indicators of a #MIO stream.
+ * See also mio_seek() and mio_clearerr().
+ */
+void mio_rewind (MIO *mio)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		rewind (mio->impl.file.fp);
+	else
+	{
+		mio->impl.mem.pos = 0;
+		mio->impl.mem.ungetch = EOF;
+		mio->impl.mem.eof = FALSE;
+		mio->impl.mem.error = FALSE;
+	}
+}
+
+/**
+ * mio_getpos:
+ * @mio: A #MIO stream
+ * @pos: (out): A #MIOPos object to fill-in
+ *
+ * Stores the current position (and maybe other informations about the stream
+ * state) of a #MIO stream in order to restore it later with mio_setpos(). This
+ * function behaves the same as fgetpos().
+ *
+ * Returns: 0 on success, -1 otherwise, in which case errno is set to indicate
+ *          the error.
+ */
+int mio_getpos (MIO *mio, MIOPos *pos)
+{
+	int rv = -1;
+
+	pos->type = mio->type;
+	if (mio->type == MIO_TYPE_FILE)
+		rv = fgetpos (mio->impl.file.fp, &pos->impl.file);
+	else
+	{
+		rv = -1;
+
+		if (mio->impl.mem.pos == (size_t)-1)
+		{
+			/* this happens if ungetc() was called at the start of the stream */
+#ifdef EIO
+			errno = EIO;
+#endif
+		}
+		else
+		{
+			pos->impl.mem = mio->impl.mem.pos;
+			rv = 0;
+		}
+	}
+#ifdef MIO_DEBUG
+	if (rv != -1)
+	{
+		pos->tag = mio;
+	}
+#endif /* MIO_DEBUG */
+
+	return rv;
+}
+
+/**
+ * mio_setpos:
+ * @mio: A #MIO object
+ * @pos: (in): A #MIOPos object filled-in by a previous call of mio_getpos() on
+ *       the same stream
+ *
+ * Restores the position and state indicators of a #MIO stream previously saved
+ * by mio_getpos().
+ *
+ * <warning><para>The #MIOPos object must have been initialized by a previous
+ * call to mio_getpos() on the same stream.</para></warning>
+ *
+ * Returns: 0 on success, -1 otherwise, in which case errno is set to indicate
+ *          the error.
+ */
+int mio_setpos (MIO *mio, MIOPos *pos)
+{
+	int rv = -1;
+
+#ifdef MIO_DEBUG
+	if (pos->tag != mio)
+	{
+		g_critical ("mio_setpos((MIO*)%p, (MIOPos*)%p): "
+					"Given MIOPos was not set by a previous call to mio_getpos() "
+					"on the same MIO object, which means there is a bug in "
+					"someone's code.",
+					(void *)mio, (void *)pos);
+		errno = EINVAL;
+		return -1;
+	}
+#endif /* MIO_DEBUG */
+
+	if (mio->type == MIO_TYPE_FILE)
+		rv = fsetpos (mio->impl.file.fp, &pos->impl.file);
+	else
+	{
+		rv = -1;
+
+		if (pos->impl.mem > mio->impl.mem.size)
+			errno = EINVAL;
+		else
+		{
+			mio->impl.mem.ungetch = EOF;
+			mio->impl.mem.pos = pos->impl.mem;
+			rv = 0;
+		}
+	}
+
+	return rv;
+}
+
+/**
+ * mio_flush:
+ * @mio: A #MIO object
+ *
+ * Forces a write of all user-space buffered data for the given output or update
+ * stream via the stream's underlying write function. Only applicable when using
+ * FILE back-end.
+ *
+ * Returns: 0 on success, error code otherwise.
+ */
+int mio_flush (MIO *mio)
+{
+	if (mio->type == MIO_TYPE_FILE)
+		return fflush (mio->impl.file.fp);
+	return 0;
+}

--- a/main/mio.h
+++ b/main/mio.h
@@ -1,0 +1,178 @@
+/*
+ *  MIO, an I/O abstraction layer replicating C file I/O API.
+ *  Copyright (C) 2010  Colomban Wendling <ban@herbesfolles.org>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef MIO_H
+#define MIO_H
+
+#include "general.h"  /* must always come first */
+
+#include <stdio.h>
+#include <stdarg.h>
+
+
+/**
+ * MIOType:
+ * @MIO_TYPE_FILE: #MIO object works on a file
+ * @MIO_TYPE_MEMORY: #MIO object works in-memory
+ *
+ * Existing implementations.
+ */
+enum _MIOType {
+	MIO_TYPE_FILE,
+	MIO_TYPE_MEMORY
+};
+
+typedef enum _MIOType   MIOType;
+typedef struct _MIO     MIO;
+typedef struct _MIOPos  MIOPos;
+
+/**
+ * MIOReallocFunc:
+ * @ptr: Pointer to the memory to resize
+ * @size: New size of the memory pointed by @ptr
+ *
+ * A function following the realloc() semantic.
+ *
+ * Returns: A pointer to the start of the new memory, or %NULL on failure.
+ */
+typedef void *(* MIOReallocFunc) (void * ptr, size_t size);
+
+/**
+ * MIOFOpenFunc:
+ * @filename: The filename to open
+ * @mode: fopen() modes for opening @filename
+ *
+ * A function following the fclose() semantic, used to close a #FILE
+ * object.
+ *
+ * Returns: A new #FILE object, or %NULL on failure
+ */
+typedef FILE *(* MIOFOpenFunc) (const char *filename, const char *mode);
+
+/**
+ * MIOFCloseFunc:
+ * @fp: An opened #FILE object
+ *
+ * A function following the fclose() semantic, used to close a #FILE
+ * object.
+ *
+ * Returns: 0 on success, EOF otherwise.
+ */
+typedef int (* MIOFCloseFunc) (FILE *fp);
+
+/**
+ * MIODestroyNotify:
+ * @data: Data element being destroyed
+ *
+ * Specifies the type of function which is called when a data element is
+ * destroyed. It is passed the pointer to the data element and should free any
+ * memory and resources allocated for it.
+ */
+typedef void (*MIODestroyNotify) (void *data);
+
+/**
+ * MIOPos:
+ *
+ * An object representing the state of a #MIO stream. This object can be
+ * statically allocated but all its fields are private and should not be
+ * accessed directly.
+ */
+struct _MIOPos {
+	/*< private >*/
+	unsigned int type;
+#ifdef MIO_DEBUG
+	void *tag;
+#endif
+	union {
+		fpos_t file;
+		size_t mem;
+	} impl;
+};
+
+/**
+ * MIO:
+ *
+ * An object representing a #MIO stream. No assumptions should be made about
+ * what compose this object, and none of its fields should be accessed directly.
+ */
+struct _MIO {
+	/*< private >*/
+	unsigned int type;
+	union {
+		struct {
+			FILE *fp;
+			MIOFCloseFunc close_func;
+		} file;
+		struct {
+			unsigned char *buf;
+			int ungetch;
+			size_t pos;
+			size_t size;
+			size_t allocated_size;
+			MIOReallocFunc realloc_func;
+			MIODestroyNotify free_func;
+			boolean error;
+			boolean eof;
+		} mem;
+	} impl;
+};
+
+
+MIO *mio_new_file (const char *filename, const char *mode);
+MIO *mio_new_file_full (const char *filename,
+						const char *mode,
+						MIOFOpenFunc open_func,
+						MIOFCloseFunc close_func);
+MIO *mio_new_fp (FILE *fp, MIOFCloseFunc close_func);
+MIO *mio_new_memory (unsigned char *data,
+					 size_t size,
+					 MIOReallocFunc realloc_func,
+					 MIODestroyNotify free_func);
+int mio_free (MIO *mio);
+FILE *mio_file_get_fp (MIO *mio);
+unsigned char *mio_memory_get_data (MIO *mio, size_t *size);
+size_t mio_read (MIO *mio,
+				 void *ptr,
+				 size_t size,
+				 size_t nmemb);
+size_t mio_write (MIO *mio,
+				  const void *ptr,
+				  size_t size,
+				  size_t nmemb);
+int mio_getc (MIO *mio);
+char *mio_gets (MIO *mio, char *s, size_t size);
+int mio_ungetc (MIO *mio, int ch);
+int mio_putc (MIO *mio, int c);
+int mio_puts (MIO *mio, const char *s);
+
+int mio_vprintf (MIO *mio, const char *format, va_list ap) __printf__ (2, 0);
+int mio_printf (MIO *mio, const char *format, ...) __printf__ (2, 3);
+
+void mio_clearerr (MIO *mio);
+int mio_eof (MIO *mio);
+int mio_error (MIO *mio);
+int mio_seek (MIO *mio, long offset, int whence);
+long mio_tell (MIO *mio);
+void mio_rewind (MIO *mio);
+int mio_getpos (MIO *mio, MIOPos *pos);
+int mio_setpos (MIO *mio, MIOPos *pos);
+int mio_flush (MIO *mio);
+
+#endif /* MIO_H */

--- a/main/parse.h
+++ b/main/parse.h
@@ -59,7 +59,7 @@ typedef void (*parserInitialize) (langType language);
    is called. */
 typedef void (*parserFinalize) (langType language, boolean initialized);
 
-typedef const char * (*selectLanguage) (FILE *);
+typedef const char * (*selectLanguage) (MIO *);
 
 typedef enum {
 	METHOD_NOT_CRAFTED    = 1 << 0,

--- a/main/read.h
+++ b/main/read.h
@@ -27,6 +27,7 @@
 
 #include "parse.h"
 #include "vstring.h"
+#include "mio.h"
 
 /*
 *   MACROS
@@ -84,7 +85,7 @@ typedef struct sInputFileInfo {
 } inputFileInfo;
 
 typedef struct sInputLineFposMap {
-	fpos_t *pos;
+	MIOPos *pos;
 	unsigned int count;
 	unsigned int size;
 } inputLineFposMap;
@@ -93,8 +94,8 @@ typedef struct sInputFile {
 	vString    *path;          /* path of input file (if any) */
 	vString    *line;          /* last line read from file */
 	const unsigned char* currentLine;  /* current line being worked on */
-	FILE       *fp;            /* stream used for reading the file */
-	fpos_t      filePosition;  /* file position of current line */
+	MIO        *fp;            /* stream used for reading the file */
+	MIOPos      filePosition;  /* file position of current line */
 	unsigned int ungetchIdx;
 	int         ungetchBuf[3]; /* characters that were ungotten */
 	boolean     eof;           /* have we reached the end of file? */
@@ -137,11 +138,11 @@ extern void                 ungetcToInputFile (int c);
 extern const unsigned char *readLineFromInputFile (void);
 
 /* Raw: reading from given a parameter, fp */
-extern char *readLineRaw           (vString *const vLine, FILE *const fp);
+extern char *readLineRaw           (vString *const vLine, MIO *const fp);
 extern char* readLineRawWithNoSeek (vString *const vline, FILE *const pp);
 
 /* Bypass: reading from fp in inputFile WITHOUT updating fields in input fields */
-extern char *readLineFromBypass (vString *const vLine, fpos_t location, long *const pSeekValue);
+extern char *readLineFromBypass (vString *const vLine, MIOPos location, long *const pSeekValue);
 extern char *readLineFromBypassSlow (vString *const vLine, unsigned long lineNumber,
 				     const char *pattern, long *const pSeekValue);
 

--- a/main/routines.c
+++ b/main/routines.c
@@ -827,10 +827,11 @@ extern char* relativeFilename (const char *file, const char *dir)
 	return res;
 }
 
-extern FILE *tempFile (const char *const mode, char **const pName)
+extern MIO *tempFile (const char *const mode, char **const pName)
 {
 	char *name;
 	FILE *fp;
+	MIO *mio;
 	int fd;
 #if defined(HAVE_MKSTEMP)
 	const char *const pattern = "tags.XXXXXX";
@@ -870,11 +871,12 @@ extern FILE *tempFile (const char *const mode, char **const pName)
 	fp = fdopen (fd, mode);
 	if (fp == NULL)
 		error (FATAL | PERROR, "cannot open temporary file");
+	mio = mio_new_fp (fp, fclose);
 	DebugStatement (
 		debugPrintf (DEBUG_STATUS, "opened temporary file %s\n", name); )
 	Assert (*pName == NULL);
 	*pName = name;
-	return fp;
+	return mio;
 }
 
 /* vi:set tabstop=4 shiftwidth=4: */

--- a/main/routines.c
+++ b/main/routines.c
@@ -477,26 +477,6 @@ extern boolean isRecursiveLink (const char* const dirName)
 	return result;
 }
 
-#ifndef HAVE_FGETPOS
-
-extern int fgetpos (FILE *stream, fpos_t *pos)
-{
-	int result = 0;
-
-	*pos = ftell (stream);
-	if (*pos == -1L)
-		result = -1;
-
-	return result;
-}
-
-extern int fsetpos (FILE *stream, fpos_t const *pos)
-{
-	return fseek (stream, *pos, SEEK_SET);
-}
-
-#endif
-
 /*
  *  Pathname manipulation (O/S dependent!!!)
  */

--- a/main/routines.h
+++ b/main/routines.h
@@ -128,10 +128,6 @@ extern boolean doesFileExist (const char *const fileName);
 extern boolean doesExecutableExist (const char *const fileName);
 extern boolean isRecursiveLink (const char* const dirName);
 extern boolean isSameFile (const char *const name1, const char *const name2);
-#if defined(NEED_PROTO_FGETPOS)
-extern int fgetpos  (FILE *stream, fpos_t *pos);
-extern int fsetpos  (FILE *stream, fpos_t *pos);
-#endif
 extern const char *baseFilename (const char *const filePath);
 extern const char *fileExtension (const char *const fileName);
 extern boolean isAbsolutePath (const char *const path);

--- a/main/routines.h
+++ b/main/routines.h
@@ -13,7 +13,10 @@
 *   INCLUDE FILES
 */
 #include "general.h"  /* must always come first */
+
 #include <stdio.h>
+
+#include "mio.h"
 
 /*
 *   MACROS
@@ -136,7 +139,7 @@ extern char *combinePathAndFile (const char *const path, const char *const file)
 extern char* absoluteFilename (const char *file);
 extern char* absoluteDirname (char *file);
 extern char* relativeFilename (const char *file, const char *dir);
-extern FILE *tempFile (const char *const mode, char **const pName);
+extern MIO *tempFile (const char *const mode, char **const pName);
 
 extern char* baseFilenameSansExtensionNew (const char *const fileName, const char *const templateExt);
 

--- a/main/selectors.c
+++ b/main/selectors.c
@@ -37,13 +37,13 @@ static const char *TR_DOSBATCH = "DosBatch";
 #define startsWith(line,prefix) \
   (strncmp(line, prefix, strlen(prefix)) == 0? TRUE: FALSE)
 
-static const char *selectByLines (FILE *input,
+static const char *selectByLines (MIO *input,
 				  const char* (* lineTaster) (const char *, void *),
 				  const char* defaultLang,
 				  void *userData)
 {
     char line[0x800];
-    while (fgets(line, sizeof(line), input)) {
+    while (mio_gets(input, line, sizeof(line))) {
 	const char *lang = lineTaster (line, userData);
 	if (lang)
 	    return lang;
@@ -119,7 +119,7 @@ tastePerlLine (const char *line, void *data __unused__)
 }
 
 const char *
-selectByPickingPerlVersion (FILE *input)
+selectByPickingPerlVersion (MIO *input)
 {
     /* Default to Perl 5 */
     return selectByLines (input, tastePerlLine, TR_PERL5, NULL);
@@ -160,7 +160,7 @@ tasteObjectiveCOrMatLabLines (const char *line, void *data __unused__)
 }
 
 const char *
-selectByObjectiveCAndMatLabKeywords (FILE * input)
+selectByObjectiveCAndMatLabKeywords (MIO * input)
 {
     return selectByLines (input, tasteObjectiveCOrMatLabLines,
 			  NULL, NULL);
@@ -178,7 +178,7 @@ tasteObjectiveC (const char *line, void *data __unused__)
 }
 
 const char *
-selectByObjectiveCKeywords (FILE * input)
+selectByObjectiveCKeywords (MIO * input)
 {
     /* TODO: Ideally opening input should be delayed til
        enable/disable based selection is done. */
@@ -218,7 +218,7 @@ tasteR (const char *line, void *data __unused__)
 }
 
 const char *
-selectByArrowOfR (FILE *input)
+selectByArrowOfR (MIO *input)
 {
     /* TODO: Ideally opening input should be delayed till
        enable/disable based selection is done. */
@@ -264,7 +264,7 @@ tasteREXXOrDosBatch (const char *line, void *data)
 }
 
 const char *
-selectByRexxCommentAndDosbatchLabelPrefix (FILE *input)
+selectByRexxCommentAndDosbatchLabelPrefix (MIO *input)
 {
     /* TODO: Ideally opening input should be delayed till
        enable/disable based selection is done. */
@@ -301,7 +301,7 @@ static void suppressWarning (void *ctx __unused__, const char *msg __unused__, .
 }
 
 static xmlDocPtr
-xmlParseFILE (FILE *input)
+xmlParseFILE (MIO *input)
 {
 	vString *buf;
 	xmlDocPtr doc;
@@ -364,7 +364,7 @@ selectParserForXmlDoc (xmlDocPtr doc)
 }
 
 const char *
-selectByDTD (FILE *input)
+selectByDTD (MIO *input)
 {
 	xmlDocPtr doc;
 	const char *r = NULL;

--- a/main/selectors.h
+++ b/main/selectors.h
@@ -13,23 +13,23 @@
 #include <stdio.h>
 
 const char *
-selectByPickingPerlVersion (FILE *);
+selectByPickingPerlVersion (MIO *);
 
 const char *
-selectByObjectiveCAndMatLabKeywords (FILE *);
+selectByObjectiveCAndMatLabKeywords (MIO *);
 
 const char *
-selectByObjectiveCKeywords(FILE *);
+selectByObjectiveCKeywords(MIO *);
 
 const char *
-selectByArrowOfR (FILE *);
+selectByArrowOfR (MIO *);
 
 const char *
-selectByRexxCommentAndDosbatchLabelPrefix (FILE *);
+selectByRexxCommentAndDosbatchLabelPrefix (MIO *);
 
 #ifdef HAVE_LIBXML
 const char *
-selectByDTD (FILE *input);
+selectByDTD (MIO *input);
 #endif
 
 #endif

--- a/main/sort.h
+++ b/main/sort.h
@@ -13,23 +13,26 @@
 *   INCLUDE FILES
 */
 #include "general.h"  /* must always come first */
+
 #include <stdio.h>
+
+#include "mio.h"
 
 /*
 *   FUNCTION PROTOTYPES
 */
-extern void catFile (FILE *fp);
+extern void catFile (MIO *fp);
 
 #ifdef EXTERNAL_SORT
-extern void externalSortTags (const boolean toStdout, FILE *tagFile);
+extern void externalSortTags (const boolean toStdout, MIO *tagFile);
 #else
 extern void internalSortTags (const boolean toStdout,
-			      FILE *fp,
+			      MIO *fp,
 			      size_t numTags);
 #endif
 
 /* fp is closed in this function. */
-extern void failedSort (FILE *const fp, const char* msg);
+extern void failedSort (MIO *const fp, const char* msg);
 
 #endif  /* CTAGS_MAIN_SORT_H */
 

--- a/main/strlist.c
+++ b/main/strlist.c
@@ -88,11 +88,11 @@ extern stringList* stringListNewFromArgv (const char* const* const argv)
 extern stringList* stringListNewFromFile (const char* const fileName)
 {
 	stringList* result = NULL;
-	FILE* const fp = fopen (fileName, "r");
+	MIO* const fp = mio_new_file (fileName, "r");
 	if (fp != NULL)
 	{
 		result = stringListNew ();
-		while (! feof (fp))
+		while (! mio_eof (fp))
 		{
 			vString* const str = vStringNew ();
 			readLineRaw (str, fp);

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -263,7 +263,7 @@ extern char    *vStringDeleteUnwrap       (vString *const string)
 	return buffer;
 }
 
-extern vString *vStringNewFile (FILE *input)
+extern vString *vStringNewFile (MIO *input)
 {
 	char tmp [1024];
 	vString *buf;
@@ -273,10 +273,10 @@ extern vString *vStringNewFile (FILE *input)
 	while (1)
 	{
 		if (r < sizeof (tmp)
-		    && (feof (input) || ferror (input)))
+		    && (mio_eof (input) || mio_error (input)))
 			break;
 
-		r = fread (tmp, 1, sizeof (tmp), input);
+		r = mio_read (input, tmp, 1, sizeof (tmp));
 
 		if (r > 0)
 			vStringNCatS (buf, tmp, r);

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -20,6 +20,8 @@
 
 #include <stdio.h>
 
+#include "mio.h"
+
 /*
 *   MACROS
 */
@@ -75,7 +77,7 @@ extern void vStringCatS (vString *const string, const char *const s);
 extern void vStringNCatS (vString *const string, const char *const s, const size_t length);
 extern vString *vStringNewCopy (const vString *const string);
 extern vString *vStringNewInit (const char *const s);
-extern vString *vStringNewFile (FILE *input);
+extern vString *vStringNewFile (MIO *input);
 extern void vStringCopyS (vString *const string, const char *const s);
 extern void vStringNCopyS (vString *const string, const char *const s, const size_t length);
 extern void vStringCopyToLower (vString *const dest, const vString *const src);

--- a/parsers/ada.c
+++ b/parsers/ada.c
@@ -306,7 +306,7 @@ static const char *line;
 static int lineLen;
 static int pos;
 static unsigned long matchLineNum;
-static fpos_t matchFilePos;
+static MIOPos matchFilePos;
 
 /* utility functions */
 static void makeSpec(adaKind *kind);
@@ -1178,7 +1178,7 @@ static adaTokenInfo *adaParseVariables(adaTokenInfo *parent, adaKind kind)
   unsigned long int lineNum;
   int filePosIndex = 0;
   int filePosSize = 32;
-  fpos_t *filePos = xMalloc(filePosSize, fpos_t);
+  MIOPos *filePos = xMalloc(filePosSize, MIOPos);
 
   /* skip any preliminary whitespace or comments */
   skipWhiteSpace();
@@ -1294,7 +1294,7 @@ static adaTokenInfo *adaParseVariables(adaTokenInfo *parent, adaKind kind)
       while(filePosIndex >= filePosSize)
       {
         filePosSize *= 2;
-        filePos = xRealloc(filePos, filePosSize, fpos_t);
+        filePos = xRealloc(filePos, filePosSize, MIOPos);
       }
       filePos[filePosIndex] = getInputFilePosition();
 

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -206,7 +206,7 @@ typedef struct sTokenInfo {
 	keywordId     keyword;
 	vString*      name;          /* the name of the token */
 	unsigned long lineNumber;    /* line number of tag */
-	fpos_t        filePosition;  /* file position of line containing name */
+	MIOPos        filePosition;  /* file position of line containing name */
 } tokenInfo;
 
 typedef enum eImplementation {

--- a/parsers/css.c
+++ b/parsers/css.c
@@ -187,7 +187,7 @@ static void findCssTags (void)
 		else if (token.type == TOKEN_SELECTOR)
 		{ /* collect selectors and make a tag */
 			cssKind kind = K_SELECTOR;
-			fpos_t filePosition;
+			MIOPos filePosition;
 			unsigned long lineNumber;
 			vString *selector = vStringNew ();
 			do

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -263,7 +263,7 @@ static boolean cxxParserParseEnumStructClassOrUnionFullDeclarationTrailer(
 			szTypeName
 		);
 
-	fpos_t oFilePosition = getInputFilePosition();
+	MIOPos oFilePosition = getInputFilePosition();
 	int iFileLine = getInputLineNumber();
 
 	if(!cxxParserParseUpToOneOf(CXXTokenTypeEOF | CXXTokenTypeSemicolon))

--- a/parsers/cxx/cxx_token.h
+++ b/parsers/cxx/cxx_token.h
@@ -72,7 +72,7 @@ typedef struct _CXXToken
 	boolean bFollowedBySpace;
 
 	int iLineNumber;
-	fpos_t oFilePosition;
+	MIOPos oFilePosition;
 
 	struct _CXXToken * pNext;
 	struct _CXXToken * pPrev;

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -119,7 +119,7 @@ typedef struct sTokenInfo {
 	vString *		string;
 	vString *		scope;
 	unsigned long 	lineNumber;
-	fpos_t 			filePosition;
+	MIOPos 			filePosition;
 	int				nestLevel;
 	boolean			ignoreTag;
 	boolean			isClass;

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -204,7 +204,7 @@ typedef struct sTokenInfo {
 	boolean isMethod;
 	struct sTokenInfo *secondary;
 	unsigned long lineNumber;
-	fpos_t filePosition;
+	MIOPos filePosition;
 } tokenInfo;
 
 /*

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -67,7 +67,7 @@ typedef struct sTokenInfo {
 	keywordId keyword;
 	vString *string;		/* the name of the token */
 	unsigned long lineNumber;	/* line number of tag */
-	fpos_t filePosition;		/* file position of line containing name */
+	MIOPos filePosition;		/* file position of line containing name */
 } tokenInfo;
 
 /*

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -103,7 +103,7 @@ typedef struct sTokenInfo {
 	vString *		string;
 	vString *		scope;
 	unsigned long 	lineNumber;
-	fpos_t 			filePosition;
+	MIOPos 			filePosition;
 	int				nestLevel;
 	boolean			ignoreTag;
 } tokenInfo;

--- a/parsers/json.c
+++ b/parsers/json.c
@@ -58,7 +58,7 @@ typedef struct {
 	vString			*string;
 	vString			*scope;
 	unsigned long	lineNumber;
-	fpos_t			filePosition;
+	MIOPos			filePosition;
 } tokenInfo;
 
 typedef enum {

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -233,7 +233,7 @@ typedef struct {
 	vString *		string;
 	vString *		scope;
 	unsigned long 	lineNumber;
-	fpos_t			filePosition;
+	MIOPos			filePosition;
 	int 			parentKind; /* -1 if none */
 } tokenInfo;
 

--- a/parsers/rst.c
+++ b/parsers/rst.c
@@ -64,7 +64,7 @@ static NestingLevel *getNestingLevel(const int kind)
 	return nl;
 }
 
-static void makeRstTag(const vString* const name, const int kind, const fpos_t filepos)
+static void makeRstTag(const vString* const name, const int kind, const MIOPos filepos)
 {
 	const NestingLevel *const nl = getNestingLevel(kind);
 
@@ -157,10 +157,10 @@ static int utf8_strlen(const char *buf, int buf_len)
 static void findRstTags (void)
 {
 	vString *name = vStringNew ();
-	fpos_t filepos;
+	MIOPos filepos;
 	const unsigned char *line;
 
-	memset(&filepos, 0, sizeof(fpos_t));
+	memset(&filepos, 0, sizeof(MIOPos));
 	memset(kindchars, 0, sizeof kindchars);
 	nestingLevels = nestingLevelsNew();
 

--- a/parsers/rust.c
+++ b/parsers/rust.c
@@ -81,7 +81,7 @@ typedef struct {
 	int cur_token;
 	vString* token_str;
 	unsigned long line;
-	fpos_t pos;
+	MIOPos pos;
 } lexerState;
 
 /*
@@ -434,7 +434,7 @@ static void deInitLexer (lexerState *lexer)
 	lexer->token_str = NULL;
 }
 
-static void addTag (vString* ident, const char* arg_list, int kind, unsigned long line, fpos_t pos, vString *scope, int parent_kind)
+static void addTag (vString* ident, const char* arg_list, int kind, unsigned long line, MIOPos pos, vString *scope, int parent_kind)
 {
 	if (kind == K_NONE || ! rustKinds[kind].enabled)
 		return;
@@ -528,7 +528,7 @@ static void parseFn (lexerState *lexer, vString *scope, int parent_kind)
 	vString *name;
 	vString *arg_list;
 	unsigned long line;
-	fpos_t pos;
+	MIOPos pos;
 	int paren_level = 0;
 	boolean found_paren = FALSE;
 	boolean valid_signature = TRUE;
@@ -668,7 +668,7 @@ static void parseQualifiedType (lexerState *lexer, vString* name)
 static void parseImpl (lexerState *lexer, vString *scope, int parent_kind)
 {
 	unsigned long line;
-	fpos_t pos;
+	MIOPos pos;
 	vString *name;
 
 	advanceToken(lexer, TRUE);

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -162,7 +162,7 @@ typedef struct sTokenInfoSQL {
 	int         scopeKind;
 	int         begin_end_nest_lvl;
 	unsigned long lineNumber;
-	fpos_t filePosition;
+	MIOPos filePosition;
 } tokenInfo;
 
 /*

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -83,7 +83,7 @@ typedef struct sTokenInfo {
 	vString *		string;
 	vString *		scope;
 	unsigned long 	lineNumber;
-	fpos_t 			filePosition;
+	MIOPos 			filePosition;
 } tokenInfo;
 
 /*

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -75,7 +75,7 @@ typedef struct sTokenInfo {
 	verilogKind         kind;
 	vString*            name;          /* the name of the token */
 	unsigned long       lineNumber;    /* line number where token was found */
-	fpos_t              filePosition;  /* file position where token was found */
+	MIOPos              filePosition;  /* file position where token was found */
 	struct sTokenInfo*  scope;         /* context of keyword */
 	int                 nestLevel;     /* Current nest level */
 	verilogKind         lastKind;      /* Kind of last found tag */

--- a/parsers/vhdl.c
+++ b/parsers/vhdl.c
@@ -157,7 +157,7 @@ typedef struct sTokenInfo {
 	vString *string;		/* the name of the token */
 	vString *scope;
 	unsigned long lineNumber;	/* line number of tag */
-	fpos_t filePosition;		/* file position of line containing name */
+	MIOPos filePosition;		/* file position of line containing name */
 } tokenInfo;
 
 /*

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -34,7 +34,7 @@ typedef struct sLineInfo {
 	vString *	string;
 	vString *	scope;
 	unsigned long lineNumber;
-	fpos_t filePosition;
+	MIOPos filePosition;
 } lineInfo;
 #endif
 

--- a/source.mak
+++ b/source.mak
@@ -22,6 +22,7 @@ MAIN_HEADS =			\
 	main/kind.h		\
 	main/main.h		\
 	main/mbcs.h		\
+	main/mio.h		\
 	main/nestlevel.h	\
 	main/options.h		\
 	main/parse.h		\
@@ -51,6 +52,7 @@ MAIN_SRCS =				\
 	main/lxpath.c			\
 	main/main.c			\
 	main/mbcs.c			\
+	main/mio.c			\
 	main/nestlevel.c		\
 	main/options.c			\
 	main/parse.c			\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -195,6 +195,7 @@
     <ClCompile Include="..\main\vstring.c" />
     <ClCompile Include="..\parsers\windres.c" />
     <ClCompile Include="..\main\xtag.c" />
+    <ClCompile Include="..\main\mio.c" />
     <ClCompile Include="..\parsers\yacc.c" />
   </ItemGroup>
   <ItemGroup>
@@ -226,6 +227,7 @@
     <ClInclude Include="..\main\strlist.h" />
     <ClInclude Include="..\main\vstring.h" />
     <ClInclude Include="..\main\xtag.h" />
+    <ClInclude Include="..\main\mio.h" />
     <ClInclude Include="..\parsers\cxx\cxx_debug.h" />
     <ClInclude Include="..\parsers\cxx\cxx_keyword.h" />
     <ClInclude Include="..\parsers\cxx\cxx_parser.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -268,6 +268,9 @@
     <ClCompile Include="..\main\xtag.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
+    <ClCompile Include="..\main\mio.c">
+      <Filter>Source Files\Main</Filter>
+    </ClCompile>
     <ClCompile Include="..\main\repoinfo.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
@@ -403,6 +406,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
    <ClInclude Include="..\main\xtag.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\main\mio.h">
       <Filter>Header Files</Filter>
     </ClInclude>
    <ClInclude Include="..\main\ptag.h">


### PR DESCRIPTION
As discussed here #863  this pull request introduces the MIO library to be able to parse memory buffers similarly to files which is both slightly faster and useful for users using ctags as a library.

The patch is mostly trivial - I just added the mio.c/h files, added MIO instead of FILE to inputFile and the rest is just following and fixing the errors from the compiler (in addition I made a manual check of all FILE, fpos_t, etc. afterwards and converted a few extra cases). There are still a few FILE left - these are mostly in cases where e.g. printing to stdout or in pcoproc.c/h where MIO doesn't make much sense.

I kept the original variable names (which in the case of FILE was in most cases fp) - in Geany they were renamed to mio - I don't know if it's worth the rename to mio, fp is probably fine in this case.

Finally, for files smaller than 1MB I loaded them into memory before parsing and let the parser parse them from memory - it's slightly faster. Tested on linux kernel sources ctags -R . took 40s instead of 44s on my machine.

It would be useful if someone with MS Visual Studio could verify this still compiles and works on Windows.

@b4n I did the stuff I suggested in #863 - I hope I didn't screw up your library too much. What I did:

* replaced the glib types with ordinary C types
* removed the "virtual" calls and replaced them with simple if/else
* made the implementation in a single file
* reformatted the library to more or less match universal-ctags style
* removed the MIO_FORCE_ANSI ifdef as it included some glib file and we don't really need it
* added mio_flush() - of course makes sense just for the file backend (calls fflush())
* made mio_free() return error code from fclose()
* changed mio_new_fp() to return NULL when the passed FILE is NULL (simplifies logic at one place in ctags and makes sense IMO)

Are you fine with the changes I made?