### PR TITLE
Misc fix about mio

### DIFF
--- a/main/parse.c
+++ b/main/parse.c
@@ -685,9 +685,6 @@ struct getLangCtx {
     boolean     err;
 };
 
-extern MIO *getMio (const char *const fileName, const char *const openMode,
-		    boolean memStreamRequired);
-
 #define GLC_FOPEN_IF_NECESSARY0(_glc_, _label_) do {        \
     if (!(_glc_)->input) {                                  \
 	    (_glc_)->input = getMio((_glc_)->fileName, "rb", FALSE);	\

--- a/main/read.c
+++ b/main/read.c
@@ -318,8 +318,11 @@ extern MIO *getMio (const char *const fileName, const char *const openMode,
 	    && (size > MAX_IN_MEMORY_FILE_SIZE || size == 0))
 		return mio_new_file (fileName, openMode);
 
-	data = eMalloc (size);
 	src = fopen (fileName, openMode);
+	if (!src)
+		return NULL;
+
+	data = eMalloc (size);
 	if (fread (data, 1, size, src) != size)
 	{
 		eFree (data);

--- a/main/read.h
+++ b/main/read.h
@@ -130,7 +130,15 @@ extern CONST_FILE inputFile File;
 /* InputFile: reading from fp in inputFile with updating fields in input fields */
 extern void                 freeInputFileResources (void);
 extern const unsigned char *getInpufFileData (size_t *size);
+
+/* Stream opend by getMio can be passed to openInputFile as the 3rd
+   argument. If the 3rd argument is NULL, openInputFile calls getMio
+   internally. The 3rd argument is introduced for reusing mio object
+   created in parser guessing stage. */
 extern boolean              openInputFile (const char *const fileName, const langType language, MIO *mio);
+extern MIO                 *getMio (const char *const fileName, const char *const openMode,
+				    boolean memStreamRequired);
+
 extern void                 closeInputFile (void);
 extern void                *getInputFileUserData(void);
 extern int                  getcFromInputFile (void);


### PR DESCRIPTION
231e40e is critical.

The call sequence fopen `->` fread assumes the fopen doesn't return NULL.