### PR TITLE
main: allow parsers calling makeTagEntry with a tag with disabled kind

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -1384,11 +1384,16 @@ extern int makeTagEntry (const tagEntryInfo *const tag)
 {
 	int r = SCOPE_NIL;
 	Assert (tag->name != NULL);
-	Assert (getInputLanguageFileKind() == tag->kind
-		|| ( isInputLanguageKindEnabled (tag->kind->letter)
-                    && (tag->extensionFields.roleIndex == ROLE_INDEX_DEFINITION ))
-		|| (tag->extensionFields.roleIndex != ROLE_INDEX_DEFINITION
-		    && tag->kind->roles[tag->extensionFields.roleIndex].enabled ));
+
+	if (getInputLanguageFileKind() != tag->kind)
+	{
+		if (! isInputLanguageKindEnabled (tag->kind->letter) &&
+		    (tag->extensionFields.roleIndex == ROLE_INDEX_DEFINITION))
+			return SCOPE_NIL;
+		if ((tag->extensionFields.roleIndex != ROLE_INDEX_DEFINITION)
+		    && (! tag->kind->roles[tag->extensionFields.roleIndex].enabled))
+			return SCOPE_NIL;
+	}
 
 	if (tag->name [0] == '\0' && (!tag->placeholder))
 	{


### PR DESCRIPTION
Old behavior: Assertion failure when a parser calls makeTagEntry with
a tagEntryInfo which associated kind is disabled.

That means a parser must verify "enabled/disabled" of the kind
associated to a tagEntryInfo before calling makeTagEntry.

However, people may forget writing such verification.

With this commit, makeTagEntry just skips the entry silently; it
doesn't emit the passed tagEntryInfo if its kind is disabled.

In some case checking "enabled/disabled" of the kind is still
meaningful for optimization purpose; if a kind is disabled, parser
doesn't have to take time to record the information categorized to the
group.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>