### PR TITLE
main: verify the length of buffer when stripping newline at the end

### DIFF
--- a/main/vstring.c
+++ b/main/vstring.c
@@ -153,6 +153,10 @@ extern void vStringNCatS (
 extern void vStringStripNewline (vString *const string)
 {
 	const size_t final = string->length - 1;
+
+	if (string->length == 0)
+		return;
+
 	if (string->buffer [final] == '\n')
 	{
 		string->buffer [final] = '\0';


### PR DESCRIPTION
The original code didn't consider zero-length strings.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>