### PR TITLE
CXX: Add some new fields to the cxx parser

### DIFF
--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -4,4 +4,5 @@ E       UCTAGSextra     off     NONE            TRUE     Extra tag type informat
 -       UCTAGSend       off     C               TRUE     end lines of struct/function declarations
 -       UCTAGSend       off     C++             TRUE     end lines of class/function declarations
 -       UCTAGStemplate  off     C++             TRUE     template parameters           
+-       UCTAGScaptures  off     C++             TRUE     lambda capture list           
 -       UCTAGSsectionMarker off     reStructuredText TRUE     character used for declaring section

--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -1,5 +1,7 @@
 r       UCTAGSrole      off     NONE            TRUE     Role                          
 Z       UCTAGSscope     off     NONE            FALSE    Include the "scope:" key in scope field (use s)
 E       UCTAGSextra     off     NONE            TRUE     Extra tag type information    
+-       UCTAGSend       off     C               TRUE     end lines of struct/function declarations
+-       UCTAGSend       off     C++             TRUE     end lines of class/function declarations
 -       UCTAGStemplate  off     C++             TRUE     template parameters           
 -       UCTAGSsectionMarker off     reStructuredText TRUE     character used for declaring section

--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -1,4 +1,5 @@
 r       UCTAGSrole      off     NONE            TRUE     Role                          
 Z       UCTAGSscope     off     NONE            FALSE    Include the "scope:" key in scope field (use s)
 E       UCTAGSextra     off     NONE            TRUE     Extra tag type information    
+-       UCTAGStemplate  off     C++             TRUE     template parameters           
 -       UCTAGSsectionMarker off     reStructuredText TRUE     character used for declaring section

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -19,6 +19,7 @@ r	role	off	NONE	TRUE	Role
 R	NONE	off	NONE	TRUE	Marker (R or D) representing whether tag is definition or reference
 Z	scope	off	NONE	FALSE	Include the "scope:" key in scope field (use s)
 E	extra	off	NONE	TRUE	Extra tag type information
+-	template	off	C++	TRUE	template parameters
 -	sectionMarker	off	reStructuredText	TRUE	character used for declaring section
 #
 Foo	input.java	/^abstract public class Foo extends Bar$/

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -19,6 +19,8 @@ r	role	off	NONE	TRUE	Role
 R	NONE	off	NONE	TRUE	Marker (R or D) representing whether tag is definition or reference
 Z	scope	off	NONE	FALSE	Include the "scope:" key in scope field (use s)
 E	extra	off	NONE	TRUE	Extra tag type information
+-	end	off	C	TRUE	end lines of struct/function declarations
+-	end	off	C++	TRUE	end lines of class/function declarations
 -	template	off	C++	TRUE	template parameters
 -	sectionMarker	off	reStructuredText	TRUE	character used for declaring section
 #

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -22,6 +22,7 @@ E	extra	off	NONE	TRUE	Extra tag type information
 -	end	off	C	TRUE	end lines of struct/function declarations
 -	end	off	C++	TRUE	end lines of class/function declarations
 -	template	off	C++	TRUE	template parameters
+-	captures	off	C++	TRUE	lambda capture list
 -	sectionMarker	off	reStructuredText	TRUE	character used for declaring section
 #
 Foo	input.java	/^abstract public class Foo extends Bar$/

--- a/Units/parser-c.r/bit_field.c.d/args.ctags
+++ b/Units/parser-c.r/bit_field.c.d/args.ctags
@@ -1,2 +1,2 @@
 --sort=no
---fields=+{c.end}
+--fields=+{*.end}

--- a/Units/parser-c.r/bit_field.c.d/args.ctags
+++ b/Units/parser-c.r/bit_field.c.d/args.ctags
@@ -1,1 +1,2 @@
 --sort=no
+--fields=+{c.end}

--- a/Units/parser-c.r/bit_field.c.d/expected.tags
+++ b/Units/parser-c.r/bit_field.c.d/expected.tags
@@ -1,23 +1,23 @@
-bit_fields	input.c	/^struct bit_fields {$/;"	s	file:
+bit_fields	input.c	/^struct bit_fields {$/;"	s	file:	end:5
 a	input.c	/^    unsigned int a: 1;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:1	file:
 b	input.c	/^    unsigned int b: 1;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:1	file:
 c	input.c	/^    unsigned int c: 2;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:2	file:
-__anon1719c4a5010a	input.c	/^struct {$/;"	s	file:
+__anon1719c4a5010a	input.c	/^struct {$/;"	s	file:	end:12
 sign	input.c	/^    unsigned sign  : 1;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned:1	file:
 exp	input.c	/^    unsigned exp   : _FP_EXPBITS_D;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
 frac1	input.c	/^    unsigned frac1 : _FP_FRACBITS_D - (_FP_IMPLBIT_D != 0) - _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
 frac0	input.c	/^    unsigned frac0 : _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
-shortname_info	input.c	/^struct shortname_info {$/;"	s	file:
+shortname_info	input.c	/^struct shortname_info {$/;"	s	file:	end:18
 lower	input.c	/^	unsigned char lower:1,$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
 upper	input.c	/^		      upper:1,$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
 valid	input.c	/^		      valid:1;$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
-__anon1719c4a5020a	input.c	/^{$/;"	s	file:
+__anon1719c4a5020a	input.c	/^{$/;"	s	file:	end:27
 public	input.c	/^    BYTE 	public: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
 bad2	input.c	/^    BYTE 	bad2: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
 group	input.c	/^    BYTE 	group: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
 personal	input.c	/^    BYTE 	personal: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
 bitfield_flags	input.c	/^} bitfield_flags;$/;"	t	typeref:struct:__anon1719c4a5020a	file:
-__anon1719c4a5030a	input.c	/^{$/;"	s	file:
+__anon1719c4a5030a	input.c	/^{$/;"	s	file:	end:35
 this	input.c	/^    BYTE	this;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
 public	input.c	/^    BYTE	public;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
 private	input.c	/^    BYTE	private;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:

--- a/Units/parser-cxx.r/class.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/class.cpp.d/args.ctags
@@ -1,2 +1,3 @@
 --c++-kinds=*
 --sort=no
+--fields=+{c++.end}

--- a/Units/parser-cxx.r/class.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/class.cpp.d/expected.tags
@@ -1,1 +1,1 @@
-C01	input.cpp	/^MACRO03 __attribute__("fancy") __declspec(dllexport) class MY_API C01$/;"	c	file:
+C01	input.cpp	/^MACRO03 __attribute__("fancy") __declspec(dllexport) class MY_API C01$/;"	c	file:	end:12

--- a/Units/parser-cxx.r/cxx11-lambdas.d/args.ctags
+++ b/Units/parser-cxx.r/cxx11-lambdas.d/args.ctags
@@ -1,3 +1,3 @@
 --c++-kinds=+pflz
---fields=+SsK
+--fields=+SsK{c++.end}
 --sort=no

--- a/Units/parser-cxx.r/cxx11-lambdas.d/args.ctags
+++ b/Units/parser-cxx.r/cxx11-lambdas.d/args.ctags
@@ -1,3 +1,3 @@
 --c++-kinds=+pflz
---fields=+SsK{c++.end}
+--fields=+SsK{c++.end}{c++.captures}
 --sort=no

--- a/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
@@ -1,19 +1,19 @@
-call	input.cpp	/^template<typename T> void call(T x)$/;"	function	typeref:typename:void	signature:(T x)
+call	input.cpp	/^template<typename T> void call(T x)$/;"	function	typeref:typename:void	signature:(T x)	end:6
 x	input.cpp	/^template<typename T> void call(T x)$/;"	parameter	function:call	typeref:typename:T	file:
-test	input.cpp	/^int test()$/;"	function	typeref:typename:int	signature:()
-__anon4e7b1b580103	input.cpp	/^	auto l1 = [] { return 0; };$/;"	function	function:test	file:
+test	input.cpp	/^int test()$/;"	function	typeref:typename:int	signature:()	end:24
+__anon4e7b1b580103	input.cpp	/^	auto l1 = [] { return 0; };$/;"	function	function:test	file:	end:10
 l1	input.cpp	/^	auto l1 = [] { return 0; };$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580203	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	function	function:test	file:
+__anon4e7b1b580203	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	function	function:test	file:	end:12
 a	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:typename:int	file:
 b	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:typename:int	file:
 l2	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580303	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:
+__anon4e7b1b580303	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	end:17
 a	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:typename:int	file:
 b	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:typename:int	file:
-__anon4e7b1b580403	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	function	function:test::__anon4e7b1b580303	file:
+__anon4e7b1b580403	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	function	function:test::__anon4e7b1b580303	file:	end:15
 c	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	parameter	function:test::__anon4e7b1b580303::__anon4e7b1b580403	typeref:typename:int	file:
 l4	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	local	function:test::__anon4e7b1b580303	typeref:typename:auto	file:
 l3	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580503	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:
+__anon4e7b1b580503	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	end:22
 a	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:typename:int	file:
 b	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:typename:int	file:

--- a/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
@@ -1,19 +1,19 @@
 call	input.cpp	/^template<typename T> void call(T x)$/;"	function	typeref:typename:void	signature:(T x)	end:6
 x	input.cpp	/^template<typename T> void call(T x)$/;"	parameter	function:call	typeref:typename:T	file:
 test	input.cpp	/^int test()$/;"	function	typeref:typename:int	signature:()	end:24
-__anon4e7b1b580103	input.cpp	/^	auto l1 = [] { return 0; };$/;"	function	function:test	file:	end:10
+__anon4e7b1b580103	input.cpp	/^	auto l1 = [] { return 0; };$/;"	function	function:test	file:	captures:[] 	end:10
 l1	input.cpp	/^	auto l1 = [] { return 0; };$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580203	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	function	function:test	file:	end:12
+__anon4e7b1b580203	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	function	function:test	file:	captures:[]	end:12
 a	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:typename:int	file:
 b	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:typename:int	file:
 l2	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580303	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	end:17
+__anon4e7b1b580303	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	captures:[=]	end:17
 a	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:typename:int	file:
 b	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:typename:int	file:
-__anon4e7b1b580403	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	function	function:test::__anon4e7b1b580303	file:	end:15
+__anon4e7b1b580403	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	function	function:test::__anon4e7b1b580303	file:	captures:[a,b]	end:15
 c	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	parameter	function:test::__anon4e7b1b580303::__anon4e7b1b580403	typeref:typename:int	file:
 l4	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	local	function:test::__anon4e7b1b580303	typeref:typename:auto	file:
 l3	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580503	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	end:22
+__anon4e7b1b580503	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	captures:[l1,l2,l3]	end:22
 a	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:typename:int	file:
 b	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:typename:int	file:

--- a/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
@@ -3,17 +3,17 @@ x	input.cpp	/^template<typename T> void call(T x)$/;"	parameter	function:call	ty
 test	input.cpp	/^int test()$/;"	function	typeref:typename:int	signature:()	end:24
 __anon4e7b1b580103	input.cpp	/^	auto l1 = [] { return 0; };$/;"	function	function:test	file:	captures:[] 	end:10
 l1	input.cpp	/^	auto l1 = [] { return 0; };$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580203	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	function	function:test	file:	captures:[]	end:12
+__anon4e7b1b580203	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	function	function:test	file:	signature:(int a,int b) 	captures:[]	end:12
 a	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:typename:int	file:
 b	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:typename:int	file:
 l2	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580303	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	captures:[=]	end:17
+__anon4e7b1b580303	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	signature:(int a,int b) 	captures:[=]	end:17
 a	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:typename:int	file:
 b	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:typename:int	file:
-__anon4e7b1b580403	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	function	function:test::__anon4e7b1b580303	file:	captures:[a,b]	end:15
+__anon4e7b1b580403	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	function	function:test::__anon4e7b1b580303	file:	signature:(int c)	captures:[a,b]	end:15
 c	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	parameter	function:test::__anon4e7b1b580303::__anon4e7b1b580403	typeref:typename:int	file:
 l4	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	local	function:test::__anon4e7b1b580303	typeref:typename:auto	file:
 l3	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580503	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	captures:[l1,l2,l3]	end:22
+__anon4e7b1b580503	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	signature:(int a,int b) 	captures:[l1,l2,l3]	end:22
 a	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:typename:int	file:
 b	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:typename:int	file:

--- a/Units/parser-cxx.r/function-return-types.d/args.ctags
+++ b/Units/parser-cxx.r/function-return-types.d/args.ctags
@@ -1,3 +1,3 @@
 --sort=no
 --kinds-C++=fpm
---fields=+t
+--fields=+t{c++.template}

--- a/Units/parser-cxx.r/function-return-types.d/args.ctags
+++ b/Units/parser-cxx.r/function-return-types.d/args.ctags
@@ -1,3 +1,3 @@
 --sort=no
 --kinds-C++=fpm
---fields=+t{c++.template}
+--fields=+t{c++.template}{c++.end}

--- a/Units/parser-cxx.r/function-return-types.d/expected.tags
+++ b/Units/parser-cxx.r/function-return-types.d/expected.tags
@@ -17,22 +17,22 @@ p15	input.cpp	/^Union p15();$/;"	p	typeref:typename:Union	file:
 p16	input.cpp	/^Class & p16();$/;"	p	typeref:typename:Class &	file:
 p17	input.cpp	/^const enum Enum p17();$/;"	p	typeref:typename:const enum Enum	file:
 p18	input.cpp	/^Enum p18();$/;"	p	typeref:typename:Enum	file:
-f00	input.cpp	/^void f00()$/;"	f	typeref:typename:void
-f01	input.cpp	/^int f01()$/;"	f	typeref:typename:int
-f02	input.cpp	/^unsigned int f02()$/;"	f	typeref:typename:unsigned int
-f03	input.cpp	/^auto f03() -> int$/;"	f	typeref:typename:int
-f04	input.cpp	/^int * f04()$/;"	f	typeref:typename:int *
-f05	input.cpp	/^const unsigned long long int & f05()$/;"	f	typeref:typename:const unsigned long long int &
-f06	input.cpp	/^static inline int * f06()$/;"	f	typeref:typename:int *	file:
-f07	input.cpp	/^std::string & f07()$/;"	f	typeref:typename:std::string &
-f08	input.cpp	/^std::vector<std::string> * f08()$/;"	f	typeref:typename:std::vector<std::string> *
-p09	input.cpp	/^auto p09() -> std::vector<std::string> ***$/;"	f	typeref:typename:std::vector<std::string> ***
-f10	input.cpp	/^auto f10() -> std::string$/;"	f	typeref:typename:std::string
-f11	input.cpp	/^auto f11() -> int (*)(int)$/;"	f	typeref:typename:int (*)(int)
-f13	input.cpp	/^template<typename A> std::vector<A> * f13()$/;"	f	typeref:typename:std::vector<A> *	template:<typename A>
-f14	input.cpp	/^template<typename A> auto f14() -> std::vector<A> *$/;"	f	typeref:typename:std::vector<A> *	template:<typename A>
+f00	input.cpp	/^void f00()$/;"	f	typeref:typename:void	end:43
+f01	input.cpp	/^int f01()$/;"	f	typeref:typename:int	end:48
+f02	input.cpp	/^unsigned int f02()$/;"	f	typeref:typename:unsigned int	end:53
+f03	input.cpp	/^auto f03() -> int$/;"	f	typeref:typename:int	end:58
+f04	input.cpp	/^int * f04()$/;"	f	typeref:typename:int *	end:63
+f05	input.cpp	/^const unsigned long long int & f05()$/;"	f	typeref:typename:const unsigned long long int &	end:69
+f06	input.cpp	/^static inline int * f06()$/;"	f	typeref:typename:int *	file:	end:74
+f07	input.cpp	/^std::string & f07()$/;"	f	typeref:typename:std::string &	end:80
+f08	input.cpp	/^std::vector<std::string> * f08()$/;"	f	typeref:typename:std::vector<std::string> *	end:85
+p09	input.cpp	/^auto p09() -> std::vector<std::string> ***$/;"	f	typeref:typename:std::vector<std::string> ***	end:90
+f10	input.cpp	/^auto f10() -> std::string$/;"	f	typeref:typename:std::string	end:96
+f11	input.cpp	/^auto f11() -> int (*)(int)$/;"	f	typeref:typename:int (*)(int)	end:101
+f13	input.cpp	/^template<typename A> std::vector<A> * f13()$/;"	f	typeref:typename:std::vector<A> *	template:<typename A>	end:106
+f14	input.cpp	/^template<typename A> auto f14() -> std::vector<A> *$/;"	f	typeref:typename:std::vector<A> *	template:<typename A>	end:111
 m00	input.cpp	/^	void m00();$/;"	p	class:X	typeref:typename:void	file:
-m01	input.cpp	/^	constexpr int m01(){ return 0; };$/;"	f	class:X	typeref:typename:int	file:
+m01	input.cpp	/^	constexpr int m01(){ return 0; };$/;"	f	class:X	typeref:typename:int	file:	end:117
 m02	input.cpp	/^	unsigned int m02();$/;"	p	class:X	typeref:typename:unsigned int	file:
 m03	input.cpp	/^	static auto m03() -> int;$/;"	p	class:X	typeref:typename:int	file:
 m04	input.cpp	/^	int * m04();$/;"	p	class:X	typeref:typename:int *	file:

--- a/Units/parser-cxx.r/function-return-types.d/expected.tags
+++ b/Units/parser-cxx.r/function-return-types.d/expected.tags
@@ -29,8 +29,8 @@ f08	input.cpp	/^std::vector<std::string> * f08()$/;"	f	typeref:typename:std::vec
 p09	input.cpp	/^auto p09() -> std::vector<std::string> ***$/;"	f	typeref:typename:std::vector<std::string> ***
 f10	input.cpp	/^auto f10() -> std::string$/;"	f	typeref:typename:std::string
 f11	input.cpp	/^auto f11() -> int (*)(int)$/;"	f	typeref:typename:int (*)(int)
-f13	input.cpp	/^template<typename A> std::vector<A> * f13()$/;"	f	typeref:typename:std::vector<A> *
-f14	input.cpp	/^template<typename A> auto f14() -> std::vector<A> *$/;"	f	typeref:typename:std::vector<A> *
+f13	input.cpp	/^template<typename A> std::vector<A> * f13()$/;"	f	typeref:typename:std::vector<A> *	template:<typename A>
+f14	input.cpp	/^template<typename A> auto f14() -> std::vector<A> *$/;"	f	typeref:typename:std::vector<A> *	template:<typename A>
 m00	input.cpp	/^	void m00();$/;"	p	class:X	typeref:typename:void	file:
 m01	input.cpp	/^	constexpr int m01(){ return 0; };$/;"	f	class:X	typeref:typename:int	file:
 m02	input.cpp	/^	unsigned int m02();$/;"	p	class:X	typeref:typename:unsigned int	file:

--- a/Units/parser-cxx.r/functions.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/functions.cpp.d/args.ctags
@@ -1,2 +1,2 @@
 --c++-kinds=pfz
---fields=+S
+--fields=+S{c++.end}

--- a/Units/parser-cxx.r/functions.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/functions.cpp.d/expected.tags
@@ -1,18 +1,18 @@
-f01	input.cpp	/^int f01(int f01a01,int f01a02)$/;"	f	typeref:typename:int	signature:(int f01a01,int f01a02)
+f01	input.cpp	/^int f01(int f01a01,int f01a02)$/;"	f	typeref:typename:int	signature:(int f01a01,int f01a02)	end:33
 f01a01	input.cpp	/^int f01(int f01a01,int f01a02)$/;"	z	function:f01	typeref:typename:int	file:
 f01a02	input.cpp	/^int f01(int f01a01,int f01a02)$/;"	z	function:f01	typeref:typename:int	file:
-f02	input.cpp	/^unsigned short int * f02(unsigned int & f02a01,...)$/;"	f	typeref:typename:unsigned short int *	signature:(unsigned int & f02a01,...)
+f02	input.cpp	/^unsigned short int * f02(unsigned int & f02a01,...)$/;"	f	typeref:typename:unsigned short int *	signature:(unsigned int & f02a01,...)	end:38
 f02a01	input.cpp	/^unsigned short int * f02(unsigned int & f02a01,...)$/;"	z	function:f02	typeref:typename:unsigned int &	file:
-f03	input.cpp	/^auto f03(const int & f03a01,void * f03a02) -> const int &$/;"	f	typeref:typename:const int &	signature:(const int & f03a01,void * f03a02)
+f03	input.cpp	/^auto f03(const int & f03a01,void * f03a02) -> const int &$/;"	f	typeref:typename:const int &	signature:(const int & f03a01,void * f03a02)	end:43
 f03a01	input.cpp	/^auto f03(const int & f03a01,void * f03a02) -> const int &$/;"	z	function:f03	typeref:typename:const int &	file:
 f03a02	input.cpp	/^auto f03(const int & f03a01,void * f03a02) -> const int &$/;"	z	function:f03	typeref:typename:void *	file:
-f04	input.cpp	/^auto f04() -> int (*)(int)$/;"	f	typeref:typename:int (*)(int)	signature:()
-f05	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	f	typeref:typename:std::string	file:	signature:(const int *** f05a01)
+f04	input.cpp	/^auto f04() -> int (*)(int)$/;"	f	typeref:typename:int (*)(int)	signature:()	end:48
+f05	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	f	typeref:typename:std::string	file:	signature:(const int *** f05a01)	end:53
 f05a01	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	z	function:f05	typeref:typename:const int ***	file:
 f06	input.cpp	/^		auto f06(n01::c01 && f06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && f06a01)
-f06	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	f	class:n01::n02	typeref:typename:n01::n02::type01 *	signature:(n01::c01 && f06a01)
+f06	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	f	class:n01::n02	typeref:typename:n01::n02::type01 *	signature:(n01::c01 && f06a01)	end:58
 f06a01	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	z	function:n01::n02::f06	typeref:typename:n01::c01 &&	file:
-f07	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	f	typeref:typename:unsigned int	signature:(int (*f07a01)(int * x1,int x2),...)
+f07	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	f	typeref:typename:unsigned int	signature:(int (*f07a01)(int * x1,int x2),...)	end:63
 f07a01	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	z	function:f07	typeref:typename:int (*)(int * x1,int x2)	file:
 p01	input.cpp	/^int p01(int p01a01,int p01a02);$/;"	p	typeref:typename:int	file:	signature:(int p01a01,int p01a02)
 p02	input.cpp	/^unsigned short int * p02(unsigned int & p02a01,...);$/;"	p	typeref:typename:unsigned short int *	file:	signature:(unsigned int & p02a01,...)
@@ -22,7 +22,7 @@ p05	input.cpp	/^static std::string p05(const int *** p05a01);$/;"	p	typeref:type
 p06	input.cpp	/^		auto p06(n01::c01 && p06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && p06a01)
 p06	input.cpp	/^auto n01::n02::p06(n01::c01 && p06a01) -> n01::n02::type01 *;$/;"	p	typeref:typename:n01::n02::type01 *	file:	signature:(n01::c01 && p06a01)
 p07	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	p	typeref:typename:unsigned int	file:	signature:(int (*p07a01)(int * x1,int x2),...)
-t01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t01a01)
+t01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t01a01)	end:69
 t01a01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	z	function:t01	typeref:typename:T &&	file:
-t02	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t02a01)
+t02	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t02a01)	end:74
 t02a01	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	z	function:t02	typeref:typename:T &&	file:

--- a/Units/parser-cxx.r/namespace.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/namespace.cpp.d/args.ctags
@@ -1,2 +1,3 @@
 --extra=+q
 --sort=no
+--fields=+{c++.end}

--- a/Units/parser-cxx.r/namespace.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/namespace.cpp.d/expected.tags
@@ -1,10 +1,10 @@
-__anon396601200108	input.cpp	/^namespace {$/;"	n	file:
-anon_f	input.cpp	/^	void anon_f() { }$/;"	f	namespace:__anon396601200108	typeref:typename:void
+__anon396601200108	input.cpp	/^namespace {$/;"	n	file:	end:3
+anon_f	input.cpp	/^	void anon_f() { }$/;"	f	namespace:__anon396601200108	typeref:typename:void	end:2
 __anon396601200108::anon_f	input.cpp	/^	void anon_f() { }$/;"	f	namespace:__anon396601200108	typeref:typename:void
-a	input.cpp	/^namespace a {$/;"	n	file:
-a_f	input.cpp	/^	void a_f() { }$/;"	f	namespace:a	typeref:typename:void
+a	input.cpp	/^namespace a {$/;"	n	file:	end:10
+a_f	input.cpp	/^	void a_f() { }$/;"	f	namespace:a	typeref:typename:void	end:6
 a::a_f	input.cpp	/^	void a_f() { }$/;"	f	namespace:a	typeref:typename:void
-b	input.cpp	/^	namespace b {$/;"	n	namespace:a	file:
+b	input.cpp	/^	namespace b {$/;"	n	namespace:a	file:	end:9
 a::b	input.cpp	/^	namespace b {$/;"	n	namespace:a	file:
-a_b_f	input.cpp	/^		void a_b_f() { }$/;"	f	namespace:a::b	typeref:typename:void
+a_b_f	input.cpp	/^		void a_b_f() { }$/;"	f	namespace:a::b	typeref:typename:void	end:8
 a::b::a_b_f	input.cpp	/^		void a_b_f() { }$/;"	f	namespace:a::b	typeref:typename:void

--- a/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/args.ctags
@@ -1,3 +1,3 @@
 --c++-kinds=+cfl
---fields=+SsK
+--fields=+SsK{c++.captures}
 --sort=no

--- a/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/expected.tags
@@ -5,6 +5,6 @@ b	input.cpp	/^    Bar<int> b;$/;"	local	function:f1	typeref:typename:Bar<int>	fi
 t	input.cpp	/^    auto t = b.template foo<int>();$/;"	local	function:f1	typeref:typename:auto	file:
 f2	input.cpp	/^int f2()$/;"	function	typeref:typename:int	signature:()
 b	input.cpp	/^    Bar<int> b;$/;"	local	function:f2	typeref:typename:Bar<int>	file:
-__anon1763e7850103	input.cpp	/^    auto l = [](auto & p){ return p.template foo<int>();};$/;"	function	function:f2	file:
+__anon1763e7850103	input.cpp	/^    auto l = [](auto & p){ return p.template foo<int>();};$/;"	function	function:f2	file:	signature:(auto & p)	captures:[]
 l	input.cpp	/^    auto l = [](auto & p){ return p.template foo<int>();};$/;"	local	function:f2	typeref:typename:auto	file:
 main	input.cpp	/^int main()$/;"	function	typeref:typename:int	signature:()

--- a/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/args.ctags
@@ -1,3 +1,3 @@
 --c++-kinds=+cfl
---fields=+SsK{c++.template}
+--fields=+SsK{c++.template}{c++.captures}{c++.end}
 --sort=no

--- a/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/args.ctags
@@ -1,3 +1,3 @@
 --c++-kinds=+cfl
---fields=+SsK
+--fields=+SsK{c++.template}
 --sort=no

--- a/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/expected.tags
@@ -1,5 +1,5 @@
 Foo	input.cpp	/^namespace Foo$/;"	namespace	file:
-bar	input.cpp	/^T bar() $/;"	function	namespace:Foo	typeref:typename:T	signature:()
+bar	input.cpp	/^T bar() $/;"	function	namespace:Foo	typeref:typename:T	signature:()	template:<class T>
 main	input.cpp	/^int main()$/;"	function	typeref:typename:int	signature:()
 __anonaa3dc9860103	input.cpp	/^    auto l = []{return Foo::template bar<int>();};$/;"	function	function:main	file:
 l	input.cpp	/^    auto l = []{return Foo::template bar<int>();};$/;"	local	function:main	typeref:typename:auto	file:

--- a/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/expected.tags
@@ -1,5 +1,5 @@
-Foo	input.cpp	/^namespace Foo$/;"	namespace	file:
-bar	input.cpp	/^T bar() $/;"	function	namespace:Foo	typeref:typename:T	signature:()	template:<class T>
-main	input.cpp	/^int main()$/;"	function	typeref:typename:int	signature:()
-__anonaa3dc9860103	input.cpp	/^    auto l = []{return Foo::template bar<int>();};$/;"	function	function:main	file:
+Foo	input.cpp	/^namespace Foo$/;"	namespace	file:	end:10
+bar	input.cpp	/^T bar() $/;"	function	namespace:Foo	typeref:typename:T	signature:()	template:<class T>	end:9
+main	input.cpp	/^int main()$/;"	function	typeref:typename:int	signature:()	end:16
+__anonaa3dc9860103	input.cpp	/^    auto l = []{return Foo::template bar<int>();};$/;"	function	function:main	file:	captures:[]	end:14
 l	input.cpp	/^    auto l = []{return Foo::template bar<int>();};$/;"	local	function:main	typeref:typename:auto	file:

--- a/Units/parser-cxx.r/templates.d/args.ctags
+++ b/Units/parser-cxx.r/templates.d/args.ctags
@@ -1,3 +1,4 @@
 --sort=no
 --extra=+q
 --kinds-C++=*
+--fields=+{c++.template}

--- a/Units/parser-cxx.r/templates.d/expected.tags
+++ b/Units/parser-cxx.r/templates.d/expected.tags
@@ -1,10 +1,10 @@
-zero	input.cpp	/^zero (const T &v1, const T &v2)$/;"	f	typeref:typename:int
+zero	input.cpp	/^zero (const T &v1, const T &v2)$/;"	f	typeref:typename:int	template:<typename T>
 v1	input.cpp	/^zero (const T &v1, const T &v2)$/;"	z	function:zero	typeref:typename:const T &	file:
 v2	input.cpp	/^zero (const T &v1, const T &v2)$/;"	z	function:zero	typeref:typename:const T &	file:
-min	input.cpp	/^min(const T&v1, const T&v2)$/;"	f	typeref:typename:T
+min	input.cpp	/^min(const T&v1, const T&v2)$/;"	f	typeref:typename:T	template:<typename T>
 v1	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:typename:const T &	file:
 v2	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:typename:const T &	file:
-Item	input.cpp	/^class Item$/;"	c	file:
+Item	input.cpp	/^class Item$/;"	c	file:	template:<class Type>
 Item	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	f	class:Item	file:
 Item::Item	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	f	class:Item	file:
 t	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	z	function:Item::Item	typeref:typename:const Type &	file:

--- a/Units/parser-cxx.r/templates2.d/args.ctags
+++ b/Units/parser-cxx.r/templates2.d/args.ctags
@@ -1,3 +1,4 @@
 --sort=no
 --extra=+q
 --kinds-C++=*
+--fields=+{c++.template}

--- a/Units/parser-cxx.r/templates2.d/expected.tags
+++ b/Units/parser-cxx.r/templates2.d/expected.tags
@@ -1,6 +1,6 @@
-foo1	input.cpp	/^auto foo1(const Container<Elem> & p_container)$/;"	f	typeref:typename:auto
+foo1	input.cpp	/^auto foo1(const Container<Elem> & p_container)$/;"	f	typeref:typename:auto	template:<template<class...> class Container,class Elem>
 p_container	input.cpp	/^auto foo1(const Container<Elem> & p_container)$/;"	z	function:foo1	typeref:typename:const Container<Elem> &	file:
-foo2	input.cpp	/^auto foo2(const Container<Key,Elem> & p_container)$/;"	f	typeref:typename:auto
+foo2	input.cpp	/^auto foo2(const Container<Key,Elem> & p_container)$/;"	f	typeref:typename:auto	template:<template<class...> class Container,class Key,class Elem>
 p_container	input.cpp	/^auto foo2(const Container<Key,Elem> & p_container)$/;"	z	function:foo2	typeref:typename:const Container<Key,Elem> &	file:
 bar	input.cpp	/^void bar()$/;"	f	typeref:typename:void
 main	input.cpp	/^int main()$/;"	f	typeref:typename:int

--- a/Units/parser-cxx.r/templates3.d/args.ctags
+++ b/Units/parser-cxx.r/templates3.d/args.ctags
@@ -1,3 +1,4 @@
 --sort=no
 --extra=+q
 --kinds-C++=*
+--fields=+{c++.template}

--- a/Units/parser-cxx.r/templates3.d/expected.tags
+++ b/Units/parser-cxx.r/templates3.d/expected.tags
@@ -1,4 +1,4 @@
-makeArrayRef	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	f	typeref:typename:boost::disable_if_c<N==1,ArrayRef<ValueType,SizeType>>::type
+makeArrayRef	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	f	typeref:typename:boost::disable_if_c<N==1,ArrayRef<ValueType,SizeType>>::type	template:<typename ValueType,int N,typename SizeType>
 p_data	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	z	function:makeArrayRef	typeref:typename:ValueType (&)[N]	file:
 p_size	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	z	function:makeArrayRef	typeref:typename:SizeType &	file:
 foo	input.cpp	/^void foo()$/;"	f	typeref:typename:void

--- a/main/entry.c
+++ b/main/entry.c
@@ -1156,13 +1156,11 @@ static int writeCtagsEntry (const tagEntryInfo *const tag)
 
 extern void attachParserField (tagEntryInfo *const tag, fieldType ftype, const char * value)
 {
-	unsigned int index;
+	Assert (tag->usedParserFields < PRE_ALLOCATED_PARSER_FIELDS);
 
-	Assert (tag->usedParserFields + 1 < PRE_ALLOCATED_PARSER_FIELDS);
-
-	index = tag->usedParserFields++;
-	tag->parserFields [index].ftype = ftype;
-	tag->parserFields [index].value = value;
+	tag->parserFields [tag->usedParserFields].ftype = ftype;
+	tag->parserFields [tag->usedParserFields].value = value;
+	tag->usedParserFields++;
 }
 
 static void copyParserFields (const tagEntryInfo *const tag, tagEntryInfo* slot)

--- a/main/entry.c
+++ b/main/entry.c
@@ -1163,6 +1163,23 @@ extern void attachParserField (tagEntryInfo *const tag, fieldType ftype, const c
 	tag->usedParserFields++;
 }
 
+extern void attachParserFieldToCorkEntry (int index,
+					 fieldType type,
+					 const char *value)
+{
+	tagEntryInfo * tag;
+	const char * v;
+
+	if (index == SCOPE_NIL)
+		return;
+
+	tag = getEntryInCorkQueue(index);
+	Assert (tag != NULL);
+
+	v = eStrdup (value);
+	attachParserField (tag, type, v);
+}
+
 static void copyParserFields (const tagEntryInfo *const tag, tagEntryInfo* slot)
 {
 	unsigned int i;

--- a/main/entry.h
+++ b/main/entry.h
@@ -158,6 +158,7 @@ extern void    markTagExtraBit     (tagEntryInfo *const tag, xtagType extra);
 extern boolean isTagExtraBitMarked (const tagEntryInfo *const tag, xtagType extra);
 
 extern void attachParserField (tagEntryInfo *const tag, fieldType ftype, const char* value);
+extern void attachParserFieldToCorkEntry (int index, fieldType ftype, const char* value);
 
 #endif  /* CTAGS_MAIN_ENTRY_H */
 

--- a/main/field.c
+++ b/main/field.c
@@ -778,15 +778,4 @@ extern int defineField (fieldSpec *spec, int language)
 	return spec->ftype;
 }
 
-extern int attachField (fieldType type, struct sTagEntryInfo *const tag,
-			const char *value)
-{
-	Assert (tag->usedParserFields < PRE_ALLOCATED_PARSER_FIELDS);
-	Assert (tag);
-
-	tag->parserFields [ tag->usedParserFields ].ftype = type;
-	tag->parserFields [ tag->usedParserFields ].value = value;
-	return tag->usedParserFields++;
-}
-
 /* vi:set tabstop=4 shiftwidth=4: */

--- a/main/field.c
+++ b/main/field.c
@@ -781,7 +781,7 @@ extern int defineField (fieldSpec *spec, int language)
 extern int attachField (fieldType type, struct sTagEntryInfo *const tag,
 			const char *value)
 {
-	Assert (tag->usedParserFields + 1 < PRE_ALLOCATED_PARSER_FIELDS);
+	Assert (tag->usedParserFields < PRE_ALLOCATED_PARSER_FIELDS);
 	Assert (tag);
 
 	tag->parserFields [ tag->usedParserFields ].ftype = type;

--- a/main/field.h
+++ b/main/field.h
@@ -90,9 +90,6 @@ extern int countFields (void);
 /* language should be typed to langType.
    Use int here to avoid circular dependency */
 extern int defineField (fieldSpec *spec, int language);
-extern int attachField (fieldType type, struct sTagEntryInfo *const tag,
-			const char *value);
-
 extern fieldType nextFieldSibling (fieldType type);
 
 #endif	/* CTAGS_MAIN_FIELD_H */

--- a/main/parse.c
+++ b/main/parse.c
@@ -1328,7 +1328,7 @@ static void installFieldSpec (const langType language)
 
 	Assert (0 <= language  &&  language < (int) LanguageCount);
 	parser = LanguageTable [language];
-	if (! (parser->fieldSpecCount < PRE_ALLOCATED_PARSER_FIELDS))
+	if (parser->fieldSpecCount > PRE_ALLOCATED_PARSER_FIELDS)
 		error (FATAL,
 		       "INTERNAL ERROR: in a parser, fields are defined more than PRE_ALLOCATED_PARSER_FIELDS\n");
 

--- a/parsers/cxx/cxx.c
+++ b/parsers/cxx/cxx.c
@@ -87,6 +87,8 @@ parserDefinition * CParser (void)
 
 	def->kinds = cxxTagGetKindOptions();
 	def->kindCount = cxxTagGetKindOptionCount();
+	def->fieldSpecs = cxxTagGetCFieldSpecifiers();
+	def->fieldSpecCount = cxxTagGetCFieldSpecifierCount();
 	def->extensions = extensions;
 	def->parser2 = cxxCParserMain;
 	def->initialize = cxxCParserInitialize;

--- a/parsers/cxx/cxx.c
+++ b/parsers/cxx/cxx.c
@@ -85,12 +85,12 @@ parserDefinition * CParser (void)
 
 	parserDefinition* def = parserNew("C");
 
-	def->kinds      = cxxTagGetKindOptions();
-	def->kindCount  = cxxTagGetKindOptionCount();
+	def->kinds = cxxTagGetKindOptions();
+	def->kindCount = cxxTagGetKindOptionCount();
 	def->extensions = extensions;
-	def->parser2    = cxxCParserMain;
+	def->parser2 = cxxCParserMain;
 	def->initialize = cxxCParserInitialize;
-	def->finalize   = cxxParserCleanup;
+	def->finalize = cxxParserCleanup;
 	def->selectLanguage = selectors;
 	def->useCork = TRUE; // We use corking to block output until the end of file
 
@@ -113,12 +113,14 @@ parserDefinition * CppParser (void)
 
 	parserDefinition* def = parserNew("C++");
 
-	def->kinds      = cxxTagGetKindOptions();
-	def->kindCount  = cxxTagGetKindOptionCount();
+	def->kinds = cxxTagGetKindOptions();
+	def->kindCount = cxxTagGetKindOptionCount();
+	def->fieldSpecs = cxxTagGetCPPFieldSpecifiers();
+	def->fieldSpecCount = cxxTagGetCPPFieldSpecifierCount();
 	def->extensions = extensions;
-	def->parser2    = cxxCppParserMain;
+	def->parser2 = cxxCppParserMain;
 	def->initialize = cxxCppParserInitialize;
-	def->finalize   = cxxParserCleanup;
+	def->finalize = cxxParserCleanup;
 	def->selectLanguage = selectors;
 	def->useCork = TRUE; // We use corking to block output until the end of file
 

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -258,30 +258,16 @@ void cxxParserMarkEndLineForTagInCorkQueue(int iCorkQueueIndex)
 		if(!cxxTagCPPFieldEnabled(CXXTagCPPFieldEndLine))
 			return;
 
-		tagEntryInfo * e = getEntryInCorkQueue(iCorkQueueIndex);
-		if(!e)
-		{
-			CXX_DEBUG_PRINT("WARNING: Could not find class tag entry in cork queue!");
-			return;
-		}
-
 		sprintf(buf,"%ld",getInputLineNumber());
-		cxxTagSetCorkQueueCPPField(e,CXXTagCPPFieldEndLine,buf);
+		cxxTagSetCorkQueueCPPField(iCorkQueueIndex,CXXTagCPPFieldEndLine,buf);
 		return;
 	}
 
 	if(!cxxTagCFieldEnabled(CXXTagCFieldEndLine))
 		return;
 
-	tagEntryInfo * e = getEntryInCorkQueue(iCorkQueueIndex);
-	if(!e)
-	{
-		CXX_DEBUG_PRINT("WARNING: Could not find class tag entry in cork queue!");
-		return;
-	}
-
 	sprintf(buf,"%ld",getInputLineNumber());
-	cxxTagSetCorkQueueCField(e,CXXTagCFieldEndLine,buf);
+	cxxTagSetCorkQueueCField(iCorkQueueIndex,CXXTagCFieldEndLine,buf);
 }
 
 //

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -737,6 +737,19 @@ boolean cxxParserParseClassStructOrUnion(
 			}
 		}
 
+		if(
+			g_cxx.pTemplateTokenChain && (g_cxx.pTemplateTokenChain->iCount > 0) &&
+			cxxTagCPPFieldEnabled(CXXTagCPPFieldTemplate)
+		)
+		{
+			cxxTokenChainNormalizeTypeNameSpacing(g_cxx.pTemplateTokenChain);
+			cxxTokenChainCondense(g_cxx.pTemplateTokenChain,0);
+			cxxTagSetCPPField(
+					CXXTagCPPFieldTemplate,
+					vStringValue(cxxTokenChainFirst(g_cxx.pTemplateTokenChain)->pszWord)
+				);
+		}
+
 		tag->isFileScope = !isInputHeaderFile();
 
 		cxxTagCommit();

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -961,6 +961,20 @@ int cxxParserEmitFunctionTags(
 		if(pszSignature)
 			tag->extensionFields.signature = vStringValue(pszSignature);
 
+		if(
+			g_cxx.pTemplateTokenChain && (g_cxx.pTemplateTokenChain->iCount > 0) &&
+			cxxParserCurrentLanguageIsCPP() &&
+			cxxTagCPPFieldEnabled(CXXTagCPPFieldTemplate)
+		)
+		{
+			cxxTokenChainNormalizeTypeNameSpacing(g_cxx.pTemplateTokenChain);
+			cxxTokenChainCondense(g_cxx.pTemplateTokenChain,0);
+			cxxTagSetCPPField(
+					CXXTagCPPFieldTemplate,
+					vStringValue(cxxTokenChainFirst(g_cxx.pTemplateTokenChain)->pszWord)
+				);
+		}
+
 		cxxTagCommit();
 
 		if(pszSignature)

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -32,7 +32,7 @@
 // Returns -1 in case of error, 1 if a K&R style function declaration has been
 // found and parsed, 0 if no K&R style function declaration has been found.
 //
-int cxxParserMaybeExtractKnRStyleFunctionDefinition(void)
+int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 {
 #ifdef CXX_DO_DEBUGGING
 	vString * pChain = cxxTokenChainJoin(g_cxx.pTokenChain,NULL,0);
@@ -42,6 +42,9 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(void)
 		);
 	vStringDelete(pChain);
 #endif
+
+	if(piCorkQueueIndex)
+		*piCorkQueueIndex = SCOPE_NIL;
 
 	// Check if we are in the following situation:
 	//
@@ -284,7 +287,11 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(void)
 
 		if(pszSignature)
 			tag->extensionFields.signature = vStringValue(pszSignature);
-		cxxTagCommit();
+
+		int iCorkQueueIndex = cxxTagCommit();
+
+		if(piCorkQueueIndex)
+			*piCorkQueueIndex = iCorkQueueIndex;
 
 		if(pszSignature)
 			vStringDelete(pszSignature);
@@ -862,12 +869,16 @@ next_token:
 int cxxParserEmitFunctionTags(
 		CXXFunctionSignatureInfo * pInfo,
 		enum CXXTagKind eTagKind,
-		unsigned int uOptions
+		unsigned int uOptions,
+		int * piCorkQueueIndex
 	)
 {
 	CXX_DEBUG_ENTER();
 
 	int iScopesPushed = 0;
+	
+	if(piCorkQueueIndex)
+		*piCorkQueueIndex = SCOPE_NIL;
 
 	enum CXXTagKind eOuterScopeKind = cxxScopeGetKind();
 
@@ -975,7 +986,10 @@ int cxxParserEmitFunctionTags(
 				);
 		}
 
-		cxxTagCommit();
+		int iCorkQueueIndex = cxxTagCommit();
+
+		if(piCorkQueueIndex)
+			*piCorkQueueIndex = iCorkQueueIndex;
 
 		if(pszSignature)
 			vStringDelete(pszSignature);
@@ -983,6 +997,7 @@ int cxxParserEmitFunctionTags(
 		if(pTypeName)
 			cxxTokenDestroy(pTypeName);
 	}
+
 
 #ifdef CXX_DO_DEBUGGING
 	if(eTagKind == CXXTagKindFUNCTION)
@@ -1012,7 +1027,7 @@ int cxxParserEmitFunctionTags(
 // and push all the necessary scopes for the next block. It returns the number
 // of scopes pushed.
 //
-int cxxParserExtractFunctionSignatureBeforeOpeningBracket(void)
+int cxxParserExtractFunctionSignatureBeforeOpeningBracket(int * piCorkQueueIndex)
 {
 	CXX_DEBUG_ENTER();
 
@@ -1048,7 +1063,8 @@ int cxxParserExtractFunctionSignatureBeforeOpeningBracket(void)
 	int iScopesPushed = cxxParserEmitFunctionTags(
 			&oInfo,
 			CXXTagKindFUNCTION,
-			CXXEmitFunctionTagsPushScopes
+			CXXEmitFunctionTagsPushScopes,
+			piCorkQueueIndex
 		);
 
 #ifdef CXX_DO_DEBUGGING

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -82,8 +82,8 @@ typedef struct _CXXFunctionSignatureInfo
 
 } CXXFunctionSignatureInfo;
 
-int cxxParserMaybeExtractKnRStyleFunctionDefinition(void);
-int cxxParserExtractFunctionSignatureBeforeOpeningBracket(void);
+int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex);
+int cxxParserExtractFunctionSignatureBeforeOpeningBracket(int * piCorkQueueIndex);
 
 #define CXX_MAX_EXTRACTED_PARAMETERS 24
 
@@ -121,7 +121,8 @@ enum CXXEmitFunctionTagsOptions
 int cxxParserEmitFunctionTags(
 		CXXFunctionSignatureInfo * pInfo,
 		enum CXXTagKind eTagKind,
-		unsigned int uOptions
+		unsigned int uOptions,
+		int * piCorkQueueIndex
 	);
 
 void cxxParserEmitFunctionParameterTags(CXXFunctionParameterInfo * pInfo);
@@ -156,6 +157,7 @@ boolean cxxParserParseAndCondenseSubchainsUpToOneOf(
 		unsigned int uTokenTypes,
 		unsigned int uInitialSubchainMarkerTypes
 	);
+void cxxParserMarkEndLineForTagInCorkQueue(int iCorkQueueIndex);
 
 typedef enum _CXXParserKeywordState
 {

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -171,10 +171,22 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 				);
 		}
 
+		// FIXME: Return type!
+
+		vString * pszSignature = NULL;
+		if(cxxTokenTypeIs(pParenthesis,CXXTokenTypeParenthesisChain))
+			pszSignature = cxxTokenChainJoin(pParenthesis->pChain,NULL,0);
+
+		if(pszSignature)
+			tag->extensionFields.signature = vStringValue(pszSignature);
+
 		iCorkQueueIndex = cxxTagCommit();
 
 		if(pTypeName)
 			cxxTokenDestroy(pTypeName);
+
+		if(pszSignature)
+			vStringDelete(pszSignature);
 	}
 
 	cxxScopePush(

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -76,6 +76,7 @@ CXXToken * cxxParserOpeningBracketIsLambda(void)
 	return NULL;
 }
 
+// In case of a lambda without parentheses this is the capture list token.
 boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 {
 	CXX_DEBUG_ENTER();
@@ -89,6 +90,24 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 	tagEntryInfo * tag = cxxTagBegin(CXXTagKindFUNCTION,pIdentifier);
 
 	CXXToken * pAfterParenthesis = pParenthesis ? pParenthesis->pNext : NULL;
+
+	CXXToken * pCaptureList = NULL;
+	
+	if(pParenthesis)
+	{
+		if(cxxTokenTypeIs(pParenthesis,CXXTokenTypeSquareParenthesisChain))
+		{
+			// form (4) of lambda (see cxxParserOpeningBracketIsLambda()).
+			pCaptureList = pParenthesis;
+		} else if(
+			pParenthesis->pPrev &&
+			cxxTokenTypeIs(pParenthesis->pPrev,CXXTokenTypeSquareParenthesisChain)
+		)
+		{
+			// other forms of lambda (see cxxParserOpeningBracketIsLambda()).
+			pCaptureList = pParenthesis->pPrev;
+		}
+	}
 
 	if(
 		pAfterParenthesis &&
@@ -130,7 +149,6 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 		tag->isFileScope = TRUE;
 
 		// FIXME: Signature!
-		// FIXME: Captures?
 
 		CXXToken * pTypeName;
 
@@ -138,6 +156,20 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 			pTypeName = cxxTagSetTypeField(tag,pTypeStart,pTypeEnd);
 		else
 			pTypeName = NULL;
+
+		if(pCaptureList && cxxTagCPPFieldEnabled(CXXTagCPPFieldLambdaCaptureList))
+		{
+			CXX_DEBUG_ASSERT(pCaptureList->pChain,"The capture list must be a chain");
+			cxxTokenChainCondense(pCaptureList->pChain,0);
+			CXX_DEBUG_ASSERT(
+					cxxTokenChainFirst(pCaptureList->pChain),
+					"Condensation should have created a single token in the chain"
+				);
+			cxxTagSetCPPField(
+					CXXTagCPPFieldLambdaCaptureList,
+					vStringValue(cxxTokenChainFirst(pCaptureList->pChain)->pszWord)
+				);
+		}
 
 		iCorkQueueIndex = cxxTagCommit();
 
@@ -151,12 +183,12 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 			CXXScopeAccessUnknown
 		);
 
-	if(pParenthesis && cxxTagKindEnabled(CXXTagKindPARAMETER))
+	if(
+		pParenthesis &&
+		cxxTokenTypeIs(pParenthesis,CXXTokenTypeParenthesisChain) &&
+		cxxTagKindEnabled(CXXTagKindPARAMETER)
+	)
 	{
-		CXX_DEBUG_ASSERT(
-				pParenthesis->eType == CXXTokenTypeParenthesisChain,
-				"The parameter must be really a parenthesis chain"
-			);
 		CXXFunctionParameterInfo oParamInfo;
 		if(cxxParserTokenChainLooksLikeFunctionParameterList(
 				pParenthesis->pChain,&oParamInfo

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -148,8 +148,6 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 	{
 		tag->isFileScope = TRUE;
 
-		// FIXME: Signature!
-
 		CXXToken * pTypeName;
 
 		if(pTypeStart)
@@ -170,8 +168,6 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 					vStringValue(cxxTokenChainFirst(pCaptureList->pChain)->pszWord)
 				);
 		}
-
-		// FIXME: Return type!
 
 		vString * pszSignature = NULL;
 		if(cxxTokenTypeIs(pParenthesis,CXXTokenTypeParenthesisChain))

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -123,6 +123,8 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 			pTypeStart = pTypeStart->pNext;
 	}
 
+	int iCorkQueueIndex = SCOPE_NIL;
+
 	if(tag)
 	{
 		tag->isFileScope = TRUE;
@@ -137,7 +139,7 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 		else
 			pTypeName = NULL;
 
-		cxxTagCommit();
+		iCorkQueueIndex = cxxTagCommit();
 
 		if(pTypeName)
 			cxxTokenDestroy(pTypeName);
@@ -163,6 +165,9 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 	}
 
 	boolean bRet = cxxParserParseBlock(TRUE);
+
+	if(iCorkQueueIndex > SCOPE_NIL)
+		cxxParserMarkEndLineForTagInCorkQueue(iCorkQueueIndex);
 
 	cxxScopePop();
 

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -140,7 +140,6 @@ evaluate_current_token:
 				if(iTemplateLevel == 0)
 				{
 					// Non-nested > : always a terminator
-					cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 					CXX_DEBUG_LEAVE_TEXT("Found end of template");
 					return TRUE;
 				}

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -228,14 +228,14 @@ void cxxTagSetCPPField(CXXTagCPPField eField,const char * szValue)
 }
 
 void cxxTagSetCorkQueueCPPField(
-		tagEntryInfo * pTag,
+		int iIndex,
 		CXXTagCPPField eField,
 		const char * szValue
 	)
 {
 	CXX_DEBUG_ASSERT(g_aCXXCPPFields[eField].enabled,"The field must be enabled!");
 
-	attachParserField(pTag,g_aCXXCPPFields[eField].ftype,eStrdup(szValue));
+	attachParserFieldToCorkEntry(iIndex,g_aCXXCPPFields[eField].ftype,szValue);
 }
 
 void cxxTagSetCField(CXXTagCField eField,const char * szValue)
@@ -247,14 +247,14 @@ void cxxTagSetCField(CXXTagCField eField,const char * szValue)
 }
 
 void cxxTagSetCorkQueueCField(
-		tagEntryInfo * pTag,
+		int iIndex,
 		CXXTagCField eField,
 		const char * szValue
 	)
 {
 	CXX_DEBUG_ASSERT(g_aCXXCFields[eField].enabled,"The field must be enabled!");
 
-	attachParserField(pTag,g_aCXXCFields[eField].ftype,eStrdup(szValue));
+	attachParserFieldToCorkEntry(iIndex,g_aCXXCFields[eField].ftype,szValue);
 }
 
 int cxxTagCommit(void)

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -64,6 +64,15 @@ static const char * g_aCXXAccessStrings [] = {
 	"protected",
 };
 
+static fieldSpec g_aCXXCPPFields [] = {
+	{
+		//.letter = 'T', ?
+		.name = "template",
+		.description = "template parameters",
+		.enabled = FALSE,
+	}
+};
+
 kindOption * cxxTagGetKindOptions(void)
 {
 	return g_aCXXKinds;
@@ -77,6 +86,21 @@ int cxxTagGetKindOptionCount(void)
 boolean cxxTagKindEnabled(enum CXXTagKind eKindId)
 {
 	return g_aCXXKinds[eKindId].enabled;
+}
+
+fieldSpec * cxxTagGetCPPFieldSpecifiers(void)
+{
+	return g_aCXXCPPFields;
+}
+
+int cxxTagGetCPPFieldSpecifierCount(void)
+{
+	return sizeof(g_aCXXCPPFields) / sizeof(fieldSpec);
+}
+
+int cxxTagCPPFieldEnabled(CXXTagCPPField eField)
+{
+	return g_aCXXCPPFields[eField].enabled;
 }
 
 static tagEntryInfo g_oCXXTag;
@@ -155,6 +179,14 @@ CXXToken * cxxTagSetTypeField(
 	tag->extensionFields.typeRef[1] = vStringValue(pTypeName->pszWord);
 
 	return pTypeName;
+}
+
+void cxxTagSetCPPField(CXXTagCPPField eField,const char * szValue)
+{
+	if(!g_aCXXCPPFields[eField].enabled)
+		return;
+	
+	attachParserField(&g_oCXXTag,g_aCXXCPPFields[eField].ftype,szValue);
 }
 
 void cxxTagCommit(void)

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -76,6 +76,12 @@ static fieldSpec g_aCXXCPPFields [] = {
 		.name = "template",
 		.description = "template parameters",
 		.enabled = FALSE,
+	},
+	{
+		//.letter = 'L', ?
+		.name = "captures",
+		.description = "lambda capture list",
+		.enabled = FALSE
 	}
 };
 

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -41,12 +41,22 @@ enum CXXTagKind
 
 typedef enum _CXXTagCPPField
 {
+	CXXTagCPPFieldEndLine,
 	CXXTagCPPFieldTemplate
 } CXXTagCPPField;
+
+typedef enum _CXXTagCField
+{
+	CXXTagCFieldEndLine
+} CXXTagCField;
 
 fieldSpec * cxxTagGetCPPFieldSpecifiers(void);
 int cxxTagGetCPPFieldSpecifierCount(void);
 int cxxTagCPPFieldEnabled(CXXTagCPPField eField);
+
+fieldSpec * cxxTagGetCFieldSpecifiers(void);
+int cxxTagGetCFieldSpecifierCount(void);
+int cxxTagCFieldEnabled(CXXTagCField eField);
 
 kindOption * cxxTagGetKindOptions(void);
 int cxxTagGetKindOptionCount(void);
@@ -73,8 +83,32 @@ CXXToken * cxxTagSetTypeField(
 // until cxxTagCommit() is called.
 void cxxTagSetCPPField(CXXTagCPPField eField,const char * szValue);
 
+// Set a parser-local CPP field for a tag in cork queue.
+// The szValue pointer is copied.
+// Make sure that the field is enabled before calling this function.
+void cxxTagSetCorkQueueCPPField(
+		tagEntryInfo * pTag,
+		CXXTagCPPField eField,
+		const char * szValue
+	);
+
+// Set a parser-local C field. The szValue pointer must persist
+// until cxxTagCommit() is called.
+void cxxTagSetCField(CXXTagCField eField,const char * szValue);
+
+// Set a parser-local C field for a tag in cork queue.
+// The szValue pointer is copied.
+// Make sure that the field is enabled before calling this function.
+void cxxTagSetCorkQueueCField(
+		tagEntryInfo * pTag,
+		CXXTagCField eField,
+		const char * szValue
+	);
+
+
 // Commit the composed tag. Must follow a succesfull cxxTagBegin() call.
-void cxxTagCommit(void);
+// Returns the index of the tag in the cork queue.
+int cxxTagCommit(void);
 
 // Same as cxxTagBegin() eventually followed by cxxTagCommit()
 void cxxTag(enum CXXTagKind eKindId,CXXToken * pToken);

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -42,7 +42,8 @@ enum CXXTagKind
 typedef enum _CXXTagCPPField
 {
 	CXXTagCPPFieldEndLine,
-	CXXTagCPPFieldTemplate
+	CXXTagCPPFieldTemplate,
+	CXXTagCPPFieldLambdaCaptureList
 } CXXTagCPPField;
 
 typedef enum _CXXTagCField

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -39,6 +39,15 @@ enum CXXTagKind
 	CXXTagKindUSING
 };
 
+typedef enum _CXXTagCPPField
+{
+	CXXTagCPPFieldTemplate
+} CXXTagCPPField;
+
+fieldSpec * cxxTagGetCPPFieldSpecifiers(void);
+int cxxTagGetCPPFieldSpecifierCount(void);
+int cxxTagCPPFieldEnabled(CXXTagCPPField eField);
+
 kindOption * cxxTagGetKindOptions(void);
 int cxxTagGetKindOptionCount(void);
 boolean cxxTagKindEnabled(enum CXXTagKind eKindId);
@@ -59,6 +68,10 @@ CXXToken * cxxTagSetTypeField(
 		CXXToken * pTypeStart,
 		CXXToken * pTypeEnd
 	);
+
+// Set a parser-local CPP field. The szValue pointer must persist
+// until cxxTagCommit() is called.
+void cxxTagSetCPPField(CXXTagCPPField eField,const char * szValue);
 
 // Commit the composed tag. Must follow a succesfull cxxTagBegin() call.
 void cxxTagCommit(void);

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -88,7 +88,7 @@ void cxxTagSetCPPField(CXXTagCPPField eField,const char * szValue);
 // The szValue pointer is copied.
 // Make sure that the field is enabled before calling this function.
 void cxxTagSetCorkQueueCPPField(
-		tagEntryInfo * pTag,
+		int iIndex,
 		CXXTagCPPField eField,
 		const char * szValue
 	);
@@ -101,7 +101,7 @@ void cxxTagSetCField(CXXTagCField eField,const char * szValue);
 // The szValue pointer is copied.
 // Make sure that the field is enabled before calling this function.
 void cxxTagSetCorkQueueCField(
-		tagEntryInfo * pTag,
+		int iIndex,
 		CXXTagCField eField,
 		const char * szValue
 	);

--- a/parsers/maven2.c
+++ b/parsers/maven2.c
@@ -144,7 +144,7 @@ static void attachVersionIfExisting (struct sTagEntryInfo *tag, xmlNode *node)
 	}
 #endif
 	if (version)
-		attachField (Maven2Fields [F_VERSION].ftype, tag, version);
+		attachParserField (tag, Maven2Fields [F_VERSION].ftype, version);
 }
 
 static void makeTagWithScope (xmlNode *node,


### PR DESCRIPTION
- Add template parameter support in class/struct/union declarations and function prototypes/definitions.
- Add "end" field for marking end lines of classes, unions, structs, namespaces, enums function declarations and lambdas
- Add support for extracting lambda capture lists