### PR TITLE
Allow typeRef[0] == NULL and generate "unknown" for it in the tags file

### DIFF
--- a/Tmain/extra-field.d/stdout-expected.txt
+++ b/Tmain/extra-field.d/stdout-expected.txt
@@ -1,10 +1,10 @@
 X	input.cpp	/^namespace X {$/;"	n	file:	extra:fileScope
 X::Y	input.cpp	/^  extern class Y {$/;"	c	namespace:X	file:	extra:fileScope,qualified
-X::Y::m	input.cpp	/^    int m;$/;"	m	class:X::Y	typeref:typename:int	file:	extra:fileScope,qualified
+X::Y::m	input.cpp	/^    int m;$/;"	m	class:X::Y	typeref:unknown:int	file:	extra:fileScope,qualified
 X::v	input.cpp	/^  } v;$/;"	v	namespace:X	typeref:class:X::Y	extra:qualified
 Y	input.cpp	/^  extern class Y {$/;"	c	namespace:X	file:	extra:fileScope
 Z	input.cpp	/^#define Z$/;"	d	file:	extra:fileScope
 Z	input.cpp	/^#undef Z$/;"	d	file:	role:undef	extra:fileScope,reference
 input.cpp	input.cpp	7;"	F	extra:inputFileWithEndline
-m	input.cpp	/^    int m;$/;"	m	class:X::Y	typeref:typename:int	file:	extra:fileScope
+m	input.cpp	/^    int m;$/;"	m	class:X::Y	typeref:unknown:int	file:	extra:fileScope
 v	input.cpp	/^  } v;$/;"	v	namespace:X	typeref:class:X::Y

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -72,9 +72,9 @@ x	input.c	/^  struct X x;$/
 #t
 X	input.c	/^struct X {$/
 Y	input.c	/^struct Y {$/
-i	input.c	/^  int i;$/;"	typeref:typename:int
-j	input.c	/^  int j;$/;"	typeref:typename:int
-main	input.c	/^int main(void)$/;"	typeref:typename:int
+i	input.c	/^  int i;$/;"	typeref:unknown:int
+j	input.c	/^  int j;$/;"	typeref:unknown:int
+main	input.c	/^int main(void)$/;"	typeref:unknown:int
 x	input.c	/^  struct X x;$/;"	typeref:struct:X
 #r
 x	input.sh	/^source x$/;"	role:loaded

--- a/Tmain/maxdepth.d/stdout-expected.txt
+++ b/Tmain/maxdepth.d/stdout-expected.txt
@@ -1,5 +1,5 @@
 # DEPTH=1
-a	./src/a.c	/^int a (void)$/;"	f	typeref:typename:int
+a	./src/a.c	/^int a (void)$/;"	f	typeref:unknown:int
 # DEPTH=2
-a	./src/a.c	/^int a (void)$/;"	f	typeref:typename:int
-b	./src/subdir/b.c	/^int b(void)$/;"	f	typeref:typename:int
+a	./src/a.c	/^int a (void)$/;"	f	typeref:unknown:int
+b	./src/subdir/b.c	/^int b(void)$/;"	f	typeref:unknown:int

--- a/Units/extension-with-template-suffix.d/expected.tags
+++ b/Units/extension-with-template-suffix.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.c.in	/^main (void)$/;"	f	typeref:typename:int
+main	input.c.in	/^main (void)$/;"	f	typeref:unknown:int

--- a/Units/extra-file-scope-option.d/expected.tags
+++ b/Units/extra-file-scope-option.d/expected.tags
@@ -1,1 +1,1 @@
-y	input.c	/^       void y(void) {}$/;"	f	typeref:typename:void
+y	input.c	/^       void y(void) {}$/;"	f	typeref:unknown:void

--- a/Units/extra-total-lines.d/expected.tags
+++ b/Units/extra-total-lines.d/expected.tags
@@ -1,2 +1,2 @@
 input.c	input.c	6;"	F
-main	input.c	2;"	f	typeref:typename:int
+main	input.c	2;"	f	typeref:unknown:int

--- a/Units/nolang-modeline-emacs-firstline1.d/expected.tags
+++ b/Units/nolang-modeline-emacs-firstline1.d/expected.tags
@@ -1,1 +1,1 @@
-hello	input.nolang	/^hello (void)$/;"	f	typeref:typename:int
+hello	input.nolang	/^hello (void)$/;"	f	typeref:unknown:int

--- a/Units/nolang-modeline-vim0.d/expected.tags
+++ b/Units/nolang-modeline-vim0.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.nolang	/^main(void)$/;"	f	typeref:typename:int
+main	input.nolang	/^main(void)$/;"	f	typeref:unknown:int

--- a/Units/nolang-modeline-vim1.d/expected.tags
+++ b/Units/nolang-modeline-vim1.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.nolang	/^main(void)$/;"	f	typeref:typename:int
+main	input.nolang	/^main(void)$/;"	f	typeref:unknown:int

--- a/Units/nolang-modeline-vim2.d/expected.tags
+++ b/Units/nolang-modeline-vim2.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.nolang	/^main(void)$/;"	f	language:C	typeref:typename:int
+main	input.nolang	/^main(void)$/;"	f	language:C	typeref:unknown:int

--- a/Units/option-disable-kind-in-regex.d/expected.tags
+++ b/Units/option-disable-kind-in-regex.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.c	/^main(void)$/;"	f	typeref:typename:int
+main	input.c	/^main(void)$/;"	f	typeref:unknown:int

--- a/Units/option-langmap-ext--ext.d/expected.tags
+++ b/Units/option-langmap-ext--ext.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.x	/^main(void)$/;"	f	typeref:typename:int
+main	input.x	/^main(void)$/;"	f	typeref:unknown:int

--- a/Units/option-langmap-ext--pat-ext.d/expected.tags
+++ b/Units/option-langmap-ext--pat-ext.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.zzz	/^main(void)$/;"	f	typeref:typename:int
+main	input.zzz	/^main(void)$/;"	f	typeref:unknown:int

--- a/Units/option-langmap-ext-pat--ext.d/expected.tags
+++ b/Units/option-langmap-ext-pat--ext.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.x	/^main(void)$/;"	f	typeref:typename:int
+main	input.x	/^main(void)$/;"	f	typeref:unknown:int

--- a/Units/option-langmap-pat--ext.d/expected.tags
+++ b/Units/option-langmap-pat--ext.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.x	/^main(void)$/;"	f	typeref:typename:int
+main	input.x	/^main(void)$/;"	f	typeref:unknown:int

--- a/Units/option-langmap-pat--pat-ext.d/expected.tags
+++ b/Units/option-langmap-pat--pat-ext.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.zzz	/^main(void)$/;"	f	typeref:typename:int
+main	input.zzz	/^main(void)$/;"	f	typeref:unknown:int

--- a/Units/option-same-kind-in-regex-and-builtin.d/expected.tags
+++ b/Units/option-same-kind-in-regex-and-builtin.d/expected.tags
@@ -1,2 +1,2 @@
 a	input.c	/^  define a;$/;"	f
-main	input.c	/^main(void)$/;"	f	typeref:typename:int
+main	input.c	/^main(void)$/;"	f	typeref:unknown:int

--- a/Units/parser-c.r/backslash-in-input.c.d/expected.tags
+++ b/Units/parser-c.r/backslash-in-input.c.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.c	/^int main \\$/;"	f	typeref:typename:int
+main	input.c	/^int main \\$/;"	f	typeref:unknown:int

--- a/Units/parser-c.r/bit_field.c.d/expected.tags
+++ b/Units/parser-c.r/bit_field.c.d/expected.tags
@@ -1,25 +1,25 @@
 bit_fields	input.c	/^struct bit_fields {$/;"	s	file:
-a	input.c	/^    unsigned int a: 1;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:1	file:
-b	input.c	/^    unsigned int b: 1;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:1	file:
-c	input.c	/^    unsigned int c: 2;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:2	file:
+a	input.c	/^    unsigned int a: 1;$/;"	m	struct:bit_fields	typeref:unknown:unsigned int:1	file:
+b	input.c	/^    unsigned int b: 1;$/;"	m	struct:bit_fields	typeref:unknown:unsigned int:1	file:
+c	input.c	/^    unsigned int c: 2;$/;"	m	struct:bit_fields	typeref:unknown:unsigned int:2	file:
 __anon1719c4a5010a	input.c	/^struct {$/;"	s	file:
-sign	input.c	/^    unsigned sign  : 1;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned:1	file:
-exp	input.c	/^    unsigned exp   : _FP_EXPBITS_D;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
-frac1	input.c	/^    unsigned frac1 : _FP_FRACBITS_D - (_FP_IMPLBIT_D != 0) - _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
-frac0	input.c	/^    unsigned frac0 : _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
+sign	input.c	/^    unsigned sign  : 1;$/;"	m	struct:__anon1719c4a5010a	typeref:unknown:unsigned:1	file:
+exp	input.c	/^    unsigned exp   : _FP_EXPBITS_D;$/;"	m	struct:__anon1719c4a5010a	typeref:unknown:unsigned	file:
+frac1	input.c	/^    unsigned frac1 : _FP_FRACBITS_D - (_FP_IMPLBIT_D != 0) - _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a5010a	typeref:unknown:unsigned	file:
+frac0	input.c	/^    unsigned frac0 : _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a5010a	typeref:unknown:unsigned	file:
 shortname_info	input.c	/^struct shortname_info {$/;"	s	file:
-lower	input.c	/^	unsigned char lower:1,$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
-upper	input.c	/^		      upper:1,$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
-valid	input.c	/^		      valid:1;$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
+lower	input.c	/^	unsigned char lower:1,$/;"	m	struct:shortname_info	typeref:unknown:unsigned char:1	file:
+upper	input.c	/^		      upper:1,$/;"	m	struct:shortname_info	typeref:unknown:unsigned char:1	file:
+valid	input.c	/^		      valid:1;$/;"	m	struct:shortname_info	typeref:unknown:unsigned char:1	file:
 __anon1719c4a5020a	input.c	/^{$/;"	s	file:
-public	input.c	/^    BYTE 	public: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
-bad2	input.c	/^    BYTE 	bad2: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
-group	input.c	/^    BYTE 	group: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
-personal	input.c	/^    BYTE 	personal: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
+public	input.c	/^    BYTE 	public: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:unknown:BYTE:1	file:
+bad2	input.c	/^    BYTE 	bad2: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:unknown:BYTE:1	file:
+group	input.c	/^    BYTE 	group: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:unknown:BYTE:1	file:
+personal	input.c	/^    BYTE 	personal: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:unknown:BYTE:1	file:
 bitfield_flags	input.c	/^} bitfield_flags;$/;"	t	typeref:struct:__anon1719c4a5020a	file:
 __anon1719c4a5030a	input.c	/^{$/;"	s	file:
-this	input.c	/^    BYTE	this;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
-public	input.c	/^    BYTE	public;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
-private	input.c	/^    BYTE	private;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
-that	input.c	/^    BYTE	that;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
+this	input.c	/^    BYTE	this;$/;"	m	struct:__anon1719c4a5030a	typeref:unknown:BYTE	file:
+public	input.c	/^    BYTE	public;$/;"	m	struct:__anon1719c4a5030a	typeref:unknown:BYTE	file:
+private	input.c	/^    BYTE	private;$/;"	m	struct:__anon1719c4a5030a	typeref:unknown:BYTE	file:
+that	input.c	/^    BYTE	that;$/;"	m	struct:__anon1719c4a5030a	typeref:unknown:BYTE	file:
 mystruct	input.c	/^} mystruct;$/;"	t	typeref:struct:__anon1719c4a5030a	file:

--- a/Units/parser-c.r/bug1020715.c.d/expected.tags
+++ b/Units/parser-c.r/bug1020715.c.d/expected.tags
@@ -1,1 +1,1 @@
-f	input.c	43;"	f	typeref:typename:void	signature:()
+f	input.c	43;"	f	typeref:unknown:void	signature:()

--- a/Units/parser-c.r/bug1085585.c.d/expected.tags
+++ b/Units/parser-c.r/bug1085585.c.d/expected.tags
@@ -1,2 +1,2 @@
-check_parity	input.c	/^static int check_parity(des_cblock (*key));$/;"	p	typeref:typename:int	file:
-des_check_key	input.c	/^int des_check_key=0;$/;"	v	typeref:typename:int
+check_parity	input.c	/^static int check_parity(des_cblock (*key));$/;"	p	typeref:unknown:int	file:
+des_check_key	input.c	/^int des_check_key=0;$/;"	v	typeref:unknown:int

--- a/Units/parser-c.r/bug1086609.c.d/expected.tags
+++ b/Units/parser-c.r/bug1086609.c.d/expected.tags
@@ -1,1 +1,1 @@
-func2	input.c	/^int func2(int a)$/;"	f	typeref:typename:int
+func2	input.c	/^int func2(int a)$/;"	f	typeref:unknown:int

--- a/Units/parser-c.r/bug1458930.c.d/expected.tags
+++ b/Units/parser-c.r/bug1458930.c.d/expected.tags
@@ -1,2 +1,2 @@
-x	input.c	/^char x();$/;"	p	typeref:typename:char	file:
-y	input.c	/^wchar_t y();$/;"	p	typeref:typename:wchar_t	file:
+x	input.c	/^char x();$/;"	p	typeref:unknown:char	file:
+y	input.c	/^wchar_t y();$/;"	p	typeref:unknown:wchar_t	file:

--- a/Units/parser-c.r/bug1466117.c.d/expected.tags
+++ b/Units/parser-c.r/bug1466117.c.d/expected.tags
@@ -1,7 +1,7 @@
 __anonadd2b98b010a	input.c	/^typedef struct {$/;"	s	file:
-a	input.c	/^	int a;$/;"	m	struct:__anonadd2b98b010a	typeref:typename:int	file:
-a	input.c	/^	int a;$/;"	m	struct:mystruct	typeref:typename:int	file:
-b	input.c	/^	int b;$/;"	m	struct:__anonadd2b98b010a	typeref:typename:int	file:
-b	input.c	/^	int b;$/;"	m	struct:mystruct	typeref:typename:int	file:
+a	input.c	/^	int a;$/;"	m	struct:__anonadd2b98b010a	typeref:unknown:int	file:
+a	input.c	/^	int a;$/;"	m	struct:mystruct	typeref:unknown:int	file:
+b	input.c	/^	int b;$/;"	m	struct:__anonadd2b98b010a	typeref:unknown:int	file:
+b	input.c	/^	int b;$/;"	m	struct:mystruct	typeref:unknown:int	file:
 mystruct	input.c	/^typedef struct mystruct {$/;"	s	file:
 mystruct	input.c	/^} mystruct;$/;"	t	typeref:struct:__anonadd2b98b010a	file:

--- a/Units/parser-c.r/bug1491666.c.d/expected.tags
+++ b/Units/parser-c.r/bug1491666.c.d/expected.tags
@@ -1,7 +1,7 @@
 __anon329ddd92010a	input.c	/^typedef struct {$/;"	s	file:
-main	input.c	/^void main (void) {$/;"	f	typeref:typename:void
+main	input.c	/^void main (void) {$/;"	f	typeref:unknown:void
 my_struct	input.c	/^} my_struct;$/;"	t	typeref:struct:__anon329ddd92010a	file:
-var1	input.c	/^	my_struct var1;$/;"	l	function:main	typeref:typename:my_struct	file:
-var2	input.c	/^		var2;$/;"	l	function:main	typeref:typename:my_struct	file:
-x	input.c	/^		x;$/;"	m	struct:__anon329ddd92010a	typeref:typename:int	file:
-y	input.c	/^		y;$/;"	m	struct:__anon329ddd92010a	typeref:typename:float	file:
+var1	input.c	/^	my_struct var1;$/;"	l	function:main	typeref:unknown:my_struct	file:
+var2	input.c	/^		var2;$/;"	l	function:main	typeref:unknown:my_struct	file:
+x	input.c	/^		x;$/;"	m	struct:__anon329ddd92010a	typeref:unknown:int	file:
+y	input.c	/^		y;$/;"	m	struct:__anon329ddd92010a	typeref:unknown:float	file:

--- a/Units/parser-c.r/bug1764143.h.d/expected.tags
+++ b/Units/parser-c.r/bug1764143.h.d/expected.tags
@@ -1,2 +1,2 @@
-arch_reset	input.h	/^static inline void arch_reset(char mode)$/;"	f	typeref:typename:void
-omap1_arch_reset	input.h	/^static inline void omap1_arch_reset(char mode)$/;"	f	typeref:typename:void
+arch_reset	input.h	/^static inline void arch_reset(char mode)$/;"	f	typeref:unknown:void
+omap1_arch_reset	input.h	/^static inline void omap1_arch_reset(char mode)$/;"	f	typeref:unknown:void

--- a/Units/parser-c.r/bug507864.c.d/expected.tags
+++ b/Units/parser-c.r/bug507864.c.d/expected.tags
@@ -1,2 +1,2 @@
-func1	input.c	/^FUNCSTS func1(ENTSEQNO(seq)) {}$/;"	f	typeref:typename:FUNCSTS
-func2	input.c	/^FUNCSTS func2 (MEMTXT(form_msg), MEMTXT (text), MEMTXT (mail)) {}$/;"	f	typeref:typename:FUNCSTS
+func1	input.c	/^FUNCSTS func1(ENTSEQNO(seq)) {}$/;"	f	typeref:unknown:FUNCSTS
+func2	input.c	/^FUNCSTS func2 (MEMTXT(form_msg), MEMTXT (text), MEMTXT (mail)) {}$/;"	f	typeref:unknown:FUNCSTS

--- a/Units/parser-c.r/c-digraphs.d/expected.tags
+++ b/Units/parser-c.r/c-digraphs.d/expected.tags
@@ -3,9 +3,9 @@ B	input.c	/^%:define B /;"	d	file:
 M3_INIT	input.c	/^%:define M3_INIT(/;"	d	file:
 STRINGIFY	input.c	/^%:define STRINGIFY(/;"	d	file:
 STRINGIFY_INTERN	input.c	/^%:define STRINGIFY_INTERN(/;"	d	file:
-buf	input.c	/^  char *buf;$/;"	m	struct:str	typeref:typename:char *	file:
-len	input.c	/^  unsigned int len, size;$/;"	m	struct:str	typeref:typename:unsigned int	file:
-main	input.c	/^int main(void)$/;"	f	typeref:typename:int
-matrix3	input.c	/^typedef int matrix3<:3:>;$/;"	t	typeref:typename:int[3]	file:
-size	input.c	/^  unsigned int len, size;$/;"	m	struct:str	typeref:typename:unsigned int	file:
+buf	input.c	/^  char *buf;$/;"	m	struct:str	typeref:unknown:char *	file:
+len	input.c	/^  unsigned int len, size;$/;"	m	struct:str	typeref:unknown:unsigned int	file:
+main	input.c	/^int main(void)$/;"	f	typeref:unknown:int
+matrix3	input.c	/^typedef int matrix3<:3:>;$/;"	t	typeref:unknown:int[3]	file:
+size	input.c	/^  unsigned int len, size;$/;"	m	struct:str	typeref:unknown:unsigned int	file:
 str	input.c	/^struct str <%$/;"	s	file:

--- a/Units/parser-c.r/c-knr.d/expected.tags
+++ b/Units/parser-c.r/c-knr.d/expected.tags
@@ -1,12 +1,12 @@
-f01	input.c	/^int f01()$/;"	f	typeref:typename:int
+f01	input.c	/^int f01()$/;"	f	typeref:unknown:int
 f02	input.c	/^int f02(f02a01,f02a02)$/;"	f
-f02a01	input.c	/^  int f02a01;$/;"	z	function:f02	typeref:typename:int	file:
-f02a02	input.c	/^  int f02a02;$/;"	z	function:f02	typeref:typename:int	file:
-f03	input.c	/^int f03(void)$/;"	f	typeref:typename:int
-f04	input.c	/^int f04(...)$/;"	f	typeref:typename:int
+f02a01	input.c	/^  int f02a01;$/;"	z	function:f02	typeref:unknown:int	file:
+f02a02	input.c	/^  int f02a02;$/;"	z	function:f02	typeref:unknown:int	file:
+f03	input.c	/^int f03(void)$/;"	f	typeref:unknown:int
+f04	input.c	/^int f04(...)$/;"	f	typeref:unknown:int
 f05	input.c	/^int f05($/;"	f
-f05a01	input.c	/^	unsigned short f05a01;$/;"	z	function:f05	typeref:typename:unsigned short	file:
-f05a02	input.c	/^	int * f05a02;$/;"	z	function:f05	typeref:typename:int *	file:
+f05a01	input.c	/^	unsigned short f05a01;$/;"	z	function:f05	typeref:unknown:unsigned short	file:
+f05a02	input.c	/^	int * f05a02;$/;"	z	function:f05	typeref:unknown:int *	file:
 f06	input.c	/^int f06(f06a01,f06a02)$/;"	f
-f06a01	input.c	/^	unsigned short int f06a01, ** f06a02;$/;"	z	function:f06	typeref:typename:unsigned short int	file:
-f06a02	input.c	/^	unsigned short int f06a01, ** f06a02;$/;"	z	function:f06	typeref:typename:unsigned short int **	file:
+f06a01	input.c	/^	unsigned short int f06a01, ** f06a02;$/;"	z	function:f06	typeref:unknown:unsigned short int	file:
+f06a02	input.c	/^	unsigned short int f06a01, ** f06a02;$/;"	z	function:f06	typeref:unknown:unsigned short int **	file:

--- a/Units/parser-c.r/c-label.d/expected.tags
+++ b/Units/parser-c.r/c-label.d/expected.tags
@@ -1,2 +1,2 @@
-main	input.c	/^main(int argc)$/;"	f	typeref:typename:int
+main	input.c	/^main(int argc)$/;"	f	typeref:unknown:int
 out	input.c	/^   out:$/;"	L	function:main	file:

--- a/Units/parser-c.r/c-multichars-between-single-quotes.d/expected.tags
+++ b/Units/parser-c.r/c-multichars-between-single-quotes.d/expected.tags
@@ -1,1 +1,1 @@
-c	input.c	/^char c[]={'o.'};$/;"	v	typeref:typename:char[]
+c	input.c	/^char c[]={'o.'};$/;"	v	typeref:unknown:char[]

--- a/Units/parser-c.r/c-sample.d/expected.tags
+++ b/Units/parser-c.r/c-sample.d/expected.tags
@@ -1,1 +1,1 @@
-main	input.c	/^main(void)$/;"	f	typeref:typename:int
+main	input.c	/^main(void)$/;"	f	typeref:unknown:int

--- a/Units/parser-c.r/c-size_t-wchar_t-typedef.d/expected.tags
+++ b/Units/parser-c.r/c-size_t-wchar_t-typedef.d/expected.tags
@@ -1,2 +1,2 @@
-size_t	input.c	/^typedef int size_t;$/;"	t	typeref:typename:int	file:
-wchar_t	input.c	/^typedef int wchar_t;$/;"	t	typeref:typename:int	file:
+size_t	input.c	/^typedef int size_t;$/;"	t	typeref:unknown:int	file:
+wchar_t	input.c	/^typedef int wchar_t;$/;"	t	typeref:unknown:int	file:

--- a/Units/parser-c.r/c-trigraphs.d/expected.tags
+++ b/Units/parser-c.r/c-trigraphs.d/expected.tags
@@ -6,9 +6,9 @@ F	input.c	/^??=define F /;"	d	file:
 M3_INIT	input.c	/^??=define M3_INIT(/;"	d	file:
 STRINGIFY	input.c	/^??=define STRINGIFY(/;"	d	file:
 STRINGIFY_INTERN	input.c	/^??=define STRINGIFY_INTERN(/;"	d	file:
-buf	input.c	/^  char *buf;$/;"	m	struct:str	typeref:typename:char *	file:
-len	input.c	/^  unsigned int len, size;$/;"	m	struct:str	typeref:typename:unsigned int	file:
-main	input.c	/^int main(void)$/;"	f	typeref:typename:int
-matrix3	input.c	/^typedef int matrix3??(3??);$/;"	t	typeref:typename:int[3]	file:
-size	input.c	/^  unsigned int len, size;$/;"	m	struct:str	typeref:typename:unsigned int	file:
+buf	input.c	/^  char *buf;$/;"	m	struct:str	typeref:unknown:char *	file:
+len	input.c	/^  unsigned int len, size;$/;"	m	struct:str	typeref:unknown:unsigned int	file:
+main	input.c	/^int main(void)$/;"	f	typeref:unknown:int
+matrix3	input.c	/^typedef int matrix3??(3??);$/;"	t	typeref:unknown:int[3]	file:
+size	input.c	/^  unsigned int len, size;$/;"	m	struct:str	typeref:unknown:unsigned int	file:
 str	input.c	/^struct str ??<$/;"	s	file:

--- a/Units/parser-c.r/complex_decl.c.d/expected.tags
+++ b/Units/parser-c.r/complex_decl.c.d/expected.tags
@@ -1,1 +1,1 @@
-ScanAction	input.c	/^static void (* const(ScanAction[5][5]))(void *)= {};$/;"	v	typeref:typename:void (* const ([5][5]))(void *)	file:
+ScanAction	input.c	/^static void (* const(ScanAction[5][5]))(void *)= {};$/;"	v	typeref:unknown:void (* const ([5][5]))(void *)	file:

--- a/Units/parser-c.r/directives.c.d/expected.tags
+++ b/Units/parser-c.r/directives.c.d/expected.tags
@@ -9,13 +9,13 @@ PATH1b	input.c	/^#define PATH1b$/;"	d	file:
 SEE_THIS_MACRO	input.c	/^# define SEE_THIS_MACRO /;"	d	file:
 VARIABLE_LIKE	input.c	/^#define VARIABLE_LIKE	/;"	d	file:
 WeakSymbol	input.c	/^#pragma weak WeakSymbol /;"	d	file:
-a	input.c	/^int a;$/;"	v	typeref:typename:int
-b	input.c	/^int b;$/;"	v	typeref:typename:int
-bar1	input.c	/^int bar1 (void)$/;"	f	typeref:typename:int
-c	input.c	/^int c;$/;"	v	typeref:typename:int
-d	input.c	/^int d;$/;"	v	typeref:typename:int
-foo1	input.c	/^int foo1 (void)$/;"	f	typeref:typename:int
-g	input.c	/^int g;$/;"	v	typeref:typename:int
-p1	input.c	/^int p1;$/;"	v	typeref:typename:int
+a	input.c	/^int a;$/;"	v	typeref:unknown:int
+b	input.c	/^int b;$/;"	v	typeref:unknown:int
+bar1	input.c	/^int bar1 (void)$/;"	f	typeref:unknown:int
+c	input.c	/^int c;$/;"	v	typeref:unknown:int
+d	input.c	/^int d;$/;"	v	typeref:unknown:int
+foo1	input.c	/^int foo1 (void)$/;"	f	typeref:unknown:int
+g	input.c	/^int g;$/;"	v	typeref:unknown:int
+p1	input.c	/^int p1;$/;"	v	typeref:unknown:int
 with_long_comment	input.c	/^#define with_long_comment /;"	d	file:
 z_this_branch_is_chosen	input.c	/^#define  z_this_branch_is_chosen /;"	d	file:

--- a/Units/parser-c.r/line_directives.c.d/expected.tags
+++ b/Units/parser-c.r/line_directives.c.d/expected.tags
@@ -1,5 +1,5 @@
-a	a.c	10;"	v	language:C	typeref:typename:int
-b	b.c	20;"	v	language:C	typeref:typename:int
-c	c.c	30;"	v	language:C	typeref:typename:int
-d	OK.zzz	2;"	v	language:NEWLANG	typeref:typename:int
-e	OK.y	100;"	v	language:YACC	typeref:typename:int
+a	a.c	10;"	v	language:C	typeref:unknown:int
+b	b.c	20;"	v	language:C	typeref:unknown:int
+c	c.c	30;"	v	language:C	typeref:unknown:int
+d	OK.zzz	2;"	v	language:NEWLANG	typeref:unknown:int
+e	OK.y	100;"	v	language:YACC	typeref:unknown:int

--- a/Units/parser-c.r/local.c.d/expected.tags
+++ b/Units/parser-c.r/local.c.d/expected.tags
@@ -1,6 +1,6 @@
-a	input.c	/^    int a;$/;"	l	function:main	typeref:typename:int	file:
-b	input.c	/^    int b = 3;$/;"	l	function:main	typeref:typename:int	file:
-isContextualKeyword	input.c	/^static boolean isContextualKeyword (const tokenInfo *const token)$/;"	f	typeref:typename:boolean	file:
+a	input.c	/^    int a;$/;"	l	function:main	typeref:unknown:int	file:
+b	input.c	/^    int b = 3;$/;"	l	function:main	typeref:unknown:int	file:
+isContextualKeyword	input.c	/^static boolean isContextualKeyword (const tokenInfo *const token)$/;"	f	typeref:unknown:boolean	file:
 label	input.c	/^label:$/;"	L	function:isContextualKeyword	file:
 main	input.c	/^main ()$/;"	f
-result	input.c	/^    boolean result;$/;"	l	function:isContextualKeyword	typeref:typename:boolean	file:
+result	input.c	/^    boolean result;$/;"	l	function:isContextualKeyword	typeref:unknown:boolean	file:

--- a/Units/parser-c.r/macros.c.d/expected.tags
+++ b/Units/parser-c.r/macros.c.d/expected.tags
@@ -5,5 +5,5 @@ FUNCTION_LIKE	input.c	/^#undef FUNCTION_LIKE$/;"	d	file:	role:undef
 VARIABLE_LIKE	input.c	/^#define VARIABLE_LIKE	/;"	d	file:
 VARIABLE_LIKE	input.c	/^#undef VARIABLE_LIKE$/;"	d	file:	role:undef
 WeakSymbol	input.c	/^#pragma weak WeakSymbol /;"	d	file:
-prototype1	input.c	/^void prototype1 __ARGS((int arg1, void *arg2));$/;"	p	typeref:typename:void	file:	signature:(int arg1, void *arg2)
-prototype2	input.c	/^void prototype2 __ARGS((int arg1, void *arg2))$/;"	f	typeref:typename:void	signature:(int arg1, void *arg2)
+prototype1	input.c	/^void prototype1 __ARGS((int arg1, void *arg2));$/;"	p	typeref:unknown:void	file:	signature:(int arg1, void *arg2)
+prototype2	input.c	/^void prototype2 __ARGS((int arg1, void *arg2))$/;"	f	typeref:unknown:void	signature:(int arg1, void *arg2)

--- a/Units/parser-c.r/spurious_label_tags.c.d/expected.tags
+++ b/Units/parser-c.r/spurious_label_tags.c.d/expected.tags
@@ -1,1 +1,1 @@
-label_forced_tags	input.c	/^static void label_forced_tags(void)$/;"	f	typeref:typename:void	file:
+label_forced_tags	input.c	/^static void label_forced_tags(void)$/;"	f	typeref:unknown:void	file:

--- a/Units/parser-c.r/static_array.c.d/expected.tags
+++ b/Units/parser-c.r/static_array.c.d/expected.tags
@@ -1,1 +1,1 @@
-charset2uni	input.c	/^static wchar_t charset2uni[256] = {$/;"	v	typeref:typename:wchar_t[256]	file:
+charset2uni	input.c	/^static wchar_t charset2uni[256] = {$/;"	v	typeref:unknown:wchar_t[256]	file:

--- a/Units/parser-cxx.r/angle_bracket.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/angle_bracket.cpp.d/expected.tags
@@ -1,3 +1,3 @@
-bar	input.cpp	/^static void bar (int value)$/;"	f	typeref:typename:void	file:
+bar	input.cpp	/^static void bar (int value)$/;"	f	typeref:unknown:void	file:
 bar2	input.cpp	/^static bar2 (void)$/;"	f	file:
-foo	input.cpp	/^static void foo (int nelem)$/;"	f	typeref:typename:void	file:
+foo	input.cpp	/^static void foo (int nelem)$/;"	f	typeref:unknown:void	file:

--- a/Units/parser-cxx.r/brackets.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/brackets.cpp.d/expected.tags
@@ -1,16 +1,16 @@
 n01	input.cpp	/^namespace n01 {$/;"	namespace	file:
-g01	input.cpp	/^	std::string g01 { "" };$/;"	variable	namespace:n01	typeref:typename:std::string
-f01	input.cpp	/^	auto f01(std::string p01) -> std::string {$/;"	function	namespace:n01	typeref:typename:std::string	signature:(std::string p01)
-p01	input.cpp	/^	auto f01(std::string p01) -> std::string {$/;"	parameter	function:n01::f01	typeref:typename:std::string	file:
-l01	input.cpp	/^		std::string l01 { "" };$/;"	local	function:n01::f01	typeref:typename:std::string	file:
-l02	input.cpp	/^		std::string l02 = { "" };$/;"	local	function:n01::f01	typeref:typename:std::string	file:
+g01	input.cpp	/^	std::string g01 { "" };$/;"	variable	namespace:n01	typeref:unknown:std::string
+f01	input.cpp	/^	auto f01(std::string p01) -> std::string {$/;"	function	namespace:n01	typeref:unknown:std::string	signature:(std::string p01)
+p01	input.cpp	/^	auto f01(std::string p01) -> std::string {$/;"	parameter	function:n01::f01	typeref:unknown:std::string	file:
+l01	input.cpp	/^		std::string l01 { "" };$/;"	local	function:n01::f01	typeref:unknown:std::string	file:
+l02	input.cpp	/^		std::string l02 = { "" };$/;"	local	function:n01::f01	typeref:unknown:std::string	file:
 C01	input.cpp	/^	class C01$/;"	class	namespace:n01	file:
-m01	input.cpp	/^		std::string m01 { "" };$/;"	member	class:n01::C01	typeref:typename:std::string	file:
-m02	input.cpp	/^		std::string m02;$/;"	member	class:n01::C01	typeref:typename:std::string	file:
-m03	input.cpp	/^		std::string m03;$/;"	member	class:n01::C01	typeref:typename:std::string	file:
+m01	input.cpp	/^		std::string m01 { "" };$/;"	member	class:n01::C01	typeref:unknown:std::string	file:
+m02	input.cpp	/^		std::string m02;$/;"	member	class:n01::C01	typeref:unknown:std::string	file:
+m03	input.cpp	/^		std::string m03;$/;"	member	class:n01::C01	typeref:unknown:std::string	file:
 C01	input.cpp	/^		C01(std::string p02)$/;"	function	class:n01::C01	file:	signature:(std::string p02)
-p02	input.cpp	/^		C01(std::string p02)$/;"	parameter	function:n01::C01::C01	typeref:typename:std::string	file:
+p02	input.cpp	/^		C01(std::string p02)$/;"	parameter	function:n01::C01::C01	typeref:unknown:std::string	file:
 C01	input.cpp	/^		C01()$/;"	function	class:n01::C01	file:	signature:()
-l03	input.cpp	/^			std::string l03 { "" };$/;"	local	function:n01::C01::C01	typeref:typename:std::string	file:
-l04	input.cpp	/^			std::string l04 { "" };$/;"	local	function:n01::C01::C01	typeref:typename:std::string	file:
-l05	input.cpp	/^			C01 l05{ "" };$/;"	local	function:n01::C01::C01	typeref:typename:C01	file:
+l03	input.cpp	/^			std::string l03 { "" };$/;"	local	function:n01::C01::C01	typeref:unknown:std::string	file:
+l04	input.cpp	/^			std::string l04 { "" };$/;"	local	function:n01::C01::C01	typeref:unknown:std::string	file:
+l05	input.cpp	/^			C01 l05{ "" };$/;"	local	function:n01::C01::C01	typeref:unknown:C01	file:

--- a/Units/parser-cxx.r/bug-github-871.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug-github-871.cpp.d/expected.tags
@@ -1,2 +1,2 @@
-funa	input.cpp	/^bool funa()$/;"	f	typeref:typename:bool
-funb	input.cpp	/^int funb()$/;"	f	typeref:typename:int
+funa	input.cpp	/^bool funa()$/;"	f	typeref:unknown:bool
+funb	input.cpp	/^int funb()$/;"	f	typeref:unknown:int

--- a/Units/parser-cxx.r/bug1020715.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1020715.cpp.d/expected.tags
@@ -1,1 +1,1 @@
-f	input.cpp	/^void f() {$/;"	f	typeref:typename:void
+f	input.cpp	/^void f() {$/;"	f	typeref:unknown:void

--- a/Units/parser-cxx.r/bug1093123.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1093123.cpp.d/expected.tags
@@ -1,3 +1,3 @@
-main	input.cpp	/^int main() {$/;"	f	typeref:typename:int
+main	input.cpp	/^int main() {$/;"	f	typeref:unknown:int
 std	input.cpp	/^using namespace std;$/;"	U	function:main
-m	input.cpp	/^int m;$/;"	l	function:main	typeref:typename:int	file:
+m	input.cpp	/^int m;$/;"	l	function:main	typeref:unknown:int	file:

--- a/Units/parser-cxx.r/bug1548443.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1548443.cpp.d/expected.tags
@@ -1,6 +1,6 @@
 TestStruct	input.cpp	/^struct TestStruct$/;"	s	file:
-TestStruct::_number	input.cpp	/^int _number;$/;"	m	struct:TestStruct	typeref:typename:int	file:	access:public
+TestStruct::_number	input.cpp	/^int _number;$/;"	m	struct:TestStruct	typeref:unknown:int	file:	access:public
 TestUnion	input.cpp	/^union TestUnion$/;"	u	file:
-TestUnion::_number	input.cpp	/^int _number;$/;"	m	union:TestUnion	typeref:typename:int	file:	access:public
-_number	input.cpp	/^int _number;$/;"	m	struct:TestStruct	typeref:typename:int	file:	access:public
-_number	input.cpp	/^int _number;$/;"	m	union:TestUnion	typeref:typename:int	file:	access:public
+TestUnion::_number	input.cpp	/^int _number;$/;"	m	union:TestUnion	typeref:unknown:int	file:	access:public
+_number	input.cpp	/^int _number;$/;"	m	struct:TestStruct	typeref:unknown:int	file:	access:public
+_number	input.cpp	/^int _number;$/;"	m	union:TestUnion	typeref:unknown:int	file:	access:public

--- a/Units/parser-cxx.r/bug1563476.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1563476.cpp.d/expected.tags
@@ -1,3 +1,3 @@
-g	input.cpp	/^int g() {$/;"	f	typeref:typename:int
+g	input.cpp	/^int g() {$/;"	f	typeref:unknown:int
 IntroduceBitDef	input.cpp	/^struct IntroduceBitDef< Accessor, typename$/;"	s	file:
-f	input.cpp	/^ int f() { }$/;"	f	struct:IntroduceBitDef	typeref:typename:int	file:
+f	input.cpp	/^ int f() { }$/;"	f	struct:IntroduceBitDef	typeref:unknown:int	file:

--- a/Units/parser-cxx.r/bug1575055.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1575055.cpp.d/expected.tags
@@ -1,3 +1,3 @@
 MyClass	input.cpp	/^	class MyClass { };$/;"	c	namespace:TheNamespace	file:
 TheNamespace	input.cpp	/^namespace TheNamespace {$/;"	n	file:
-variable	input.cpp	/^	int variable;$/;"	v	namespace:TheNamespace	typeref:typename:int
+variable	input.cpp	/^	int variable;$/;"	v	namespace:TheNamespace	typeref:unknown:int

--- a/Units/parser-cxx.r/bug1770479.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1770479.cpp.d/expected.tags
@@ -1,4 +1,4 @@
-a	input.cpp	/^  std::ostringstream a;$/;"	l	function:main	typeref:typename:std::ostringstream	file:
-b	input.cpp	/^  std::ostringstream b;$/;"	l	function:main	typeref:typename:std::ostringstream	file:
-foo	input.cpp	/^int foo (int i)$/;"	f	typeref:typename:int
-main	input.cpp	/^int main (int argc, char **argv)$/;"	f	typeref:typename:int
+a	input.cpp	/^  std::ostringstream a;$/;"	l	function:main	typeref:unknown:std::ostringstream	file:
+b	input.cpp	/^  std::ostringstream b;$/;"	l	function:main	typeref:unknown:std::ostringstream	file:
+foo	input.cpp	/^int foo (int i)$/;"	f	typeref:unknown:int
+main	input.cpp	/^int main (int argc, char **argv)$/;"	f	typeref:unknown:int

--- a/Units/parser-cxx.r/bug1773926.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1773926.cpp.d/expected.tags
@@ -1,4 +1,4 @@
 ERROR_HAPPENED	input.cpp	3;"	d	file:
 NEXT_DEFINE	input.cpp	5;"	d	file:
 OK	input.cpp	4;"	d	file:
-main	input.cpp	7;"	f	typeref:typename:int
+main	input.cpp	7;"	f	typeref:unknown:int

--- a/Units/parser-cxx.r/bug1799340.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1799340.cpp.d/expected.tags
@@ -1,3 +1,3 @@
-f1	input.cpp	/^std::string & f1() {}$/;"	f	typeref:typename:std::string &
-f2	input.cpp	/^const std::string & f2() {}$/;"	f	typeref:typename:const std::string &
-f3	input.cpp	/^std::string const & f3() {}$/;"	f	typeref:typename:std::string const &
+f1	input.cpp	/^std::string & f1() {}$/;"	f	typeref:unknown:std::string &
+f2	input.cpp	/^const std::string & f2() {}$/;"	f	typeref:unknown:const std::string &
+f3	input.cpp	/^std::string const & f3() {}$/;"	f	typeref:unknown:std::string const &

--- a/Units/parser-cxx.r/bug1799343-1.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1799343-1.cpp.d/expected.tags
@@ -1,7 +1,7 @@
 C	input.cpp	/^struct C { int x; };$/;"	s	file:
-x	input.cpp	/^struct C { int x; };$/;"	m	struct:C	typeref:typename:int	file:
+x	input.cpp	/^struct C { int x; };$/;"	m	struct:C	typeref:unknown:int	file:
 D	input.cpp	/^struct D : ::C {$/;"	s	file:
 D	input.cpp	/^ D() { x = 123; }$/;"	f	struct:D	file:
 ~D	input.cpp	/^ ~D() { std::cout << x << std::endl; }$/;"	f	struct:D	file:
-main	input.cpp	/^int main(void) {$/;"	f	typeref:typename:int
-d	input.cpp	/^ D d;$/;"	l	function:main	typeref:typename:D	file:
+main	input.cpp	/^int main(void) {$/;"	f	typeref:unknown:int
+d	input.cpp	/^ D d;$/;"	l	function:main	typeref:unknown:D	file:

--- a/Units/parser-cxx.r/bug1799343-2.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1799343-2.cpp.d/expected.tags
@@ -1,15 +1,15 @@
 P	input.cpp	/^class P {$/;"	c	file:
-x	input.cpp	/^   int x;$/;"	m	class:P	typeref:typename:int	file:
+x	input.cpp	/^   int x;$/;"	m	class:P	typeref:unknown:int	file:
 A	input.cpp	/^namespace A {$/;"	n	file:
 P	input.cpp	/^   class P {$/;"	c	namespace:A	file:
-x	input.cpp	/^     int x;$/;"	m	class:A::P	typeref:typename:int	file:
+x	input.cpp	/^     int x;$/;"	m	class:A::P	typeref:unknown:int	file:
 Q	input.cpp	/^   class Q {$/;"	c	namespace:A	file:
-y	input.cpp	/^     int y;$/;"	m	class:A::Q	typeref:typename:int	file:
+y	input.cpp	/^     int y;$/;"	m	class:A::Q	typeref:unknown:int	file:
 C	input.cpp	/^   namespace C {$/;"	n	namespace:A	file:
 R	input.cpp	/^     class R: ::P, A::Q {$/;"	c	namespace:A::C	file:
-z	input.cpp	/^       int z;$/;"	m	class:A::C::R	typeref:typename:int	file:
-f	input.cpp	/^       int f (int v) { return v + x; }$/;"	f	class:A::C::R	typeref:typename:int	file:
-v	input.cpp	/^       int f (int v) { return v + x; }$/;"	z	function:A::C::R::f	typeref:typename:int	file:
+z	input.cpp	/^       int z;$/;"	m	class:A::C::R	typeref:unknown:int	file:
+f	input.cpp	/^       int f (int v) { return v + x; }$/;"	f	class:A::C::R	typeref:unknown:int	file:
+v	input.cpp	/^       int f (int v) { return v + x; }$/;"	z	function:A::C::R::f	typeref:unknown:int	file:
 B	input.cpp	/^namespace B {$/;"	n	file:
 S	input.cpp	/^   class S : A::C::R {$/;"	c	namespace:B	file:
-t	input.cpp	/^     int t;$/;"	m	class:B::S	typeref:typename:int	file:
+t	input.cpp	/^     int t;$/;"	m	class:B::S	typeref:unknown:int	file:

--- a/Units/parser-cxx.r/bug1907083.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1907083.cpp.d/expected.tags
@@ -1,4 +1,4 @@
-m1	input.cpp	/^C::T * C::m1() {}$/;"	f	class:C	typeref:typename:C::T *
-m2	input.cpp	/^C::T * const C::m2() {}$/;"	f	class:C	typeref:typename:C::T * const
-m3	input.cpp	/^C::T const * C::m3() {}$/;"	f	class:C	typeref:typename:C::T const *
-m4	input.cpp	/^C::T const * const C::m4() {}$/;"	f	class:C	typeref:typename:C::T const * const
+m1	input.cpp	/^C::T * C::m1() {}$/;"	f	class:C	typeref:unknown:C::T *
+m2	input.cpp	/^C::T * const C::m2() {}$/;"	f	class:C	typeref:unknown:C::T * const
+m3	input.cpp	/^C::T const * C::m3() {}$/;"	f	class:C	typeref:unknown:C::T const *
+m4	input.cpp	/^C::T const * const C::m4() {}$/;"	f	class:C	typeref:unknown:C::T const * const

--- a/Units/parser-cxx.r/bug1924919.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1924919.cpp.d/expected.tags
@@ -1,4 +1,4 @@
 mud	input.cpp	/^namespace mud {$/;"	n	file:
-MajorVersion	input.cpp	/^	std::string MajorVersion;$/;"	v	namespace:mud	typeref:typename:std::string
-MinorVersion	input.cpp	/^	std::string MinorVersion;$/;"	v	namespace:mud	typeref:typename:std::string
-foo	input.cpp	/^	int (* foo) (void);$/;"	v	namespace:mud	typeref:typename:int (*)(void)
+MajorVersion	input.cpp	/^	std::string MajorVersion;$/;"	v	namespace:mud	typeref:unknown:std::string
+MinorVersion	input.cpp	/^	std::string MinorVersion;$/;"	v	namespace:mud	typeref:unknown:std::string
+foo	input.cpp	/^	int (* foo) (void);$/;"	v	namespace:mud	typeref:unknown:int (*)(void)

--- a/Units/parser-cxx.r/bug639644.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug639644.cpp.d/expected.tags
@@ -1,2 +1,2 @@
 __anon21d591360108	input.h	/^{$/;"	n
-foo	input.h	/^  int foo;$/;"	v	namespace:__anon21d591360108	typeref:typename:int
+foo	input.h	/^  int foo;$/;"	v	namespace:__anon21d591360108	typeref:unknown:int

--- a/Units/parser-cxx.r/bug834.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug834.cpp.d/expected.tags
@@ -1,5 +1,5 @@
 std	input.cpp	/^using namespace std;$/;"	U	file:
-C	input.cpp	/^vector<vector<int>> C;$/;"	v	typeref:typename:vector<vector<int>>
+C	input.cpp	/^vector<vector<int>> C;$/;"	v	typeref:unknown:vector<vector<int>>
 A	input.cpp	/^struct A {$/;"	s	file:
-a	input.cpp	/^    int a;$/;"	m	struct:A	typeref:typename:int	file:
-b	input.cpp	/^    int b;$/;"	m	struct:A	typeref:typename:int	file:
+a	input.cpp	/^    int a;$/;"	m	struct:A	typeref:unknown:int	file:
+b	input.cpp	/^    int b;$/;"	m	struct:A	typeref:unknown:int	file:

--- a/Units/parser-cxx.r/bug849591.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug849591.cpp.d/expected.tags
@@ -1,2 +1,2 @@
-Foo	input.cpp	/^void MainClass< ParamClass1&, ParamClass2>::Foo()$/;"	f	class:MainClass	typeref:typename:void
-Foo	input.cpp	/^void MainClass<ParamClass1&, ParamClass2>::Foo()$/;"	f	class:MainClass	typeref:typename:void
+Foo	input.cpp	/^void MainClass< ParamClass1&, ParamClass2>::Foo()$/;"	f	class:MainClass	typeref:unknown:void
+Foo	input.cpp	/^void MainClass<ParamClass1&, ParamClass2>::Foo()$/;"	f	class:MainClass	typeref:unknown:void

--- a/Units/parser-cxx.r/bug852368.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug852368.cpp.d/expected.tags
@@ -1,1 +1,1 @@
-foo	input.cpp	/^void foo(std::vector<float> &);$/;"	p	typeref:typename:void	file:	signature:(std::vector<float> &)
+foo	input.cpp	/^void foo(std::vector<float> &);$/;"	p	typeref:unknown:void	file:	signature:(std::vector<float> &)

--- a/Units/parser-cxx.r/bug872494.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug872494.cpp.d/expected.tags
@@ -1,5 +1,5 @@
 FooClass2	input.cpp	/^class FooClass2{};$/;"	c	file:
 TemplClass	input.cpp	/^template<> class TemplClass< char* > { int i;};$/;"	c	file:
 TemplClass	input.cpp	/^template<class T> class TemplClass { double i;};$/;"	c	file:
-i	input.cpp	/^template<> class TemplClass< char* > { int i;};$/;"	m	class:TemplClass	typeref:typename:int	file:
-i	input.cpp	/^template<class T> class TemplClass { double i;};$/;"	m	class:TemplClass	typeref:typename:double	file:
+i	input.cpp	/^template<> class TemplClass< char* > { int i;};$/;"	m	class:TemplClass	typeref:unknown:int	file:
+i	input.cpp	/^template<class T> class TemplClass { double i;};$/;"	m	class:TemplClass	typeref:unknown:double	file:

--- a/Units/parser-cxx.r/cpp-type-alias-with-using-keyword.d/expected.tags
+++ b/Units/parser-cxx.r/cpp-type-alias-with-using-keyword.d/expected.tags
@@ -1,2 +1,2 @@
-Integer	input.cpp	/^using Integer = int;$/;"	t	typeref:typename:int	file:
-Vector	input.cpp	/^using Vector = std::vector<T>;$/;"	t	typeref:typename:std::vector<T>	file:
+Integer	input.cpp	/^using Integer = int;$/;"	t	typeref:unknown:int	file:
+Vector	input.cpp	/^using Vector = std::vector<T>;$/;"	t	typeref:unknown:std::vector<T>	file:

--- a/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.d/expected.tags
+++ b/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.d/expected.tags
@@ -1,4 +1,4 @@
 c	input.cpp	/^template <int P> class c {};$/;"	c	file:
-bVar	input.cpp	/^c< 8 > bVar;$/;"	v	typeref:typename:c<8>
-aVar	input.cpp	/^c< 1<<8 > aVar;$/;"	v	typeref:typename:c<1<<8>
+bVar	input.cpp	/^c< 8 > bVar;$/;"	v	typeref:unknown:c<8>
+aVar	input.cpp	/^c< 1<<8 > aVar;$/;"	v	typeref:unknown:c<1<<8>
 f12	input.cpp	/^template<int X> f12( c< 1<<X> & aVar) { };$/;"	f	signature:( c< 1<<X> & aVar)

--- a/Units/parser-cxx.r/cxx11-delete.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-delete.d/expected.tags
@@ -1,3 +1,3 @@
 Del	input.cpp	/^    Del(const Del &) = delete;$/;"	p	class:Del	file:	signature:(const Del &)
 Del	input.cpp	/^class Del$/;"	c	file:
-operator =	input.cpp	/^    void operator=(const Del& rDel) = delete;$/;"	p	class:Del	typeref:typename:void	file:	signature:(const Del& rDel)
+operator =	input.cpp	/^    void operator=(const Del& rDel) = delete;$/;"	p	class:Del	typeref:unknown:void	file:	signature:(const Del& rDel)

--- a/Units/parser-cxx.r/cxx11-final.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-final.d/expected.tags
@@ -1,8 +1,8 @@
 Base	input.cpp	/^class Base$/;"	c	file:
 Derived	input.cpp	/^class Derived final : public Base$/;"	c	file:
-final	input.cpp	/^	virtual void final();$/;"	p	class:Derived	typeref:typename:void	file:	signature:()
-final	input.cpp	/^void Derived::final()$/;"	f	class:Derived	typeref:typename:void	signature:()
-foo	input.cpp	/^	virtual void foo() = 0;$/;"	p	class:Base	typeref:typename:void	file:	signature:()
-foo	input.cpp	/^	virtual void foo() final;$/;"	p	class:Derived	typeref:typename:void	file:	signature:()
-foo	input.cpp	/^void Base::foo()$/;"	f	class:Base	typeref:typename:void	signature:()
-foo	input.cpp	/^void Derived::foo()$/;"	f	class:Derived	typeref:typename:void	signature:()
+final	input.cpp	/^	virtual void final();$/;"	p	class:Derived	typeref:unknown:void	file:	signature:()
+final	input.cpp	/^void Derived::final()$/;"	f	class:Derived	typeref:unknown:void	signature:()
+foo	input.cpp	/^	virtual void foo() = 0;$/;"	p	class:Base	typeref:unknown:void	file:	signature:()
+foo	input.cpp	/^	virtual void foo() final;$/;"	p	class:Derived	typeref:unknown:void	file:	signature:()
+foo	input.cpp	/^void Base::foo()$/;"	f	class:Base	typeref:unknown:void	signature:()
+foo	input.cpp	/^void Derived::foo()$/;"	f	class:Derived	typeref:unknown:void	signature:()

--- a/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
@@ -1,19 +1,19 @@
-call	input.cpp	/^template<typename T> void call(T x)$/;"	function	typeref:typename:void	signature:(T x)
-x	input.cpp	/^template<typename T> void call(T x)$/;"	parameter	function:call	typeref:typename:T	file:
-test	input.cpp	/^int test()$/;"	function	typeref:typename:int	signature:()
+call	input.cpp	/^template<typename T> void call(T x)$/;"	function	typeref:unknown:void	signature:(T x)
+x	input.cpp	/^template<typename T> void call(T x)$/;"	parameter	function:call	typeref:unknown:T	file:
+test	input.cpp	/^int test()$/;"	function	typeref:unknown:int	signature:()
 __anon4e7b1b580103	input.cpp	/^	auto l1 = [] { return 0; };$/;"	function	function:test	file:
-l1	input.cpp	/^	auto l1 = [] { return 0; };$/;"	local	function:test	typeref:typename:auto	file:
+l1	input.cpp	/^	auto l1 = [] { return 0; };$/;"	local	function:test	typeref:unknown:auto	file:
 __anon4e7b1b580203	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	function	function:test	file:
-a	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:typename:int	file:
-b	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:typename:int	file:
-l2	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580303	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:
-a	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:typename:int	file:
-b	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:typename:int	file:
+a	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:unknown:int	file:
+b	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:unknown:int	file:
+l2	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	local	function:test	typeref:unknown:auto	file:
+__anon4e7b1b580303	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	function	function:test	typeref:unknown:int	file:
+a	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:unknown:int	file:
+b	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:unknown:int	file:
 __anon4e7b1b580403	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	function	function:test::__anon4e7b1b580303	file:
-c	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	parameter	function:test::__anon4e7b1b580303::__anon4e7b1b580403	typeref:typename:int	file:
-l4	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	local	function:test::__anon4e7b1b580303	typeref:typename:auto	file:
-l3	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580503	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:
-a	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:typename:int	file:
-b	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:typename:int	file:
+c	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	parameter	function:test::__anon4e7b1b580303::__anon4e7b1b580403	typeref:unknown:int	file:
+l4	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	local	function:test::__anon4e7b1b580303	typeref:unknown:auto	file:
+l3	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	local	function:test	typeref:unknown:auto	file:
+__anon4e7b1b580503	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:unknown:int	file:
+a	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:unknown:int	file:
+b	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:unknown:int	file:

--- a/Units/parser-cxx.r/cxx11-noexcept.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-noexcept.d/expected.tags
@@ -1,4 +1,4 @@
 Base	input.cpp	/^class Base$/;"	c	file:
-bar	input.cpp	/^	virtual void bar() const noexcept = 0;$/;"	p	class:Base	typeref:typename:void	file:	signature:() const
-baz	input.cpp	/^	int baz() noexcept { return 42; }$/;"	f	class:Base	typeref:typename:int	file:	signature:()
-foo	input.cpp	/^	virtual void foo() noexcept = 0;$/;"	p	class:Base	typeref:typename:void	file:	signature:()
+bar	input.cpp	/^	virtual void bar() const noexcept = 0;$/;"	p	class:Base	typeref:unknown:void	file:	signature:() const
+baz	input.cpp	/^	int baz() noexcept { return 42; }$/;"	f	class:Base	typeref:unknown:int	file:	signature:()
+foo	input.cpp	/^	virtual void foo() noexcept = 0;$/;"	p	class:Base	typeref:unknown:void	file:	signature:()

--- a/Units/parser-cxx.r/cxx11-override.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-override.d/expected.tags
@@ -1,8 +1,8 @@
 Base	input.cpp	/^class Base$/;"	c	file:
 Derived	input.cpp	/^class Derived : public Base$/;"	c	file:
-foo	input.cpp	/^	virtual void foo() = 0;$/;"	p	class:Base	typeref:typename:void	file:	signature:()
-foo	input.cpp	/^	virtual void foo() override;$/;"	p	class:Derived	typeref:typename:void	file:	signature:()
-foo	input.cpp	/^void Base::foo()$/;"	f	class:Base	typeref:typename:void	signature:()
-foo	input.cpp	/^void Derived::foo()$/;"	f	class:Derived	typeref:typename:void	signature:()
-override	input.cpp	/^	virtual void override();$/;"	p	class:Derived	typeref:typename:void	file:	signature:()
-override	input.cpp	/^void Derived::override()$/;"	f	class:Derived	typeref:typename:void	signature:()
+foo	input.cpp	/^	virtual void foo() = 0;$/;"	p	class:Base	typeref:unknown:void	file:	signature:()
+foo	input.cpp	/^	virtual void foo() override;$/;"	p	class:Derived	typeref:unknown:void	file:	signature:()
+foo	input.cpp	/^void Base::foo()$/;"	f	class:Base	typeref:unknown:void	signature:()
+foo	input.cpp	/^void Derived::foo()$/;"	f	class:Derived	typeref:unknown:void	signature:()
+override	input.cpp	/^	virtual void override();$/;"	p	class:Derived	typeref:unknown:void	file:	signature:()
+override	input.cpp	/^void Derived::override()$/;"	f	class:Derived	typeref:unknown:void	signature:()

--- a/Units/parser-cxx.r/cxx11-raw-strings.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-raw-strings.d/expected.tags
@@ -1,18 +1,18 @@
 FOUR	input.cpp	/^#define FOUR /;"	d	file:
-memb1	input.cpp	/^struct typ1 { int memb1; };$/;"	m	struct:typ1	typeref:typename:int	file:
-memb2	input.cpp	/^struct typ2 { int memb2; };$/;"	m	struct:typ2	typeref:typename:int	file:
-memb3	input.cpp	/^struct typ3 { int memb3; };$/;"	m	struct:typ3	typeref:typename:int	file:
-memb4	input.cpp	/^struct typ4 { int memb4; };$/;"	m	struct:typ4	typeref:typename:int	file:
-memb5	input.cpp	/^struct typ5 { int memb5; };$/;"	m	struct:typ5	typeref:typename:int	file:
-memb6	input.cpp	/^struct typ6 { int memb6; };$/;"	m	struct:typ6	typeref:typename:int	file:
-memb7	input.cpp	/^struct typ7 { int memb7; };$/;"	m	struct:typ7	typeref:typename:int	file:
-str1	input.cpp	/^static const char* str1 = R"blah($/;"	v	typeref:typename:const char *	file:
-str2	input.cpp	/^static const char* str2 = R"blah($/;"	v	typeref:typename:const char *	file:
-str3	input.cpp	/^static const char* str3 = FOUR"f(iv)e";$/;"	v	typeref:typename:const char *	file:
-str4	input.cpp	/^static const char* str4 = LR"blah(";int bug4;)blah";$/;"	v	typeref:typename:const char *	file:
-str5	input.cpp	/^static const char* str5 = u8R"blah(";int bug5;)blah";$/;"	v	typeref:typename:const char *	file:
-str6	input.cpp	/^static const char* str6 = uR"blah(";int bug6;)blah";$/;"	v	typeref:typename:const char *	file:
-str7	input.cpp	/^static const char* str7 = UR"blah(";int bug7;)blah";$/;"	v	typeref:typename:const char *	file:
+memb1	input.cpp	/^struct typ1 { int memb1; };$/;"	m	struct:typ1	typeref:unknown:int	file:
+memb2	input.cpp	/^struct typ2 { int memb2; };$/;"	m	struct:typ2	typeref:unknown:int	file:
+memb3	input.cpp	/^struct typ3 { int memb3; };$/;"	m	struct:typ3	typeref:unknown:int	file:
+memb4	input.cpp	/^struct typ4 { int memb4; };$/;"	m	struct:typ4	typeref:unknown:int	file:
+memb5	input.cpp	/^struct typ5 { int memb5; };$/;"	m	struct:typ5	typeref:unknown:int	file:
+memb6	input.cpp	/^struct typ6 { int memb6; };$/;"	m	struct:typ6	typeref:unknown:int	file:
+memb7	input.cpp	/^struct typ7 { int memb7; };$/;"	m	struct:typ7	typeref:unknown:int	file:
+str1	input.cpp	/^static const char* str1 = R"blah($/;"	v	typeref:unknown:const char *	file:
+str2	input.cpp	/^static const char* str2 = R"blah($/;"	v	typeref:unknown:const char *	file:
+str3	input.cpp	/^static const char* str3 = FOUR"f(iv)e";$/;"	v	typeref:unknown:const char *	file:
+str4	input.cpp	/^static const char* str4 = LR"blah(";int bug4;)blah";$/;"	v	typeref:unknown:const char *	file:
+str5	input.cpp	/^static const char* str5 = u8R"blah(";int bug5;)blah";$/;"	v	typeref:unknown:const char *	file:
+str6	input.cpp	/^static const char* str6 = uR"blah(";int bug6;)blah";$/;"	v	typeref:unknown:const char *	file:
+str7	input.cpp	/^static const char* str7 = UR"blah(";int bug7;)blah";$/;"	v	typeref:unknown:const char *	file:
 typ1	input.cpp	/^struct typ1 { int memb1; };$/;"	s	file:
 typ2	input.cpp	/^struct typ2 { int memb2; };$/;"	s	file:
 typ3	input.cpp	/^struct typ3 { int memb3; };$/;"	s	file:

--- a/Units/parser-cxx.r/cxx14-combined.d/expected.tags
+++ b/Units/parser-cxx.r/cxx14-combined.d/expected.tags
@@ -1,5 +1,5 @@
 Base	input.cpp	/^struct Base {$/;"	s	file:
 Foo	input.cpp	/^struct Foo final : public Base {$/;"	s	file:
-bar	input.cpp	/^  static constexpr auto bar() noexcept { return 1; }$/;"	f	struct:Foo	typeref:typename:auto	file:	signature:()
-baz	input.cpp	/^  virtual void baz() const throw() = 0;$/;"	p	struct:Base	typeref:typename:void	file:	signature:() const
-baz	input.cpp	/^  virtual void baz() const throw() final override;$/;"	p	struct:Foo	typeref:typename:void	file:	signature:() const
+bar	input.cpp	/^  static constexpr auto bar() noexcept { return 1; }$/;"	f	struct:Foo	typeref:unknown:auto	file:	signature:()
+baz	input.cpp	/^  virtual void baz() const throw() = 0;$/;"	p	struct:Base	typeref:unknown:void	file:	signature:() const
+baz	input.cpp	/^  virtual void baz() const throw() final override;$/;"	p	struct:Foo	typeref:unknown:void	file:	signature:() const

--- a/Units/parser-cxx.r/function-return-types.d/expected.tags
+++ b/Units/parser-cxx.r/function-return-types.d/expected.tags
@@ -1,45 +1,45 @@
-p00	input.cpp	/^void p00();$/;"	p	typeref:typename:void	file:
-p01	input.cpp	/^int p01();$/;"	p	typeref:typename:int	file:
-p02	input.cpp	/^unsigned int p02();$/;"	p	typeref:typename:unsigned int	file:
-p03	input.cpp	/^auto p03() -> int;$/;"	p	typeref:typename:int	file:
-p04	input.cpp	/^int * p04();$/;"	p	typeref:typename:int *	file:
-p05	input.cpp	/^const unsigned long long int & p05();$/;"	p	typeref:typename:const unsigned long long int &	file:
-p06	input.cpp	/^static inline int * p06();$/;"	p	typeref:typename:int *	file:
-p07	input.cpp	/^std::string & p07();$/;"	p	typeref:typename:std::string &	file:
-p08	input.cpp	/^std::vector<std::string> * p08();$/;"	p	typeref:typename:std::vector<std::string> *	file:
-p09	input.cpp	/^auto p09() -> std::vector<std::string> ***;$/;"	p	typeref:typename:std::vector<std::string> ***	file:
-p10	input.cpp	/^auto p10() -> std::string;$/;"	p	typeref:typename:std::string	file:
-p11	input.cpp	/^auto p11() -> int (*)(int);$/;"	p	typeref:typename:int (*)(int)	file:
+p00	input.cpp	/^void p00();$/;"	p	typeref:unknown:void	file:
+p01	input.cpp	/^int p01();$/;"	p	typeref:unknown:int	file:
+p02	input.cpp	/^unsigned int p02();$/;"	p	typeref:unknown:unsigned int	file:
+p03	input.cpp	/^auto p03() -> int;$/;"	p	typeref:unknown:int	file:
+p04	input.cpp	/^int * p04();$/;"	p	typeref:unknown:int *	file:
+p05	input.cpp	/^const unsigned long long int & p05();$/;"	p	typeref:unknown:const unsigned long long int &	file:
+p06	input.cpp	/^static inline int * p06();$/;"	p	typeref:unknown:int *	file:
+p07	input.cpp	/^std::string & p07();$/;"	p	typeref:unknown:std::string &	file:
+p08	input.cpp	/^std::vector<std::string> * p08();$/;"	p	typeref:unknown:std::vector<std::string> *	file:
+p09	input.cpp	/^auto p09() -> std::vector<std::string> ***;$/;"	p	typeref:unknown:std::vector<std::string> ***	file:
+p10	input.cpp	/^auto p10() -> std::string;$/;"	p	typeref:unknown:std::string	file:
+p11	input.cpp	/^auto p11() -> int (*)(int);$/;"	p	typeref:unknown:int (*)(int)	file:
 p12	input.cpp	/^struct Struct p12();$/;"	p	typeref:struct:Struct	file:
-p13	input.cpp	/^Struct p13();$/;"	p	typeref:typename:Struct	file:
+p13	input.cpp	/^Struct p13();$/;"	p	typeref:unknown:Struct	file:
 p14	input.cpp	/^union Union p14();$/;"	p	typeref:union:Union	file:
-p15	input.cpp	/^Union p15();$/;"	p	typeref:typename:Union	file:
-p16	input.cpp	/^Class & p16();$/;"	p	typeref:typename:Class &	file:
-p17	input.cpp	/^const enum Enum p17();$/;"	p	typeref:typename:const enum Enum	file:
-p18	input.cpp	/^Enum p18();$/;"	p	typeref:typename:Enum	file:
-f00	input.cpp	/^void f00()$/;"	f	typeref:typename:void
-f01	input.cpp	/^int f01()$/;"	f	typeref:typename:int
-f02	input.cpp	/^unsigned int f02()$/;"	f	typeref:typename:unsigned int
-f03	input.cpp	/^auto f03() -> int$/;"	f	typeref:typename:int
-f04	input.cpp	/^int * f04()$/;"	f	typeref:typename:int *
-f05	input.cpp	/^const unsigned long long int & f05()$/;"	f	typeref:typename:const unsigned long long int &
-f06	input.cpp	/^static inline int * f06()$/;"	f	typeref:typename:int *	file:
-f07	input.cpp	/^std::string & f07()$/;"	f	typeref:typename:std::string &
-f08	input.cpp	/^std::vector<std::string> * f08()$/;"	f	typeref:typename:std::vector<std::string> *
-p09	input.cpp	/^auto p09() -> std::vector<std::string> ***$/;"	f	typeref:typename:std::vector<std::string> ***
-f10	input.cpp	/^auto f10() -> std::string$/;"	f	typeref:typename:std::string
-f11	input.cpp	/^auto f11() -> int (*)(int)$/;"	f	typeref:typename:int (*)(int)
-f13	input.cpp	/^template<typename A> std::vector<A> * f13()$/;"	f	typeref:typename:std::vector<A> *
-f14	input.cpp	/^template<typename A> auto f14() -> std::vector<A> *$/;"	f	typeref:typename:std::vector<A> *
-m00	input.cpp	/^	void m00();$/;"	p	class:X	typeref:typename:void	file:
-m01	input.cpp	/^	constexpr int m01(){ return 0; };$/;"	f	class:X	typeref:typename:int	file:
-m02	input.cpp	/^	unsigned int m02();$/;"	p	class:X	typeref:typename:unsigned int	file:
-m03	input.cpp	/^	static auto m03() -> int;$/;"	p	class:X	typeref:typename:int	file:
-m04	input.cpp	/^	int * m04();$/;"	p	class:X	typeref:typename:int *	file:
-m05	input.cpp	/^	const unsigned long long int & m05();$/;"	p	class:X	typeref:typename:const unsigned long long int &	file:
-m06	input.cpp	/^	static inline int * m06();$/;"	p	class:X	typeref:typename:int *	file:
-m07	input.cpp	/^	virtual std::string & m07();$/;"	p	class:X	typeref:typename:std::string &	file:
-m08	input.cpp	/^	std::vector<std::string> * m08();$/;"	p	class:X	typeref:typename:std::vector<std::string> *	file:
-m09	input.cpp	/^	auto m09() -> std::vector<std::string> ***;$/;"	p	class:X	typeref:typename:std::vector<std::string> ***	file:
-m10	input.cpp	/^	virtual auto m10() const -> std::string;$/;"	p	class:X	typeref:typename:std::string	file:
-m11	input.cpp	/^	virtual auto m11() const -> int (*)(int);$/;"	p	class:X	typeref:typename:int (*)(int)	file:
+p15	input.cpp	/^Union p15();$/;"	p	typeref:unknown:Union	file:
+p16	input.cpp	/^Class & p16();$/;"	p	typeref:unknown:Class &	file:
+p17	input.cpp	/^const enum Enum p17();$/;"	p	typeref:unknown:const enum Enum	file:
+p18	input.cpp	/^Enum p18();$/;"	p	typeref:unknown:Enum	file:
+f00	input.cpp	/^void f00()$/;"	f	typeref:unknown:void
+f01	input.cpp	/^int f01()$/;"	f	typeref:unknown:int
+f02	input.cpp	/^unsigned int f02()$/;"	f	typeref:unknown:unsigned int
+f03	input.cpp	/^auto f03() -> int$/;"	f	typeref:unknown:int
+f04	input.cpp	/^int * f04()$/;"	f	typeref:unknown:int *
+f05	input.cpp	/^const unsigned long long int & f05()$/;"	f	typeref:unknown:const unsigned long long int &
+f06	input.cpp	/^static inline int * f06()$/;"	f	typeref:unknown:int *	file:
+f07	input.cpp	/^std::string & f07()$/;"	f	typeref:unknown:std::string &
+f08	input.cpp	/^std::vector<std::string> * f08()$/;"	f	typeref:unknown:std::vector<std::string> *
+p09	input.cpp	/^auto p09() -> std::vector<std::string> ***$/;"	f	typeref:unknown:std::vector<std::string> ***
+f10	input.cpp	/^auto f10() -> std::string$/;"	f	typeref:unknown:std::string
+f11	input.cpp	/^auto f11() -> int (*)(int)$/;"	f	typeref:unknown:int (*)(int)
+f13	input.cpp	/^template<typename A> std::vector<A> * f13()$/;"	f	typeref:unknown:std::vector<A> *
+f14	input.cpp	/^template<typename A> auto f14() -> std::vector<A> *$/;"	f	typeref:unknown:std::vector<A> *
+m00	input.cpp	/^	void m00();$/;"	p	class:X	typeref:unknown:void	file:
+m01	input.cpp	/^	constexpr int m01(){ return 0; };$/;"	f	class:X	typeref:unknown:int	file:
+m02	input.cpp	/^	unsigned int m02();$/;"	p	class:X	typeref:unknown:unsigned int	file:
+m03	input.cpp	/^	static auto m03() -> int;$/;"	p	class:X	typeref:unknown:int	file:
+m04	input.cpp	/^	int * m04();$/;"	p	class:X	typeref:unknown:int *	file:
+m05	input.cpp	/^	const unsigned long long int & m05();$/;"	p	class:X	typeref:unknown:const unsigned long long int &	file:
+m06	input.cpp	/^	static inline int * m06();$/;"	p	class:X	typeref:unknown:int *	file:
+m07	input.cpp	/^	virtual std::string & m07();$/;"	p	class:X	typeref:unknown:std::string &	file:
+m08	input.cpp	/^	std::vector<std::string> * m08();$/;"	p	class:X	typeref:unknown:std::vector<std::string> *	file:
+m09	input.cpp	/^	auto m09() -> std::vector<std::string> ***;$/;"	p	class:X	typeref:unknown:std::vector<std::string> ***	file:
+m10	input.cpp	/^	virtual auto m10() const -> std::string;$/;"	p	class:X	typeref:unknown:std::string	file:
+m11	input.cpp	/^	virtual auto m11() const -> int (*)(int);$/;"	p	class:X	typeref:unknown:int (*)(int)	file:

--- a/Units/parser-cxx.r/functions.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/functions.cpp.d/expected.tags
@@ -1,28 +1,28 @@
-f01	input.cpp	/^int f01(int f01a01,int f01a02)$/;"	f	typeref:typename:int	signature:(int f01a01,int f01a02)
-f01a01	input.cpp	/^int f01(int f01a01,int f01a02)$/;"	z	function:f01	typeref:typename:int	file:
-f01a02	input.cpp	/^int f01(int f01a01,int f01a02)$/;"	z	function:f01	typeref:typename:int	file:
-f02	input.cpp	/^unsigned short int * f02(unsigned int & f02a01,...)$/;"	f	typeref:typename:unsigned short int *	signature:(unsigned int & f02a01,...)
-f02a01	input.cpp	/^unsigned short int * f02(unsigned int & f02a01,...)$/;"	z	function:f02	typeref:typename:unsigned int &	file:
-f03	input.cpp	/^auto f03(const int & f03a01,void * f03a02) -> const int &$/;"	f	typeref:typename:const int &	signature:(const int & f03a01,void * f03a02)
-f03a01	input.cpp	/^auto f03(const int & f03a01,void * f03a02) -> const int &$/;"	z	function:f03	typeref:typename:const int &	file:
-f03a02	input.cpp	/^auto f03(const int & f03a01,void * f03a02) -> const int &$/;"	z	function:f03	typeref:typename:void *	file:
-f04	input.cpp	/^auto f04() -> int (*)(int)$/;"	f	typeref:typename:int (*)(int)	signature:()
-f05	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	f	typeref:typename:std::string	file:	signature:(const int *** f05a01)
-f05a01	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	z	function:f05	typeref:typename:const int ***	file:
-f06	input.cpp	/^		auto f06(n01::c01 && f06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && f06a01)
-f06	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	f	class:n01::n02	typeref:typename:n01::n02::type01 *	signature:(n01::c01 && f06a01)
-f06a01	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	z	function:n01::n02::f06	typeref:typename:n01::c01 &&	file:
-f07	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	f	typeref:typename:unsigned int	signature:(int (*f07a01)(int * x1,int x2),...)
-f07a01	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	z	function:f07	typeref:typename:int (*)(int * x1,int x2)	file:
-p01	input.cpp	/^int p01(int p01a01,int p01a02);$/;"	p	typeref:typename:int	file:	signature:(int p01a01,int p01a02)
-p02	input.cpp	/^unsigned short int * p02(unsigned int & p02a01,...);$/;"	p	typeref:typename:unsigned short int *	file:	signature:(unsigned int & p02a01,...)
-p03	input.cpp	/^auto p03(const int & p03a01,void * p03a02) -> const int &;$/;"	p	typeref:typename:const int &	file:	signature:(const int & p03a01,void * p03a02)
-p04	input.cpp	/^auto p04() -> int (*)(int);$/;"	p	typeref:typename:int (*)(int)	file:	signature:()
-p05	input.cpp	/^static std::string p05(const int *** p05a01);$/;"	p	typeref:typename:std::string	file:	signature:(const int *** p05a01)
-p06	input.cpp	/^		auto p06(n01::c01 && p06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && p06a01)
-p06	input.cpp	/^auto n01::n02::p06(n01::c01 && p06a01) -> n01::n02::type01 *;$/;"	p	typeref:typename:n01::n02::type01 *	file:	signature:(n01::c01 && p06a01)
-p07	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	p	typeref:typename:unsigned int	file:	signature:(int (*p07a01)(int * x1,int x2),...)
-t01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t01a01)
-t01a01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	z	function:t01	typeref:typename:T &&	file:
-t02	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t02a01)
-t02a01	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	z	function:t02	typeref:typename:T &&	file:
+f01	input.cpp	/^int f01(int f01a01,int f01a02)$/;"	f	typeref:unknown:int	signature:(int f01a01,int f01a02)
+f01a01	input.cpp	/^int f01(int f01a01,int f01a02)$/;"	z	function:f01	typeref:unknown:int	file:
+f01a02	input.cpp	/^int f01(int f01a01,int f01a02)$/;"	z	function:f01	typeref:unknown:int	file:
+f02	input.cpp	/^unsigned short int * f02(unsigned int & f02a01,...)$/;"	f	typeref:unknown:unsigned short int *	signature:(unsigned int & f02a01,...)
+f02a01	input.cpp	/^unsigned short int * f02(unsigned int & f02a01,...)$/;"	z	function:f02	typeref:unknown:unsigned int &	file:
+f03	input.cpp	/^auto f03(const int & f03a01,void * f03a02) -> const int &$/;"	f	typeref:unknown:const int &	signature:(const int & f03a01,void * f03a02)
+f03a01	input.cpp	/^auto f03(const int & f03a01,void * f03a02) -> const int &$/;"	z	function:f03	typeref:unknown:const int &	file:
+f03a02	input.cpp	/^auto f03(const int & f03a01,void * f03a02) -> const int &$/;"	z	function:f03	typeref:unknown:void *	file:
+f04	input.cpp	/^auto f04() -> int (*)(int)$/;"	f	typeref:unknown:int (*)(int)	signature:()
+f05	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	f	typeref:unknown:std::string	file:	signature:(const int *** f05a01)
+f05a01	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	z	function:f05	typeref:unknown:const int ***	file:
+f06	input.cpp	/^		auto f06(n01::c01 && f06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:unknown:type01 *	file:	signature:(n01::c01 && f06a01)
+f06	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	f	class:n01::n02	typeref:unknown:n01::n02::type01 *	signature:(n01::c01 && f06a01)
+f06a01	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	z	function:n01::n02::f06	typeref:unknown:n01::c01 &&	file:
+f07	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	f	typeref:unknown:unsigned int	signature:(int (*f07a01)(int * x1,int x2),...)
+f07a01	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	z	function:f07	typeref:unknown:int (*)(int * x1,int x2)	file:
+p01	input.cpp	/^int p01(int p01a01,int p01a02);$/;"	p	typeref:unknown:int	file:	signature:(int p01a01,int p01a02)
+p02	input.cpp	/^unsigned short int * p02(unsigned int & p02a01,...);$/;"	p	typeref:unknown:unsigned short int *	file:	signature:(unsigned int & p02a01,...)
+p03	input.cpp	/^auto p03(const int & p03a01,void * p03a02) -> const int &;$/;"	p	typeref:unknown:const int &	file:	signature:(const int & p03a01,void * p03a02)
+p04	input.cpp	/^auto p04() -> int (*)(int);$/;"	p	typeref:unknown:int (*)(int)	file:	signature:()
+p05	input.cpp	/^static std::string p05(const int *** p05a01);$/;"	p	typeref:unknown:std::string	file:	signature:(const int *** p05a01)
+p06	input.cpp	/^		auto p06(n01::c01 && p06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:unknown:type01 *	file:	signature:(n01::c01 && p06a01)
+p06	input.cpp	/^auto n01::n02::p06(n01::c01 && p06a01) -> n01::n02::type01 *;$/;"	p	typeref:unknown:n01::n02::type01 *	file:	signature:(n01::c01 && p06a01)
+p07	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	p	typeref:unknown:unsigned int	file:	signature:(int (*p07a01)(int * x1,int x2),...)
+t01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	f	typeref:unknown:std::unique_ptr<T>	signature:(T && t01a01)
+t01a01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	z	function:t01	typeref:unknown:T &&	file:
+t02	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	f	typeref:unknown:std::unique_ptr<T>	signature:(T && t02a01)
+t02a01	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	z	function:t02	typeref:unknown:T &&	file:

--- a/Units/parser-cxx.r/iostream.d/expected.tags
+++ b/Units/parser-cxx.r/iostream.d/expected.tags
@@ -1,1 +1,1 @@
-foo	input.cpp	/^void foo (int &x, int y, int z)$/;"	f	typeref:typename:void
+foo	input.cpp	/^void foo (int &x, int y, int z)$/;"	f	typeref:unknown:void

--- a/Units/parser-cxx.r/less-than-operator-between-anglebrackets.d/expected.tags
+++ b/Units/parser-cxx.r/less-than-operator-between-anglebrackets.d/expected.tags
@@ -1,13 +1,13 @@
-f0	input.cpp	/^template<char i, bool B = (i>0)>     void f0(void) { }$/;"	f	typeref:typename:void
-f1	input.cpp	/^template<char i, bool B = i < 10>    void f1(void) { }$/;"	f	typeref:typename:void
-f2	input.cpp	/^template<char i, long j = (i << 10)> void f2(void) { }$/;"	f	typeref:typename:void
-f3	input.cpp	/^template<char i, long j = i << 10>   void f3(void) { }$/;"	f	typeref:typename:void
-f4	input.cpp	/^template<char i, long j = (i >> 10)> void f4(void) { }$/;"	f	typeref:typename:void
-f5	input.cpp	/^template<char i, long j = (i > 10)>  void f5(void) { }$/;"	f	typeref:typename:void
-f6	input.cpp	/^template<char i, bool B = (i <= 10)> void f6(void) { }$/;"	f	typeref:typename:void
-f7	input.cpp	/^template<char i, bool B = (i >= 10)> void f7(void) { }$/;"	f	typeref:typename:void
-f8	input.cpp	/^template<char i, char j, bool B = i < 10 && (30 > j)> void f8(void) { }$/;"	f	typeref:typename:void
-f9	input.cpp	/^template<char i, char j, bool B = i < (10 && 30 > j)> void f9(void) { }$/;"	f	typeref:typename:void
-f10	input.cpp	/^template<char i, char j, bool B = (i < 10 && 30 > j)> void f10(void) { }$/;"	f	typeref:typename:void
-f11	input.cpp	/^template<bool b = 0 < 2 && 2 < 4> void f11(void) { }$/;"	f	typeref:typename:void
-main	input.cpp	/^int main(void) { return 0; }$/;"	f	typeref:typename:int
+f0	input.cpp	/^template<char i, bool B = (i>0)>     void f0(void) { }$/;"	f	typeref:unknown:void
+f1	input.cpp	/^template<char i, bool B = i < 10>    void f1(void) { }$/;"	f	typeref:unknown:void
+f2	input.cpp	/^template<char i, long j = (i << 10)> void f2(void) { }$/;"	f	typeref:unknown:void
+f3	input.cpp	/^template<char i, long j = i << 10>   void f3(void) { }$/;"	f	typeref:unknown:void
+f4	input.cpp	/^template<char i, long j = (i >> 10)> void f4(void) { }$/;"	f	typeref:unknown:void
+f5	input.cpp	/^template<char i, long j = (i > 10)>  void f5(void) { }$/;"	f	typeref:unknown:void
+f6	input.cpp	/^template<char i, bool B = (i <= 10)> void f6(void) { }$/;"	f	typeref:unknown:void
+f7	input.cpp	/^template<char i, bool B = (i >= 10)> void f7(void) { }$/;"	f	typeref:unknown:void
+f8	input.cpp	/^template<char i, char j, bool B = i < 10 && (30 > j)> void f8(void) { }$/;"	f	typeref:unknown:void
+f9	input.cpp	/^template<char i, char j, bool B = i < (10 && 30 > j)> void f9(void) { }$/;"	f	typeref:unknown:void
+f10	input.cpp	/^template<char i, char j, bool B = (i < 10 && 30 > j)> void f10(void) { }$/;"	f	typeref:unknown:void
+f11	input.cpp	/^template<bool b = 0 < 2 && 2 < 4> void f11(void) { }$/;"	f	typeref:unknown:void
+main	input.cpp	/^int main(void) { return 0; }$/;"	f	typeref:unknown:int

--- a/Units/parser-cxx.r/namespace.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/namespace.cpp.d/expected.tags
@@ -1,10 +1,10 @@
 __anon396601200108	input.cpp	/^namespace {$/;"	n	file:
-anon_f	input.cpp	/^	void anon_f() { }$/;"	f	namespace:__anon396601200108	typeref:typename:void
-__anon396601200108::anon_f	input.cpp	/^	void anon_f() { }$/;"	f	namespace:__anon396601200108	typeref:typename:void
+anon_f	input.cpp	/^	void anon_f() { }$/;"	f	namespace:__anon396601200108	typeref:unknown:void
+__anon396601200108::anon_f	input.cpp	/^	void anon_f() { }$/;"	f	namespace:__anon396601200108	typeref:unknown:void
 a	input.cpp	/^namespace a {$/;"	n	file:
-a_f	input.cpp	/^	void a_f() { }$/;"	f	namespace:a	typeref:typename:void
-a::a_f	input.cpp	/^	void a_f() { }$/;"	f	namespace:a	typeref:typename:void
+a_f	input.cpp	/^	void a_f() { }$/;"	f	namespace:a	typeref:unknown:void
+a::a_f	input.cpp	/^	void a_f() { }$/;"	f	namespace:a	typeref:unknown:void
 b	input.cpp	/^	namespace b {$/;"	n	namespace:a	file:
 a::b	input.cpp	/^	namespace b {$/;"	n	namespace:a	file:
-a_b_f	input.cpp	/^		void a_b_f() { }$/;"	f	namespace:a::b	typeref:typename:void
-a::b::a_b_f	input.cpp	/^		void a_b_f() { }$/;"	f	namespace:a::b	typeref:typename:void
+a_b_f	input.cpp	/^		void a_b_f() { }$/;"	f	namespace:a::b	typeref:unknown:void
+a::b::a_b_f	input.cpp	/^		void a_b_f() { }$/;"	f	namespace:a::b	typeref:unknown:void

--- a/Units/parser-cxx.r/new-delete.d/expected.tags
+++ b/Units/parser-cxx.r/new-delete.d/expected.tags
@@ -1,1 +1,1 @@
-fn	input.cpp	/^Class fn()$/;"	f	typeref:typename:Class
+fn	input.cpp	/^Class fn()$/;"	f	typeref:unknown:Class

--- a/Units/parser-cxx.r/operators.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/operators.cpp.d/expected.tags
@@ -1,17 +1,17 @@
-operator =	input.cpp	/^	X & operator = (const X &x)$/;"	f	class:X	typeref:typename:X &	file:
-operator ==	input.cpp	/^	bool operator == (const X &x)$/;"	f	class:X	typeref:typename:bool	file:
-operator -=	input.cpp	/^	inline X & operator-=(const X &x)$/;"	f	class:X	typeref:typename:X &	file:
-operator +=	input.cpp	/^	inline X & operator += (const X &x)$/;"	f	class:X	typeref:typename:X &	file:
-operator *=	input.cpp	/^	X & operator *= (int x);$/;"	p	class:X	typeref:typename:X &	file:
-operator *=	input.cpp	/^	X & operator *= (const X & x);$/;"	p	class:X	typeref:typename:X &	file:
-operator /=	input.cpp	/^	inline void operator \/= (int)$/;"	f	class:X	typeref:typename:void	file:
-operator ()	input.cpp	/^	inline void *** operator()()$/;"	f	class:X	typeref:typename:void ***	file:
-operator ++	input.cpp	/^	inline X & operator++()$/;"	f	class:X	typeref:typename:X &	file:
-operator --	input.cpp	/^	X & operator--()$/;"	f	class:X	typeref:typename:X &	file:
-operator []	input.cpp	/^	int operator[](int)$/;"	f	class:X	typeref:typename:int	file:
-operator *	input.cpp	/^	inline friend X operator*(const X &a, const X &b)$/;"	f	class:X	typeref:typename:X	file:
-operator &&	input.cpp	/^	friend X operator && (const X &a,const X & b);$/;"	p	class:X	typeref:typename:X	file:
-operator *=	input.cpp	/^X & X::operator *= (int x)$/;"	f	class:X	typeref:typename:X &
-operator *=	input.cpp	/^X & X::operator *= (const X & x)$/;"	f	class:X	typeref:typename:X &
-operator &&	input.cpp	/^X X::operator && (const X &a,const X & b)$/;"	f	class:X	typeref:typename:X
-main	input.cpp	/^int main(int argc,char ** argv)$/;"	f	typeref:typename:int
+operator =	input.cpp	/^	X & operator = (const X &x)$/;"	f	class:X	typeref:unknown:X &	file:
+operator ==	input.cpp	/^	bool operator == (const X &x)$/;"	f	class:X	typeref:unknown:bool	file:
+operator -=	input.cpp	/^	inline X & operator-=(const X &x)$/;"	f	class:X	typeref:unknown:X &	file:
+operator +=	input.cpp	/^	inline X & operator += (const X &x)$/;"	f	class:X	typeref:unknown:X &	file:
+operator *=	input.cpp	/^	X & operator *= (int x);$/;"	p	class:X	typeref:unknown:X &	file:
+operator *=	input.cpp	/^	X & operator *= (const X & x);$/;"	p	class:X	typeref:unknown:X &	file:
+operator /=	input.cpp	/^	inline void operator \/= (int)$/;"	f	class:X	typeref:unknown:void	file:
+operator ()	input.cpp	/^	inline void *** operator()()$/;"	f	class:X	typeref:unknown:void ***	file:
+operator ++	input.cpp	/^	inline X & operator++()$/;"	f	class:X	typeref:unknown:X &	file:
+operator --	input.cpp	/^	X & operator--()$/;"	f	class:X	typeref:unknown:X &	file:
+operator []	input.cpp	/^	int operator[](int)$/;"	f	class:X	typeref:unknown:int	file:
+operator *	input.cpp	/^	inline friend X operator*(const X &a, const X &b)$/;"	f	class:X	typeref:unknown:X	file:
+operator &&	input.cpp	/^	friend X operator && (const X &a,const X & b);$/;"	p	class:X	typeref:unknown:X	file:
+operator *=	input.cpp	/^X & X::operator *= (int x)$/;"	f	class:X	typeref:unknown:X &
+operator *=	input.cpp	/^X & X::operator *= (const X & x)$/;"	f	class:X	typeref:unknown:X &
+operator &&	input.cpp	/^X X::operator && (const X &a,const X & b)$/;"	f	class:X	typeref:unknown:X
+main	input.cpp	/^int main(int argc,char ** argv)$/;"	f	typeref:unknown:int

--- a/Units/parser-cxx.r/signature.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/signature.cpp.d/expected.tags
@@ -1,4 +1,4 @@
-BAR::bar	input.cpp	/^char *BAR::bar (char *c, double d[]) const {}$/;"	f	class:BAR	typeref:typename:char *	signature:(char *c, double d[]) const
-bar	input.cpp	/^char *BAR::bar (char *c, double d[]) const {}$/;"	f	class:BAR	typeref:typename:char *	signature:(char *c, double d[]) const
-foo	input.cpp	/^void foo (int a, char b) {}$/;"	f	typeref:typename:void	signature:(int a, char b)
-foobar	input.cpp	/^void foobar __ARGS ((int a, char b));$/;"	p	typeref:typename:void	file:	signature:(int a, char b)
+BAR::bar	input.cpp	/^char *BAR::bar (char *c, double d[]) const {}$/;"	f	class:BAR	typeref:unknown:char *	signature:(char *c, double d[]) const
+bar	input.cpp	/^char *BAR::bar (char *c, double d[]) const {}$/;"	f	class:BAR	typeref:unknown:char *	signature:(char *c, double d[]) const
+foo	input.cpp	/^void foo (int a, char b) {}$/;"	f	typeref:unknown:void	signature:(int a, char b)
+foobar	input.cpp	/^void foobar __ARGS ((int a, char b));$/;"	p	typeref:unknown:void	file:	signature:(int a, char b)

--- a/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/expected.tags
@@ -1,10 +1,10 @@
 Bar	input.cpp	/^class Bar$/;"	class	file:
-foo	input.cpp	/^    A foo()$/;"	function	class:Bar	typeref:typename:A	file:	signature:()
-f1	input.cpp	/^int f1()$/;"	function	typeref:typename:int	signature:()
-b	input.cpp	/^    Bar<int> b;$/;"	local	function:f1	typeref:typename:Bar<int>	file:
-t	input.cpp	/^    auto t = b.template foo<int>();$/;"	local	function:f1	typeref:typename:auto	file:
-f2	input.cpp	/^int f2()$/;"	function	typeref:typename:int	signature:()
-b	input.cpp	/^    Bar<int> b;$/;"	local	function:f2	typeref:typename:Bar<int>	file:
+foo	input.cpp	/^    A foo()$/;"	function	class:Bar	typeref:unknown:A	file:	signature:()
+f1	input.cpp	/^int f1()$/;"	function	typeref:unknown:int	signature:()
+b	input.cpp	/^    Bar<int> b;$/;"	local	function:f1	typeref:unknown:Bar<int>	file:
+t	input.cpp	/^    auto t = b.template foo<int>();$/;"	local	function:f1	typeref:unknown:auto	file:
+f2	input.cpp	/^int f2()$/;"	function	typeref:unknown:int	signature:()
+b	input.cpp	/^    Bar<int> b;$/;"	local	function:f2	typeref:unknown:Bar<int>	file:
 __anon1763e7850103	input.cpp	/^    auto l = [](auto & p){ return p.template foo<int>();};$/;"	function	function:f2	file:
-l	input.cpp	/^    auto l = [](auto & p){ return p.template foo<int>();};$/;"	local	function:f2	typeref:typename:auto	file:
-main	input.cpp	/^int main()$/;"	function	typeref:typename:int	signature:()
+l	input.cpp	/^    auto l = [](auto & p){ return p.template foo<int>();};$/;"	local	function:f2	typeref:unknown:auto	file:
+main	input.cpp	/^int main()$/;"	function	typeref:unknown:int	signature:()

--- a/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/expected.tags
@@ -1,5 +1,5 @@
 Foo	input.cpp	/^namespace Foo$/;"	namespace	file:
-bar	input.cpp	/^T bar() $/;"	function	namespace:Foo	typeref:typename:T	signature:()
-main	input.cpp	/^int main()$/;"	function	typeref:typename:int	signature:()
+bar	input.cpp	/^T bar() $/;"	function	namespace:Foo	typeref:unknown:T	signature:()
+main	input.cpp	/^int main()$/;"	function	typeref:unknown:int	signature:()
 __anonaa3dc9860103	input.cpp	/^    auto l = []{return Foo::template bar<int>();};$/;"	function	function:main	file:
-l	input.cpp	/^    auto l = []{return Foo::template bar<int>();};$/;"	local	function:main	typeref:typename:auto	file:
+l	input.cpp	/^    auto l = []{return Foo::template bar<int>();};$/;"	local	function:main	typeref:unknown:auto	file:

--- a/Units/parser-cxx.r/templates.d/expected.tags
+++ b/Units/parser-cxx.r/templates.d/expected.tags
@@ -1,14 +1,14 @@
-zero	input.cpp	/^zero (const T &v1, const T &v2)$/;"	f	typeref:typename:int
-v1	input.cpp	/^zero (const T &v1, const T &v2)$/;"	z	function:zero	typeref:typename:const T &	file:
-v2	input.cpp	/^zero (const T &v1, const T &v2)$/;"	z	function:zero	typeref:typename:const T &	file:
-min	input.cpp	/^min(const T&v1, const T&v2)$/;"	f	typeref:typename:T
-v1	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:typename:const T &	file:
-v2	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:typename:const T &	file:
+zero	input.cpp	/^zero (const T &v1, const T &v2)$/;"	f	typeref:unknown:int
+v1	input.cpp	/^zero (const T &v1, const T &v2)$/;"	z	function:zero	typeref:unknown:const T &	file:
+v2	input.cpp	/^zero (const T &v1, const T &v2)$/;"	z	function:zero	typeref:unknown:const T &	file:
+min	input.cpp	/^min(const T&v1, const T&v2)$/;"	f	typeref:unknown:T
+v1	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:unknown:const T &	file:
+v2	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:unknown:const T &	file:
 Item	input.cpp	/^class Item$/;"	c	file:
 Item	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	f	class:Item	file:
 Item::Item	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	f	class:Item	file:
-t	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	z	function:Item::Item	typeref:typename:const Type &	file:
-item	input.cpp	/^  Type item;$/;"	m	class:Item	typeref:typename:Type	file:
-Item::item	input.cpp	/^  Type item;$/;"	m	class:Item	typeref:typename:Type	file:
-next	input.cpp	/^  Item *next;$/;"	m	class:Item	typeref:typename:Item *	file:
-Item::next	input.cpp	/^  Item *next;$/;"	m	class:Item	typeref:typename:Item *	file:
+t	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	z	function:Item::Item	typeref:unknown:const Type &	file:
+item	input.cpp	/^  Type item;$/;"	m	class:Item	typeref:unknown:Type	file:
+Item::item	input.cpp	/^  Type item;$/;"	m	class:Item	typeref:unknown:Type	file:
+next	input.cpp	/^  Item *next;$/;"	m	class:Item	typeref:unknown:Item *	file:
+Item::next	input.cpp	/^  Item *next;$/;"	m	class:Item	typeref:unknown:Item *	file:

--- a/Units/parser-cxx.r/templates2.d/expected.tags
+++ b/Units/parser-cxx.r/templates2.d/expected.tags
@@ -1,8 +1,8 @@
-foo1	input.cpp	/^auto foo1(const Container<Elem> & p_container)$/;"	f	typeref:typename:auto
-p_container	input.cpp	/^auto foo1(const Container<Elem> & p_container)$/;"	z	function:foo1	typeref:typename:const Container<Elem> &	file:
-foo2	input.cpp	/^auto foo2(const Container<Key,Elem> & p_container)$/;"	f	typeref:typename:auto
-p_container	input.cpp	/^auto foo2(const Container<Key,Elem> & p_container)$/;"	z	function:foo2	typeref:typename:const Container<Key,Elem> &	file:
-bar	input.cpp	/^void bar()$/;"	f	typeref:typename:void
-main	input.cpp	/^int main()$/;"	f	typeref:typename:int
-v	input.cpp	/^    auto v = foo1(std::vector<int>{1,2,3});$/;"	l	function:main	typeref:typename:auto	file:
-m	input.cpp	/^    auto m = foo2(std::map<int,int>{{1,2}});$/;"	l	function:main	typeref:typename:auto	file:
+foo1	input.cpp	/^auto foo1(const Container<Elem> & p_container)$/;"	f	typeref:unknown:auto
+p_container	input.cpp	/^auto foo1(const Container<Elem> & p_container)$/;"	z	function:foo1	typeref:unknown:const Container<Elem> &	file:
+foo2	input.cpp	/^auto foo2(const Container<Key,Elem> & p_container)$/;"	f	typeref:unknown:auto
+p_container	input.cpp	/^auto foo2(const Container<Key,Elem> & p_container)$/;"	z	function:foo2	typeref:unknown:const Container<Key,Elem> &	file:
+bar	input.cpp	/^void bar()$/;"	f	typeref:unknown:void
+main	input.cpp	/^int main()$/;"	f	typeref:unknown:int
+v	input.cpp	/^    auto v = foo1(std::vector<int>{1,2,3});$/;"	l	function:main	typeref:unknown:auto	file:
+m	input.cpp	/^    auto m = foo2(std::map<int,int>{{1,2}});$/;"	l	function:main	typeref:unknown:auto	file:

--- a/Units/parser-cxx.r/templates3.d/expected.tags
+++ b/Units/parser-cxx.r/templates3.d/expected.tags
@@ -1,4 +1,4 @@
 makeArrayRef	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	f	typeref:typename:boost::disable_if_c<N==1,ArrayRef<ValueType,SizeType>>::type
-p_data	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	z	function:makeArrayRef	typeref:typename:ValueType (&)[N]	file:
-p_size	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	z	function:makeArrayRef	typeref:typename:SizeType &	file:
-foo	input.cpp	/^void foo()$/;"	f	typeref:typename:void
+p_data	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	z	function:makeArrayRef	typeref:unknown:ValueType (&)[N]	file:
+p_size	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	z	function:makeArrayRef	typeref:unknown:SizeType &	file:
+foo	input.cpp	/^void foo()$/;"	f	typeref:unknown:void

--- a/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
@@ -5,17 +5,17 @@ T04	input.cpp	/^typedef enum AEnum T04;$/;"	t	typeref:enum:AEnum	file:
 T11	input.cpp	/^typedef struct { int a; } T11;$/;"	t	typeref:struct:__anon0e56f337010a	file:
 T12	input.cpp	/^typedef union { int a; int b; } T12;$/;"	t	typeref:union:__anon0e56f337020c	file:
 T13	input.cpp	/^typedef enum { E2 } T13;$/;"	t	typeref:enum:__anon0e56f3370304	file:
-T21	input.cpp	/^typedef int* T21;$/;"	t	typeref:typename:int *	file:
-T22	input.cpp	/^typedef const AClass* *  T22;$/;"	t	typeref:typename:const AClass **	file:
-T31	input.cpp	/^typedef int (*T31) (int &,int , AUnion *);$/;"	t	typeref:typename:int (*)(int &,int,AUnion *)	file:
-T32	input.cpp	/^typedef AClass &(* T32)(AClass &);$/;"	t	typeref:typename:AClass & (*)(AClass &)	file:
-T41	input.cpp	/^typedef int T41 [ 10];$/;"	t	typeref:typename:int[10]	file:
-T51	input.cpp	/^typedef ATemplate1<int > T51;$/;"	t	typeref:typename:ATemplate1<int>	file:
-T52	input.cpp	/^typedef ATemplate1< unsigned short int> T52;$/;"	t	typeref:typename:ATemplate1<unsigned short int>	file:
-T53	input.cpp	/^typedef ATemplate1<ATemplate2 < AStruct,AClass> > T53;$/;"	t	typeref:typename:ATemplate1<ATemplate2<AStruct,AClass>>	file:
-T54	input.cpp	/^typedef ATemplate1<int > (*T54)();$/;"	t	typeref:typename:ATemplate1<int> (*)()	file:
-T61	input.cpp	/^	typedef Type::iterator1 T61;$/;"	t	class:Container	typeref:typename:Type::iterator1	file:
+T21	input.cpp	/^typedef int* T21;$/;"	t	typeref:unknown:int *	file:
+T22	input.cpp	/^typedef const AClass* *  T22;$/;"	t	typeref:unknown:const AClass **	file:
+T31	input.cpp	/^typedef int (*T31) (int &,int , AUnion *);$/;"	t	typeref:unknown:int (*)(int &,int,AUnion *)	file:
+T32	input.cpp	/^typedef AClass &(* T32)(AClass &);$/;"	t	typeref:unknown:AClass & (*)(AClass &)	file:
+T41	input.cpp	/^typedef int T41 [ 10];$/;"	t	typeref:unknown:int[10]	file:
+T51	input.cpp	/^typedef ATemplate1<int > T51;$/;"	t	typeref:unknown:ATemplate1<int>	file:
+T52	input.cpp	/^typedef ATemplate1< unsigned short int> T52;$/;"	t	typeref:unknown:ATemplate1<unsigned short int>	file:
+T53	input.cpp	/^typedef ATemplate1<ATemplate2 < AStruct,AClass> > T53;$/;"	t	typeref:unknown:ATemplate1<ATemplate2<AStruct,AClass>>	file:
+T54	input.cpp	/^typedef ATemplate1<int > (*T54)();$/;"	t	typeref:unknown:ATemplate1<int> (*)()	file:
+T61	input.cpp	/^	typedef Type::iterator1 T61;$/;"	t	class:Container	typeref:unknown:Type::iterator1	file:
 T62	input.cpp	/^	typedef typename Type :: iterator2 T62;$/;"	t	class:Container	typeref:typename:Type::iterator2	file:
-T63	input.cpp	/^	typedef ATemplate<Type> T63;$/;"	t	class:Container	typeref:typename:ATemplate<Type>	file:
-T64	input.cpp	/^	typedef int (*T64)(ATemplate< Type> &);$/;"	t	class:Container	typeref:typename:int (*)(ATemplate<Type> &)	file:
+T63	input.cpp	/^	typedef ATemplate<Type> T63;$/;"	t	class:Container	typeref:unknown:ATemplate<Type>	file:
+T64	input.cpp	/^	typedef int (*T64)(ATemplate< Type> &);$/;"	t	class:Container	typeref:unknown:int (*)(ATemplate<Type> &)	file:
 T71	input.cpp	/^typedef DECLPOINTER(struct AStruct) T71;$/;"	t	file:

--- a/Units/parser-cxx.r/using.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/using.cpp.d/expected.tags
@@ -4,6 +4,6 @@ std	input.cpp	/^using namespace std;$/;"	using	file:
 string	input.cpp	/^#include <string>/;"	header	role:system
 string	input.cpp	/^using std::string;$/;"	name	file:
 test	input.cpp	/^	using A::test;$/;"	name	class:B
-test	input.cpp	/^	void test();$/;"	prototype	class:A	typeref:typename:void	file:	signature:()
-test	input.cpp	/^	void test(x t);$/;"	prototype	class:B	typeref:typename:void	file:	signature:(x t)
-x	input.cpp	/^using x = std::string;$/;"	typedef	typeref:typename:std::string	file:
+test	input.cpp	/^	void test();$/;"	prototype	class:A	typeref:unknown:void	file:	signature:()
+test	input.cpp	/^	void test(x t);$/;"	prototype	class:B	typeref:unknown:void	file:	signature:(x t)
+x	input.cpp	/^using x = std::string;$/;"	typedef	typeref:unknown:std::string	file:

--- a/Units/parser-cxx.r/variable-declarations.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/variable-declarations.cpp.d/expected.tags
@@ -1,38 +1,38 @@
-l01	input.cpp	/^	unsigned short int l01;$/;"	l	function:main	typeref:typename:unsigned short int	file:
-l02	input.cpp	/^	unsigned long long int * const l02 = NULL, * l03 = NULL;$/;"	l	function:main	typeref:typename:unsigned long long int * const	file:
-l03	input.cpp	/^	unsigned long long int * const l02 = NULL, * l03 = NULL;$/;"	l	function:main	typeref:typename:unsigned long long int * const *	file:
-l04	input.cpp	/^	register int ** l04 = 0;$/;"	l	function:main	typeref:typename:register int **	file:
-l05	input.cpp	/^	std::string l05;$/;"	l	function:main	typeref:typename:std::string	file:
-l06	input.cpp	/^	std::string l06("test");$/;"	l	function:main	typeref:typename:std::string	file:
-l07	input.cpp	/^	std::string l07 = "test";$/;"	l	function:main	typeref:typename:std::string	file:
-l08	input.cpp	/^	const std::string & l08 = l07, l09 = l07;$/;"	l	function:main	typeref:typename:const std::string &	file:
-l09	input.cpp	/^	const std::string & l08 = l07, l09 = l07;$/;"	l	function:main	typeref:typename:const std::string &	file:
-l10	input.cpp	/^	const void * (*l10)() = NULL;$/;"	l	function:main	typeref:typename:const void * (*)()	file:
-l11	input.cpp	/^	unsigned long int & (*l11)(void *);$/;"	l	function:main	typeref:typename:unsigned long int & (*)(void *)	file:
-l12	input.cpp	/^	std::string & (*l12)(void);$/;"	l	function:main	typeref:typename:std::string & (*)(void)	file:
-l13	input.cpp	/^	std::string ** (*l13)(int a,int b);$/;"	l	function:main	typeref:typename:std::string ** (*)(int a,int b)	file:
-l14	input.cpp	/^	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > l14;$/;"	l	function:main	typeref:typename:std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>	file:
+l01	input.cpp	/^	unsigned short int l01;$/;"	l	function:main	typeref:unknown:unsigned short int	file:
+l02	input.cpp	/^	unsigned long long int * const l02 = NULL, * l03 = NULL;$/;"	l	function:main	typeref:unknown:unsigned long long int * const	file:
+l03	input.cpp	/^	unsigned long long int * const l02 = NULL, * l03 = NULL;$/;"	l	function:main	typeref:unknown:unsigned long long int * const *	file:
+l04	input.cpp	/^	register int ** l04 = 0;$/;"	l	function:main	typeref:unknown:register int **	file:
+l05	input.cpp	/^	std::string l05;$/;"	l	function:main	typeref:unknown:std::string	file:
+l06	input.cpp	/^	std::string l06("test");$/;"	l	function:main	typeref:unknown:std::string	file:
+l07	input.cpp	/^	std::string l07 = "test";$/;"	l	function:main	typeref:unknown:std::string	file:
+l08	input.cpp	/^	const std::string & l08 = l07, l09 = l07;$/;"	l	function:main	typeref:unknown:const std::string &	file:
+l09	input.cpp	/^	const std::string & l08 = l07, l09 = l07;$/;"	l	function:main	typeref:unknown:const std::string &	file:
+l10	input.cpp	/^	const void * (*l10)() = NULL;$/;"	l	function:main	typeref:unknown:const void * (*)()	file:
+l11	input.cpp	/^	unsigned long int & (*l11)(void *);$/;"	l	function:main	typeref:unknown:unsigned long int & (*)(void *)	file:
+l12	input.cpp	/^	std::string & (*l12)(void);$/;"	l	function:main	typeref:unknown:std::string & (*)(void)	file:
+l13	input.cpp	/^	std::string ** (*l13)(int a,int b);$/;"	l	function:main	typeref:unknown:std::string ** (*)(int a,int b)	file:
+l14	input.cpp	/^	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > l14;$/;"	l	function:main	typeref:unknown:std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>	file:
 l15	input.cpp	/^	struct Struct1 l15;$/;"	l	function:main	typeref:struct:Struct1	file:
 l16	input.cpp	/^	struct Struct1 * l16, l17, l18[10];$/;"	l	function:main	typeref:struct:Struct1 *	file:
 l17	input.cpp	/^	struct Struct1 * l16, l17, l18[10];$/;"	l	function:main	typeref:struct:Struct1 *	file:
 l18	input.cpp	/^	struct Struct1 * l16, l17, l18[10];$/;"	l	function:main	typeref:struct:Struct1 * [10]	file:
-l19	input.cpp	/^	Struct1 l19 = {};$/;"	l	function:main	typeref:typename:Struct1	file:
-l20	input.cpp	/^	std::string ** l20[SIZE];$/;"	l	function:main	typeref:typename:std::string ** []	file:
-l21	input.cpp	/^	std::string l21[1 << 2];$/;"	l	function:main	typeref:typename:std::string[]	file:
-l22	input.cpp	/^	std::string * const l22[SIZE][SIZE];$/;"	l	function:main	typeref:typename:std::string * const[][]	file:
-l23	input.cpp	/^	std::string l23[5][2];$/;"	l	function:main	typeref:typename:std::string[5][2]	file:
-m01	input.cpp	/^	unsigned int m01;$/;"	m	struct:Struct1	typeref:typename:unsigned int	file:
-m02	input.cpp	/^	std::string m02;$/;"	m	struct:Struct1	typeref:typename:std::string	file:
-m03	input.cpp	/^	std::string ** m03, m04;$/;"	m	struct:Struct1	typeref:typename:std::string **	file:
-m04	input.cpp	/^	std::string ** m03, m04;$/;"	m	struct:Struct1	typeref:typename:std::string **	file:
-m05	input.cpp	/^	std::string & (*m05)(int a,int b);$/;"	m	struct:Struct1	typeref:typename:std::string & (*)(int a,int b)	file:
-m06	input.cpp	/^	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > m06[10];$/;"	m	struct:Struct1	typeref:typename:std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>[10]	file:
+l19	input.cpp	/^	Struct1 l19 = {};$/;"	l	function:main	typeref:unknown:Struct1	file:
+l20	input.cpp	/^	std::string ** l20[SIZE];$/;"	l	function:main	typeref:unknown:std::string ** []	file:
+l21	input.cpp	/^	std::string l21[1 << 2];$/;"	l	function:main	typeref:unknown:std::string[]	file:
+l22	input.cpp	/^	std::string * const l22[SIZE][SIZE];$/;"	l	function:main	typeref:unknown:std::string * const[][]	file:
+l23	input.cpp	/^	std::string l23[5][2];$/;"	l	function:main	typeref:unknown:std::string[5][2]	file:
+m01	input.cpp	/^	unsigned int m01;$/;"	m	struct:Struct1	typeref:unknown:unsigned int	file:
+m02	input.cpp	/^	std::string m02;$/;"	m	struct:Struct1	typeref:unknown:std::string	file:
+m03	input.cpp	/^	std::string ** m03, m04;$/;"	m	struct:Struct1	typeref:unknown:std::string **	file:
+m04	input.cpp	/^	std::string ** m03, m04;$/;"	m	struct:Struct1	typeref:unknown:std::string **	file:
+m05	input.cpp	/^	std::string & (*m05)(int a,int b);$/;"	m	struct:Struct1	typeref:unknown:std::string & (*)(int a,int b)	file:
+m06	input.cpp	/^	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > m06[10];$/;"	m	struct:Struct1	typeref:unknown:std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>[10]	file:
 v01	input.cpp	/^} v01, v02[10];$/;"	v	typeref:struct:Struct1
 v02	input.cpp	/^} v01, v02[10];$/;"	v	typeref:struct:Struct1[10]
 v03	input.cpp	/^} v03, * v04;$/;"	v	typeref:enum:Enum1
 v04	input.cpp	/^} v03, * v04;$/;"	v	typeref:enum:Enum1 *
 v05	input.cpp	/^struct Struct1 v05, * v06 = NULL;$/;"	v	typeref:struct:Struct1
 v06	input.cpp	/^struct Struct1 v05, * v06 = NULL;$/;"	v	typeref:struct:Struct1 *
-v07	input.cpp	/^std::string v07("test"), v08("test");$/;"	v	typeref:typename:std::string
-v08	input.cpp	/^std::string v07("test"), v08("test");$/;"	v	typeref:typename:std::string
-v09	input.cpp	/^std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > ** v09;$/;"	v	typeref:typename:std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>> **
+v07	input.cpp	/^std::string v07("test"), v08("test");$/;"	v	typeref:unknown:std::string
+v08	input.cpp	/^std::string v07("test"), v08("test");$/;"	v	typeref:unknown:std::string
+v09	input.cpp	/^std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > ** v09;$/;"	v	typeref:unknown:std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>> **

--- a/Units/parser-cxx.r/variables-in-control-statements.d/expected.tags
+++ b/Units/parser-cxx.r/variables-in-control-statements.d/expected.tags
@@ -1,12 +1,12 @@
-f01	input.cpp	/^	for(int f01=0;f01<10;f01++)$/;"	l	function:test	typeref:typename:int	file:
-f02	input.cpp	/^	for(int f02 = getUShort(), * f03 = getPointer();f03 < (getPointer() + 10);f03++)$/;"	l	function:test	typeref:typename:int	file:
-f03	input.cpp	/^	for(int f02 = getUShort(), * f03 = getPointer();f03 < (getPointer() + 10);f03++)$/;"	l	function:test	typeref:typename:int *	file:
-f04	input.cpp	/^	for(int f04=0,f05=5,f06=10;f04<10;f04++)$/;"	l	function:test	typeref:typename:int	file:
-f05	input.cpp	/^	for(int f04=0,f05=5,f06=10;f04<10;f04++)$/;"	l	function:test	typeref:typename:int	file:
-f06	input.cpp	/^	for(int f04=0,f05=5,f06=10;f04<10;f04++)$/;"	l	function:test	typeref:typename:int	file:
-f07	input.cpp	/^	for(std::string f07 = "test";;)$/;"	l	function:test	typeref:typename:std::string	file:
-f09	input.cpp	/^	for(std::unique_ptr<int> f09 = 0;;)$/;"	l	function:test	typeref:typename:std::unique_ptr<int>	file:
-f10	input.cpp	/^	for(std::unique_ptr<int> f10(getPointer());;)$/;"	l	function:test	typeref:typename:std::unique_ptr<int>	file:
-f11	input.cpp	/^	for(std::pair<int,int> f11;;)$/;"	l	function:test	typeref:typename:std::pair<int,int>	file:
-i01	input.cpp	/^	if(int i01 = 10 + 20)$/;"	l	function:test	typeref:typename:int	file:
-w01	input.cpp	/^	while(unsigned short int w01 = getUShort())$/;"	l	function:test	typeref:typename:unsigned short int	file:
+f01	input.cpp	/^	for(int f01=0;f01<10;f01++)$/;"	l	function:test	typeref:unknown:int	file:
+f02	input.cpp	/^	for(int f02 = getUShort(), * f03 = getPointer();f03 < (getPointer() + 10);f03++)$/;"	l	function:test	typeref:unknown:int	file:
+f03	input.cpp	/^	for(int f02 = getUShort(), * f03 = getPointer();f03 < (getPointer() + 10);f03++)$/;"	l	function:test	typeref:unknown:int *	file:
+f04	input.cpp	/^	for(int f04=0,f05=5,f06=10;f04<10;f04++)$/;"	l	function:test	typeref:unknown:int	file:
+f05	input.cpp	/^	for(int f04=0,f05=5,f06=10;f04<10;f04++)$/;"	l	function:test	typeref:unknown:int	file:
+f06	input.cpp	/^	for(int f04=0,f05=5,f06=10;f04<10;f04++)$/;"	l	function:test	typeref:unknown:int	file:
+f07	input.cpp	/^	for(std::string f07 = "test";;)$/;"	l	function:test	typeref:unknown:std::string	file:
+f09	input.cpp	/^	for(std::unique_ptr<int> f09 = 0;;)$/;"	l	function:test	typeref:unknown:std::unique_ptr<int>	file:
+f10	input.cpp	/^	for(std::unique_ptr<int> f10(getPointer());;)$/;"	l	function:test	typeref:unknown:std::unique_ptr<int>	file:
+f11	input.cpp	/^	for(std::pair<int,int> f11;;)$/;"	l	function:test	typeref:unknown:std::pair<int,int>	file:
+i01	input.cpp	/^	if(int i01 = 10 + 20)$/;"	l	function:test	typeref:unknown:int	file:
+w01	input.cpp	/^	while(unsigned short int w01 = getUShort())$/;"	l	function:test	typeref:unknown:unsigned short int	file:

--- a/Units/readtags.r/backslash-at-the-end-of-pattern.d/expected.tags
+++ b/Units/readtags.r/backslash-at-the-end-of-pattern.d/expected.tags
@@ -1,2 +1,2 @@
 M	input.c	/^#define M\\/;"	d	file:
-main	input.c	/^int main() {$/;"	f	typeref:typename:int
+main	input.c	/^int main() {$/;"	f	typeref:unknown:int

--- a/Units/review-needed.r/rojas.h.t/expected.tags
+++ b/Units/review-needed.r/rojas.h.t/expected.tags
@@ -1,5 +1,5 @@
-FFunc	input.h	/^typedef uint32 (*FFunc) (const astruct * pP, int n);$/;"	t	typeref:typename:uint32 (*)(const astruct * pP,int n)
-FooBar	input.h	/^typedef void * FooBar;$/;"	t	typeref:typename:void *
+FFunc	input.h	/^typedef uint32 (*FFunc) (const astruct * pP, int n);$/;"	t	typeref:unknown:uint32 (*)(const astruct * pP,int n)
+FooBar	input.h	/^typedef void * FooBar;$/;"	t	typeref:unknown:void *
 astruct	input.h	/^struct astruct$/;"	s
 astruct	input.h	/^typedef struct astruct astruct;$/;"	t	typeref:struct:astruct
-m_member	input.h	/^    int m_member;$/;"	m	struct:astruct	typeref:typename:int
+m_member	input.h	/^    int m_member;$/;"	m	struct:astruct	typeref:unknown:int

--- a/main/entry.c
+++ b/main/entry.c
@@ -974,12 +974,16 @@ static int addExtensionFields (const tagEntryInfo *const tag)
 	}
 
 	if (getFieldDesc (FIELD_TYPE_REF)->enabled &&
-			tag->extensionFields.typeRef [0] != NULL  &&
 			tag->extensionFields.typeRef [1] != NULL)
+	{
+		const char *typeRef0 = tag->extensionFields.typeRef [0];
+
+		typeRef0 = typeRef0 ? typeRef0 : "unknown";
 		length += mio_printf (TagFile.fp, "%s\t%s:%s:%s", sep,
 				   getFieldName (FIELD_TYPE_REF),
-				   tag->extensionFields.typeRef [0],
+				   typeRef0,
 				   escapeName (tag, FIELD_TYPE_REF));
+	}
 
 	if (getFieldDesc (FIELD_FILE_SCOPE)->enabled &&  tag->isFileScope)
 		length += mio_printf (TagFile.fp, "%s\t%s:", sep,

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -121,12 +121,7 @@ CXXToken * cxxTagSetTypeField(
 {
 	CXX_DEBUG_ASSERT(tag && pTypeStart && pTypeEnd,"Non null parameters are expected");
 
-	const char * szTypeRef0;
-
-	// "typename" is debatable since it's not really
-	// allowed by C++ for unqualified types. However I haven't been able
-	// to come up with something better... so "typename" it is for now.
-	static const char * szTypename = "typename";
+	const char * szTypeRef0 = NULL;
 
 	if(pTypeStart != pTypeEnd)
 	{
@@ -139,11 +134,7 @@ CXXToken * cxxTagSetTypeField(
 		{
 			szTypeRef0 = cxxKeywordName(pTypeStart->eKeyword);
 			pTypeStart = pTypeStart->pNext;
-		} else {
-			szTypeRef0 = szTypename;
 		}
-	} else {
-		szTypeRef0 = szTypename;
 	}
 
 	cxxTokenChainNormalizeTypeNameSpacingInRange(pTypeStart,pTypeEnd);

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -1366,10 +1366,7 @@ static void readQualifiedName (tokenInfo *const token, vString *name,
 static boolean parseUse (tokenInfo *const token)
 {
 	boolean readNext = FALSE;
-	/* we can't know the use type, because class, interface and namespaces
-	 * aliases are the same, and the only difference is the referenced name's
-	 * type */
-	const char *refType = "unknown";
+	const char *refType = NULL;
 	vString *refName = vStringNew ();
 	tokenInfo *nameToken = newToken ();
 	boolean grouped = FALSE;


### PR DESCRIPTION
At the moment the value of typeRef[0] when no referenced type exists is
parser-specific. The cxx parser uses "typename" in this case, the php
parser uses "unknown". Instead, allow typeRef[0] to be set to NULL and
generate "unknown" for it when writing out the tag entry. This will make
the output identical for all languages.