### PR TITLE
Normalize spacing in function signatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
       description: "Build submitted via Travis CI"
     notification_email: coverityctags@gmail.com
     build_command_prepend: "./autogen.sh ; ./configure ; make clean"
-    build_command:   "make -j 4"
+    build_command:   "make -j 4 CFLAGS=-O0"
     branch_pattern: master
 
 sudo: false

--- a/Units/parser-c.r/macros.c.d/expected.tags
+++ b/Units/parser-c.r/macros.c.d/expected.tags
@@ -1,9 +1,9 @@
 DECL1	input.c	/^DECL1(foo); \/* gcc will accept this as function prototype (with some warnings) *\/$/;"	p	file:	signature:(foo)
-DECL3	input.c	/^DECL3(x, y); \/* gcc will accept this as function prototype (with some warnings) *\/$/;"	p	file:	signature:(x, y)
+DECL3	input.c	/^DECL3(x, y); \/* gcc will accept this as function prototype (with some warnings) *\/$/;"	p	file:	signature:(x,y)
 FUNCTION_LIKE	input.c	/^#define FUNCTION_LIKE(/;"	d	file:	signature:(a,b)
 FUNCTION_LIKE	input.c	/^#undef FUNCTION_LIKE$/;"	d	file:	role:undef
 VARIABLE_LIKE	input.c	/^#define VARIABLE_LIKE	/;"	d	file:
 VARIABLE_LIKE	input.c	/^#undef VARIABLE_LIKE$/;"	d	file:	role:undef
 WeakSymbol	input.c	/^#pragma weak WeakSymbol /;"	d	file:
-prototype1	input.c	/^void prototype1 __ARGS((int arg1, void *arg2));$/;"	p	typeref:typename:void	file:	signature:(int arg1, void *arg2)
-prototype2	input.c	/^void prototype2 __ARGS((int arg1, void *arg2))$/;"	f	typeref:typename:void	signature:(int arg1, void *arg2)
+prototype1	input.c	/^void prototype1 __ARGS((int arg1, void *arg2));$/;"	p	typeref:typename:void	file:	signature:(int arg1,void * arg2)
+prototype2	input.c	/^void prototype2 __ARGS((int arg1, void *arg2))$/;"	f	typeref:typename:void	signature:(int arg1,void * arg2)

--- a/Units/parser-cxx.r/bug-github-pull-972.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug-github-pull-972.cpp.d/expected.tags
@@ -1,6 +1,6 @@
 A	input.cpp	/^class A : public T$/;"	class	file:	inherits:T	template:<typename T=void,bool B1=true>
 this_type	input.cpp	/^    typedef A<T, B1> this_type;$/;"	typedef	scope:class:A	typeref:typename:A<T,B1>	file:
-A	input.cpp	/^    A(int i ) : m_i(i)$/;"	function	scope:class:A	file:	signature:(int i )
+A	input.cpp	/^    A(int i ) : m_i(i)$/;"	function	scope:class:A	file:	signature:(int i)
 create	input.cpp	/^    static A create(int i)$/;"	function	scope:class:A	typeref:typename:A	file:	signature:(int i)	properties:static
 g_i	input.cpp	/^    static int g_i;$/;"	member	scope:class:A	typeref:typename:int	file:	properties:static
 m_i	input.cpp	/^    int m_i;$/;"	member	scope:class:A	typeref:typename:int	file:

--- a/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.d/expected.tags
+++ b/Units/parser-cxx.r/cxx-shift-operators-in-template-parameters.d/expected.tags
@@ -1,4 +1,4 @@
 c	input.cpp	/^template <int P> class c {};$/;"	c	file:
 bVar	input.cpp	/^c< 8 > bVar;$/;"	v	typeref:typename:c<8>
 aVar	input.cpp	/^c< 1<<8 > aVar;$/;"	v	typeref:typename:c<1<<8>
-f12	input.cpp	/^template<int X> f12( c< 1<<X> & aVar) { };$/;"	f	signature:( c< 1<<X> & aVar)
+f12	input.cpp	/^template<int X> f12( c< 1<<X> & aVar) { };$/;"	f	signature:(c<1<<X> & aVar)

--- a/Units/parser-cxx.r/cxx11-delete.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-delete.d/expected.tags
@@ -1,3 +1,3 @@
 Del	input.cpp	/^    Del(const Del &) = delete;$/;"	p	class:Del	file:	signature:(const Del &)
 Del	input.cpp	/^class Del$/;"	c	file:
-operator =	input.cpp	/^    void operator=(const Del& rDel) = delete;$/;"	p	class:Del	typeref:typename:void	file:	signature:(const Del& rDel)
+operator =	input.cpp	/^    void operator=(const Del& rDel) = delete;$/;"	p	class:Del	typeref:typename:void	file:	signature:(const Del & rDel)

--- a/Units/parser-cxx.r/functions.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/functions.cpp.d/expected.tags
@@ -12,7 +12,7 @@ f05a01	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	z	fun
 f06	input.cpp	/^		auto f06(n01::c01 && f06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && f06a01)
 f06	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	f	class:n01::n02	typeref:typename:n01::n02::type01 *	signature:(n01::c01 && f06a01)	end:58
 f06a01	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	z	function:n01::n02::f06	typeref:typename:n01::c01 &&	file:
-f07	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	f	typeref:typename:unsigned int	signature:(int (*f07a01)(int * x1,int x2),...)	end:63
+f07	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	f	typeref:typename:unsigned int	signature:(int (* f07a01)(int * x1,int x2),...)	end:63
 f07a01	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	z	function:f07	typeref:typename:int (*)(int * x1,int x2)	file:
 p01	input.cpp	/^int p01(int p01a01,int p01a02);$/;"	p	typeref:typename:int	file:	signature:(int p01a01,int p01a02)
 p02	input.cpp	/^unsigned short int * p02(unsigned int & p02a01,...);$/;"	p	typeref:typename:unsigned short int *	file:	signature:(unsigned int & p02a01,...)
@@ -21,7 +21,7 @@ p04	input.cpp	/^auto p04() -> int (*)(int);$/;"	p	typeref:typename:int (*)(int)	
 p05	input.cpp	/^static std::string p05(const int *** p05a01);$/;"	p	typeref:typename:std::string	file:	signature:(const int *** p05a01)
 p06	input.cpp	/^		auto p06(n01::c01 && p06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && p06a01)
 p06	input.cpp	/^auto n01::n02::p06(n01::c01 && p06a01) -> n01::n02::type01 *;$/;"	p	class:n01::n02	typeref:typename:n01::n02::type01 *	file:	signature:(n01::c01 && p06a01)
-p07	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	p	typeref:typename:unsigned int	file:	signature:(int (*p07a01)(int * x1,int x2),...)
+p07	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	p	typeref:typename:unsigned int	file:	signature:(int (* p07a01)(int * x1,int x2),...)
 t01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t01a01)	end:69
 t01a01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	z	function:t01	typeref:typename:T &&	file:
 t02	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t02a01)	end:74

--- a/Units/parser-cxx.r/signature.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/signature.cpp.d/expected.tags
@@ -1,4 +1,4 @@
-BAR::bar	input.cpp	/^char *BAR::bar (char *c, double d[]) const {}$/;"	f	class:BAR	typeref:typename:char *	signature:(char *c, double d[]) const
-bar	input.cpp	/^char *BAR::bar (char *c, double d[]) const {}$/;"	f	class:BAR	typeref:typename:char *	signature:(char *c, double d[]) const
-foo	input.cpp	/^void foo (int a, char b) {}$/;"	f	typeref:typename:void	signature:(int a, char b)
-foobar	input.cpp	/^void foobar __ARGS ((int a, char b));$/;"	p	typeref:typename:void	file:	signature:(int a, char b)
+BAR::bar	input.cpp	/^char *BAR::bar (char *c, double d[]) const {}$/;"	f	class:BAR	typeref:typename:char *	signature:(char * c,double d[]) const
+bar	input.cpp	/^char *BAR::bar (char *c, double d[]) const {}$/;"	f	class:BAR	typeref:typename:char *	signature:(char * c,double d[]) const
+foo	input.cpp	/^void foo (int a, char b) {}$/;"	f	typeref:typename:void	signature:(int a,char b)
+foobar	input.cpp	/^void foobar __ARGS ((int a, char b));$/;"	p	typeref:typename:void	file:	signature:(int a,char b)

--- a/Units/parser-cxx.r/template-specializations.d/expected.tags
+++ b/Units/parser-cxx.r/template-specializations.d/expected.tags
@@ -1,14 +1,14 @@
 A	input.cpp	/^struct A {$/;"	s	file:	template:<typename T>
 f	input.cpp	/^    void f(T); \/\/ member, declared in the primary template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T)
 h	input.cpp	/^    void h(T) {} \/\/ member, defined in the primary template$/;"	f	struct:A	typeref:typename:void	file:	signature:(T)
-g1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T, X1)	template:<class X1>
-g2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T, X2)	template:<class X2>
+g1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T,X1)	template:<class X1>
+g2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T,X2)	template:<class X2>
 f	input.cpp	/^template<> void A<int>::f(int);$/;"	p	class:A	typeref:typename:void	file:	signature:(int)	template:<>	properties:scopespecialization,specialization
 h	input.cpp	/^template<> void A<int>::h(int) {}$/;"	f	class:A	typeref:typename:void	signature:(int)	template:<>	properties:scopespecialization,specialization
-g1	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	f	class:A	typeref:typename:void	signature:(T, X1)	template:<class X1>	properties:scopespecialization,specialization
-g1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	p	class:A	typeref:typename:void	file:	signature:(int, X1)	template:<class X1>	properties:scopespecialization,specialization
-g2	input.cpp	/^template<> void A<int>::g2<char>(int, char); \/\/ for X2 = char$/;"	p	class:A	typeref:typename:void	file:	signature:(int, char)	template:<>	properties:scopespecialization,specialization
-g1	input.cpp	/^template<> void A<int>::g1(int, char);$/;"	p	class:A	typeref:typename:void	file:	signature:(int, char)	template:<>	properties:scopespecialization,specialization
+g1	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	f	class:A	typeref:typename:void	signature:(T,X1)	template:<class X1>	properties:scopespecialization,specialization
+g1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	p	class:A	typeref:typename:void	file:	signature:(int,X1)	template:<class X1>	properties:scopespecialization,specialization
+g2	input.cpp	/^template<> void A<int>::g2<char>(int, char); \/\/ for X2 = char$/;"	p	class:A	typeref:typename:void	file:	signature:(int,char)	template:<>	properties:scopespecialization,specialization
+g1	input.cpp	/^template<> void A<int>::g1(int, char);$/;"	p	class:A	typeref:typename:void	file:	signature:(int,char)	template:<>	properties:scopespecialization,specialization
 m	input.cpp	/^template<typename X> void m(X)$/;"	f	typeref:typename:void	signature:(X)	template:<typename X>
 m	input.cpp	/^template<> void m<int>(int)$/;"	f	typeref:typename:void	signature:(int)	template:<>	properties:specialization
 m	input.cpp	/^template<> void m(char)$/;"	f	typeref:typename:void	signature:(char)	template:<>	properties:specialization

--- a/Units/parser-cxx.r/variables-prototypes-2.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/variables-prototypes-2.cpp.d/expected.tags
@@ -1,3 +1,3 @@
 listOfStrings	input.cpp	/^	List<String> listOfStrings(argv); \/\/ local$/;"	local	line:4
-main	input.cpp	/^int  main( int  argc, char ** argv )$/;"	function	line:1	signature:( int argc, char ** argv )
+main	input.cpp	/^int  main( int  argc, char ** argv )$/;"	function	line:1	signature:(int argc,char ** argv)
 sample	input.cpp	/^	String sample(argc); \/\/ local$/;"	local	line:3

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -274,6 +274,8 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 	{
 		if(pParenthesis->pChain->pTail)
 		{
+			// normalize signature
+			cxxTokenChainNormalizeTypeNameSpacing(pParenthesis->pChain);
 			// make sure we don't emit the trailing space
 			pParenthesis->pChain->pTail->bFollowedBySpace = FALSE;
 		}
@@ -1053,6 +1055,8 @@ int cxxParserEmitFunctionTags(
 	{
 		if(pInfo->pParenthesis->pChain->pTail)
 		{
+			// normalize signature
+			cxxTokenChainNormalizeTypeNameSpacing(pInfo->pParenthesis->pChain);
 			// make sure we don't emit the trailing space
 			pInfo->pParenthesis->pChain->pTail->bFollowedBySpace = FALSE;
 		}

--- a/parsers/cxx/cxx_token_chain.h
+++ b/parsers/cxx/cxx_token_chain.h
@@ -228,6 +228,9 @@ int cxxTokenChainFirstKeywordIndex(
 
 // Assuming that pChain contains a type name, attempt to normalize the
 // spacing within the whole chain.
+//
+// Please note that this will work also for entire function signatures
+// (since type names can contain function pointers which have signatures)
 void cxxTokenChainNormalizeTypeNameSpacing(
 		CXXTokenChain * pChain
 	);


### PR DESCRIPTION
Normalize spacing in function signatures.
The spacing used might be debatable: I'm not sure if it's better to choose `int *x` or `int * x`... but that's a minor matter. Normalization is certainly a good thing.