### PR TITLE
refactor: Introduce vStringNewOrClear utility function

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -1076,10 +1076,7 @@ static int   makePatternStringCommon (const tagEntryInfo *const tag,
 	if (!tag->truncateLine)
 	{
 		making_cache = TRUE;
-		if (cached_pattern == NULL)
-			cached_pattern = vStringNew();
-		else
-			vStringClear (cached_pattern);
+		cached_pattern = vStringNewOrClear (cached_pattern);
 
 		puts_o_func = puts_func;
 		o_output    = output;
@@ -1444,10 +1441,7 @@ extern int makeQualifiedTagEntry (const tagEntryInfo *const e)
 		x = *e;
 		markTagExtraBit (&x, XTAG_QUALIFIED_TAGS);
 
-		if (fqn == NULL)
-			fqn = vStringNew ();
-		else
-			vStringClear (fqn);
+		fqn = vStringNewOrClear (fqn);
 
 		if (e->extensionFields.scopeName)
 		{

--- a/main/field.c
+++ b/main/field.c
@@ -463,10 +463,7 @@ extern const char* renderFieldEscaped (fieldType type,
 	Assert (tag);
 	Assert (fdesc->spec->renderEscaped);
 
-	if (fdesc->buffer == NULL)
-		fdesc->buffer = vStringNew ();
-	else
-		vStringClear (fdesc->buffer);
+	fdesc->buffer = vStringNewOrClear (fdesc->buffer);
 
 	if (index >= 0)
 	{
@@ -523,10 +520,7 @@ static const char *renderFieldCompactInputLine (const tagEntryInfo *const tag,
 	const char *line;
 	static vString *tmp;
 
-	if (tmp == NULL)
-		tmp = vStringNew ();
-	else
-		vStringClear (tmp);
+	tmp = vStringNewOrClear (tmp);
 
 	line = readLineFromBypassAnyway (tmp, tag, NULL);
 	if (line)

--- a/main/get.c
+++ b/main/get.c
@@ -161,10 +161,7 @@ extern void cppInit (const boolean state, const boolean hasAtLiteralStrings,
 	Cpp.directive.ifdef [0].branchChosen = FALSE;
 	Cpp.directive.ifdef [0].ignoring     = FALSE;
 
-	if (Cpp.directive.name == NULL)
-		Cpp.directive.name = vStringNew ();
-	else
-		vStringClear (Cpp.directive.name);
+	Cpp.directive.name = vStringNewOrClear (Cpp.directive.name);
 }
 
 extern void cppTerminate (void)
@@ -410,10 +407,7 @@ static int directiveDefine (const int c, boolean undef)
 			p = getcFromInputFile ();
 			if (p == '(')
 			{
-				if (! signature)
-					signature = vStringNew ();
-				else
-					vStringClear (signature);
+				signature = vStringNewOrClear (signature);
 				do {
 					if (!isspacetab(p))
 						vStringPut (signature, p);

--- a/main/options.c
+++ b/main/options.c
@@ -1105,10 +1105,7 @@ static void processFieldsOption (
 	boolean inLongName = FALSE;
 	langType language;
 
-	if (!longName)
-		longName = vStringNew ();
-	else
-		vStringClear (longName);
+	longName = vStringNewOrClear (longName);
 
 	if (*p == '*')
 	{

--- a/main/read.c
+++ b/main/read.c
@@ -510,9 +510,7 @@ static vString *iFileGetLine (void)
 {
 	vString *result = NULL;
 	int c;
-	if (File.line == NULL)
-		File.line = vStringNew ();
-	vStringClear (File.line);
+	File.line = vStringNewOrClear (File.line);
 	do
 	{
 		c = iFileGetc ();

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -337,4 +337,15 @@ extern void vStringCatSWithEscapingAsPattern (vString *output, const char* input
 	}
 }
 
+extern vString *vStringNewOrClear (vString *const string)
+{
+	if (string)
+	{
+		vStringClear (string);
+		return string;
+	}
+	else
+		return vStringNew ();
+}
+
 /* vi:set tabstop=4 shiftwidth=4: */

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -83,6 +83,8 @@ extern void vStringCopyToLower (vString *const dest, const vString *const src);
 extern void vStringSetLength (vString *const string);
 extern void vStringTruncate (vString *const string, const size_t length);
 
+extern vString *vStringNewOrClear (vString *const string);
+
 extern vString *vStringNewOwn (char *s);
 extern char    *vStringDeleteUnwrap (vString *const string);
 


### PR DESCRIPTION
This new function simplifies writing the following idiom:

     static vString *tmp;

     if (tmp)
     	vStringClear (tmp);
     else
        tmp = vStringNew (tmp);

Signed-off-by: Masatake YAMATO <yamato@redhat.com>