### PR TITLE
units: don't use bash own parameter expansion

### DIFF
--- a/misc/units
+++ b/misc/units
@@ -506,11 +506,10 @@ run_tcase ()
 
     if [ -f "${ffeatures}" ] && ! tmp=$(check_features "${ffeatures}"); then
 	L_SKIPPED_BY_FEATURES="$L_SKIPPED_BY_FEATURES ${category}/${name}"
-	if [ "${tmp:0:1}" = '!' ]; then
-	    run_result skip "${oresult}" "unwated feature \"${tmp:1}\" is available"
-	else
-	    run_result skip "${oresult}" "required feature \"$tmp\" is not available"
-	fi
+	case "${tmp}" in
+	    !*) run_result skip "${oresult}" "unwated feature \"${tmp#?}\" is available";;
+	    *)  run_result skip "${oresult}" "required feature \"${tmp}\" is not available";;
+	esac
 	return 1
     elif [ -f "${flanguages}" ] && ! tmp=$(check_languages "${flanguages}"); then
 	L_SKIPPED_BY_LANGUAGES="$L_SKIPPED_BY_LANGUAGES ${category}/${name}"


### PR DESCRIPTION
The parameter expansion ${V:n:m} for getting substring of
${V} is not available in /bin/dash.

May close #932.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>