### PR TITLE
eiffel: Add support the across loop

### DIFF
--- a/parsers/eiffel.c
+++ b/parsers/eiffel.c
@@ -44,7 +44,7 @@
  */
 typedef enum eKeywordId {
 	KEYWORD_NONE = -1,
-	KEYWORD_alias, KEYWORD_all, KEYWORD_and,
+	KEYWORD_across, KEYWORD_alias, KEYWORD_all, KEYWORD_and,
 	KEYWORD_as, KEYWORD_assign, KEYWORD_attached,
 	KEYWORD_check, KEYWORD_class, KEYWORD_convert, KEYWORD_create,
 	KEYWORD_creation, KEYWORD_Current,
@@ -116,6 +116,7 @@ static kindOption EiffelKinds [] = {
 
 static const keywordTable const EiffelKeywordTable [] = {
 	/* keyword          keyword ID */
+	{ "across",         KEYWORD_across     },
 	{ "alias",          KEYWORD_alias      },
 	{ "all",            KEYWORD_all        },
 	{ "and",            KEYWORD_and        },
@@ -806,6 +807,7 @@ static void findFeatureEnd (tokenInfo *const token)
 					case KEYWORD_check:
 					case KEYWORD_debug:
 					case KEYWORD_from:
+					case KEYWORD_across:
 					case KEYWORD_if:
 					case KEYWORD_inspect:
 						++depth;


### PR DESCRIPTION
This adds support for Eiffel's [across loop](https://www.eiffel.org/doc/eiffel/ET%3A%20Instructions#A%20closer%20look%20at%20the%20%27%27iteration%27%27%20form) instruction.