### PR TITLE
readtags: use mio in query dsl implementation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,10 +9,8 @@ if USE_READCMD
 bin_PROGRAMS+= readtags
 readtags_CPPFLAGS = -DREADTAGS_MAIN -I. -I$(srcdir) -I$(srcdir)/main
 dist_readtags_SOURCES = readtags.c readtags.h
-if HAVE_FMEMOPEN
-readtags_CPPFLAGS += -DQUALIFIER
+readtags_CPPFLAGS += -DQUALIFIER -I$(srcdir)/dsl
 dist_readtags_SOURCES += $(QUALIFIER_SRCS) $(QUALIFIER_HEAD)
-endif
 endif
 
 if !HAVE_FNMATCH

--- a/configure.ac
+++ b/configure.ac
@@ -80,8 +80,6 @@ AH_TEMPLATE([NON_CONST_PUTENV_PROTOTYPE],
 	doesn't declare its argument as "const char *".])
 AH_TEMPLATE([MSDOS_STYLE_PATH],
 	[Define to 1 if your system uses MS-DOS style path.])
-AH_TEMPLATE([HAVE_FMEMOPEN],
-	[Define this value if your system has fmemopen.])
 
 
 # Report system info
@@ -591,9 +589,6 @@ PKG_CHECK_MODULES(LIBXML, libxml-2.0,
 		       AC_DEFINE(HAVE_LIBXML)],
 		       [have_libxml=no])
 AM_CONDITIONAL(HAVE_LIBXML, test "x$have_libxml" = xyes)
-
-AC_CHECK_FUNCS(fmemopen,[have_fmemopen=yes],[have_fmemopen=no])
-AM_CONDITIONAL(HAVE_FMEMOPEN, test "x$have_fmemopen" = xyes)
 
 
 # Checks for missing prototypes

--- a/dsl/es-lang-c-stdc99.h
+++ b/dsl/es-lang-c-stdc99.h
@@ -27,6 +27,8 @@
 #endif
 #include <stdio.h>
 
+#include "mio.h"
+
 #ifdef  __cplusplus
 extern "C" {
 #endif
@@ -145,13 +147,13 @@ EsObject*    es_cdr         (const EsObject* object);
  * Print
  */
 void         es_print           (const EsObject* object,
-				 FILE*           out);
+				 MIO*           out);
 char*        es_print_to_string (EsObject*        object);
 
 /*
  * Read
  */
-EsObject*    es_read            (FILE* in);
+EsObject*    es_read            (MIO* in);
 EsObject*    es_read_from_string(const char* in,
 				 const char** saveptr);
 
@@ -163,7 +165,7 @@ EsObject*    es_read_from_string(const char* in,
  * Comment
  */
 void         es_comment           (const char* comment,
-				   FILE*       out);
+				   MIO*       out);
 char*        es_comment_to_string (const char* comment);
 
 /*

--- a/dsl/qualifier.c
+++ b/dsl/qualifier.c
@@ -661,11 +661,15 @@ enum QRESULT q_is_acceptable  (QCode *code, tagEntry *entry)
 		i = Q_REJECT;
 	else if (es_error_p (r))
 	{
+		MIO  *mioerr = mio_new_fp (stderr, NULL);;
+
 		fprintf(stderr, "GOT ERROR in QUALIFYING: %s: ",
 			 es_error_name (r));
-		es_print(es_error_get_object(r), stderr);
+		es_print(es_error_get_object(r), mioerr);
 		putc('\n', stderr);
 		i = Q_ERROR;
+
+		mio_free(mioerr);
 	}
 	else
 		i = Q_ACCEPT;

--- a/main/mio.c
+++ b/main/mio.c
@@ -18,11 +18,14 @@
  *
  */
 
+#ifndef QUALIFIER
 #include "general.h"  /* must always come first */
 
-#include "mio.h"
 #include "routines.h"
 #include "debug.h"
+#endif
+
+#include "mio.h"
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -30,6 +33,63 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <limits.h>
+
+#ifdef QUALIFIER
+#define xMalloc(n,Type)    (Type *)eMalloc((size_t)(n) * sizeof (Type))
+#define xCalloc(n,Type)    (Type *)eCalloc((size_t)(n), sizeof (Type))
+#define xRealloc(p,n,Type) (Type *)eRealloc((p), (n) * sizeof (Type))
+
+extern void *eMalloc (const size_t size)
+{
+	void *buffer = malloc (size);
+
+	if (buffer == NULL)
+	{
+		fprintf(stderr, "out of memory");
+		abort ();
+	}
+
+	return buffer;
+}
+
+extern void *eCalloc (const size_t count, const size_t size)
+{
+	void *buffer = calloc (count, size);
+
+	if (buffer == NULL)
+	{
+		fprintf(stderr, "out of memory");
+		abort ();
+	}
+
+	return buffer;
+}
+
+extern void *eRealloc (void *const ptr, const size_t size)
+{
+	void *buffer;
+	if (ptr == NULL)
+		buffer = eMalloc (size);
+	else
+	{
+		buffer = realloc (ptr, size);
+		if (buffer == NULL)
+		{
+			fprintf(stderr, "out of memory");
+			abort ();
+		}
+	}
+	return buffer;
+}
+
+extern void eFree (void *const ptr)
+{
+	free (ptr);
+}
+
+#  define Assert(c)
+#  define AssertNotReached()
+#endif
 
 /* minimal reallocation chunk size */
 #define MIO_CHUNK_SIZE 4096

--- a/readtags.c
+++ b/readtags.c
@@ -472,7 +472,7 @@ static tagFile *initialize (const char *const filePath, tagFileInfo *const info)
 		result->fields.max = 20;
 		result->fields.list = (tagExtensionField*) calloc (
 			result->fields.max, sizeof (tagExtensionField));
-		result->fp = fopen (filePath, "r");
+		result->fp = fopen (filePath, "rb");
 		if (result->fp == NULL)
 		{
 			free (result);

--- a/source.mak
+++ b/source.mak
@@ -8,6 +8,9 @@ REPOINFO_HEADS = main/repoinfo.h
 REPOINFO_SRCS  = main/repoinfo.c
 REPOINFO_OBJS  = $(REPOINFO_SRCS:.c=.$(OBJEXT))
 
+MIO_HEADS = main/mio.h
+MIO_SRCS  = main/mio.c
+
 MAIN_HEADS =			\
 	main/args.h		\
 	main/ctags.h		\
@@ -22,7 +25,6 @@ MAIN_HEADS =			\
 	main/kind.h		\
 	main/main.h		\
 	main/mbcs.h		\
-	main/mio.h		\
 	main/nestlevel.h	\
 	main/options.h		\
 	main/parse.h		\
@@ -35,7 +37,9 @@ MAIN_HEADS =			\
 	main/sort.h		\
 	main/strlist.h		\
 	main/vstring.h		\
-	main/xtag.h
+	main/xtag.h		\
+	\
+	$(MIO_HEADS)
 
 MAIN_SRCS =				\
 	main/args.c			\
@@ -52,7 +56,6 @@ MAIN_SRCS =				\
 	main/lxpath.c			\
 	main/main.c			\
 	main/mbcs.c			\
-	main/mio.c			\
 	main/nestlevel.c		\
 	main/options.c			\
 	main/parse.c			\
@@ -67,6 +70,7 @@ MAIN_SRCS =				\
 	main/xtag.c			\
 	\
 	$(REPOINFO_SRCS) \
+	$(MIO_SRCS)      \
 	\
 	$(NULL)
 
@@ -185,9 +189,19 @@ FNMATCH_SRCS = fnmatch/fnmatch.c
 FNMATCH_OBJS = $(FNMATCH_SRCS:.c=.$(OBJEXT))
 
 QUALIFIER_HEAD = dsl/es-lang-c-stdc99.h \
-		 dsl/qualifier.h
+		 dsl/qualifier.h \
+		 \
+		 $(MIO_HEADS) \
+		 \
+		 $(NULL)
+
 QUALIFIER_SRCS = dsl/es-lang-c-stdc99.c \
-		 dsl/qualifier.c
+		 dsl/qualifier.c \
+		 \
+		 $(MIO_SRCS) \
+		 \
+		 $(NULL)
+
 QUALIFIER_OBJS = $(QUALIFIER_SRCS:.c=.$(OBJEXT))
 
 ALL_OBJS = \


### PR DESCRIPTION
open_memstream and fmemopen were used to parse a query string.

Quoted from man fmemopen(3):

       fmemopen(), open_memstream(), open_wmemstream():
           Since glibc 2.10:
               _POSIX_C_SOURCE >= 200809L
           Before glibc 2.10:
               _GNU_SOURCE

It seems that open_memstream and fmemopen become parts of POSIX in
2008. MIO may be more portable than them.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>