### PR TITLE
CXX: Refactor and cleanup [not for merging yet]

### DIFF
--- a/Tmain/list-kinds-full.d/stdout-expected.txt
+++ b/Tmain/list-kinds-full.d/stdout-expected.txt
@@ -1,13 +1,11 @@
 #LETTER	NAME	ENABLED	REFONLY	NROLES	DESCRIPTION
-c	class	on	FALSE	0	classes
 d	macro	on	FALSE	1	macro definitions
 e	enumerator	on	FALSE	0	enumerators (values inside an enumeration)
 f	function	on	FALSE	0	function definitions
 g	enum	on	FALSE	0	enumeration names
 h	header	off	TRUE	2	included header files
 l	local	off	FALSE	0	local variables
-m	member	on	FALSE	0	class, struct, and union members
-n	namespace	on	FALSE	0	namespaces
+m	member	on	FALSE	0	struct, and union members
 p	prototype	off	FALSE	0	function prototypes
 s	struct	on	FALSE	0	structure names
 t	typedef	on	FALSE	0	typedefs
@@ -16,5 +14,3 @@ v	variable	on	FALSE	0	variable definitions
 x	externvar	off	FALSE	0	external and forward variable declarations
 z	parameter	off	FALSE	0	function parameters inside function definitions
 L	label	off	FALSE	0	goto labels
-N	name	off	FALSE	0	names imported via using scope::symbol
-U	using	off	TRUE	0	using namespace statements

--- a/Units/parser-c.r/bit_field.c.d/expected.tags
+++ b/Units/parser-c.r/bit_field.c.d/expected.tags
@@ -2,24 +2,24 @@ bit_fields	input.c	/^struct bit_fields {$/;"	s	file:	end:5
 a	input.c	/^    unsigned int a: 1;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:1	file:
 b	input.c	/^    unsigned int b: 1;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:1	file:
 c	input.c	/^    unsigned int c: 2;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:2	file:
-__anon1719c4a5010a	input.c	/^struct {$/;"	s	file:	end:12
-sign	input.c	/^    unsigned sign  : 1;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned:1	file:
-exp	input.c	/^    unsigned exp   : _FP_EXPBITS_D;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
-frac1	input.c	/^    unsigned frac1 : _FP_FRACBITS_D - (_FP_IMPLBIT_D != 0) - _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
-frac0	input.c	/^    unsigned frac0 : _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
+__anon1719c4a50108	input.c	/^struct {$/;"	s	file:	end:12
+sign	input.c	/^    unsigned sign  : 1;$/;"	m	struct:__anon1719c4a50108	typeref:typename:unsigned:1	file:
+exp	input.c	/^    unsigned exp   : _FP_EXPBITS_D;$/;"	m	struct:__anon1719c4a50108	typeref:typename:unsigned	file:
+frac1	input.c	/^    unsigned frac1 : _FP_FRACBITS_D - (_FP_IMPLBIT_D != 0) - _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a50108	typeref:typename:unsigned	file:
+frac0	input.c	/^    unsigned frac0 : _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a50108	typeref:typename:unsigned	file:
 shortname_info	input.c	/^struct shortname_info {$/;"	s	file:	end:18
 lower	input.c	/^	unsigned char lower:1,$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
 upper	input.c	/^		      upper:1,$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
 valid	input.c	/^		      valid:1;$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
-__anon1719c4a5020a	input.c	/^{$/;"	s	file:	end:27
-public	input.c	/^    BYTE 	public: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
-bad2	input.c	/^    BYTE 	bad2: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
-group	input.c	/^    BYTE 	group: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
-personal	input.c	/^    BYTE 	personal: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
-bitfield_flags	input.c	/^} bitfield_flags;$/;"	t	typeref:struct:__anon1719c4a5020a	file:
-__anon1719c4a5030a	input.c	/^{$/;"	s	file:	end:35
-this	input.c	/^    BYTE	this;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
-public	input.c	/^    BYTE	public;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
-private	input.c	/^    BYTE	private;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
-that	input.c	/^    BYTE	that;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
-mystruct	input.c	/^} mystruct;$/;"	t	typeref:struct:__anon1719c4a5030a	file:
+__anon1719c4a50208	input.c	/^{$/;"	s	file:	end:27
+public	input.c	/^    BYTE 	public: 1;$/;"	m	struct:__anon1719c4a50208	typeref:typename:BYTE:1	file:
+bad2	input.c	/^    BYTE 	bad2: 1;$/;"	m	struct:__anon1719c4a50208	typeref:typename:BYTE:1	file:
+group	input.c	/^    BYTE 	group: 1;$/;"	m	struct:__anon1719c4a50208	typeref:typename:BYTE:1	file:
+personal	input.c	/^    BYTE 	personal: 1;$/;"	m	struct:__anon1719c4a50208	typeref:typename:BYTE:1	file:
+bitfield_flags	input.c	/^} bitfield_flags;$/;"	t	typeref:struct:__anon1719c4a50208	file:
+__anon1719c4a50308	input.c	/^{$/;"	s	file:	end:35
+this	input.c	/^    BYTE	this;$/;"	m	struct:__anon1719c4a50308	typeref:typename:BYTE	file:
+public	input.c	/^    BYTE	public;$/;"	m	struct:__anon1719c4a50308	typeref:typename:BYTE	file:
+private	input.c	/^    BYTE	private;$/;"	m	struct:__anon1719c4a50308	typeref:typename:BYTE	file:
+that	input.c	/^    BYTE	that;$/;"	m	struct:__anon1719c4a50308	typeref:typename:BYTE	file:
+mystruct	input.c	/^} mystruct;$/;"	t	typeref:struct:__anon1719c4a50308	file:

--- a/Units/parser-c.r/bug1466117.c.d/expected.tags
+++ b/Units/parser-c.r/bug1466117.c.d/expected.tags
@@ -1,7 +1,7 @@
-__anonadd2b98b010a	input.c	/^typedef struct {$/;"	s	file:
-a	input.c	/^	int a;$/;"	m	struct:__anonadd2b98b010a	typeref:typename:int	file:
+__anonadd2b98b0108	input.c	/^typedef struct {$/;"	s	file:
+a	input.c	/^	int a;$/;"	m	struct:__anonadd2b98b0108	typeref:typename:int	file:
 a	input.c	/^	int a;$/;"	m	struct:mystruct	typeref:typename:int	file:
-b	input.c	/^	int b;$/;"	m	struct:__anonadd2b98b010a	typeref:typename:int	file:
+b	input.c	/^	int b;$/;"	m	struct:__anonadd2b98b0108	typeref:typename:int	file:
 b	input.c	/^	int b;$/;"	m	struct:mystruct	typeref:typename:int	file:
 mystruct	input.c	/^typedef struct mystruct {$/;"	s	file:
-mystruct	input.c	/^} mystruct;$/;"	t	typeref:struct:__anonadd2b98b010a	file:
+mystruct	input.c	/^} mystruct;$/;"	t	typeref:struct:__anonadd2b98b0108	file:

--- a/Units/parser-c.r/bug1491666.c.d/expected.tags
+++ b/Units/parser-c.r/bug1491666.c.d/expected.tags
@@ -1,7 +1,7 @@
-__anon329ddd92010a	input.c	/^typedef struct {$/;"	s	file:
+__anon329ddd920108	input.c	/^typedef struct {$/;"	s	file:
 main	input.c	/^void main (void) {$/;"	f	typeref:typename:void
-my_struct	input.c	/^} my_struct;$/;"	t	typeref:struct:__anon329ddd92010a	file:
+my_struct	input.c	/^} my_struct;$/;"	t	typeref:struct:__anon329ddd920108	file:
 var1	input.c	/^	my_struct var1;$/;"	l	function:main	typeref:typename:my_struct	file:
 var2	input.c	/^		var2;$/;"	l	function:main	typeref:typename:my_struct	file:
-x	input.c	/^		x;$/;"	m	struct:__anon329ddd92010a	typeref:typename:int	file:
-y	input.c	/^		y;$/;"	m	struct:__anon329ddd92010a	typeref:typename:float	file:
+x	input.c	/^		x;$/;"	m	struct:__anon329ddd920108	typeref:typename:int	file:
+y	input.c	/^		y;$/;"	m	struct:__anon329ddd920108	typeref:typename:float	file:

--- a/Units/parser-c.r/bug556646.c.d/expected.tags
+++ b/Units/parser-c.r/bug556646.c.d/expected.tags
@@ -1,21 +1,21 @@
-A	input.c	/^  A = INDX_T2$/;"	e	enum:__anone0aee1a10104	file:
-INDX_C1	input.c	/^  INDX_C1,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_C2	input.c	/^  INDX_C2,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_IM1	input.c	/^  INDX_IM1,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_IM2	input.c	/^  INDX_IM2,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_L	input.c	/^  INDX_L,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_L2	input.c	/^  INDX_L2,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_M	input.c	/^  INDX_M,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_NIL	input.c	/^  INDX_NIL =   0x00,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_P	input.c	/^  INDX_P,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_R	input.c	/^  INDX_R,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_R2	input.c	/^  INDX_R2,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_S	input.c	/^  INDX_S,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_S1	input.c	/^  INDX_S1,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_S2	input.c	/^  INDX_S2,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_S3	input.c	/^  INDX_S3,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_S4	input.c	/^  INDX_S4,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_T	input.c	/^  INDX_T,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_T2	input.c	/^  INDX_T2,$/;"	e	enum:__anone0aee1a10104	file:
-__anone0aee1a10104	input.c	/^typedef enum{$/;"	g	file:
-task_indx_type	input.c	/^} task_indx_type;$/;"	t	typeref:enum:__anone0aee1a10104	file:
+A	input.c	/^  A = INDX_T2$/;"	e	enum:__anone0aee1a10103	file:
+INDX_C1	input.c	/^  INDX_C1,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_C2	input.c	/^  INDX_C2,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_IM1	input.c	/^  INDX_IM1,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_IM2	input.c	/^  INDX_IM2,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_L	input.c	/^  INDX_L,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_L2	input.c	/^  INDX_L2,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_M	input.c	/^  INDX_M,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_NIL	input.c	/^  INDX_NIL =   0x00,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_P	input.c	/^  INDX_P,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_R	input.c	/^  INDX_R,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_R2	input.c	/^  INDX_R2,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_S	input.c	/^  INDX_S,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_S1	input.c	/^  INDX_S1,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_S2	input.c	/^  INDX_S2,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_S3	input.c	/^  INDX_S3,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_S4	input.c	/^  INDX_S4,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_T	input.c	/^  INDX_T,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_T2	input.c	/^  INDX_T2,$/;"	e	enum:__anone0aee1a10103	file:
+__anone0aee1a10103	input.c	/^typedef enum{$/;"	g	file:
+task_indx_type	input.c	/^} task_indx_type;$/;"	t	typeref:enum:__anone0aee1a10103	file:

--- a/Units/parser-cxx.r/bug1770479.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/bug1770479.cpp.d/args.ctags
@@ -1,1 +1,1 @@
---kinds-c=+l
+--kinds-c++=+l

--- a/Units/parser-cxx.r/extern.d/args.ctags
+++ b/Units/parser-cxx.r/extern.d/args.ctags
@@ -1,2 +1,2 @@
---c-kinds=+px
+--c++-kinds=+px
 --fields=+{c++.properties}

--- a/parsers/cxx/cxx.c
+++ b/parsers/cxx/cxx.c
@@ -85,8 +85,8 @@ parserDefinition * CParser (void)
 
 	parserDefinition* def = parserNew("C");
 
-	def->kinds = cxxTagGetKindOptions();
-	def->kindCount = cxxTagGetKindOptionCount();
+	def->kinds = cxxTagGetCKindOptions();
+	def->kindCount = cxxTagGetCKindOptionCount();
 	def->fieldSpecs = cxxTagGetCFieldSpecifiers();
 	def->fieldSpecCount = cxxTagGetCFieldSpecifierCount();
 	def->extensions = extensions;
@@ -115,8 +115,8 @@ parserDefinition * CppParser (void)
 
 	parserDefinition* def = parserNew("C++");
 
-	def->kinds = cxxTagGetKindOptions();
-	def->kindCount = cxxTagGetKindOptionCount();
+	def->kinds = cxxTagGetCPPKindOptions();
+	def->kindCount = cxxTagGetCPPKindOptionCount();
 	def->fieldSpecs = cxxTagGetCPPFieldSpecifiers();
 	def->fieldSpecCount = cxxTagGetCPPFieldSpecifierCount();
 	def->extensions = extensions;

--- a/parsers/cxx/cxx_keyword.c
+++ b/parsers/cxx/cxx_keyword.c
@@ -129,24 +129,24 @@ static const CXXKeywordDescriptor g_aCXXKeywordTable[] = {
 	//{ 0, 1, "xor_eq", 0 }
 };
 
-const char * cxxKeywordName(enum CXXKeyword eKeywordId)
+const char * cxxKeywordName(CXXKeyword eKeywordId)
 {
 	return g_aCXXKeywordTable[eKeywordId].szName;
 }
 
-boolean cxxKeywordMayBePartOfTypeName(enum CXXKeyword eKeywordId)
+boolean cxxKeywordMayBePartOfTypeName(CXXKeyword eKeywordId)
 {
 	return g_aCXXKeywordTable[eKeywordId].uFlags &
 			CXXKeywordFlagMayBePartOfTypeName;
 }
 
-boolean cxxKeywordIsTypeRefMarker(enum CXXKeyword eKeywordId)
+boolean cxxKeywordIsTypeRefMarker(CXXKeyword eKeywordId)
 {
 	return g_aCXXKeywordTable[eKeywordId].uFlags &
 			CXXKeywordIsTypeRefMarker;
 }
 
-boolean cxxKeywordExcludeFromTypeNames(enum CXXKeyword eKeywordId)
+boolean cxxKeywordExcludeFromTypeNames(CXXKeyword eKeywordId)
 {
 	return g_aCXXKeywordTable[eKeywordId].uFlags &
 			CXXKeywordExcludeFromTypeNames;

--- a/parsers/cxx/cxx_keyword.h
+++ b/parsers/cxx/cxx_keyword.h
@@ -13,7 +13,7 @@
 #include "parse.h"
 
 // WARNING: There is a table in cxx_keyword.c that must match order in this enum
-enum CXXKeyword
+typedef enum _CXXKeyword
 {
 	CXXKeyword__ATTRIBUTE__, // GCC
 	CXXKeyword__DECLSPEC, // Microsoft C/C++
@@ -109,13 +109,13 @@ enum CXXKeyword
 	//CXXKeywordXOR,
 	//CXXKeywordXOR_EQ,
 	// WARNING: There is a table in cxx_keyword.c that must match order in this enumeration
-};
+} CXXKeyword;
 
-boolean cxxKeywordMayBePartOfTypeName(enum CXXKeyword eKeywordId);
-boolean cxxKeywordIsTypeRefMarker(enum CXXKeyword eKeywordId);
-boolean cxxKeywordExcludeFromTypeNames(enum CXXKeyword eKeywordId);
+boolean cxxKeywordMayBePartOfTypeName(CXXKeyword eKeywordId);
+boolean cxxKeywordIsTypeRefMarker(CXXKeyword eKeywordId);
+boolean cxxKeywordExcludeFromTypeNames(CXXKeyword eKeywordId);
 
-const char * cxxKeywordName(enum CXXKeyword eKeywordId);
+const char * cxxKeywordName(CXXKeyword eKeywordId);
 
 void cxxBuildKeywordHash(const langType language,boolean bCXX);
 

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -478,7 +478,7 @@ boolean cxxParserParseEnum(void)
 			CXXToken * pNext = pNamespaceBegin->pNext;
 			cxxTokenChainTake(g_cxx.pTokenChain,pNamespaceBegin);
 			// FIXME: We don't really know if it's a class!
-			cxxScopePush(pNamespaceBegin,CXXTagCPPKindCLASS,CXXScopeAccessUnknown);
+			cxxScopePush(pNamespaceBegin,g_cxx.uClassKind,CXXScopeAccessUnknown);
 			iPushedScopes++;
 			pNamespaceBegin = pNext->pNext;
 		}
@@ -486,14 +486,14 @@ boolean cxxParserParseEnum(void)
 		CXX_DEBUG_PRINT("Enum name is %s",vStringValue(pEnumName->pszWord));
 		cxxTokenChainTake(g_cxx.pTokenChain,pEnumName);
 	} else {
-		pEnumName = cxxTokenCreateAnonymousIdentifier(CXXTagCPPKindENUM);
+		pEnumName = cxxTokenCreateAnonymousIdentifier(g_cxx.uEnumKind);
 		CXX_DEBUG_PRINT(
 				"Enum name is %s (anonymous)",
 				vStringValue(pEnumName->pszWord)
 			);
 	}
 
-	tagEntryInfo * tag = cxxTagBegin(CXXTagCPPKindENUM,pEnumName);
+	tagEntryInfo * tag = cxxTagBegin(g_cxx.uEnumKind,pEnumName);
 
 	int iCorkQueueIndex = CORK_NIL;
 
@@ -505,7 +505,7 @@ boolean cxxParserParseEnum(void)
 		iCorkQueueIndex = cxxTagCommit();
 	}
 
-	cxxScopePush(pEnumName,CXXTagCPPKindENUM,CXXScopeAccessPublic);
+	cxxScopePush(pEnumName,g_cxx.uEnumKind,CXXScopeAccessPublic);
 	iPushedScopes++;
 
 	vString * pScopeName = cxxScopeGetFullNameAsString();
@@ -533,7 +533,7 @@ boolean cxxParserParseEnum(void)
 				cxxTokenTypeIs(pFirst,CXXTokenTypeIdentifier)
 			)
 		{
-			tag = cxxTagBegin(CXXTagCPPKindENUMERATOR,pFirst);
+			tag = cxxTagBegin(g_cxx.uEnumeratorKind,pFirst);
 			if(tag)
 			{
 				tag->isFileScope = !isInputHeaderFile();

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -33,7 +33,7 @@ static boolean cxxParserParseBlockHandleOpeningBracket(void)
 			"This must be called when pointing at an opening bracket!"
 		);
 
-	enum CXXTagKind eScopeKind = cxxScopeGetKind();
+	unsigned int uScopeKind = cxxScopeGetKind();
 	boolean bIsCPP = cxxParserCurrentLanguageIsCPP();
 
 	if(
@@ -42,8 +42,8 @@ static boolean cxxParserParseBlockHandleOpeningBracket(void)
 				(g_cxx.pToken->pPrev) &&
 				cxxTokenTypeIs(g_cxx.pToken->pPrev,CXXTokenTypeAssignment) &&
 				(
-					(eScopeKind == CXXTagKindFUNCTION) ||
-					(eScopeKind == CXXTagKindNAMESPACE)
+					(uScopeKind == g_cxx.uFunctionKind) ||
+					(uScopeKind == g_cxx.uNamespaceKind)
 				)
 			) || (
 				// T { arg1, arg2, ... } (1)
@@ -85,7 +85,7 @@ static boolean cxxParserParseBlockHandleOpeningBracket(void)
 	// FIXME: Why the invalid cork queue entry index is CORK_NIL?
 	int iCorkQueueIndex = CORK_NIL;
 	
-	if(eScopeKind != CXXTagKindFUNCTION)
+	if(uScopeKind != g_cxx.uFunctionKind)
 	{
 		// very likely a function definition
 		iScopes = cxxParserExtractFunctionSignatureBeforeOpeningBracket(&iCorkQueueIndex);
@@ -193,8 +193,8 @@ process_token:
 				{
 					case CXXKeywordNAMESPACE:
 					{
-						int iCurrentScopeKind = cxxScopeGetKind();
-						if(iCurrentScopeKind == CXXTagKindNAMESPACE)
+						unsigned int uCurrentScopeKind = cxxScopeGetKind();
+						if(uCurrentScopeKind == g_cxx.uNamespaceKind)
 						{
 							// namespaces can be nested only within themselves
 							if(!cxxParserParseNamespace())
@@ -234,21 +234,21 @@ process_token:
 						}
 					break;
 					case CXXKeywordCLASS:
-						if(!cxxParserParseClassStructOrUnion(CXXKeywordCLASS,CXXTagKindCLASS))
+						if(!cxxParserParseClassStructOrUnion(CXXKeywordCLASS,g_cxx.uClassKind))
 						{
 							CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
 							return FALSE;
 						}
 					break;
 					case CXXKeywordSTRUCT:
-						if(!cxxParserParseClassStructOrUnion(CXXKeywordSTRUCT,CXXTagKindSTRUCT))
+						if(!cxxParserParseClassStructOrUnion(CXXKeywordSTRUCT,g_cxx.uStructKind))
 						{
 							CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
 							return FALSE;
 						}
 					break;
 					case CXXKeywordUNION:
-						if(!cxxParserParseClassStructOrUnion(CXXKeywordUNION,CXXTagKindUNION))
+						if(!cxxParserParseClassStructOrUnion(CXXKeywordUNION,g_cxx.uUnionKind))
 						{
 							CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
 							return FALSE;
@@ -323,7 +323,7 @@ process_token:
 					break;
 					case CXXKeywordTHROW:
 						// ignore when inside a function
-						if(cxxScopeGetKind() == CXXTagKindFUNCTION)
+						if(cxxScopeGetKind() == g_cxx.uFunctionKind)
 						{
 							if(!cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF))
 							{
@@ -491,7 +491,7 @@ process_token:
 				{
 					CXXToken * pFirst = cxxTokenChainFirst(g_cxx.pTokenChain);
 					// assume it's label
-					tagEntryInfo * tag = cxxTagBegin(CXXTagKindLABEL,pFirst);
+					tagEntryInfo * tag = cxxTagBegin(g_cxx.uLabelKind,pFirst);
 
 					if(tag)
 					{

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -268,7 +268,7 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 		return 0;
 	}
 
-	tagEntryInfo * tag = cxxTagBegin(CXXTagKindFUNCTION,pIdentifier);
+	tagEntryInfo * tag = cxxTagBegin(g_cxx.uFunctionKind,pIdentifier);
 
 	if(tag)
 	{
@@ -307,10 +307,10 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 			vStringValue(pIdentifier->pszWord)
 		);
 
-	cxxScopePush(pIdentifier,CXXTagKindFUNCTION,CXXScopeAccessUnknown);
+	cxxScopePush(pIdentifier,g_cxx.uFunctionKind,CXXScopeAccessUnknown);
 
 	// emit parameters
-	if(cxxTagKindEnabled(CXXTagKindPARAMETER))
+	if(cxxTagKindEnabled(g_cxx.uParameterKind))
 	{
 		// The chain contains 1 + iExtraStatementsInChain statements now
 		int iIdx = 0;
@@ -985,7 +985,7 @@ next_token:
 //
 int cxxParserEmitFunctionTags(
 		CXXFunctionSignatureInfo * pInfo,
-		enum CXXTagKind eTagKind,
+		unsigned int uTagKind,
 		unsigned int uOptions,
 		int * piCorkQueueIndex
 	)
@@ -997,7 +997,7 @@ int cxxParserEmitFunctionTags(
 	if(piCorkQueueIndex)
 		*piCorkQueueIndex = CORK_NIL;
 
-	enum CXXTagKind eOuterScopeKind = cxxScopeGetKind();
+	unsigned int uOuterScopeKind = cxxScopeGetKind();
 
 	boolean bPushScopes = uOptions & CXXEmitFunctionTagsPushScopes;
 
@@ -1024,7 +1024,7 @@ int cxxParserEmitFunctionTags(
 
 			cxxScopePush(
 					pScopeId,
-					CXXTagKindCLASS,
+					g_cxx.uClassKind,
 					// WARNING: We don't know if it's really a class! (FIXME?)
 					CXXScopeAccessUnknown
 				);
@@ -1049,7 +1049,7 @@ int cxxParserEmitFunctionTags(
 
 	CXX_DEBUG_PRINT("Identifier is '%s'",vStringValue(pIdentifier->pszWord));
 
-	tagEntryInfo * tag = cxxTagBegin(eTagKind,pIdentifier);
+	tagEntryInfo * tag = cxxTagBegin(uTagKind,pIdentifier);
 
 	if(tag)
 	{
@@ -1061,12 +1061,12 @@ int cxxParserEmitFunctionTags(
 			pInfo->pParenthesis->pChain->pTail->bFollowedBySpace = FALSE;
 		}
 
-		if(eTagKind == CXXTagKindPROTOTYPE)
+		if(uTagKind == g_cxx.uPrototypeKind)
 		{
 			tag->isFileScope = !isInputHeaderFile();
 		} else {
 			// function definitions
-			if(eOuterScopeKind == CXXTagKindNAMESPACE)
+			if(uOuterScopeKind == g_cxx.uNamespaceKind)
 			{
 				// in a namespace only static stuff declared in cpp files is file scoped
 				tag->isFileScope = (
@@ -1174,7 +1174,7 @@ int cxxParserEmitFunctionTags(
 
 
 #ifdef CXX_DO_DEBUGGING
-	if(eTagKind == CXXTagKindFUNCTION)
+	if(uTagKind == g_cxx.uFunctionKind)
 		CXX_DEBUG_PRINT("Emitted function '%s'",vStringValue(pIdentifier->pszWord));
 	else
 		CXX_DEBUG_PRINT("Emitted prototype '%s'",vStringValue(pIdentifier->pszWord));
@@ -1182,7 +1182,7 @@ int cxxParserEmitFunctionTags(
 
 	if(bPushScopes)
 	{
-		cxxScopePush(pIdentifier,CXXTagKindFUNCTION,CXXScopeAccessUnknown);
+		cxxScopePush(pIdentifier,g_cxx.uFunctionKind,CXXScopeAccessUnknown);
 		iScopesPushed++;
 	} else {
 		cxxTokenDestroy(pIdentifier);
@@ -1236,7 +1236,7 @@ int cxxParserExtractFunctionSignatureBeforeOpeningBracket(int * piCorkQueueIndex
 
 	int iScopesPushed = cxxParserEmitFunctionTags(
 			&oInfo,
-			CXXTagKindFUNCTION,
+			g_cxx.uFunctionKind,
 			CXXEmitFunctionTagsPushScopes,
 			piCorkQueueIndex
 		);
@@ -1250,7 +1250,7 @@ int cxxParserExtractFunctionSignatureBeforeOpeningBracket(int * piCorkQueueIndex
 	vStringDelete(pJoinedChain);
 #endif
 
-	if(cxxTagKindEnabled(CXXTagKindPARAMETER))
+	if(cxxTagKindEnabled(g_cxx.uParameterKind))
 		cxxParserEmitFunctionParameterTags(&oParamInfo);
 
 	CXX_DEBUG_LEAVE();
@@ -1266,7 +1266,7 @@ void cxxParserEmitFunctionParameterTags(CXXFunctionParameterInfo * pInfo)
 	while(i < pInfo->uParameterCount)
 	{
 		tagEntryInfo * tag = cxxTagBegin(
-				CXXTagKindPARAMETER,
+				g_cxx.uParameterKind,
 				pInfo->aIdentifiers[i]
 			);
 

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -245,6 +245,7 @@ typedef struct _CXXParserState
 	unsigned int uParameterKind;
 	unsigned int uTypedefKind;
 	unsigned int uExternvarKind;
+	unsigned int uEnumeratorKind;
 	
 	// FIXME: Do the same for fields!!!
 

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -150,7 +150,7 @@ enum CXXEmitFunctionTagsOptions
 
 int cxxParserEmitFunctionTags(
 		CXXFunctionSignatureInfo * pInfo,
-		enum CXXTagKind eTagKind,
+		unsigned int uTagKind,
 		unsigned int uOptions,
 		int * piCorkQueueIndex
 	);
@@ -170,8 +170,8 @@ void cxxParserNewStatement(void);
 boolean cxxParserParseNamespace(void);
 boolean cxxParserParseEnum(void);
 boolean cxxParserParseClassStructOrUnion(
-		enum CXXKeyword eKeyword,
-		enum CXXTagKind eTagKind
+		CXXKeyword eKeyword,
+		unsigned int uTagKind
 	);
 boolean cxxParserParseAndCondenseCurrentSubchain(
 		unsigned int uInitialSubchainMarkerTypes,
@@ -223,6 +223,30 @@ typedef struct _CXXParserState
 {
 	// The current language
 	langType eLanguage;
+
+	// The array of kind options for the current language.
+	kindOption * aKindOptions;
+	unsigned int uKindOptionCount;
+	
+	// Cached kind values to avoid switching everywhere on the current language
+	unsigned int uFunctionKind;
+	unsigned int uEnumKind;
+	unsigned int uMacroKind;
+	unsigned int uIncludeKind;
+	unsigned int uClassKind; // in C this is CXXTagKindInvalid
+	unsigned int uNamespaceKind; // in C this is CXXTagKindInvalid
+	unsigned int uVariableKind;
+	unsigned int uStructKind;
+	unsigned int uUnionKind;
+	unsigned int uMemberKind;
+	unsigned int uLocalKind;
+	unsigned int uPrototypeKind;
+	unsigned int uLabelKind;
+	unsigned int uParameterKind;
+	unsigned int uTypedefKind;
+	unsigned int uExternvarKind;
+	
+	// FIXME: Do the same for fields!!!
 
 	// The identifier of the CPP language, as indicated by ctags core
 	langType eCPPLanguage;

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -81,13 +81,13 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 {
 	CXX_DEBUG_ENTER();
 
-	CXXToken * pIdentifier = cxxTokenCreateAnonymousIdentifier(CXXTagKindFUNCTION);
+	CXXToken * pIdentifier = cxxTokenCreateAnonymousIdentifier(g_cxx.uFunctionKind);
 
 	CXXTokenChain * pSave = g_cxx.pTokenChain;
 	CXXTokenChain * pNew = cxxTokenChainCreate();
 	g_cxx.pTokenChain = pNew;
 
-	tagEntryInfo * tag = cxxTagBegin(CXXTagKindFUNCTION,pIdentifier);
+	tagEntryInfo * tag = cxxTagBegin(g_cxx.uFunctionKind,pIdentifier);
 
 	CXXToken * pAfterParenthesis = pParenthesis ? pParenthesis->pNext : NULL;
 
@@ -189,14 +189,14 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 
 	cxxScopePush(
 			pIdentifier,
-			CXXTagKindFUNCTION,
+			g_cxx.uFunctionKind,
 			CXXScopeAccessUnknown
 		);
 
 	if(
 		pParenthesis &&
 		cxxTokenTypeIs(pParenthesis,CXXTokenTypeParenthesisChain) &&
-		cxxTagKindEnabled(CXXTagKindPARAMETER)
+		cxxTagKindEnabled(g_cxx.uParameterKind)
 	)
 	{
 		CXXFunctionParameterInfo oParamInfo;

--- a/parsers/cxx/cxx_parser_namespace.c
+++ b/parsers/cxx/cxx_parser_namespace.c
@@ -27,6 +27,8 @@
 boolean cxxParserParseNamespace(void)
 {
 	CXX_DEBUG_ENTER();
+	
+	CXX_DEBUG_ASSERT(cxxParserCurrentLanguageIsCPP(),"This should be called only in C++");
 
 	// FIXME: Do it better...
 
@@ -67,7 +69,7 @@ boolean cxxParserParseNamespace(void)
 		{
 			case CXXTokenTypeIdentifier:
 				CXX_DEBUG_PRINT("Got identifier %s",g_cxx.pToken->pszWord->buffer);
-				tagEntryInfo * tag = cxxTagBegin(CXXTagKindNAMESPACE,g_cxx.pToken);
+				tagEntryInfo * tag = cxxTagBegin(g_cxx.uNamespaceKind,g_cxx.pToken);
 				if(tag)
 				{
 					// This is highly questionable but well.. it's how old ctags did, so we do.
@@ -76,7 +78,7 @@ boolean cxxParserParseNamespace(void)
 				}
 				cxxScopePush(
 						cxxTokenChainTakeLast(g_cxx.pTokenChain),
-						CXXTagKindNAMESPACE,
+						g_cxx.uNamespaceKind,
 						CXXScopeAccessUnknown
 					);
 				iScopeCount++;
@@ -106,14 +108,14 @@ boolean cxxParserParseNamespace(void)
 				if(iScopeCount == 0)
 				{
 					// anonymous namespace!
-					CXXToken * t = cxxTokenCreateAnonymousIdentifier(CXXTagKindNAMESPACE);
-					tagEntryInfo * tag = cxxTagBegin(CXXTagKindNAMESPACE,t);
+					CXXToken * t = cxxTokenCreateAnonymousIdentifier(g_cxx.uNamespaceKind);
+					tagEntryInfo * tag = cxxTagBegin(g_cxx.uNamespaceKind,t);
 					if(tag)
 					{
 						tag->isFileScope = !isInputHeaderFile();
 						iCorkQueueIndex = cxxTagCommit();
 					}
-					cxxScopePush(t,CXXTagKindNAMESPACE,CXXScopeAccessUnknown);
+					cxxScopePush(t,g_cxx.uNamespaceKind,CXXScopeAccessUnknown);
 					iScopeCount++;
 				}
 

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -963,7 +963,7 @@ boolean cxxParserParseNextToken(void)
 				t->eType = CXXTokenTypeIdentifier;
 			} else {
 				t->eType = CXXTokenTypeKeyword;
-				t->eKeyword = (enum CXXKeyword)iCXXKeyword;
+				t->eKeyword = (CXXKeyword)iCXXKeyword;
 			}
 		} else {
 			boolean bIgnoreParens = FALSE;

--- a/parsers/cxx/cxx_parser_typedef.c
+++ b/parsers/cxx/cxx_parser_typedef.c
@@ -212,7 +212,7 @@ skip_to_comma_or_end:
 			return; // EOF
 		}
 
-		tagEntryInfo * tag = cxxTagBegin(CXXTagKindTYPEDEF,t);
+		tagEntryInfo * tag = cxxTagBegin(g_cxx.uTypedefKind,t);
 
 		if(tag)
 		{

--- a/parsers/cxx/cxx_parser_using.c
+++ b/parsers/cxx/cxx_parser_using.c
@@ -22,6 +22,8 @@
 boolean cxxParserParseUsingClause(void)
 {
 	CXX_DEBUG_ENTER();
+	
+	CXX_DEBUG_ASSERT(cxxParserCurrentLanguageIsCPP(),"This should be called only in C++");
 
 	// using-directives for namespaces and using-declarations
 	// for namespace members
@@ -130,7 +132,7 @@ boolean cxxParserParseUsingClause(void)
 						"Found using clause '%s' which extends scope",
 						vStringValue(t->pszWord)
 					);
-				tag = cxxTagBegin(CXXTagKindUSING,t);
+				tag = cxxTagBegin(CXXTagCPPKindUSING,t);
 			} else {
 
 				t = cxxTokenChainLast(g_cxx.pTokenChain);
@@ -139,14 +141,14 @@ boolean cxxParserParseUsingClause(void)
 						"Found using clause '%s' which imports a name",
 						vStringValue(t->pszWord)
 					);
-				tag = cxxTagBegin(CXXTagKindNAME,t);
+				tag = cxxTagBegin(CXXTagCPPKindNAME,t);
 
 				// FIXME: We need something like "nameref:<condensed>" here!
 			}
 
 			if(tag)
 			{
-				tag->isFileScope = (cxxScopeGetKind() == CXXTagKindNAMESPACE) &&
+				tag->isFileScope = (cxxScopeGetKind() == g_cxx.uNamespaceKind) &&
 							(!isInputHeaderFile());
 				cxxTagCommit();
 			}

--- a/parsers/cxx/cxx_parser_variable.c
+++ b/parsers/cxx/cxx_parser_variable.c
@@ -85,7 +85,7 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 
 	CXXToken * t = cxxTokenChainFirst(pChain);
 
-	enum CXXTagKind eScopeKind = cxxScopeGetKind();
+	unsigned int uScopeKind = cxxScopeGetKind();
 
 	CXX_DEBUG_ASSERT(t,"There should be an initial token here");
 
@@ -237,8 +237,8 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 				} else if(
 						cxxTokenTypeIs(t->pPrev,CXXTokenTypeIdentifier) &&
 						(
-							(eScopeKind == CXXTagKindNAMESPACE) ||
-							(eScopeKind == CXXTagKindFUNCTION)
+							(uScopeKind == g_cxx.uNamespaceKind) ||
+							(uScopeKind == g_cxx.uFunctionKind)
 						) &&
 						cxxParserCurrentLanguageIsCPP() &&
 						cxxParserTokenChainLooksLikeConstructorParameterSet(t->pChain)
@@ -476,7 +476,7 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 				CXXToken * pScopeId = cxxTokenChainExtractRange(pScopeStart,pPartEnd->pPrev,0);
 				cxxScopePush(
 						pScopeId,
-						CXXTagKindCLASS,
+						g_cxx.uClassKind,
 						// WARNING: We don't know if it's really a class! (FIXME?)
 						CXXScopeAccessUnknown
 					);
@@ -496,9 +496,9 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 
 		tagEntryInfo * tag = cxxTagBegin(
 				bKnRStyleParameters ?
-					CXXTagKindPARAMETER :
+					g_cxx.uParameterKind :
 					((g_cxx.uKeywordState & CXXParserKeywordStateSeenExtern) ?
-							CXXTagKindEXTERNVAR : cxxScopeGetVariableKind()),
+							g_cxx.uExternvarKind : cxxScopeGetVariableKind()),
 				pIdentifier
 			);
 
@@ -541,15 +541,15 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 					TRUE :
 					(
 						(
-							(eScopeKind == CXXTagKindNAMESPACE) &&
+							(uScopeKind == g_cxx.uNamespaceKind) &&
 							(g_cxx.uKeywordState & CXXParserKeywordStateSeenStatic) &&
 							(!isInputHeaderFile())
 						) ||
 						// locals are always hidden
-						(eScopeKind == CXXTagKindFUNCTION) ||
+						(uScopeKind == g_cxx.uFunctionKind) ||
 						(
-							(eScopeKind != CXXTagKindNAMESPACE) &&
-							(eScopeKind != CXXTagKindFUNCTION) &&
+							(uScopeKind != g_cxx.uNamespaceKind) &&
+							(uScopeKind != g_cxx.uFunctionKind) &&
 							(!isInputHeaderFile())
 						)
 					);

--- a/parsers/cxx/cxx_scope.h
+++ b/parsers/cxx/cxx_scope.h
@@ -48,8 +48,8 @@ vString * cxxScopeGetFullNameAsString(void);
 vString * cxxScopeGetFullNameExceptLastComponentAsString(void);
 
 // Returns the current scope kind
-enum CXXTagKind cxxScopeGetKind(void);
-enum CXXTagKind cxxScopeGetVariableKind(void);
+unsigned int cxxScopeGetKind(void);
+unsigned int cxxScopeGetVariableKind(void);
 enum CXXScopeAccess cxxScopeGetAccess(void);
 // Are we in global scope?
 boolean cxxScopeIsGlobal(void);
@@ -57,7 +57,7 @@ boolean cxxScopeIsGlobal(void);
 // Add a token to the scope chain. The token ownership is transferred.
 void cxxScopePush(
 		CXXToken * t,
-		enum CXXTagKind eScopeKind,
+		unsigned int uScopeKind,
 		enum CXXScopeAccess eInitialAccess
 	);
 void cxxScopeSetAccess(enum CXXScopeAccess eAccess);

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -28,7 +28,29 @@ static roleDesc CHeaderRoles [] = {
 	RoleTemplateLocal,
 };
 
-static kindOption g_aCXXKinds [] = {
+static kindOption g_aCXXCKinds [] = {
+	{ TRUE,  'd', "macro",      "macro definitions",
+			.referenceOnly = FALSE, ATTACH_ROLES(CMacroRoles)
+	},
+	{ TRUE,  'e', "enumerator", "enumerators (values inside an enumeration)" },
+	{ TRUE,  'f', "function",   "function definitions" },
+	{ TRUE,  'g', "enum",       "enumeration names" },
+	{ FALSE, 'h', "header",     "included header files",
+			.referenceOnly = TRUE,  ATTACH_ROLES(CHeaderRoles)
+	},
+	{ FALSE, 'l', "local",      "local variables" },
+	{ TRUE,  'm', "member",     "struct, and union members" },
+	{ FALSE, 'p', "prototype",  "function prototypes" },
+	{ TRUE,  's', "struct",     "structure names" },
+	{ TRUE,  't', "typedef",    "typedefs" },
+	{ TRUE,  'u', "union",      "union names" },
+	{ TRUE,  'v', "variable",   "variable definitions" },
+	{ FALSE, 'x', "externvar",  "external and forward variable declarations" },
+	{ FALSE, 'z', "parameter",  "function parameters inside function definitions" },
+	{ FALSE, 'L', "label",      "goto labels" }
+};
+
+static kindOption g_aCXXCPPKinds [] = {
 	{ TRUE,  'c', "class",      "classes" },
 	{ TRUE,  'd', "macro",      "macro definitions",
 			.referenceOnly = FALSE, ATTACH_ROLES(CMacroRoles)
@@ -107,19 +129,84 @@ static fieldSpec g_aCXXCFields [] = {
 	}
 };
 
-kindOption * cxxTagGetKindOptions(void)
+void cxxTagInitGlobals(langType eLangType)
 {
-	return g_aCXXKinds;
+	g_cxx.eLanguage = eLangType;
+	
+	if(eLangType == g_cxx.eCLanguage)
+	{
+		g_cxx.aKindOptions = g_aCXXCKinds;
+		g_cxx.uKindOptionCount = sizeof(g_aCXXCKinds) / sizeof(kindOption);
+		g_cxx.uFunctionKind = CXXTagCKindFUNCTION;
+		g_cxx.uEnumKind = CXXTagCKindENUM;
+		g_cxx.uMacroKind = CXXTagCKindMACRO;
+		g_cxx.uIncludeKind = CXXTagCKindINCLUDE;
+		g_cxx.uClassKind = CXXTagKindInvalid;
+		g_cxx.uNamespaceKind = CXXTagKindInvalid;
+		g_cxx.uVariableKind = CXXTagCKindVARIABLE;
+		g_cxx.uStructKind = CXXTagCKindSTRUCT;
+		g_cxx.uUnionKind = CXXTagCKindUNION;
+		g_cxx.uMemberKind = CXXTagCKindMEMBER;
+		g_cxx.uLocalKind = CXXTagCKindLOCAL;
+		g_cxx.uPrototypeKind = CXXTagCKindPROTOTYPE;
+		g_cxx.uLabelKind = CXXTagCKindLABEL;
+		g_cxx.uParameterKind = CXXTagCKindPARAMETER;
+		g_cxx.uTypedefKind = CXXTagCKindTYPEDEF;
+		g_cxx.uExternvarKind = CXXTagCKindEXTERNVAR;
+	} else if(eLangType == g_cxx.eCPPLanguage)
+	{
+		g_cxx.aKindOptions = g_aCXXCPPKinds;
+		g_cxx.uKindOptionCount = sizeof(g_aCXXCPPKinds) / sizeof(kindOption);
+		g_cxx.uFunctionKind = CXXTagCPPKindFUNCTION;
+		g_cxx.uEnumKind = CXXTagCPPKindENUM;
+		g_cxx.uMacroKind = CXXTagCPPKindMACRO;
+		g_cxx.uIncludeKind = CXXTagCPPKindINCLUDE;
+		g_cxx.uClassKind = CXXTagCPPKindCLASS;
+		g_cxx.uNamespaceKind = CXXTagCPPKindNAMESPACE;
+		g_cxx.uVariableKind = CXXTagCPPKindVARIABLE;
+		g_cxx.uStructKind = CXXTagCPPKindSTRUCT;
+		g_cxx.uUnionKind = CXXTagCPPKindUNION;
+		g_cxx.uMemberKind = CXXTagCPPKindMEMBER;
+		g_cxx.uLocalKind = CXXTagCPPKindLOCAL;
+		g_cxx.uPrototypeKind = CXXTagCPPKindPROTOTYPE;
+		g_cxx.uLabelKind = CXXTagCPPKindLABEL;
+		g_cxx.uParameterKind = CXXTagCPPKindPARAMETER;
+		g_cxx.uTypedefKind = CXXTagCPPKindTYPEDEF;
+		g_cxx.uExternvarKind = CXXTagCPPKindEXTERNVAR;
+	} else {
+		CXX_DEBUG_ASSERT(false,"This should never happen: wrong language");
+	}
 }
 
-int cxxTagGetKindOptionCount(void)
+boolean cxxTagKindEnabled(unsigned int uKindId)
 {
-	return sizeof(g_aCXXKinds) / sizeof(kindOption);
+	CXX_DEBUG_ASSERT(
+			uKindId < g_cxx.uKindOptionCount,
+			"The specified kind probably belongs to the wrong language"
+		);
+
+	return g_cxx.aKindOptions[uKindId].enabled;
 }
 
-boolean cxxTagKindEnabled(enum CXXTagKind eKindId)
+
+kindOption * cxxTagGetCKindOptions(void)
 {
-	return g_aCXXKinds[eKindId].enabled;
+	return g_aCXXCKinds;
+}
+
+unsigned int cxxTagGetCKindOptionCount(void)
+{
+	return sizeof(g_aCXXCKinds) / sizeof(kindOption);
+}
+
+kindOption * cxxTagGetCPPKindOptions(void)
+{
+	return g_aCXXCPPKinds;
+}
+
+unsigned int cxxTagGetCPPKindOptionCount(void)
+{
+	return sizeof(g_aCXXCPPKinds) / sizeof(kindOption);
 }
 
 fieldSpec * cxxTagGetCPPFieldSpecifiers(void)
@@ -157,18 +244,25 @@ int cxxTagCFieldEnabled(CXXTagCField eField)
 static tagEntryInfo g_oCXXTag;
 
 
-tagEntryInfo * cxxTagBegin(enum CXXTagKind eKindId,CXXToken * pToken)
+tagEntryInfo * cxxTagBegin(unsigned int uKindId,CXXToken * pToken)
 {
-	if(!g_aCXXKinds[eKindId].enabled)
+	CXX_DEBUG_ASSERT(
+			uKindId < g_cxx.uKindOptionCount,
+			"The specified kind probably belongs to the wrong language"
+		);
+
+	kindOption * pKindOption = g_cxx.aKindOptions + uKindId;
+
+	if(!pKindOption->enabled)
 	{
-		//CXX_DEBUG_PRINT("Tag kind %s is not enabled",g_aCXXKinds[eKindId].name);
+		//CXX_DEBUG_PRINT("Tag kind %s is not enabled",aKindOptions[uKindId].name);
 		return NULL;
 	}
 
 	initTagEntry(
 			&g_oCXXTag,
 			vStringValue(pToken->pszWord),
-			&(g_aCXXKinds[eKindId])
+			pKindOption
 		);
 
 	g_oCXXTag.lineNumber = pToken->iLineNumber;
@@ -177,7 +271,7 @@ tagEntryInfo * cxxTagBegin(enum CXXTagKind eKindId,CXXToken * pToken)
 
 	if(!cxxScopeIsGlobal())
 	{
-		g_oCXXTag.extensionFields.scopeKind = &g_aCXXKinds[cxxScopeGetKind()];
+		g_oCXXTag.extensionFields.scopeKind = g_cxx.aKindOptions + cxxScopeGetKind();
 		g_oCXXTag.extensionFields.scopeName = cxxScopeGetFullName();
 	}
 
@@ -375,9 +469,9 @@ int cxxTagCommit(void)
 	// WARNING: The following code assumes that the scope
 	// didn't change between cxxTagBegin() and cxxTagCommit().
 
-	enum CXXTagKind eScopeKind = cxxScopeGetKind();
+	unsigned int uScopeKind = cxxScopeGetKind();
 
-	if(eScopeKind == CXXTagKindFUNCTION)
+	if(uScopeKind == g_cxx.uFunctionKind)
 	{
 		// old ctags didn't do this, and --extra=+q is mainly
 		// for backward compatibility so...
@@ -388,7 +482,7 @@ int cxxTagCommit(void)
 
 	vString * x;
 
-	if(eScopeKind == CXXTagKindENUM)
+	if(uScopeKind == g_cxx.uEnumKind)
 	{
 		// If the scope kind is enumeration then we need to remove the
 		// last scope part. This is what old ctags did.
@@ -420,8 +514,8 @@ int cxxTagCommit(void)
 	return iCorkQueueIndex;
 }
 
-void cxxTag(enum CXXTagKind eKindId,CXXToken * pToken)
+void cxxTag(unsigned int uKindId,CXXToken * pToken)
 {
-	if(cxxTagBegin(eKindId,pToken) != NULL)
+	if(cxxTagBegin(uKindId,pToken) != NULL)
 		cxxTagCommit();
 }

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -153,6 +153,7 @@ void cxxTagInitGlobals(langType eLangType)
 		g_cxx.uParameterKind = CXXTagCKindPARAMETER;
 		g_cxx.uTypedefKind = CXXTagCKindTYPEDEF;
 		g_cxx.uExternvarKind = CXXTagCKindEXTERNVAR;
+		g_cxx.uEnumeratorKind = CXXTagCKindENUMERATOR;
 	} else if(eLangType == g_cxx.eCPPLanguage)
 	{
 		g_cxx.aKindOptions = g_aCXXCPPKinds;
@@ -173,6 +174,7 @@ void cxxTagInitGlobals(langType eLangType)
 		g_cxx.uParameterKind = CXXTagCPPKindPARAMETER;
 		g_cxx.uTypedefKind = CXXTagCPPKindTYPEDEF;
 		g_cxx.uExternvarKind = CXXTagCPPKindEXTERNVAR;
+		g_cxx.uEnumeratorKind = CXXTagCPPKindENUMERATOR;
 	} else {
 		CXX_DEBUG_ASSERT(false,"This should never happen: wrong language");
 	}

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -13,31 +13,54 @@
 
 #include "kind.h"
 #include "entry.h"
+#include "parse.h"
 
 #include "cxx_token.h"
 
-enum CXXTagKind
+enum CXXTagCPPKind
 {
-	CXXTagKindCLASS,
-	CXXTagKindMACRO,
-	CXXTagKindENUMERATOR,
-	CXXTagKindFUNCTION,
-	CXXTagKindENUM,
-	CXXTagKindINCLUDE,
-	CXXTagKindLOCAL,
-	CXXTagKindMEMBER,
-	CXXTagKindNAMESPACE,
-	CXXTagKindPROTOTYPE,
-	CXXTagKindSTRUCT,
-	CXXTagKindTYPEDEF,
-	CXXTagKindUNION,
-	CXXTagKindVARIABLE,
-	CXXTagKindEXTERNVAR,
-	CXXTagKindPARAMETER,
-	CXXTagKindLABEL,
-	CXXTagKindNAME,
-	CXXTagKindUSING
+	CXXTagCPPKindCLASS,
+	CXXTagCPPKindMACRO,
+	CXXTagCPPKindENUMERATOR,
+	CXXTagCPPKindFUNCTION,
+	CXXTagCPPKindENUM,
+	CXXTagCPPKindINCLUDE,
+	CXXTagCPPKindLOCAL,
+	CXXTagCPPKindMEMBER,
+	CXXTagCPPKindNAMESPACE,
+	CXXTagCPPKindPROTOTYPE,
+	CXXTagCPPKindSTRUCT,
+	CXXTagCPPKindTYPEDEF,
+	CXXTagCPPKindUNION,
+	CXXTagCPPKindVARIABLE,
+	CXXTagCPPKindEXTERNVAR,
+	CXXTagCPPKindPARAMETER,
+	CXXTagCPPKindLABEL,
+	CXXTagCPPKindNAME,
+	CXXTagCPPKindUSING
 };
+
+enum CXXTagCKind
+{
+	CXXTagCKindMACRO,
+	CXXTagCKindENUMERATOR,
+	CXXTagCKindFUNCTION,
+	CXXTagCKindENUM,
+	CXXTagCKindINCLUDE,
+	CXXTagCKindLOCAL,
+	CXXTagCKindMEMBER,
+	CXXTagCKindPROTOTYPE,
+	CXXTagCKindSTRUCT,
+	CXXTagCKindTYPEDEF,
+	CXXTagCKindUNION,
+	CXXTagCKindVARIABLE,
+	CXXTagCKindEXTERNVAR,
+	CXXTagCKindPARAMETER,
+	CXXTagCKindLABEL
+};
+
+// Must fit in a byte.
+#define CXXTagKindInvalid 0xff
 
 typedef enum _CXXTagCPPField
 {
@@ -53,24 +76,42 @@ typedef enum _CXXTagCField
 	CXXTagCFieldProperties
 } CXXTagCField;
 
-fieldSpec * cxxTagGetCPPFieldSpecifiers(void);
-int cxxTagGetCPPFieldSpecifierCount(void);
-int cxxTagCPPFieldEnabled(CXXTagCPPField eField);
-
 fieldSpec * cxxTagGetCFieldSpecifiers(void);
 int cxxTagGetCFieldSpecifierCount(void);
 int cxxTagCFieldEnabled(CXXTagCField eField);
 
-kindOption * cxxTagGetKindOptions(void);
-int cxxTagGetKindOptionCount(void);
-boolean cxxTagKindEnabled(enum CXXTagKind eKindId);
+fieldSpec * cxxTagGetCPPFieldSpecifiers(void);
+int cxxTagGetCPPFieldSpecifierCount(void);
+int cxxTagCPPFieldEnabled(CXXTagCPPField eField);
 
-// Begin composing a tag.
+//
+// Initialize the g_cxx structure for parsing a file in the specified language.
+//
+void cxxTagInitGlobals(langType eLangType);
+
+//
+// Returns true if the specified tag kind, belonging to the current language,
+// is enabled.
+//
+boolean cxxTagKindEnabled(unsigned int uKindId);
+
+
+kindOption * cxxTagGetCKindOptions(void);
+unsigned int cxxTagGetCKindOptionCount(void);
+kindOption * cxxTagGetCPPKindOptions(void);
+unsigned int cxxTagGetCPPKindOptionCount(void);
+
+//
+// Begin composing a tag for the current language.
+//
 // Returns NULL if the tag should *not* be included in the output
 // or the tag entry info that can be filled up with extension fields.
 // Must be followed by cxxTagCommit() if it returns a non-NULL value.
 // The pToken ownership is NOT transferred.
-tagEntryInfo * cxxTagBegin(enum CXXTagKind eKindId,CXXToken * pToken);
+//
+// WARNING: uKindId must be a kind of the current language.
+//
+tagEntryInfo * cxxTagBegin(unsigned int uKindId,CXXToken * pToken);
 
 // Set the type of the current tag from the specified token sequence
 // (which must belong to the same chain!).
@@ -155,7 +196,7 @@ void cxxTagSetCorkQueueCField(
 int cxxTagCommit(void);
 
 // Same as cxxTagBegin() eventually followed by cxxTagCommit()
-void cxxTag(enum CXXTagKind eKindId,CXXToken * pToken);
+void cxxTag(unsigned int uKindId,CXXToken * pToken);
 
 typedef enum {
 	CR_MACRO_UNDEF,

--- a/parsers/cxx/cxx_token.c
+++ b/parsers/cxx/cxx_token.c
@@ -112,7 +112,7 @@ void cxxTokenForceDestroy(CXXToken * t)
 	eFree(t);
 }
 
-CXXToken * cxxTokenCreateKeyword(int iLineNumber,MIOPos oFilePosition,enum CXXKeyword eKeyword)
+CXXToken * cxxTokenCreateKeyword(int iLineNumber,MIOPos oFilePosition,CXXKeyword eKeyword)
 {
 	CXXToken * pToken = cxxTokenCreate();
 	pToken->iLineNumber = iLineNumber;
@@ -138,7 +138,7 @@ static unsigned int hash(const unsigned char *str)
 }
 
 
-CXXToken * cxxTokenCreateAnonymousIdentifier(enum CXXTagKind k)
+CXXToken * cxxTokenCreateAnonymousIdentifier(unsigned int uKindId)
 {
 	g_uNextAnonumousIdentiferId++;
 
@@ -156,7 +156,7 @@ CXXToken * cxxTokenCreateAnonymousIdentifier(enum CXXTagKind k)
 
 	unsigned int uHash = hash((const unsigned char *)getInputFileName());
 
-	sprintf(szNum,"%08x%02x%02x",uHash,g_uNextAnonumousIdentiferId, k);
+	sprintf(szNum,"%08x%02x%02x",uHash,g_uNextAnonumousIdentiferId,uKindId);
 
 	vStringCatS(t->pszWord,szNum);
 	t->bFollowedBySpace = TRUE;

--- a/parsers/cxx/cxx_token.h
+++ b/parsers/cxx/cxx_token.h
@@ -67,7 +67,7 @@ typedef struct _CXXToken
 {
 	enum CXXTokenType eType;
 	vString * pszWord;
-	enum CXXKeyword eKeyword;
+	CXXKeyword eKeyword;
 	CXXTokenChain * pChain; // this is NOT the parent chain!
 	boolean bFollowedBySpace;
 
@@ -89,11 +89,9 @@ CXXToken * cxxTokenCreate(void);
 void cxxTokenDestroy(CXXToken * t);
 
 // A shortcut for quickly creating keyword tokens.
-CXXToken * cxxTokenCreateKeyword(int iLineNumber,MIOPos oFilePosition,enum CXXKeyword eKeyword);
+CXXToken * cxxTokenCreateKeyword(int iLineNumber,MIOPos oFilePosition,CXXKeyword eKeyword);
 
-enum CXXTagKind;
-
-CXXToken * cxxTokenCreateAnonymousIdentifier(enum CXXTagKind k);
+CXXToken * cxxTokenCreateAnonymousIdentifier(unsigned int uKindId);
 
 #define cxxTokenTypeIsOneOf(_pToken,_uTypes) (_pToken->eType & (_uTypes))
 #define cxxTokenTypeIs(_pToken,_eType) (_pToken->eType == _eType)

--- a/parsers/cxx/cxx_token_chain.c
+++ b/parsers/cxx/cxx_token_chain.c
@@ -712,7 +712,7 @@ int cxxTokenChainFindToken(
 
 CXXToken * cxxTokenChainPreviousKeyword(
 		CXXToken * from,
-		enum CXXKeyword eKeyword
+		CXXKeyword eKeyword
 	)
 {
 	if(!from)
@@ -731,7 +731,7 @@ CXXToken * cxxTokenChainPreviousKeyword(
 
 CXXToken * cxxTokenChainNextKeyword(
 		CXXToken * from,
-		enum CXXKeyword eKeyword
+		CXXKeyword eKeyword
 	)
 {
 	if(!from)
@@ -750,7 +750,7 @@ CXXToken * cxxTokenChainNextKeyword(
 
 int cxxTokenChainFirstKeywordIndex(
 		CXXTokenChain * tc,
-		enum CXXKeyword eKeyword
+		CXXKeyword eKeyword
 	)
 {
 	if(!tc)
@@ -776,7 +776,7 @@ int cxxTokenChainFirstKeywordIndex(
 // Remove the #if above if needed.
 CXXToken * cxxTokenChainFirstKeyword(
 		CXXTokenChain * tc,
-		enum CXXKeyword eKeyword
+		CXXKeyword eKeyword
 	)
 {
 	if(!tc)

--- a/parsers/cxx/cxx_token_chain.h
+++ b/parsers/cxx/cxx_token_chain.h
@@ -208,12 +208,12 @@ CXXToken * cxxTokenChainExtractIndexRange(
 
 CXXToken * cxxTokenChainPreviousKeyword(
 		CXXToken * from,
-		enum CXXKeyword eKeyword
+		CXXKeyword eKeyword
 	);
 
 CXXToken * cxxTokenChainNextKeyword(
 		CXXToken * from,
-		enum CXXKeyword eKeyword
+		CXXKeyword eKeyword
 	);
 
 CXXToken * cxxTokenChainNextIdentifier(
@@ -223,7 +223,7 @@ CXXToken * cxxTokenChainNextIdentifier(
 
 int cxxTokenChainFirstKeywordIndex(
 		CXXTokenChain * tc,
-		enum CXXKeyword eKeyword
+		CXXKeyword eKeyword
 	);
 
 #if 0
@@ -231,7 +231,7 @@ int cxxTokenChainFirstKeywordIndex(
 // Remove the #if above if needed.
 CXXToken * cxxTokenChainFirstKeyword(
 		CXXTokenChain * tc,
-		enum CXXKeyword eKeyword
+		CXXKeyword eKeyword
 	);
 #endif
 


### PR DESCRIPTION
In order to hack-in Objective-C support the C/C++ kind options must be splitted. Well, unless we want to have also "interface" / "implementation" / "protocol" and similar stuff mixed with C/C++ kinds.

The shared kind options were a sort of anomaly since in many (most?) other places C and C++ are treated as separate languages. On the other side this change brings a subtle side effect which is not fully backward compatible: one no longer can rely on C++ kinds being set by using --kinds-c=something. So people/tools that were launching ctags on a mixed source tree with only one set of flags might end up having unexpected or missing tags in the output.
