### PR TITLE
C++, C: use per parser finalizer

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -522,9 +522,6 @@ static void sanitizeEnviron (void)
 	}
 }
 
-extern void cxxParserCleanup(void);
-
-
 /*
  *		Start up code
  */
@@ -551,7 +548,6 @@ extern int main (int __unused__ argc, char **argv)
 
 	/*  Clean up.
 	 */
-	cxxParserCleanup();
 	cArgDelete (args);
 	freeKeywordTable ();
 	freeRoutineResources ();

--- a/parsers/cxx/cxx.c
+++ b/parsers/cxx/cxx.c
@@ -90,6 +90,7 @@ parserDefinition * CParser (void)
 	def->extensions = extensions;
 	def->parser2    = cxxCParserMain;
 	def->initialize = cxxCParserInitialize;
+	def->finalize   = cxxParserCleanup;
 	def->selectLanguage = selectors;
 	def->useCork = TRUE; // We use corking to block output until the end of file
 
@@ -117,6 +118,7 @@ parserDefinition * CppParser (void)
 	def->extensions = extensions;
 	def->parser2    = cxxCppParserMain;
 	def->initialize = cxxCppParserInitialize;
+	def->finalize   = cxxParserCleanup;
 	def->selectLanguage = selectors;
 	def->useCork = TRUE; // We use corking to block output until the end of file
 

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1119,10 +1119,14 @@ void cxxCParserInitialize(const langType language)
 	cxxBuildKeywordHash(language,FALSE);
 }
 
-void cxxParserCleanup(void)
+void cxxParserCleanup (langType language __unused__, boolean initialized __unused__)
 {
 	if(g_bFirstRun)
 		return; // didn't run at all
+
+	// This function is used as finalizer for both C and C++ parsers.
+	// The next line forces this function to be called only once
+	g_bFirstRun = TRUE;
 
 	if(g_cxx.pTokenChain)
 		cxxTokenChainDestroy(g_cxx.pTokenChain);

--- a/parsers/cxx/cxx_parser.h
+++ b/parsers/cxx/cxx_parser.h
@@ -18,5 +18,6 @@ rescanReason cxxCParserMain(const unsigned int passCount);
 rescanReason cxxCppParserMain(const unsigned int passCount);
 void cxxCppParserInitialize(const langType language);
 void cxxCParserInitialize(const langType language);
+void cxxParserCleanup (langType language, boolean initialized);
 
 #endif //!ctags_cxx_parser_h_


### PR DESCRIPTION
cxxParserCleanup was called directly from main function.
Ideally main part should not have any knowledge about parser.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>