### PR TITLE
Fix bug #971

### DIFF
--- a/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
@@ -1,33 +1,41 @@
-T01	input.cpp	/^typedef struct AStruct T01;$/;"	t	typeref:struct:AStruct	file:
-T02	input.cpp	/^typedef class AClass T02;$/;"	t	typeref:class:AClass	file:
-T03	input.cpp	/^typedef union AUnion T03;$/;"	t	typeref:union:AUnion	file:
-T04	input.cpp	/^typedef enum AEnum T04;$/;"	t	typeref:enum:AEnum	file:
-T11	input.cpp	/^typedef struct { int a; } T11;$/;"	t	typeref:struct:__anon0e56f337010a	file:
-T12	input.cpp	/^typedef union { int a; int b; } T12;$/;"	t	typeref:union:__anon0e56f337020c	file:
-T13	input.cpp	/^typedef enum { E2 } T13;$/;"	t	typeref:enum:__anon0e56f3370304	file:
-T21	input.cpp	/^typedef int* T21;$/;"	t	typeref:typename:int *	file:
-T22	input.cpp	/^typedef const AClass* *  T22;$/;"	t	typeref:typename:const AClass **	file:
-T31	input.cpp	/^typedef int (*T31) (int &,int , AUnion *);$/;"	t	typeref:typename:int (*)(int &,int,AUnion *)	file:
-T32	input.cpp	/^typedef AClass &(* T32)(AClass &);$/;"	t	typeref:typename:AClass & (*)(AClass &)	file:
-T41	input.cpp	/^typedef int T41 [ 10];$/;"	t	typeref:typename:int[10]	file:
-T51	input.cpp	/^typedef ATemplate1<int > T51;$/;"	t	typeref:typename:ATemplate1<int>	file:
-T52	input.cpp	/^typedef ATemplate1< unsigned short int> T52;$/;"	t	typeref:typename:ATemplate1<unsigned short int>	file:
-T53	input.cpp	/^typedef ATemplate1<ATemplate2 < AStruct,AClass> > T53;$/;"	t	typeref:typename:ATemplate1<ATemplate2<AStruct,AClass>>	file:
-T54	input.cpp	/^typedef ATemplate1<int > (*T54)();$/;"	t	typeref:typename:ATemplate1<int> (*)()	file:
-T61	input.cpp	/^	typedef typename Type::iterator1 T61;$/;"	t	class:Container	typeref:typename:Type::iterator1	file:
-T62	input.cpp	/^	typedef typename Type :: iterator2 T62;$/;"	t	class:Container	typeref:typename:Type::iterator2	file:
-T63	input.cpp	/^	typedef ATemplate1<AClass> T63;$/;"	t	class:Container	typeref:typename:ATemplate1<AClass>	file:
-T64	input.cpp	/^	typedef int (*T64)(ATemplate1<AUnion> &);$/;"	t	class:Container	typeref:typename:int (*)(ATemplate1<AUnion> &)	file:
-T71	input.cpp	/^typedef DECLPOINTER(struct AStruct) T71;$/;"	t	file:
-T81	input.cpp	/^} T81, *T82;$/;"	t	typeref:struct:_ABC	file:
-T82	input.cpp	/^} T81, *T82;$/;"	t	typeref:struct:_ABC *	file:
-T83	input.cpp	/^typedef int T83, *T84, **T85;$/;"	t	typeref:typename:int	file:
-T84	input.cpp	/^typedef int T83, *T84, **T85;$/;"	t	typeref:typename:int *	file:
-T85	input.cpp	/^typedef int T83, *T84, **T85;$/;"	t	typeref:typename:int **	file:
-T86	input.cpp	/^typedef ATemplate2< ATemplate2< ATemplate1<int *>, AClass>, AStruct> T86, **T87;$/;"	t	typeref:typename:ATemplate2<ATemplate2<ATemplate1<int * >,AClass>,AStruct>	file:
-T87	input.cpp	/^typedef ATemplate2< ATemplate2< ATemplate1<int *>, AClass>, AStruct> T86, **T87;$/;"	t	typeref:typename:ATemplate2<ATemplate2<ATemplate1<int * >,AClass>,AStruct> **	file:
-T88	input.cpp	/^typedef int T88, *T89, (&T90)(int, int *), T91[10], &T92;$/;"	t	typeref:typename:int	file:
-T89	input.cpp	/^typedef int T88, *T89, (&T90)(int, int *), T91[10], &T92;$/;"	t	typeref:typename:int *	file:
-T90	input.cpp	/^typedef int T88, *T89, (&T90)(int, int *), T91[10], &T92;$/;"	t	typeref:typename:int (&)(int,int *)	file:
-T91	input.cpp	/^typedef int T88, *T89, (&T90)(int, int *), T91[10], &T92;$/;"	t	typeref:typename:int[10]	file:
-T92	input.cpp	/^typedef int T88, *T89, (&T90)(int, int *), T91[10], &T92;$/;"	t	typeref:typename:int &	file:
+T001	input.cpp	/^typedef struct AStruct T001;$/;"	t	typeref:struct:AStruct	file:
+T002	input.cpp	/^typedef class AClass T002;$/;"	t	typeref:class:AClass	file:
+T003	input.cpp	/^typedef union AUnion T003;$/;"	t	typeref:union:AUnion	file:
+T004	input.cpp	/^typedef enum AEnum T004;$/;"	t	typeref:enum:AEnum	file:
+T101	input.cpp	/^typedef struct { int a; } T101;$/;"	t	typeref:struct:__anon0e56f337010a	file:
+T102	input.cpp	/^typedef union { int a; int b; } T102;$/;"	t	typeref:union:__anon0e56f337020c	file:
+T103	input.cpp	/^typedef enum { E2 } T103;$/;"	t	typeref:enum:__anon0e56f3370304	file:
+T201	input.cpp	/^typedef int* T201;$/;"	t	typeref:typename:int *	file:
+T202	input.cpp	/^typedef const AClass* *  T202;$/;"	t	typeref:typename:const AClass **	file:
+T301	input.cpp	/^typedef int (*T301) (int &,int , AUnion *);$/;"	t	typeref:typename:int (*)(int &,int,AUnion *)	file:
+T302	input.cpp	/^typedef AClass &(* T302)(AClass &);$/;"	t	typeref:typename:AClass & (*)(AClass &)	file:
+T401	input.cpp	/^typedef int T401 [ 10];$/;"	t	typeref:typename:int[10]	file:
+T501	input.cpp	/^typedef ATemplate1<int > T501;$/;"	t	typeref:typename:ATemplate1<int>	file:
+T502	input.cpp	/^typedef ATemplate1< unsigned short int> T502;$/;"	t	typeref:typename:ATemplate1<unsigned short int>	file:
+T503	input.cpp	/^typedef ATemplate1<ATemplate2 < AStruct,AClass> > T503;$/;"	t	typeref:typename:ATemplate1<ATemplate2<AStruct,AClass>>	file:
+T504	input.cpp	/^typedef ATemplate1<int > (*T504)();$/;"	t	typeref:typename:ATemplate1<int> (*)()	file:
+T601	input.cpp	/^	typedef typename Type::iterator1 T601;$/;"	t	class:Container	typeref:typename:Type::iterator1	file:
+T602	input.cpp	/^	typedef typename Type :: iterator2 T602;$/;"	t	class:Container	typeref:typename:Type::iterator2	file:
+T603	input.cpp	/^	typedef ATemplate1<AClass> T603;$/;"	t	class:Container	typeref:typename:ATemplate1<AClass>	file:
+T604	input.cpp	/^	typedef int (*T604)(ATemplate1<AUnion> &);$/;"	t	class:Container	typeref:typename:int (*)(ATemplate1<AUnion> &)	file:
+T701	input.cpp	/^typedef DECLPOINTER(struct AStruct) T701;$/;"	t	file:
+T801	input.cpp	/^} T801, *T802;$/;"	t	typeref:struct:_ABC	file:
+T802	input.cpp	/^} T801, *T802;$/;"	t	typeref:struct:_ABC *	file:
+T803	input.cpp	/^typedef int T803, *T804, **T805;$/;"	t	typeref:typename:int	file:
+T804	input.cpp	/^typedef int T803, *T804, **T805;$/;"	t	typeref:typename:int *	file:
+T805	input.cpp	/^typedef int T803, *T804, **T805;$/;"	t	typeref:typename:int **	file:
+T806	input.cpp	/^typedef ATemplate2< ATemplate2< ATemplate1<int *>, AClass>, AStruct> T806, **T807;$/;"	t	typeref:typename:ATemplate2<ATemplate2<ATemplate1<int * >,AClass>,AStruct>	file:
+T807	input.cpp	/^typedef ATemplate2< ATemplate2< ATemplate1<int *>, AClass>, AStruct> T806, **T807;$/;"	t	typeref:typename:ATemplate2<ATemplate2<ATemplate1<int * >,AClass>,AStruct> **	file:
+T808	input.cpp	/^typedef int T808, *T809, (&T810)(int, int *), T811[10], &T812;$/;"	t	typeref:typename:int	file:
+T809	input.cpp	/^typedef int T808, *T809, (&T810)(int, int *), T811[10], &T812;$/;"	t	typeref:typename:int *	file:
+T810	input.cpp	/^typedef int T808, *T809, (&T810)(int, int *), T811[10], &T812;$/;"	t	typeref:typename:int (&)(int,int *)	file:
+T811	input.cpp	/^typedef int T808, *T809, (&T810)(int, int *), T811[10], &T812;$/;"	t	typeref:typename:int[10]	file:
+T812	input.cpp	/^typedef int T808, *T809, (&T810)(int, int *), T811[10], &T812;$/;"	t	typeref:typename:int &	file:
+T901	input.cpp	/^} T901, *T902;$/;"	t	typeref:typename:const struct AStruct1	file:
+T902	input.cpp	/^} T901, *T902;$/;"	t	typeref:typename:const struct AStruct1 *	file:
+T903	input.cpp	/^typedef const struct AStruct1 T903;$/;"	t	typeref:typename:const struct AStruct1	file:
+T904	input.cpp	/^typedef const struct AStruct1 * T904,* T905;$/;"	t	typeref:typename:const struct AStruct1 *	file:
+T905	input.cpp	/^typedef const struct AStruct1 * T904,* T905;$/;"	t	typeref:typename:const struct AStruct1 *	file:
+T906	input.cpp	/^typedef volatile struct AStruct1 * T906;$/;"	t	typeref:typename:volatile struct AStruct1 *	file:
+T907	input.cpp	/^typedef const enum AEnum T907, &T908;$/;"	t	typeref:typename:const enum AEnum	file:
+T908	input.cpp	/^typedef const enum AEnum T907, &T908;$/;"	t	typeref:typename:const enum AEnum &	file:

--- a/Units/parser-cxx.r/typedefs.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/typedefs.cpp.d/input.cpp
@@ -9,54 +9,64 @@ template<typename AType> class ATemplate1;
 template<typename AType1,typename AType2> class ATemplate2;
 
 // class/struct/union/enum typedefs
-typedef struct AStruct T01;
-typedef class AClass T02;
-typedef union AUnion T03;
-typedef enum AEnum T04;
+typedef struct AStruct T001;
+typedef class AClass T002;
+typedef union AUnion T003;
+typedef enum AEnum T004;
 
 // typedefs with anonymous types
-typedef struct { int a; } T11;
-typedef union { int a; int b; } T12;
-typedef enum { E2 } T13;
+typedef struct { int a; } T101;
+typedef union { int a; int b; } T102;
+typedef enum { E2 } T103;
 
 // plain types, pointers etc
-typedef int* T21;
-typedef const AClass* *  T22;
+typedef int* T201;
+typedef const AClass* *  T202;
 
 // function pointers
-typedef int (*T31) (int &,int , AUnion *);
-typedef AClass &(* T32)(AClass &);
+typedef int (*T301) (int &,int , AUnion *);
+typedef AClass &(* T302)(AClass &);
 
 // arrays
-typedef int T41 [ 10];
+typedef int T401 [ 10];
 
 // stuff containing template instantiations
-typedef ATemplate1<int > T51;
-typedef ATemplate1< unsigned short int> T52;
-typedef ATemplate1<ATemplate2 < AStruct,AClass> > T53;
-typedef ATemplate1<int > (*T54)();
+typedef ATemplate1<int > T501;
+typedef ATemplate1< unsigned short int> T502;
+typedef ATemplate1<ATemplate2 < AStruct,AClass> > T503;
+typedef ATemplate1<int > (*T504)();
 
 // typedefs within a class
 template<typename Type> class Container
 {
 public:
-	typedef typename Type::iterator1 T61;
-	typedef typename Type :: iterator2 T62;
-	typedef ATemplate1<AClass> T63;
-	typedef int (*T64)(ATemplate1<AUnion> &);
+	typedef typename Type::iterator1 T601;
+	typedef typename Type :: iterator2 T602;
+	typedef ATemplate1<AClass> T603;
+	typedef int (*T604)(ATemplate1<AUnion> &);
 };
 
 // This should appear as typedef but have not typeref since we can't resolve macros
 #define DECLPOINTER(name) name *
 
-typedef DECLPOINTER(struct AStruct) T71;
+typedef DECLPOINTER(struct AStruct) T701;
 
 // Multiple typedefs
 typedef struct _ABC {
 	int a;
 	int b;
-} T81, *T82;
+} T801, *T802;
 
-typedef int T83, *T84, **T85;
-typedef ATemplate2< ATemplate2< ATemplate1<int *>, AClass>, AStruct> T86, **T87;
-typedef int T88, *T89, (&T90)(int, int *), T91[10], &T92;
+typedef int T803, *T804, **T805;
+typedef ATemplate2< ATemplate2< ATemplate1<int *>, AClass>, AStruct> T806, **T807;
+typedef int T808, *T809, (&T810)(int, int *), T811[10], &T812;
+
+// Typedefs with const/volatile prefix
+typedef const struct AStruct1 {
+	int a;
+} T901, *T902;
+
+typedef const struct AStruct1 T903;
+typedef const struct AStruct1 * T904,* T905;
+typedef volatile struct AStruct1 * T906;
+typedef const enum AEnum T907, &T908;

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -404,14 +404,18 @@ process_token:
 						g_cxx.uKeywordState |= CXXParserKeywordStateSeenVirtual;
 						cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 					break;
-					//case CXXKeywordVOLATILE:
-					// Volatile is actually part of the type!
-					//	g_cxx.uKeywordState |= CXXParserKeywordStateSeenVolatile;
-					//	cxxTokenChainDestroyLast(g_cxx.pTokenChain);
-					//break;
 					case CXXKeywordMUTABLE:
 						g_cxx.uKeywordState |= CXXParserKeywordStateSeenMutable;
 						cxxTokenChainDestroyLast(g_cxx.pTokenChain);
+					break;
+					// "const" and "volatile" are part of the type. Don't treat them specially
+					// and don't attempt to extract an eventual typedef yet,
+					// as there might be a struct/class/union keyword following.
+					case CXXKeywordVOLATILE:
+						g_cxx.uKeywordState |= CXXParserKeywordStateSeenVolatile;
+					break;
+					case CXXKeywordCONST:
+						g_cxx.uKeywordState |= CXXParserKeywordStateSeenConst;
 					break;
 					default:
 						if(g_cxx.uKeywordState & CXXParserKeywordStateSeenTypedef)

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -212,7 +212,11 @@ typedef enum _CXXParserKeywordState
 	// "return" has been seen
 	CXXParserKeywordStateSeenReturn = (1 << 7),
 	// "mutable" has been seen
-	CXXParserKeywordStateSeenMutable = (1 << 8)
+	CXXParserKeywordStateSeenMutable = (1 << 8),
+	// "const" has been seen at block level
+	CXXParserKeywordStateSeenConst = (1 << 9),
+	// "volatile" has been seen at block level
+	CXXParserKeywordStateSeenVolatile = (1 << 10)
 } CXXParserKeywordState;
 
 typedef struct _CXXParserState

--- a/parsers/cxx/cxx_parser_typedef.c
+++ b/parsers/cxx/cxx_parser_typedef.c
@@ -221,18 +221,20 @@ skip_to_comma_or_end:
 			cxxTokenChainTake(pTParentChain,t);
 
 			// Avoid emitting typerefs for strange things like
-			//  typedef MACRO(stuff,stuff) X
+			//  typedef MACRO(stuff,stuff) X;
+			// or parsing errors we might make in ugly cases like
+			//  typedef WHATEVER struct x { ... } y;
 			if(
 					(pTParentChain == pChain) && // not function pointer (see above)
 					(
 						pComma ? 
 							cxxTokenChainPreviousTokenOfType(
 									pComma,
-									CXXTokenTypeParenthesisChain
+									CXXTokenTypeParenthesisChain | CXXTokenTypeAngleBracketChain
 								) :
 							cxxTokenChainLastTokenOfType(
 									pChain,
-									CXXTokenTypeParenthesisChain
+									CXXTokenTypeParenthesisChain | CXXTokenTypeAngleBracketChain
 								)
 					)
 				)

--- a/parsers/cxx/cxx_token.c
+++ b/parsers/cxx/cxx_token.c
@@ -15,6 +15,7 @@
 
 #include "cxx_token_chain.h"
 #include "cxx_debug.h"
+#include "cxx_keyword.h"
 #include "cxx_tag.h"
 
 #define CXX_TOKEN_POOL_MAXIMUM_SIZE 8192
@@ -109,6 +110,19 @@ void cxxTokenForceDestroy(CXXToken * t)
 	vStringDelete(t->pszWord);
 
 	eFree(t);
+}
+
+CXXToken * cxxTokenCreateKeyword(int iLineNumber,MIOPos oFilePosition,enum CXXKeyword eKeyword)
+{
+	CXXToken * pToken = cxxTokenCreate();
+	pToken->iLineNumber = iLineNumber;
+	pToken->oFilePosition = oFilePosition;
+	pToken->eType = CXXTokenTypeKeyword;
+	pToken->eKeyword = eKeyword;
+	pToken->bFollowedBySpace = TRUE;
+	vStringCatS(pToken->pszWord,cxxKeywordName(eKeyword));
+
+	return pToken;
 }
 
 

--- a/parsers/cxx/cxx_token.h
+++ b/parsers/cxx/cxx_token.h
@@ -88,6 +88,9 @@ typedef struct _CXXToken
 CXXToken * cxxTokenCreate(void);
 void cxxTokenDestroy(CXXToken * t);
 
+// A shortcut for quickly creating keyword tokens.
+CXXToken * cxxTokenCreateKeyword(int iLineNumber,MIOPos oFilePosition,enum CXXKeyword eKeyword);
+
 enum CXXTagKind;
 
 CXXToken * cxxTokenCreateAnonymousIdentifier(enum CXXTagKind k);

--- a/parsers/cxx/cxx_token_chain.c
+++ b/parsers/cxx/cxx_token_chain.c
@@ -771,6 +771,9 @@ int cxxTokenChainFirstKeywordIndex(
 	return -1;
 }
 
+#if 0
+// This is working code but it's unused and coveralls complains.. sigh.
+// Remove the #if above if needed.
 CXXToken * cxxTokenChainFirstKeyword(
 		CXXTokenChain * tc,
 		enum CXXKeyword eKeyword
@@ -791,6 +794,7 @@ CXXToken * cxxTokenChainFirstKeyword(
 
 	return NULL;
 }
+#endif
 
 CXXToken * cxxTokenChainNextIdentifier(
 		CXXToken * from,

--- a/parsers/cxx/cxx_token_chain.c
+++ b/parsers/cxx/cxx_token_chain.c
@@ -771,6 +771,27 @@ int cxxTokenChainFirstKeywordIndex(
 	return -1;
 }
 
+CXXToken * cxxTokenChainFirstKeyword(
+		CXXTokenChain * tc,
+		enum CXXKeyword eKeyword
+	)
+{
+	if(!tc)
+		return NULL;
+	if(tc->iCount < 1)
+		return NULL;
+
+	CXXToken * pToken = tc->pHead;
+	while(pToken)
+	{
+		if(cxxTokenIsKeyword(pToken,eKeyword))
+			return pToken;
+		pToken = pToken->pNext;
+	}
+
+	return NULL;
+}
+
 CXXToken * cxxTokenChainNextIdentifier(
 		CXXToken * from,
 		const char * szIdentifier

--- a/parsers/cxx/cxx_token_chain.h
+++ b/parsers/cxx/cxx_token_chain.h
@@ -226,10 +226,14 @@ int cxxTokenChainFirstKeywordIndex(
 		enum CXXKeyword eKeyword
 	);
 
+#if 0
+// This is working code but it's unused and coveralls complains.. sigh.
+// Remove the #if above if needed.
 CXXToken * cxxTokenChainFirstKeyword(
 		CXXTokenChain * tc,
 		enum CXXKeyword eKeyword
 	);
+#endif
 
 // Assuming that pChain contains a type name, attempt to normalize the
 // spacing within the whole chain.

--- a/parsers/cxx/cxx_token_chain.h
+++ b/parsers/cxx/cxx_token_chain.h
@@ -226,6 +226,11 @@ int cxxTokenChainFirstKeywordIndex(
 		enum CXXKeyword eKeyword
 	);
 
+CXXToken * cxxTokenChainFirstKeyword(
+		CXXTokenChain * tc,
+		enum CXXKeyword eKeyword
+	);
+
 // Assuming that pChain contains a type name, attempt to normalize the
 // spacing within the whole chain.
 void cxxTokenChainNormalizeTypeNameSpacing(


### PR DESCRIPTION
Handle const/volatile prefixes in struct/union/enum (typedef) declarations.
Fix bug #971