### PR TITLE
CXX: Yet more work on the cxx parser

### DIFF
--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -1,8 +1,10 @@
 r       UCTAGSrole      off     NONE            TRUE     Role                          
 Z       UCTAGSscope     off     NONE            FALSE    Include the "scope:" key in scope field (use s)
 E       UCTAGSextra     off     NONE            TRUE     Extra tag type information    
--       UCTAGSend       off     C               TRUE     end lines of struct/function declarations, and macro
--       UCTAGSend       off     C++             TRUE     end lines of class/function declarations, and macro
+-       UCTAGSend       off     C               TRUE     end lines of various constructs
+-       UCTAGSproperties off     C               TRUE     properties (static, inline, mutable,...)
+-       UCTAGSend       off     C++             TRUE     end lines of various constructs
 -       UCTAGStemplate  off     C++             TRUE     template parameters           
 -       UCTAGScaptures  off     C++             TRUE     lambda capture list           
+-       UCTAGSproperties off     C++             TRUE     properties (static, virtual, inline, mutable,...)
 -       UCTAGSsectionMarker off     reStructuredText TRUE     character used for declaring section

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -19,10 +19,12 @@ r	role	off	NONE	TRUE	Role
 R	NONE	off	NONE	TRUE	Marker (R or D) representing whether tag is definition or reference
 Z	scope	off	NONE	FALSE	Include the "scope:" key in scope field (use s)
 E	extra	off	NONE	TRUE	Extra tag type information
--	end	off	C	TRUE	end lines of struct/function declarations, and macro
--	end	off	C++	TRUE	end lines of class/function declarations, and macro
+-	end	off	C	TRUE	end lines of various constructs
+-	properties	off	C	TRUE	properties (static, inline, mutable,...)
+-	end	off	C++	TRUE	end lines of various constructs
 -	template	off	C++	TRUE	template parameters
 -	captures	off	C++	TRUE	lambda capture list
+-	properties	off	C++	TRUE	properties (static, virtual, inline, mutable,...)
 -	sectionMarker	off	reStructuredText	TRUE	character used for declaring section
 #
 Foo	input.java	/^abstract public class Foo extends Bar$/

--- a/Units/parser-cxx.r/functions.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/functions.cpp.d/expected.tags
@@ -20,7 +20,7 @@ p03	input.cpp	/^auto p03(const int & p03a01,void * p03a02) -> const int &;$/;"	p
 p04	input.cpp	/^auto p04() -> int (*)(int);$/;"	p	typeref:typename:int (*)(int)	file:	signature:()
 p05	input.cpp	/^static std::string p05(const int *** p05a01);$/;"	p	typeref:typename:std::string	file:	signature:(const int *** p05a01)
 p06	input.cpp	/^		auto p06(n01::c01 && p06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && p06a01)
-p06	input.cpp	/^auto n01::n02::p06(n01::c01 && p06a01) -> n01::n02::type01 *;$/;"	p	typeref:typename:n01::n02::type01 *	file:	signature:(n01::c01 && p06a01)
+p06	input.cpp	/^auto n01::n02::p06(n01::c01 && p06a01) -> n01::n02::type01 *;$/;"	p	class:n01::n02	typeref:typename:n01::n02::type01 *	file:	signature:(n01::c01 && p06a01)
 p07	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	p	typeref:typename:unsigned int	file:	signature:(int (*p07a01)(int * x1,int x2),...)
 t01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t01a01)	end:69
 t01a01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	z	function:t01	typeref:typename:T &&	file:

--- a/Units/parser-cxx.r/properties.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/properties.cpp.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--kinds-c++=*
+--fields=+x{c++.properties}

--- a/Units/parser-cxx.r/properties.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/properties.cpp.d/expected.tags
@@ -1,0 +1,22 @@
+C01	input.cpp	/^class C01$/;"	c	file:
+C01	input.cpp	/^	C01() = default;$/;"	p	class:C01	file:	properties:default
+mp01	input.cpp	/^	static int mp01;$/;"	m	class:C01	typeref:typename:int	file:	properties:static
+mp02	input.cpp	/^	mutable int mp02;$/;"	m	class:C01	typeref:typename:int	file:	properties:mutable
+mf01	input.cpp	/^	virtual void mf01();$/;"	p	class:C01	typeref:typename:void	file:	properties:virtual
+mf02	input.cpp	/^	virtual void mf02() final;$/;"	p	class:C01	typeref:typename:void	file:	properties:final,virtual
+C02	input.cpp	/^class C02 : public C01$/;"	c	file:
+C02	input.cpp	/^	C02() = delete;$/;"	p	class:C02	file:	properties:delete
+C02	input.cpp	/^	explicit C02(int i)$/;"	f	class:C02	file:	properties:explicit
+i	input.cpp	/^	explicit C02(int i)$/;"	z	function:C02::C02	typeref:typename:int	file:
+mf01	input.cpp	/^	void mf01() override;$/;"	p	class:C02	typeref:typename:void	file:	properties:override,virtual
+mf03	input.cpp	/^	virtual void mf03() = 0;$/;"	p	class:C02	typeref:typename:void	file:	properties:pure,virtual
+mf04	input.cpp	/^	virtual void mf04() final;$/;"	p	class:C02	typeref:typename:void	file:	properties:final,virtual
+mf05	input.cpp	/^	static inline void mf05()$/;"	f	class:C02	typeref:typename:void	file:	properties:inline,static
+mf06	input.cpp	/^	inline void mf06() const;$/;"	p	class:C02	typeref:typename:void	file:	properties:const,inline
+mf07	input.cpp	/^	void static mf07() volatile;$/;"	p	class:C02	typeref:typename:void	file:	properties:static,volatile
+v01	input.cpp	/^extern int v01;$/;"	x	typeref:typename:int	properties:extern
+v02	input.cpp	/^static volatile int v02;$/;"	v	typeref:typename:volatile int	file:	properties:static
+p01	input.cpp	/^static void p01();$/;"	p	typeref:typename:void	file:	properties:static
+p02	input.cpp	/^extern void p02();$/;"	p	typeref:typename:void	file:	properties:extern
+f01	input.cpp	/^static void f01()$/;"	f	typeref:typename:void	file:	properties:static
+f02	input.cpp	/^static inline void f02()$/;"	f	typeref:typename:void	file:	properties:inline,static

--- a/Units/parser-cxx.r/properties.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/properties.cpp.d/input.cpp
@@ -1,0 +1,44 @@
+
+class C01
+{
+public:
+	C01() = default;
+
+	static int mp01;
+	mutable int mp02;
+
+	virtual void mf01();
+	virtual void mf02() final;
+};
+
+class C02 : public C01
+{
+public:
+	C02() = delete;
+	explicit C02(int i)
+	{
+	}
+	
+	void mf01() override;
+	virtual void mf03() = 0;
+	virtual void mf04() final;
+	static inline void mf05()
+	{
+	}
+	inline void mf06() const;
+	void static mf07() volatile;
+};
+
+extern int v01;
+static volatile int v02;
+
+static void p01();
+extern void p02();
+
+static void f01()
+{
+}
+
+static inline void f02()
+{
+}

--- a/Units/parser-cxx.r/template-specializations.d/args.ctags
+++ b/Units/parser-cxx.r/template-specializations.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--kinds-C++=*
+--fields=+sS{c++.template}{c++.properties}

--- a/Units/parser-cxx.r/template-specializations.d/expected.tags
+++ b/Units/parser-cxx.r/template-specializations.d/expected.tags
@@ -1,0 +1,14 @@
+A	input.cpp	/^struct A {$/;"	s	file:	template:<typename T>
+f	input.cpp	/^    void f(T); \/\/ member, declared in the primary template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T)
+h	input.cpp	/^    void h(T) {} \/\/ member, defined in the primary template$/;"	f	struct:A	typeref:typename:void	file:	signature:(T)
+g1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T, X1)	template:<class X1>
+g2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T, X2)	template:<class X2>
+f	input.cpp	/^template<> void A<int>::f(int);$/;"	p	class:A	typeref:typename:void	file:	signature:(int)	template:<>	properties:scopespecialization,specialization
+h	input.cpp	/^template<> void A<int>::h(int) {}$/;"	f	class:A	typeref:typename:void	signature:(int)	template:<>	properties:scopespecialization,specialization
+g1	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	f	class:A	typeref:typename:void	signature:(T, X1)	template:<class X1>	properties:scopespecialization,specialization
+g1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	p	class:A	typeref:typename:void	file:	signature:(int, X1)	template:<class X1>	properties:scopespecialization,specialization
+g2	input.cpp	/^template<> void A<int>::g2<char>(int, char); \/\/ for X2 = char$/;"	p	class:A	typeref:typename:void	file:	signature:(int, char)	template:<>	properties:scopespecialization,specialization
+g1	input.cpp	/^template<> void A<int>::g1(int, char);$/;"	p	class:A	typeref:typename:void	file:	signature:(int, char)	template:<>	properties:scopespecialization,specialization
+m	input.cpp	/^template<typename X> void m(X)$/;"	f	typeref:typename:void	signature:(X)	template:<typename X>
+m	input.cpp	/^template<> void m<int>(int)$/;"	f	typeref:typename:void	signature:(int)	template:<>	properties:specialization
+m	input.cpp	/^template<> void m(char)$/;"	f	typeref:typename:void	signature:(char)	template:<>	properties:specialization

--- a/Units/parser-cxx.r/template-specializations.d/input.cpp
+++ b/Units/parser-cxx.r/template-specializations.d/input.cpp
@@ -1,0 +1,39 @@
+template<typename T>
+struct A {
+    void f(T); // member, declared in the primary template
+    void h(T) {} // member, defined in the primary template
+    template<class X1> void g1(T, X1); // member template
+    template<class X2> void g2(T, X2); // member template
+};
+ 
+// specialization of a member
+template<> void A<int>::f(int);
+// member specialization OK even if defined in-class
+template<> void A<int>::h(int) {}
+ 
+// out of class member template definition
+template<class T>
+template<class X1> void A<T>::g1(T, X1) { }
+ 
+// member template specialization
+template<>
+template<class X1> void A<int>::g1(int, X1);
+ 
+// member template specialization
+template<>
+template<> void A<int>::g2<char>(int, char); // for X2 = char
+// same, using template argument deduction (X1 = char)
+template<> 
+template<> void A<int>::g1(int, char);
+
+template<typename X> void m(X)
+{
+}
+
+template<> void m<int>(int)
+{
+}
+
+template<> void m(char)
+{
+}

--- a/Units/parser-cxx.r/variables-in-control-statements.d/input.cpp
+++ b/Units/parser-cxx.r/variables-in-control-statements.d/input.cpp
@@ -23,6 +23,8 @@ int n04()
 	return 0;
 }
 
+int n05,n06,n07,n08,n09,n10;
+
 // The real test
 
 void test()
@@ -85,6 +87,19 @@ void test()
 	if(int i01 = 10 + 20)
 	{
 		
+	}
+
+	// non valid declarations inside if
+	if(n05 & n06)
+	{
+	}
+	
+	if(n07 * n08)
+	{
+	}
+	
+	if(n09 && n10)
+	{
 	}
 
 	// Valid variable declarations inside a while

--- a/main/entry.h
+++ b/main/entry.h
@@ -79,7 +79,7 @@ typedef struct sTagEntryInfo {
 		int roleIndex; /* for role of reference tag */
 	} extensionFields;  /* list of extension fields*/
 
-#define PRE_ALLOCATED_PARSER_FIELDS 3
+#define PRE_ALLOCATED_PARSER_FIELDS 4
 #define NO_PARSER_FIELD -1
 	unsigned int usedParserFields;
 	tagField     parserFields [PRE_ALLOCATED_PARSER_FIELDS];

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -930,7 +930,12 @@ void cxxParserAnalyzeOtherStatement(void)
 	// prefer function.
 	if(cxxParserLookForFunctionSignature(g_cxx.pTokenChain,&oInfo,NULL))
 	{
-		cxxParserEmitFunctionTags(&oInfo,CXXTagKindPROTOTYPE,0,NULL);
+		int iScopesPushed = cxxParserEmitFunctionTags(&oInfo,CXXTagKindPROTOTYPE,CXXEmitFunctionTagsPushScopes,NULL);
+		while(iScopesPushed > 0)
+		{
+			cxxScopePop();
+			iScopesPushed--;
+		}
 		CXX_DEBUG_LEAVE_TEXT("Found function prototypes");
 		return;
 	}

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -342,25 +342,35 @@ boolean cxxParserParseBlock(boolean bExpectClosingBracket)
 					break;
 					case CXXKeywordEXTERN:
 						g_cxx.uKeywordState |= CXXParserKeywordStateSeenExtern;
-						cxxTokenChainClear(g_cxx.pTokenChain);
+						cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 					break;
 					case CXXKeywordSTATIC:
 						g_cxx.uKeywordState |= CXXParserKeywordStateSeenStatic;
-						cxxTokenChainClear(g_cxx.pTokenChain);
+						cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 					break;
 					case CXXKeywordINLINE:
 						g_cxx.uKeywordState |= CXXParserKeywordStateSeenInline;
-						cxxTokenChainClear(g_cxx.pTokenChain);
+						cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 					break;
 					case CXXKeywordEXPLICIT:
 						g_cxx.uKeywordState |= CXXParserKeywordStateSeenExplicit;
-						cxxTokenChainClear(g_cxx.pTokenChain);
+						cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 					break;
 					case CXXKeywordOPERATOR:
 						g_cxx.uKeywordState |= CXXParserKeywordStateSeenOperator;
 					break;
 					case CXXKeywordVIRTUAL:
 						g_cxx.uKeywordState |= CXXParserKeywordStateSeenVirtual;
+						cxxTokenChainDestroyLast(g_cxx.pTokenChain);
+					break;
+					//case CXXKeywordVOLATILE:
+					// Volatile is actually part of the type!
+					//	g_cxx.uKeywordState |= CXXParserKeywordStateSeenVolatile;
+					//	cxxTokenChainDestroyLast(g_cxx.pTokenChain);
+					//break;
+					case CXXKeywordMUTABLE:
+						g_cxx.uKeywordState |= CXXParserKeywordStateSeenMutable;
+						cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 					break;
 					default:
 						if(g_cxx.uKeywordState & CXXParserKeywordStateSeenTypedef)

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -538,10 +538,7 @@ boolean cxxParserLookForFunctionSignature(
 
 	while(pToken)
 	{
-		if(
-				cxxTokenTypeIs(pToken,CXXTokenTypeKeyword) &&
-				(pToken->eKeyword == CXXKeywordOPERATOR)
-			)
+		if(cxxTokenIsKeyword(pToken,CXXKeywordOPERATOR))
 		{
 			// Special case for operator <something> ()
 

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -284,6 +284,7 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 		vString * pszSignature = cxxTokenChainJoin(pParenthesis->pChain,NULL,0);
 
 		// FIXME: Return type!
+		// FIXME: Properties?
 
 		if(pszSignature)
 			tag->extensionFields.signature = vStringValue(pszSignature);
@@ -526,6 +527,7 @@ boolean cxxParserLookForFunctionSignature(
 
 	CXXToken * pToken = cxxTokenChainFirst(pChain);
 
+	pInfo->uFlags = 0;
 	pInfo->pParenthesis = NULL;
 
 	CXXToken * pIdentifierStart = NULL;
@@ -790,14 +792,64 @@ next_token:
 
 		// Look for trailing const.
 
-		if(
-				pTopLevelParenthesis->pNext &&
-				cxxTokenTypeIs(pTopLevelParenthesis->pNext,CXXTokenTypeKeyword) &&
-				(pTopLevelParenthesis->pNext->eKeyword == CXXKeywordCONST)
-		)
-			pInfo->pSignatureConst = pTopLevelParenthesis->pNext;
-		else
+		if(pTopLevelParenthesis->pNext)
+		{
+			if(cxxTokenIsKeyword(pTopLevelParenthesis->pNext,CXXKeywordCONST))
+				pInfo->pSignatureConst = pTopLevelParenthesis->pNext;
+			else
+				pInfo->pSignatureConst = NULL;
+				
+			// Look for = 0 for "pure" modifier
+			CXXToken * pAssignment = cxxTokenChainNextTokenOfType(
+					pTopLevelParenthesis,
+					CXXTokenTypeAssignment
+				);
+	
+			if(pAssignment && pAssignment->pNext)
+			{
+				if(
+					cxxTokenTypeIs(pAssignment->pNext,CXXTokenTypeNumber) &&
+					(strcmp(vStringValue(pAssignment->pNext->pszWord),"0") == 0)
+				)
+					pInfo->uFlags |= CXXFunctionSignatureInfoPure;
+				else if(cxxTokenTypeIs(pAssignment->pNext,CXXTokenTypeKeyword))
+				{
+					if(pAssignment->pNext->eKeyword == CXXKeywordDEFAULT)
+						pInfo->uFlags |= CXXFunctionSignatureInfoDefault;
+					if(pAssignment->pNext->eKeyword == CXXKeywordDELETE)
+						pInfo->uFlags |= CXXFunctionSignatureInfoDelete;
+				}
+			}
+			
+			CXXToken * pIdentOrKeyword = cxxTokenChainNextTokenOfType(
+					pTopLevelParenthesis,
+					CXXTokenTypeIdentifier | CXXTokenTypeKeyword
+				);
+
+			while(pIdentOrKeyword)
+			{
+				// override is a keyword only in specific contexts so we handle it as identifier
+				if(cxxTokenTypeIs(pIdentOrKeyword,CXXTokenTypeKeyword))
+				{
+					if(pIdentOrKeyword->eKeyword == CXXKeywordVOLATILE)
+						pInfo->uFlags |= CXXFunctionSignatureInfoVolatile;
+				} else {
+					// The "final" keyword is actually disabled in most contexts so we handle
+					// it as identifier. "override is always handled as identifier.
+					if(strcmp(vStringValue(pIdentOrKeyword->pszWord),"final") == 0)
+						pInfo->uFlags |= CXXFunctionSignatureInfoFinal;
+					else if(strcmp(vStringValue(pIdentOrKeyword->pszWord),"override") == 0)
+						pInfo->uFlags |= CXXFunctionSignatureInfoOverride;
+				}
+
+				pIdentOrKeyword = cxxTokenChainNextTokenOfType(
+						pIdentOrKeyword,
+						CXXTokenTypeIdentifier | CXXTokenTypeKeyword
+					);
+			}
+		} else {
 			pInfo->pSignatureConst = NULL;
+		}
 	} else {
 		pInfo->pSignatureConst = NULL;
 	}
@@ -965,7 +1017,7 @@ int cxxParserEmitFunctionTags(
 		CXXToken * pTypeName;
 
 		if(pInfo->pTypeStart)
-			pTypeName = cxxTagSetTypeField(tag,pInfo->pTypeStart,pInfo->pTypeEnd);
+			pTypeName = cxxTagSetTypeField(pInfo->pTypeStart,pInfo->pTypeEnd);
 		else
 			pTypeName = NULL;
 
@@ -985,6 +1037,43 @@ int cxxParserEmitFunctionTags(
 					vStringValue(cxxTokenChainFirst(g_cxx.pTemplateTokenChain)->pszWord)
 				);
 		}
+		
+		vString * pszProperties = NULL;
+		
+		if(
+			(cxxParserCurrentLanguageIsCPP() && cxxTagCPPFieldEnabled(CXXTagCPPFieldProperties)) ||
+			(cxxParserCurrentLanguageIsC() && cxxTagCFieldEnabled(CXXTagCFieldProperties))
+		)
+		{
+			unsigned int uProperties = 0;
+	
+			if(g_cxx.uKeywordState & CXXParserKeywordStateSeenVirtual)
+				uProperties |= CXXTagPropertyVirtual;
+			if(g_cxx.uKeywordState & CXXParserKeywordStateSeenStatic)
+				uProperties |= CXXTagPropertyStatic;
+			// FIXME: Handle __inline, __inline__, __forceinline, __attribute__((always_inline)) ?
+			if(g_cxx.uKeywordState & CXXParserKeywordStateSeenInline)
+				uProperties |= CXXTagPropertyInline;
+			if(g_cxx.uKeywordState & CXXParserKeywordStateSeenExplicit)
+				uProperties |= CXXTagPropertyExplicit; // FIXME: Handle "CXXTagPropertyConstructor"?
+			if(g_cxx.uKeywordState & CXXParserKeywordStateSeenExtern)
+				uProperties |= CXXTagPropertyExtern;
+			if(pInfo->pSignatureConst)
+				uProperties |= CXXTagPropertyConst;
+			if(pInfo->uFlags & CXXFunctionSignatureInfoPure)
+				uProperties |= CXXTagPropertyPure | CXXTagPropertyVirtual;
+			if(pInfo->uFlags & CXXFunctionSignatureInfoOverride)
+				uProperties |= CXXTagPropertyOverride | CXXTagPropertyVirtual;
+			if(pInfo->uFlags & CXXFunctionSignatureInfoFinal)
+				uProperties |= CXXTagPropertyFinal | CXXTagPropertyVirtual;
+			if(pInfo->uFlags & CXXFunctionSignatureInfoDefault)
+				uProperties |= CXXTagPropertyDefault;
+			if(pInfo->uFlags & CXXFunctionSignatureInfoDelete)
+				uProperties |= CXXTagPropertyDelete;
+			if(pInfo->uFlags & CXXFunctionSignatureInfoVolatile)
+				uProperties |= CXXTagPropertyVolatile;
+			pszProperties = cxxTagSetProperties(uProperties);
+		}
 
 		int iCorkQueueIndex = cxxTagCommit();
 
@@ -993,6 +1082,9 @@ int cxxParserEmitFunctionTags(
 
 		if(pszSignature)
 			vStringDelete(pszSignature);
+
+		if(pszProperties)
+			vStringDelete(pszProperties);
 
 		if(pTypeName)
 			cxxTokenDestroy(pTypeName);
@@ -1125,7 +1217,6 @@ void cxxParserEmitFunctionParameterTags(CXXFunctionParameterInfo * pInfo)
 				cxxTokenChainTakeRecursive(pInfo->pChain,pInfo->aIdentifiers[i]);
 
 				pTypeName = cxxTagSetTypeField(
-						tag,
 						pTypeStart,
 						pTypeEnd
 					);

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -67,7 +67,12 @@ typedef enum _CXXFunctionSignatureInfoFlag
 	// Followed by = delete
 	CXXFunctionSignatureInfoDelete = (1 << 4),
 	// Followed by volatile
-	CXXFunctionSignatureInfoVolatile = (1 << 5)
+	CXXFunctionSignatureInfoVolatile = (1 << 5),
+	// Is template specialization  a<x>()
+	CXXFunctionSignatureInfoTemplateSpecialization = (1 << 6),
+	// Is scope template specialization a<x>::b()
+	// (implies that this is a template specialization too)
+	CXXFunctionSignatureInfoScopeTemplateSpecialization = (1 << 7)
 } CXXFunctionSignatureInfoFlag;
 
 //

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -54,6 +54,22 @@ boolean cxxParserTokenChainLooksLikeConstructorParameterSet(
 		CXXTokenChain * pChain
 	);
 
+typedef enum _CXXFunctionSignatureInfoFlag
+{
+	// Followed by = 0
+	CXXFunctionSignatureInfoPure = 1,
+	// Followed by = default
+	CXXFunctionSignatureInfoDefault = (1 << 1),
+	// Followed by "override"
+	CXXFunctionSignatureInfoOverride = (1 << 2),
+	// Followed by "final"
+	CXXFunctionSignatureInfoFinal = (1 << 3),
+	// Followed by = delete
+	CXXFunctionSignatureInfoDelete = (1 << 4),
+	// Followed by volatile
+	CXXFunctionSignatureInfoVolatile = (1 << 5)
+} CXXFunctionSignatureInfoFlag;
+
 //
 // Description of a function signature.
 //
@@ -79,6 +95,9 @@ typedef struct _CXXFunctionSignatureInfo
 	// Non-NULL if a return type has been identified
 	CXXToken * pTypeStart;
 	CXXToken * pTypeEnd;
+
+	// Additional informations
+	unsigned int uFlags;
 
 } CXXFunctionSignatureInfo;
 
@@ -166,23 +185,24 @@ typedef enum _CXXParserKeywordState
 	CXXParserKeywordStateSeenTypedef = 1,
 	// We are parsing a statement that comes right after
 	// an inline keyword
-	CXXParserKeywordStateSeenInline = 2,
+	CXXParserKeywordStateSeenInline = (1 << 1),
 	// We are parsing a statement that comes right after
 	// a extern keyword
-	CXXParserKeywordStateSeenExtern = 4,
+	CXXParserKeywordStateSeenExtern = (1 << 2),
 	// We are parsing a statement that comes right after
 	// a static keyword
-	CXXParserKeywordStateSeenStatic = 8,
+	CXXParserKeywordStateSeenStatic = (1 << 3),
 	// an "explicit" keyword has been seen
-	CXXParserKeywordStateSeenExplicit = 16,
+	CXXParserKeywordStateSeenExplicit = (1 << 4),
 	// an "operator" keyword has been seen
-	CXXParserKeywordStateSeenOperator = 32,
+	CXXParserKeywordStateSeenOperator = (1 << 5),
 	// "virtual" has been seen
-	CXXParserKeywordStateSeenVirtual = 64,
+	CXXParserKeywordStateSeenVirtual = (1 << 6),
 	// "return" has been seen
-	CXXParserKeywordStateSeenReturn = 128
+	CXXParserKeywordStateSeenReturn = (1 << 7),
+	// "mutable" has been seen
+	CXXParserKeywordStateSeenMutable = (1 << 8)
 } CXXParserKeywordState;
-
 
 typedef struct _CXXParserState
 {

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -151,7 +151,7 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 		CXXToken * pTypeName;
 
 		if(pTypeStart)
-			pTypeName = cxxTagSetTypeField(tag,pTypeStart,pTypeEnd);
+			pTypeName = cxxTagSetTypeField(pTypeStart,pTypeEnd);
 		else
 			pTypeName = NULL;
 
@@ -168,6 +168,8 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 					vStringValue(cxxTokenChainFirst(pCaptureList->pChain)->pszWord)
 				);
 		}
+
+		// FIXME: Properties?
 
 		vString * pszSignature = NULL;
 		if(cxxTokenTypeIs(pParenthesis,CXXTokenTypeParenthesisChain))

--- a/parsers/cxx/cxx_parser_typedef.c
+++ b/parsers/cxx/cxx_parser_typedef.c
@@ -173,7 +173,6 @@ void cxxParserExtractTypedef(
 			CXX_DEBUG_ASSERT(pChain->iCount > 0,"There should be at least another token here!");
 
 			pTypeName = cxxTagSetTypeField(
-						tag,
 						cxxTokenChainFirst(pChain),
 						cxxTokenChainLast(pChain)
 					);

--- a/parsers/cxx/cxx_parser_variable.c
+++ b/parsers/cxx/cxx_parser_variable.c
@@ -535,7 +535,7 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 			}
 
 			// anything that remains is part of type
-			CXXToken * pTypeToken = cxxTagSetTypeField(tag,cxxTokenChainFirst(pChain),t->pPrev);
+			CXXToken * pTypeToken = cxxTagSetTypeField(cxxTokenChainFirst(pChain),t->pPrev);
 
 			tag->isFileScope = bKnRStyleParameters ?
 					TRUE :
@@ -554,10 +554,34 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 						)
 					);
 
+			vString * pszProperties = NULL;
+			
+			if(
+				(cxxParserCurrentLanguageIsCPP() && cxxTagCPPFieldEnabled(CXXTagCPPFieldProperties)) ||
+				(cxxParserCurrentLanguageIsC() && cxxTagCFieldEnabled(CXXTagCFieldProperties))
+			)
+			{
+				unsigned int uProperties = 0;
+		
+				if(g_cxx.uKeywordState & CXXParserKeywordStateSeenStatic)
+					uProperties |= CXXTagPropertyStatic;
+				if(g_cxx.uKeywordState & CXXParserKeywordStateSeenExtern)
+					uProperties |= CXXTagPropertyExtern;
+				if(g_cxx.uKeywordState & CXXParserKeywordStateSeenMutable)
+					uProperties |= CXXTagPropertyMutable;
+				// Volatile is part of the type, so we don't mark it as a property
+				//if(g_cxx.uKeywordState & CXXParserKeywordStateSeenVolatile)
+				//	uProperties |= CXXTagPropertyVolatile;
+
+				pszProperties = cxxTagSetProperties(uProperties);
+			}
+	
 			cxxTagCommit();
 
 			if(pTypeToken)
 				cxxTokenDestroy(pTypeToken);
+			if(pszProperties)
+				vStringDelete(pszProperties);
 			cxxTokenDestroy(pIdentifier);
 		}
 

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -234,8 +234,12 @@ vString * cxxTagSetProperties(unsigned int uProperties)
 		ADD_PROPERTY("override");
 	if(uProperties & CXXTagPropertyPure)
 		ADD_PROPERTY("pure");
+	if(uProperties & CXXTagPropertyScopeTemplateSpecialization)
+		ADD_PROPERTY("scopespecialization");
 	if(uProperties & CXXTagPropertyStatic)
 		ADD_PROPERTY("static");
+	if(uProperties & CXXTagPropertyTemplateSpecialization)
+		ADD_PROPERTY("specialization");
 	if(uProperties & CXXTagPropertyVirtual)
 		ADD_PROPERTY("virtual");
 	if(uProperties & CXXTagPropertyVolatile)

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -110,7 +110,11 @@ typedef enum _CXXTagProperty
 	CXXTagPropertyMutable = (1 << 11),
 	// Function (note: NOT variable) is marked as volatile as in "int a() volatile"
 	// (Because for variables it's treated as part of type)
-	CXXTagPropertyVolatile = (1 << 12)
+	CXXTagPropertyVolatile = (1 << 12),
+	// Template specialization a<x>()
+	CXXTagPropertyTemplateSpecialization = (1 << 13),
+	// Template specialization of scope a<x>::b() (which implies TemplateSpec too)
+	CXXTagPropertyScopeTemplateSpecialization = (1 << 14)
 } CXXTagProperty;
 
 // Set the modifiers field of the tag.

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -43,12 +43,14 @@ typedef enum _CXXTagCPPField
 {
 	CXXTagCPPFieldEndLine,
 	CXXTagCPPFieldTemplate,
-	CXXTagCPPFieldLambdaCaptureList
+	CXXTagCPPFieldLambdaCaptureList,
+	CXXTagCPPFieldProperties
 } CXXTagCPPField;
 
 typedef enum _CXXTagCField
 {
-	CXXTagCFieldEndLine
+	CXXTagCFieldEndLine,
+	CXXTagCFieldProperties
 } CXXTagCField;
 
 fieldSpec * cxxTagGetCPPFieldSpecifiers(void);
@@ -75,10 +77,47 @@ tagEntryInfo * cxxTagBegin(enum CXXTagKind eKindId,CXXToken * pToken);
 // Returns a token that must be destroyed after cxxTagCommit() has
 // been called.
 CXXToken * cxxTagSetTypeField(
-		tagEntryInfo * tag,
 		CXXToken * pTypeStart,
 		CXXToken * pTypeEnd
 	);
+
+typedef enum _CXXTagProperty
+{
+	// Function is virtual
+	CXXTagPropertyVirtual = 1,
+	// Function/variable is static
+	CXXTagPropertyStatic = (1 << 1),
+	// Function is inline
+	CXXTagPropertyInline = (1 << 2),
+	// Function is explicit
+	CXXTagPropertyExplicit = (1 << 3),
+	// Function/variable is extern
+	CXXTagPropertyExtern = (1 << 4),
+	// Function is const
+	CXXTagPropertyConst = (1 << 5),
+	// Function is pure virtual
+	CXXTagPropertyPure = (1 << 6),
+	// Function is marked as override
+	CXXTagPropertyOverride = (1 << 7),
+	// Functoin is marked as default
+	CXXTagPropertyDefault = (1 << 8),
+	// Function is marked as final
+	CXXTagPropertyFinal = (1 << 9),
+	// Function is marked as delete
+	CXXTagPropertyDelete = (1 << 10),
+	// Variable is marked as mutable
+	// (C++ treats "mutable" as storage class)
+	CXXTagPropertyMutable = (1 << 11),
+	// Function (note: NOT variable) is marked as volatile as in "int a() volatile"
+	// (Because for variables it's treated as part of type)
+	CXXTagPropertyVolatile = (1 << 12)
+} CXXTagProperty;
+
+// Set the modifiers field of the tag.
+// Returns a string that you must destroy after the call to cxxTagCommit()
+// or NULL if the modifiers weren't set for some reason (no modifiers, field
+// not enabled or similar...)
+vString * cxxTagSetProperties(unsigned int uProperties);
 
 // Set a parser-local CPP field. The szValue pointer must persist
 // until cxxTagCommit() is called.

--- a/parsers/cxx/cxx_token.h
+++ b/parsers/cxx/cxx_token.h
@@ -94,6 +94,11 @@ CXXToken * cxxTokenCreateAnonymousIdentifier(enum CXXTagKind k);
 
 #define cxxTokenTypeIsOneOf(_pToken,_uTypes) (_pToken->eType & (_uTypes))
 #define cxxTokenTypeIs(_pToken,_eType) (_pToken->eType == _eType)
+#define cxxTokenIsKeyword(_pToken,_eKeyword) \
+		( \
+			(_pToken->eType == CXXTokenTypeKeyword) && \
+			(_pToken->eKeyword == _eKeyword) \
+		)
 
 // FIXME: Bad argument order
 void cxxTokenAppendToString(vString * s,CXXToken * t);

--- a/parsers/cxx/cxx_token_chain.c
+++ b/parsers/cxx/cxx_token_chain.c
@@ -721,10 +721,7 @@ CXXToken * cxxTokenChainPreviousKeyword(
 	CXXToken * t = from->pPrev;
 	while(t)
 	{
-		if(
-				(t->eType == CXXTokenTypeKeyword) &&
-				(t->eKeyword == eKeyword)
-			)
+		if(cxxTokenIsKeyword(t,eKeyword))
 			return t;
 		t = t->pPrev;
 	}
@@ -732,6 +729,24 @@ CXXToken * cxxTokenChainPreviousKeyword(
 	return NULL;
 }
 
+CXXToken * cxxTokenChainNextKeyword(
+		CXXToken * from,
+		enum CXXKeyword eKeyword
+	)
+{
+	if(!from)
+		return NULL;
+
+	CXXToken * t = from->pNext;
+	while(t)
+	{
+		if(cxxTokenIsKeyword(t,eKeyword))
+			return t;
+		t = t->pNext;
+	}
+
+	return NULL;
+}
 
 int cxxTokenChainFirstKeywordIndex(
 		CXXTokenChain * tc,
@@ -747,16 +762,35 @@ int cxxTokenChainFirstKeywordIndex(
 	int idx = 0;
 	while(pToken)
 	{
-		if(
-			(pToken->eType == CXXTokenTypeKeyword) &&
-			(pToken->eKeyword == eKeyword)
-		)
+		if(cxxTokenIsKeyword(pToken,eKeyword))
 			return idx;
 		idx++;
 		pToken = pToken->pNext;
 	}
 
 	return -1;
+}
+
+CXXToken * cxxTokenChainNextIdentifier(
+		CXXToken * from,
+		const char * szIdentifier
+	)
+{
+	if(!from)
+		return NULL;
+
+	CXXToken * t = from->pNext;
+	while(t)
+	{
+		if(
+			cxxTokenTypeIs(t,CXXTokenTypeIdentifier) &&
+			(strcmp(vStringValue(t->pszWord),szIdentifier) == 0)
+		)
+			return t;
+		t = t->pNext;
+	}
+
+	return NULL;
 }
 
 void cxxTokenChainDestroyRange(CXXTokenChain * pChain,CXXToken * from,CXXToken * to)

--- a/parsers/cxx/cxx_token_chain.h
+++ b/parsers/cxx/cxx_token_chain.h
@@ -211,6 +211,16 @@ CXXToken * cxxTokenChainPreviousKeyword(
 		enum CXXKeyword eKeyword
 	);
 
+CXXToken * cxxTokenChainNextKeyword(
+		CXXToken * from,
+		enum CXXKeyword eKeyword
+	);
+
+CXXToken * cxxTokenChainNextIdentifier(
+		CXXToken * from,
+		const char * szIdentifier
+	);
+
 int cxxTokenChainFirstKeywordIndex(
 		CXXTokenChain * tc,
 		enum CXXKeyword eKeyword


### PR DESCRIPTION
- Extract a set of properties for functions and variables: static, inline, extern, mutable, virtual, pure...
- Try to detect template specializations in various forms
- Fix a couple of corner cases in variable extraction (i.e. do NOT extract variables from things like if(a & b)).