### PR TITLE
Units, python: don't refer pseudo tags when testing

### DIFF
--- a/Units/parser-python.r/simple.py.d/args.ctags
+++ b/Units/parser-python.r/simple.py.d/args.ctags
@@ -1,3 +1,3 @@
 --sort=no
---extra=*
+--extra=*-p
 --fields=*

--- a/Units/parser-python.r/simple.py.d/expected.tags
+++ b/Units/parser-python.r/simple.py.d/expected.tags
@@ -1,9 +1,3 @@
-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
-!_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
-!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
-!_TAG_PROGRAM_URL	/ctags.io/	/official site/
-!_TAG_PROGRAM_VERSION	0.0.0	/4285f14/
 bsddb	input.py	/^from bsddb import btopen$/;"	kind:module	line:5	language:Python	role:namespace	extra:reference
 btopen	input.py	/^from bsddb import btopen$/;"	kind:unknown	line:5	language:Python	role:imported	extra:reference
 bsddb.btopen	input.py	/^from bsddb import btopen$/;"	kind:unknown	line:5	language:Python	role:imported	extra:qualified,reference


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>