### PR TITLE
Fixing parsing failures in following test case:

### DIFF
--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -298,8 +298,8 @@ process_token:
 						if(cxxParserCurrentLanguageIsCPP())
 						{
 							// may be followed by a lambda, otherwise it's not interesting.
-							g_cxx.uKeywordState |= CXXParserKeywordStateSeenReturn;
 							cxxParserNewStatement();
+							g_cxx.uKeywordState |= CXXParserKeywordStateSeenReturn;
 						} else {
 							// ignore
 							if(!cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF))

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -349,8 +349,8 @@ boolean cxxParserTokenChainLooksLikeFunctionCallParameterSet(
 			"The token chain should start with an opening parenthesis/bracket"
 		);
 	CXX_DEBUG_ASSERT(
-			cxxTokenTypeIsOneOf(pLast,CXXTokenTypeOpeningParenthesis | CXXTokenTypeClosingBracket),
-			"The token chain should end with an opening parenthesis/bracket"
+			cxxTokenTypeIsOneOf(pLast,CXXTokenTypeClosingParenthesis | CXXTokenTypeClosingBracket),
+			"The token chain should end with an closing parenthesis/bracket"
 		);
 
 	unsigned int uTerminator = t->eType << 4;

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -193,6 +193,7 @@ evaluate_current_token:
 					}
 				}
 			break;
+			case CXXTokenTypeComma:
 			case CXXTokenTypeAssignment:
 				CXX_DEBUG_PRINT("Found assignment, trying to skip up to a 'notable' point");
 				// try to skip to the next > or , without stopping at < characters.
@@ -233,8 +234,8 @@ evaluate_current_token:
 				return TRUE;
 			break;
 			default:
-				CXX_DEBUG_ASSERT(FALSE,"Should not end up here");
 				CXX_DEBUG_LEAVE_TEXT("Found unexpected token type 0x%02x",g_cxx.pToken->eType);
+				CXX_DEBUG_ASSERT(FALSE,"Should not end up here");
 				return FALSE;
 			break;
 		}

--- a/parsers/cxx/cxx_token_chain.c
+++ b/parsers/cxx/cxx_token_chain.c
@@ -827,6 +827,7 @@ CXXToken * cxxTokenChainExtractRange(
 	CXXToken * pRet = cxxTokenCreate();
 	pRet->iLineNumber = pToken->iLineNumber;
 	pRet->oFilePosition = pToken->oFilePosition;
+    pRet->eType = pToken->eType;
 
 	cxxTokenAppendToString(pRet->pszWord,pToken);
 	if(


### PR DESCRIPTION
```
template <typename T = void, bool B1 = true> // (1) fail if there are multiple params with default values
class A : public T
{
public:
    typedef A<T, B1> this_type;

    A(int i ) : m_i(i)
    {
    }

    static A create(int i)
    {
        return this_type(i); // (2) fail here
    }

    static int g_i;
private:
    int m_i;
};

template <typename T, bool B1>
int A<T, B1>::g_i; // (3) fail during parsing static member definition
```