### PR TITLE
Fix issue #980

### DIFF
--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -64,8 +64,17 @@ CXXToken * cxxParserOpeningBracketIsLambda(void)
 		return NULL;
 	}
 
-	t = cxxTokenChainPreviousTokenOfType(t,CXXTokenTypeSquareParenthesisChain);
+	// Stop also at commas, so in very large structures we will not be searching far
+	t = cxxTokenChainPreviousTokenOfType(
+			t,
+			CXXTokenTypeSquareParenthesisChain |
+			CXXTokenTypeComma
+		);
+
 	if(!t)
+		return NULL;
+
+	if(!cxxTokenTypeIs(t,CXXTokenTypeSquareParenthesisChain))
 		return NULL;
 
 	t = t->pNext;

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -868,6 +868,13 @@ boolean cxxParserParseNextToken(void)
 {
 	CXXToken * t = cxxTokenCreate();
 
+	// The token chain should not be allowed to grow arbitrairly large.
+	// The token structures are quite big and it's easy to grow up to
+	// 5-6GB or memory usage. However this limit should be large enough
+	// to accomodate all the reasonable statements that could have some
+	// information in them. This includes multiple function prototypes
+	// in a single statement (ImageMagick has some examples) but probably
+	// does NOT include large data tables.
 	if(g_cxx.pTokenChain->iCount > 16384)
 		cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -868,6 +868,9 @@ boolean cxxParserParseNextToken(void)
 {
 	CXXToken * t = cxxTokenCreate();
 
+	if(g_cxx.pTokenChain->iCount > 16384)
+		cxxTokenChainDestroyLast(g_cxx.pTokenChain);
+
 	cxxTokenChainAppend(g_cxx.pTokenChain,t);
 
 	g_cxx.pToken = t;


### PR DESCRIPTION
Optimize lambda lookups. Reintroduce a limit on the size of the token chain.