### PR TITLE
PHP: Check if alias kind is enabled.

### DIFF
--- a/parsers/php.c
+++ b/parsers/php.c
@@ -1412,7 +1412,7 @@ static boolean parseUse (tokenInfo *const token)
 			readToken (token);
 		}
 
-		if (nameToken->type == TOKEN_IDENTIFIER)
+		if (nameToken->type == TOKEN_IDENTIFIER && PhpKinds[K_ALIAS].enabled)
 		{
 			tagEntryInfo entry;
 


### PR DESCRIPTION
Otherwise, it is not possible to disable generating this kind of tags
via the --php-kinds option.