### PR TITLE
tmain: Run xcmd-dont-run-set[ug]id-executable only on the platform where set[gu]id is available

### DIFF
--- a/Tmain/xcmd-dont-run-setgid-executable.d/run.sh
+++ b/Tmain/xcmd-dont-run-setgid-executable.d/run.sh
@@ -8,7 +8,13 @@ exit_if_no_coproc ${CTAGS}
 
 X=BACKENDCMD.tmp
 touch ${X}
-chmod g+xs ${X} 
+chmod g+xs ${X}
+
+if [ $(ls -l ${X} | sed -e 's/......\(.\).*/\1/') != 's' ]; then
+    echo "no setgid on the system"
+    exit 77
+fi
+
 ${CTAGS} --quiet --options=NONE --langdef=foo --xcmd-foo=./${X} --list-kinds | grep foo
 S=$?
 

--- a/Tmain/xcmd-dont-run-setuid-executable.d/run.sh
+++ b/Tmain/xcmd-dont-run-setuid-executable.d/run.sh
@@ -8,7 +8,14 @@ exit_if_no_coproc ${CTAGS}
 
 X=BACKENDCMD.tmp
 touch ${X}
-chmod u+xs ${X} 
+chmod u+xs ${X}
+
+if [ $(ls -l ${X} | sed -e 's/...\(.\).*/\1/') != 's' ]; then
+    echo "no setuid on the system"
+    exit 77
+fi
+
+
 ${CTAGS} --quiet --options=NONE --langdef=foo --xcmd-foo=./${X} --list-kinds | grep foo
 S=$?
 


### PR DESCRIPTION
As far as testing on msys2-64bit + autotools,
xcmd-dont-run-set[ug]id-executable were failed because there are not
set[gu]id on the platform. On such platform
xcmd-dont-run-set[ug]id-executable don't make sense.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>