### PR TITLE
Fixed "duplicate const" compiler warnings when building on OS X using clang

### DIFF
--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -322,7 +322,7 @@ sub emit_regexs {
     return if (! @{$opts->{'regexs'}});
 
     print <<EOF;
-	static const tagRegexTable const $opts->{'Clangdef'}TagRegexTable [] = {
+	static const tagRegexTable $opts->{'Clangdef'}TagRegexTable [] = {
 EOF
     for (@{$opts->{'regexs'}}) {
 	my $flags = $_-> {'flags'}? '"' . $_-> {'flags'} . '"': "NULL";

--- a/optlib/ctags-optlib.c
+++ b/optlib/ctags-optlib.c
@@ -25,7 +25,7 @@ extern parserDefinition* CtagsParser (void)
 		NULL
 	};
 
-	static const tagRegexTable const CtagsTagRegexTable [] = {
+	static const tagRegexTable CtagsTagRegexTable [] = {
 		{"^--langdef=([^ \\t]+)$", "\\1",
 		"l,langdef", NULL},
 		{"^--regex-[^=]+=.*\\/.,(.+)\\/.*", "\\1",

--- a/optlib/gdbinit.c
+++ b/optlib/gdbinit.c
@@ -28,7 +28,7 @@ extern parserDefinition* GdbinitParser (void)
 		NULL
 	};
 
-	static const tagRegexTable const GdbinitTagRegexTable [] = {
+	static const tagRegexTable GdbinitTagRegexTable [] = {
 		{"^#.*", "",
 		"", "{exclusive}"},
 		{"^define[[:space:]]+([^[:space:]]+)$", "\\1",

--- a/optlib/m4.c
+++ b/optlib/m4.c
@@ -27,7 +27,7 @@ extern parserDefinition* M4Parser (void)
 		NULL
 	};
 
-	static const tagRegexTable const M4TagRegexTable [] = {
+	static const tagRegexTable M4TagRegexTable [] = {
 		{"^dnl.*$", "",
 		"", "{exclusive}"},
 		{"^[[:space:]]*(m4_)?define\\(([[`{]|<<)?([^]'}>,]+)([]'}]|>>)?,", "\\3",

--- a/optlib/man.c
+++ b/optlib/man.c
@@ -33,7 +33,7 @@ extern parserDefinition* ManParser (void)
 		NULL
 	};
 
-	static const tagRegexTable const ManTagRegexTable [] = {
+	static const tagRegexTable ManTagRegexTable [] = {
 		{"^\\.TH[[:space:]]{1,}\"([^\"]{1,})\".*", "\\1",
 		"t,title,titles", "{exclusive}{icase}{scope=push}"},
 		{"^\\.TH[[:space:]]{1,}([^[:space:]]{1,}).*", "\\1",

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -68,7 +68,7 @@ static kindOption AsmKinds [] = {
 	{ TRUE, 't', "type",   "types (structs and records)"   }
 };
 
-static const keywordTable const AsmKeywords [] = {
+static const keywordTable AsmKeywords [] = {
 	{ "align",    OP_ALIGN       },
 	{ "endmacro", OP_ENDMACRO    },
 	{ "endm",     OP_ENDM        },

--- a/parsers/cobol.c
+++ b/parsers/cobol.c
@@ -15,7 +15,7 @@
 #include "parse.h"
 #include "routines.h"
 
-static const tagRegexTable const cobolTagRegexTable[] = {
+static const tagRegexTable cobolTagRegexTable[] = {
 	{"^[ \t]*[0-9]+[ \t]+([A-Z0-9][A-Z0-9-]*)[ \t]+("
 	 "BLANK|OCCURS|IS|JUST|PIC|REDEFINES|RENAMES|SIGN|SYNC|USAGE|VALUE"
 	 ")", "\\1",

--- a/parsers/dosbatch.c
+++ b/parsers/dosbatch.c
@@ -17,7 +17,7 @@
 #include "routines.h"
 #include "selectors.h"
 
-static const tagRegexTable const dosTagRegexTable [] = {
+static const tagRegexTable dosTagRegexTable [] = {
 	{"^:([A-Za-z_0-9]+)", "\\1",
 	 "l,label,labels", NULL},
 	{"set[ \t]+([A-Za-z_0-9]+)[ \t]*=", "\\1",

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -47,7 +47,7 @@ static kindOption DTSKinds [] = {
 	  .referenceOnly = FALSE, ATTACH_ROLES(DTSHeaderRoles)},
 };
 
-static const tagRegexTable const dtsTagRegexTable [] = {
+static const tagRegexTable dtsTagRegexTable [] = {
 	/* phandle = <0x00> */
 	{"^[ \t]*phandle[ \t]+=[ \t]+<(0x[a-fA-F0-9]+)>", "\\1",
 	 "p,phandler,phandlers", "{scope=ref}"},

--- a/parsers/eiffel.c
+++ b/parsers/eiffel.c
@@ -114,7 +114,7 @@ static kindOption EiffelKinds [] = {
 	{ FALSE, 'l', "local",   "local entities"}
 };
 
-static const keywordTable const EiffelKeywordTable [] = {
+static const keywordTable EiffelKeywordTable [] = {
 	/* keyword          keyword ID */
 	{ "across",         KEYWORD_across     },
 	{ "alias",          KEYWORD_alias      },

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -153,7 +153,7 @@ static kindOption FlexKinds [] = {
 /*	Used to determine whether keyword is valid for the token language and
  *	what its ID is.
  */
-static const keywordTable const FlexKeywordTable [] = {
+static const keywordTable FlexKeywordTable [] = {
 	/* keyword		keyword ID */
 	{ "function",	KEYWORD_function			},
 	{ "Function",	KEYWORD_capital_function	},

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -248,7 +248,7 @@ static kindOption FortranKinds [] = {
  * http://h18009.www1.hp.com/fortran/docs/lrm/dflrm.htm
  */
 
-static const keywordTable const FortranKeywordTable [] = {
+static const keywordTable FortranKeywordTable [] = {
 	/* keyword          keyword ID */
 	{ "abstract",       KEYWORD_abstract     },
 	{ "allocatable",    KEYWORD_allocatable  },

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -101,7 +101,7 @@ static kindOption GoKinds[] = {
 	{TRUE, 'm', "member", "struct members"}
 };
 
-static const keywordTable const GoKeywordTable[] = {
+static const keywordTable GoKeywordTable[] = {
 	{"package", KEYWORD_package},
 	{"import", KEYWORD_import},
 	{"const", KEYWORD_const},

--- a/parsers/html.c
+++ b/parsers/html.c
@@ -15,7 +15,7 @@
 #include "parse.h"
 #include "routines.h"
 
-static const tagRegexTable const htmlTagRegexTable [] = {
+static const tagRegexTable htmlTagRegexTable [] = {
 #define POSSIBLE_ATTRIBUTES "([ \t]+[a-z]+=\"?[^>\"]*\"?)*"
 	{"<a"
 	 POSSIBLE_ATTRIBUTES "[ \t]+name=\"?([^>\"]+)\"?" POSSIBLE_ATTRIBUTES

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -136,7 +136,7 @@ static kindOption JsKinds [] = {
 	{ TRUE,  'v', "variable",	  "global variables"   }
 };
 
-static const keywordTable const JsKeywordTable [] = {
+static const keywordTable JsKeywordTable [] = {
 	/* keyword		keyword ID */
 	{ "function",	KEYWORD_function			},
 	{ "Function",	KEYWORD_capital_function	},

--- a/parsers/json.c
+++ b/parsers/json.c
@@ -78,7 +78,7 @@ static kindOption JsonKinds [] = {
 	{ TRUE,  'z', "null",		"nulls"		}
 };
 
-static const keywordTable const JsonKeywordTable [] = {
+static const keywordTable JsonKeywordTable [] = {
 	{"true",  KEYWORD_true },
 	{"false", KEYWORD_false},
 	{"null", KEYWORD_null },

--- a/parsers/matlab.c
+++ b/parsers/matlab.c
@@ -17,7 +17,7 @@
 #include "routines.h"
 #include "selectors.h"
 
-static const tagRegexTable const matlabTagRegexTable [] = {
+static const tagRegexTable matlabTagRegexTable [] = {
 	/* function [x,y,z] = asdf */
 	{ "^function[ \t]*\\[.*\\][ \t]*=[ \t]*([a-zA-Z0-9_]+)",
 	  "\\1", "f,function", NULL},

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -112,7 +112,7 @@ typedef enum {
 
 typedef objcKeyword objcToken;
 
-static const keywordTable const objcKeywordTable[] = {
+static const keywordTable objcKeywordTable[] = {
 	{"typedef", ObjcTYPEDEF},
 	{"struct", ObjcSTRUCT},
 	{"enum", ObjcENUM},

--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -122,7 +122,7 @@ typedef struct sOcaKeywordDesc {
 
 typedef ocamlKeyword ocaToken;
 
-static const keywordTable const OcamlKeywordTable[] = {
+static const keywordTable OcamlKeywordTable[] = {
 	{ "and"       , OcaKEYWORD_and       }, 
 	{ "begin"     , OcaKEYWORD_begin     }, 
 	{ "class"     , OcaKEYWORD_class     }, 

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -138,7 +138,7 @@ static kindOption PhpKinds[COUNT_KIND] = {
 	  ATTACH_SEPARATORS(PhpGenericSeparators)},
 };
 
-static const keywordTable const PhpKeywordTable[] = {
+static const keywordTable PhpKeywordTable[] = {
 	/* keyword			keyword ID */
 	{ "abstract",		KEYWORD_abstract		},
 	{ "and",			KEYWORD_and				},

--- a/parsers/rexx.c
+++ b/parsers/rexx.c
@@ -16,7 +16,7 @@
 #include "routines.h"
 #include "selectors.h"
 
-static const tagRegexTable const rexxTagRegexTable [] = {
+static const tagRegexTable rexxTagRegexTable [] = {
 	{"^([A-Za-z0-9@#$\\.!?_]+)[ \t]*:", "\\1",
 	 "s,subroutine,subroutines", NULL},
 };

--- a/parsers/slang.c
+++ b/parsers/slang.c
@@ -16,7 +16,7 @@
 #include "parse.h"
 #include "routines.h"
 
-static const tagRegexTable const slangTagRegexTable [] = {
+static const tagRegexTable slangTagRegexTable [] = {
 	{"^.*define[ \t]+([A-Z_][A-Z0-9_]*)[^;]*$", "\\1",
 	 "f,function,functions", "i"},
 	{"^[ \t]*implements[ \t]+\\([ \t]*\"([^\"]*)\"[ \t]*\\)[ \t]*;", "\\1",

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -224,7 +224,7 @@ static kindOption SqlKinds [] = {
 	{ TRUE,  'z', "mlprop",		  "MobiLink Properties "   }
 };
 
-static const keywordTable const SqlKeywordTable [] = {
+static const keywordTable SqlKeywordTable [] = {
 	/* keyword		keyword ID */
 	{ "as",								KEYWORD_is				      },
 	{ "is",								KEYWORD_is				      },

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -125,7 +125,7 @@ static kindOption TexKinds [] = {
 	{ TRUE,  'i', "include",	  	  "includes"		   }
 };
 
-static const keywordTable const TexKeywordTable [] = {
+static const keywordTable TexKeywordTable [] = {
 	/* keyword			keyword ID */
 	{ "part",			KEYWORD_part				},
 	{ "chapter",		KEYWORD_chapter				},

--- a/parsers/vhdl.c
+++ b/parsers/vhdl.c
@@ -195,7 +195,7 @@ static kindOption VhdlKinds[] = {
 	{FALSE, 'l', "local", "local definitions"}
 };
 
-static const keywordTable const VhdlKeywordTable[] = {
+static const keywordTable VhdlKeywordTable[] = {
 	{"abs", KEYWORD_ABS},
 	{"access", KEYWORD_ACCESS},
 	{"after", KEYWORD_AFTER},

--- a/parsers/yacc.c
+++ b/parsers/yacc.c
@@ -20,7 +20,7 @@
 *   FUNCTION DEFINITIONS
 */
 
-static const tagRegexTable const yaccTagRegexTable [] = {
+static const tagRegexTable yaccTagRegexTable [] = {
 	{"^([A-Za-z][A-Za-z_0-9]+)[ \t]*:", "\\1",
 	 "l,label,labels", NULL},
 };


### PR DESCRIPTION
This was originally submitted by @siegel in #903.
I rearranged the commits into one.