### PR TITLE
CXX: Split parser kinds

### DIFF
--- a/Tmain/cxx-how-kinds-defs-are-shared-or-copyed.d/run.sh
+++ b/Tmain/cxx-how-kinds-defs-are-shared-or-copyed.d/run.sh
@@ -1,0 +1,20 @@
+# Copyright: 2016 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+printf "[C] enabling: "
+${CTAGS} --quiet --options=NONE \
+	 --kinds-C=+f --list-kinds=C | grep ^f
+
+printf "[C] disbaling: "
+${CTAGS} --quiet --options=NONE \
+	 --kinds-C=-f --list-kinds=C | grep ^f
+
+printf "[C++] enabling: "
+${CTAGS} --quiet --options=NONE \
+	 --kinds-C=+f --list-kinds=C++ | grep ^f
+
+printf "[C++] disbaling: "
+${CTAGS} --quiet --options=NONE \
+	 --kinds-C=-f --list-kinds=C++ | grep ^f

--- a/Tmain/cxx-how-kinds-defs-are-shared-or-copyed.d/stdout-expected.txt
+++ b/Tmain/cxx-how-kinds-defs-are-shared-or-copyed.d/stdout-expected.txt
@@ -1,0 +1,4 @@
+[C] enabling: f  function definitions
+[C] disbaling: f  function definitions [off]
+[C++] enabling: f  function definitions
+[C++] disbaling: f  function definitions

--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -6,9 +6,9 @@ p       UCTAGSscopeKind on      NONE             TRUE     Kind of scope as full 
 -       UCTAGSend       off     C                TRUE     end lines of various constructs
 -       UCTAGSproperties off     C                TRUE     properties (static, inline, mutable,...)
 -       UCTAGSend       off     C++              TRUE     end lines of various constructs
+-       UCTAGSproperties off     C++              TRUE     properties (static, inline, mutable,...)
 -       UCTAGStemplate  off     C++              TRUE     template parameters           
 -       UCTAGScaptures  off     C++              TRUE     lambda capture list           
--       UCTAGSproperties off     C++              TRUE     properties (static, virtual, inline, mutable,...)
 -       UCTAGSend       off     Python           TRUE     end lines of various constructs
 -       UCTAGSend       off     RpmSpec          TRUE     end lines of macros           
 -       UCTAGSsectionMarker off     reStructuredText TRUE     character used for declaring section

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -24,9 +24,9 @@ p	scopeKind	on	NONE	TRUE	Kind of scope as full name
 -	end	off	C	TRUE	end lines of various constructs
 -	properties	off	C	TRUE	properties (static, inline, mutable,...)
 -	end	off	C++	TRUE	end lines of various constructs
+-	properties	off	C++	TRUE	properties (static, inline, mutable,...)
 -	template	off	C++	TRUE	template parameters
 -	captures	off	C++	TRUE	lambda capture list
--	properties	off	C++	TRUE	properties (static, virtual, inline, mutable,...)
 -	end	off	Python	TRUE	end lines of various constructs
 -	end	off	RpmSpec	TRUE	end lines of macros
 -	sectionMarker	off	reStructuredText	TRUE	character used for declaring section

--- a/Tmain/list-kinds-full.d/stdout-expected.txt
+++ b/Tmain/list-kinds-full.d/stdout-expected.txt
@@ -1,13 +1,11 @@
 #LETTER	NAME	ENABLED	REFONLY	NROLES	DESCRIPTION
-c	class	on	FALSE	0	classes
 d	macro	on	FALSE	1	macro definitions
 e	enumerator	on	FALSE	0	enumerators (values inside an enumeration)
 f	function	on	FALSE	0	function definitions
 g	enum	on	FALSE	0	enumeration names
 h	header	off	TRUE	2	included header files
 l	local	off	FALSE	0	local variables
-m	member	on	FALSE	0	class, struct, and union members
-n	namespace	on	FALSE	0	namespaces
+m	member	on	FALSE	0	struct, and union members
 p	prototype	off	FALSE	0	function prototypes
 s	struct	on	FALSE	0	structure names
 t	typedef	on	FALSE	0	typedefs
@@ -16,5 +14,3 @@ v	variable	on	FALSE	0	variable definitions
 x	externvar	off	FALSE	0	external and forward variable declarations
 z	parameter	off	FALSE	0	function parameters inside function definitions
 L	label	off	FALSE	0	goto labels
-N	name	off	FALSE	0	names imported via using scope::symbol
-U	using	off	TRUE	0	using namespace statements

--- a/Units/parser-c.r/bit_field.c.d/expected.tags
+++ b/Units/parser-c.r/bit_field.c.d/expected.tags
@@ -2,24 +2,24 @@ bit_fields	input.c	/^struct bit_fields {$/;"	s	file:	end:5
 a	input.c	/^    unsigned int a: 1;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:1	file:
 b	input.c	/^    unsigned int b: 1;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:1	file:
 c	input.c	/^    unsigned int c: 2;$/;"	m	struct:bit_fields	typeref:typename:unsigned int:2	file:
-__anon1719c4a5010a	input.c	/^struct {$/;"	s	file:	end:12
-sign	input.c	/^    unsigned sign  : 1;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned:1	file:
-exp	input.c	/^    unsigned exp   : _FP_EXPBITS_D;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
-frac1	input.c	/^    unsigned frac1 : _FP_FRACBITS_D - (_FP_IMPLBIT_D != 0) - _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
-frac0	input.c	/^    unsigned frac0 : _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a5010a	typeref:typename:unsigned	file:
+__anon1719c4a50108	input.c	/^struct {$/;"	s	file:	end:12
+sign	input.c	/^    unsigned sign  : 1;$/;"	m	struct:__anon1719c4a50108	typeref:typename:unsigned:1	file:
+exp	input.c	/^    unsigned exp   : _FP_EXPBITS_D;$/;"	m	struct:__anon1719c4a50108	typeref:typename:unsigned	file:
+frac1	input.c	/^    unsigned frac1 : _FP_FRACBITS_D - (_FP_IMPLBIT_D != 0) - _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a50108	typeref:typename:unsigned	file:
+frac0	input.c	/^    unsigned frac0 : _FP_W_TYPE_SIZE;$/;"	m	struct:__anon1719c4a50108	typeref:typename:unsigned	file:
 shortname_info	input.c	/^struct shortname_info {$/;"	s	file:	end:18
 lower	input.c	/^	unsigned char lower:1,$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
 upper	input.c	/^		      upper:1,$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
 valid	input.c	/^		      valid:1;$/;"	m	struct:shortname_info	typeref:typename:unsigned char:1	file:
-__anon1719c4a5020a	input.c	/^{$/;"	s	file:	end:27
-public	input.c	/^    BYTE 	public: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
-bad2	input.c	/^    BYTE 	bad2: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
-group	input.c	/^    BYTE 	group: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
-personal	input.c	/^    BYTE 	personal: 1;$/;"	m	struct:__anon1719c4a5020a	typeref:typename:BYTE:1	file:
-bitfield_flags	input.c	/^} bitfield_flags;$/;"	t	typeref:struct:__anon1719c4a5020a	file:
-__anon1719c4a5030a	input.c	/^{$/;"	s	file:	end:35
-this	input.c	/^    BYTE	this;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
-public	input.c	/^    BYTE	public;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
-private	input.c	/^    BYTE	private;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
-that	input.c	/^    BYTE	that;$/;"	m	struct:__anon1719c4a5030a	typeref:typename:BYTE	file:
-mystruct	input.c	/^} mystruct;$/;"	t	typeref:struct:__anon1719c4a5030a	file:
+__anon1719c4a50208	input.c	/^{$/;"	s	file:	end:27
+public	input.c	/^    BYTE 	public: 1;$/;"	m	struct:__anon1719c4a50208	typeref:typename:BYTE:1	file:
+bad2	input.c	/^    BYTE 	bad2: 1;$/;"	m	struct:__anon1719c4a50208	typeref:typename:BYTE:1	file:
+group	input.c	/^    BYTE 	group: 1;$/;"	m	struct:__anon1719c4a50208	typeref:typename:BYTE:1	file:
+personal	input.c	/^    BYTE 	personal: 1;$/;"	m	struct:__anon1719c4a50208	typeref:typename:BYTE:1	file:
+bitfield_flags	input.c	/^} bitfield_flags;$/;"	t	typeref:struct:__anon1719c4a50208	file:
+__anon1719c4a50308	input.c	/^{$/;"	s	file:	end:35
+this	input.c	/^    BYTE	this;$/;"	m	struct:__anon1719c4a50308	typeref:typename:BYTE	file:
+public	input.c	/^    BYTE	public;$/;"	m	struct:__anon1719c4a50308	typeref:typename:BYTE	file:
+private	input.c	/^    BYTE	private;$/;"	m	struct:__anon1719c4a50308	typeref:typename:BYTE	file:
+that	input.c	/^    BYTE	that;$/;"	m	struct:__anon1719c4a50308	typeref:typename:BYTE	file:
+mystruct	input.c	/^} mystruct;$/;"	t	typeref:struct:__anon1719c4a50308	file:

--- a/Units/parser-c.r/bug1466117.c.d/expected.tags
+++ b/Units/parser-c.r/bug1466117.c.d/expected.tags
@@ -1,7 +1,7 @@
-__anonadd2b98b010a	input.c	/^typedef struct {$/;"	s	file:
-a	input.c	/^	int a;$/;"	m	struct:__anonadd2b98b010a	typeref:typename:int	file:
+__anonadd2b98b0108	input.c	/^typedef struct {$/;"	s	file:
+a	input.c	/^	int a;$/;"	m	struct:__anonadd2b98b0108	typeref:typename:int	file:
 a	input.c	/^	int a;$/;"	m	struct:mystruct	typeref:typename:int	file:
-b	input.c	/^	int b;$/;"	m	struct:__anonadd2b98b010a	typeref:typename:int	file:
+b	input.c	/^	int b;$/;"	m	struct:__anonadd2b98b0108	typeref:typename:int	file:
 b	input.c	/^	int b;$/;"	m	struct:mystruct	typeref:typename:int	file:
 mystruct	input.c	/^typedef struct mystruct {$/;"	s	file:
-mystruct	input.c	/^} mystruct;$/;"	t	typeref:struct:__anonadd2b98b010a	file:
+mystruct	input.c	/^} mystruct;$/;"	t	typeref:struct:__anonadd2b98b0108	file:

--- a/Units/parser-c.r/bug1491666.c.d/expected.tags
+++ b/Units/parser-c.r/bug1491666.c.d/expected.tags
@@ -1,7 +1,7 @@
-__anon329ddd92010a	input.c	/^typedef struct {$/;"	s	file:
+__anon329ddd920108	input.c	/^typedef struct {$/;"	s	file:
 main	input.c	/^void main (void) {$/;"	f	typeref:typename:void
-my_struct	input.c	/^} my_struct;$/;"	t	typeref:struct:__anon329ddd92010a	file:
+my_struct	input.c	/^} my_struct;$/;"	t	typeref:struct:__anon329ddd920108	file:
 var1	input.c	/^	my_struct var1;$/;"	l	function:main	typeref:typename:my_struct	file:
 var2	input.c	/^		var2;$/;"	l	function:main	typeref:typename:my_struct	file:
-x	input.c	/^		x;$/;"	m	struct:__anon329ddd92010a	typeref:typename:int	file:
-y	input.c	/^		y;$/;"	m	struct:__anon329ddd92010a	typeref:typename:float	file:
+x	input.c	/^		x;$/;"	m	struct:__anon329ddd920108	typeref:typename:int	file:
+y	input.c	/^		y;$/;"	m	struct:__anon329ddd920108	typeref:typename:float	file:

--- a/Units/parser-c.r/bug556646.c.d/expected.tags
+++ b/Units/parser-c.r/bug556646.c.d/expected.tags
@@ -1,21 +1,21 @@
-A	input.c	/^  A = INDX_T2$/;"	e	enum:__anone0aee1a10104	file:
-INDX_C1	input.c	/^  INDX_C1,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_C2	input.c	/^  INDX_C2,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_IM1	input.c	/^  INDX_IM1,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_IM2	input.c	/^  INDX_IM2,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_L	input.c	/^  INDX_L,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_L2	input.c	/^  INDX_L2,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_M	input.c	/^  INDX_M,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_NIL	input.c	/^  INDX_NIL =   0x00,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_P	input.c	/^  INDX_P,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_R	input.c	/^  INDX_R,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_R2	input.c	/^  INDX_R2,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_S	input.c	/^  INDX_S,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_S1	input.c	/^  INDX_S1,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_S2	input.c	/^  INDX_S2,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_S3	input.c	/^  INDX_S3,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_S4	input.c	/^  INDX_S4,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_T	input.c	/^  INDX_T,$/;"	e	enum:__anone0aee1a10104	file:
-INDX_T2	input.c	/^  INDX_T2,$/;"	e	enum:__anone0aee1a10104	file:
-__anone0aee1a10104	input.c	/^typedef enum{$/;"	g	file:
-task_indx_type	input.c	/^} task_indx_type;$/;"	t	typeref:enum:__anone0aee1a10104	file:
+A	input.c	/^  A = INDX_T2$/;"	e	enum:__anone0aee1a10103	file:
+INDX_C1	input.c	/^  INDX_C1,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_C2	input.c	/^  INDX_C2,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_IM1	input.c	/^  INDX_IM1,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_IM2	input.c	/^  INDX_IM2,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_L	input.c	/^  INDX_L,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_L2	input.c	/^  INDX_L2,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_M	input.c	/^  INDX_M,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_NIL	input.c	/^  INDX_NIL =   0x00,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_P	input.c	/^  INDX_P,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_R	input.c	/^  INDX_R,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_R2	input.c	/^  INDX_R2,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_S	input.c	/^  INDX_S,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_S1	input.c	/^  INDX_S1,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_S2	input.c	/^  INDX_S2,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_S3	input.c	/^  INDX_S3,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_S4	input.c	/^  INDX_S4,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_T	input.c	/^  INDX_T,$/;"	e	enum:__anone0aee1a10103	file:
+INDX_T2	input.c	/^  INDX_T2,$/;"	e	enum:__anone0aee1a10103	file:
+__anone0aee1a10103	input.c	/^typedef enum{$/;"	g	file:
+task_indx_type	input.c	/^} task_indx_type;$/;"	t	typeref:enum:__anone0aee1a10103	file:

--- a/Units/parser-cxx.r/bug1770479.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/bug1770479.cpp.d/args.ctags
@@ -1,1 +1,1 @@
---kinds-c=+l
+--kinds-c++=+l

--- a/Units/parser-cxx.r/bug639639.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug639639.cpp.d/expected.tags
@@ -1,3 +1,3 @@
 Namespace1	input.h	/^namespace Namespace1$/;"	n
-__anon4605901a0104	input.h	/^enum {anon2=1000};$/;"	g
-anon2	input.h	/^enum {anon2=1000};$/;"	e	enum:__anon4605901a0104
+__anon4605901a0103	input.h	/^enum {anon2=1000};$/;"	g
+anon2	input.h	/^enum {anon2=1000};$/;"	e	enum:__anon4605901a0103

--- a/Units/parser-cxx.r/bug639644.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug639644.cpp.d/expected.tags
@@ -1,2 +1,2 @@
-__anon21d591360108	input.h	/^{$/;"	n
-foo	input.h	/^  int foo;$/;"	v	namespace:__anon21d591360108	typeref:typename:int
+__anon21d591360110	input.h	/^{$/;"	n
+foo	input.h	/^  int foo;$/;"	v	namespace:__anon21d591360110	typeref:typename:int

--- a/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
@@ -1,19 +1,19 @@
 call	input.cpp	/^template<typename T> void call(T x)$/;"	function	typeref:typename:void	signature:(T x)	end:6
 x	input.cpp	/^template<typename T> void call(T x)$/;"	parameter	function:call	typeref:typename:T	file:
 test	input.cpp	/^int test()$/;"	function	typeref:typename:int	signature:()	end:24
-__anon4e7b1b580103	input.cpp	/^	auto l1 = [] { return 0; };$/;"	function	function:test	file:	captures:[] 	end:10
+__anon4e7b1b580102	input.cpp	/^	auto l1 = [] { return 0; };$/;"	function	function:test	file:	captures:[] 	end:10
 l1	input.cpp	/^	auto l1 = [] { return 0; };$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580203	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	function	function:test	file:	signature:(int a,int b) 	captures:[]	end:12
-a	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:typename:int	file:
-b	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580203	typeref:typename:int	file:
+__anon4e7b1b580202	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	function	function:test	file:	signature:(int a,int b) 	captures:[]	end:12
+a	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580202	typeref:typename:int	file:
+b	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:test::__anon4e7b1b580202	typeref:typename:int	file:
 l2	input.cpp	/^	auto l2 = [](int a,int b) { return a > b ? a : b; };$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580303	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	signature:(int a,int b) 	captures:[=]	end:17
-a	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:typename:int	file:
-b	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580303	typeref:typename:int	file:
-__anon4e7b1b580403	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	function	function:test::__anon4e7b1b580303	file:	signature:(int c)	captures:[a,b]	end:15
-c	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	parameter	function:test::__anon4e7b1b580303::__anon4e7b1b580403	typeref:typename:int	file:
-l4	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	local	function:test::__anon4e7b1b580303	typeref:typename:auto	file:
+__anon4e7b1b580302	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	signature:(int a,int b) 	captures:[=]	end:17
+a	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580302	typeref:typename:int	file:
+b	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580302	typeref:typename:int	file:
+__anon4e7b1b580402	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	function	function:test::__anon4e7b1b580302	file:	signature:(int c)	captures:[a,b]	end:15
+c	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	parameter	function:test::__anon4e7b1b580302::__anon4e7b1b580402	typeref:typename:int	file:
+l4	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	local	function:test::__anon4e7b1b580302	typeref:typename:auto	file:
 l3	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580503	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	signature:(int a,int b) 	captures:[l1,l2,l3]	end:22
-a	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:typename:int	file:
-b	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580503	typeref:typename:int	file:
+__anon4e7b1b580502	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	signature:(int a,int b) 	captures:[l1,l2,l3]	end:22
+a	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580502	typeref:typename:int	file:
+b	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580502	typeref:typename:int	file:

--- a/Units/parser-cxx.r/extern.d/args.ctags
+++ b/Units/parser-cxx.r/extern.d/args.ctags
@@ -1,2 +1,2 @@
---c-kinds=+px
+--c++-kinds=+px
 --fields=+{c++.properties}

--- a/Units/parser-cxx.r/namespace.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/namespace.cpp.d/expected.tags
@@ -1,6 +1,6 @@
-__anon396601200108	input.cpp	/^namespace {$/;"	n	file:	end:3
-anon_f	input.cpp	/^	void anon_f() { }$/;"	f	namespace:__anon396601200108	typeref:typename:void	end:2
-__anon396601200108::anon_f	input.cpp	/^	void anon_f() { }$/;"	f	namespace:__anon396601200108	typeref:typename:void
+__anon396601200110	input.cpp	/^namespace {$/;"	n	file:	end:3
+anon_f	input.cpp	/^	void anon_f() { }$/;"	f	namespace:__anon396601200110	typeref:typename:void	end:2
+__anon396601200110::anon_f	input.cpp	/^	void anon_f() { }$/;"	f	namespace:__anon396601200110	typeref:typename:void
 a	input.cpp	/^namespace a {$/;"	n	file:	end:10
 a_f	input.cpp	/^	void a_f() { }$/;"	f	namespace:a	typeref:typename:void	end:6
 a::a_f	input.cpp	/^	void a_f() { }$/;"	f	namespace:a	typeref:typename:void

--- a/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/templates-in-labmdas-1.cpp.d/expected.tags
@@ -5,6 +5,6 @@ b	input.cpp	/^    Bar<int> b;$/;"	local	function:f1	typeref:typename:Bar<int>	fi
 t	input.cpp	/^    auto t = b.template foo<int>();$/;"	local	function:f1	typeref:typename:auto	file:
 f2	input.cpp	/^int f2()$/;"	function	typeref:typename:int	signature:()
 b	input.cpp	/^    Bar<int> b;$/;"	local	function:f2	typeref:typename:Bar<int>	file:
-__anon1763e7850103	input.cpp	/^    auto l = [](auto & p){ return p.template foo<int>();};$/;"	function	function:f2	file:	signature:(auto & p)	captures:[]
+__anon1763e7850102	input.cpp	/^    auto l = [](auto & p){ return p.template foo<int>();};$/;"	function	function:f2	file:	signature:(auto & p)	captures:[]
 l	input.cpp	/^    auto l = [](auto & p){ return p.template foo<int>();};$/;"	local	function:f2	typeref:typename:auto	file:
 main	input.cpp	/^int main()$/;"	function	typeref:typename:int	signature:()

--- a/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/templates-in-labmdas-2.cpp.d/expected.tags
@@ -1,5 +1,5 @@
 Foo	input.cpp	/^namespace Foo$/;"	namespace	file:	end:10
 bar	input.cpp	/^T bar() $/;"	function	namespace:Foo	typeref:typename:T	signature:()	template:<class T>	end:9
 main	input.cpp	/^int main()$/;"	function	typeref:typename:int	signature:()	end:16
-__anonaa3dc9860103	input.cpp	/^    auto l = []{return Foo::template bar<int>();};$/;"	function	function:main	file:	captures:[]	end:14
+__anonaa3dc9860102	input.cpp	/^    auto l = []{return Foo::template bar<int>();};$/;"	function	function:main	file:	captures:[]	end:14
 l	input.cpp	/^    auto l = []{return Foo::template bar<int>();};$/;"	local	function:main	typeref:typename:auto	file:

--- a/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
@@ -2,9 +2,9 @@ T001	input.cpp	/^typedef struct AStruct T001;$/;"	t	typeref:struct:AStruct	file:
 T002	input.cpp	/^typedef class AClass T002;$/;"	t	typeref:class:AClass	file:
 T003	input.cpp	/^typedef union AUnion T003;$/;"	t	typeref:union:AUnion	file:
 T004	input.cpp	/^typedef enum AEnum T004;$/;"	t	typeref:enum:AEnum	file:
-T101	input.cpp	/^typedef struct { int a; } T101;$/;"	t	typeref:struct:__anon0e56f337010a	file:
-T102	input.cpp	/^typedef union { int a; int b; } T102;$/;"	t	typeref:union:__anon0e56f337020c	file:
-T103	input.cpp	/^typedef enum { E2 } T103;$/;"	t	typeref:enum:__anon0e56f3370304	file:
+T101	input.cpp	/^typedef struct { int a; } T101;$/;"	t	typeref:struct:__anon0e56f3370108	file:
+T102	input.cpp	/^typedef union { int a; int b; } T102;$/;"	t	typeref:union:__anon0e56f337020a	file:
+T103	input.cpp	/^typedef enum { E2 } T103;$/;"	t	typeref:enum:__anon0e56f3370303	file:
 T201	input.cpp	/^typedef int* T201;$/;"	t	typeref:typename:int *	file:
 T202	input.cpp	/^typedef const AClass* *  T202;$/;"	t	typeref:typename:const AClass **	file:
 T301	input.cpp	/^typedef int (*T301) (int &,int , AUnion *);$/;"	t	typeref:typename:int (*)(int &,int,AUnion *)	file:

--- a/docs/parser-cxx.rst
+++ b/docs/parser-cxx.rst
@@ -125,3 +125,37 @@ not available it uses the 'typename' keyword.
 
 Generally, you should ignore the information in field A and use
 only information in field B.
+
+Kinds separation
+----------------------------------------------------------------------
+
+Old C and C++ parsers share the definition of kinds. So
+enabling/disabling a kind in one parser affects another parser.  In
+the new parsers, they are separated.
+
+
+Let's see an example::
+
+    $ ./ctags --kinds-OldC=+f --list-kinds=OldC++ | grep ^f
+    f  function definitions
+    $ ./ctags --kinds-OldC=-f --list-kinds=OldC++ | grep ^f
+    f  function definitions [off]
+
+In the first command invocation, `f` kind of OldC parser is enabled
+and all kinds of OldC++ parser are listed. grep is appended for
+extracting the information about `f` kind of OldC++ parser. In the
+second command invocation, `f` kind of OldC parser is disabled. Both
+operations are for the kind of OldC parser, however the kind having the
+same name (`f`) of OldC++ parser gets affected by the operations.
+
+Let's do the same on new C and new C++ parsers::
+
+    $ ./ctags --kinds-C=+f --list-kinds=C++ | grep ^f
+    ./ctags --kinds-C=+f --list-kinds=C++ | grep ^f
+    f  function definitions
+    $ ./ctags --kinds-C=-f --list-kinds=C++ | grep ^f
+    ./ctags --kinds-C=-f --list-kinds=C++ | grep ^f
+    f  function definitions
+
+Enabling and disabling a kind of C parser don't affect the kind having
+the same name of C++ parser.

--- a/parsers/cxx/cxx.c
+++ b/parsers/cxx/cxx.c
@@ -15,6 +15,7 @@
 #include "cxx_token_chain.h"
 #include "cxx_parser.h"
 #include "cxx_scope.h"
+#include "cxx_tag.h"
 
 #include "selectors.h"
 
@@ -85,8 +86,8 @@ parserDefinition * CParser (void)
 
 	parserDefinition* def = parserNew("C");
 
-	def->kinds = cxxTagGetKindOptions();
-	def->kindCount = cxxTagGetKindOptionCount();
+	def->kinds = cxxTagGetCKindOptions();
+	def->kindCount = cxxTagGetCKindOptionCount();
 	def->fieldSpecs = cxxTagGetCFieldSpecifiers();
 	def->fieldSpecCount = cxxTagGetCFieldSpecifierCount();
 	def->extensions = extensions;
@@ -115,8 +116,8 @@ parserDefinition * CppParser (void)
 
 	parserDefinition* def = parserNew("C++");
 
-	def->kinds = cxxTagGetKindOptions();
-	def->kindCount = cxxTagGetKindOptionCount();
+	def->kinds = cxxTagGetCPPKindOptions();
+	def->kindCount = cxxTagGetCPPKindOptionCount();
 	def->fieldSpecs = cxxTagGetCPPFieldSpecifiers();
 	def->fieldSpecCount = cxxTagGetCPPFieldSpecifierCount();
 	def->extensions = extensions;

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -254,21 +254,11 @@ void cxxParserMarkEndLineForTagInCorkQueue(int iCorkQueueIndex)
 
 	char buf[16];
 
-	if(cxxParserCurrentLanguageIsCPP())
-	{
-		if(!cxxTagCPPFieldEnabled(CXXTagCPPFieldEndLine))
-			return;
-
-		sprintf(buf,"%ld",getInputLineNumber());
-		cxxTagSetCorkQueueCPPField(iCorkQueueIndex,CXXTagCPPFieldEndLine,buf);
-		return;
-	}
-
-	if(!cxxTagCFieldEnabled(CXXTagCFieldEndLine))
+	if(!cxxTagFieldEnabled(CXXTagFieldEndLine))
 		return;
 
 	sprintf(buf,"%ld",getInputLineNumber());
-	cxxTagSetCorkQueueCField(iCorkQueueIndex,CXXTagCFieldEndLine,buf);
+	cxxTagSetCorkQueueField(iCorkQueueIndex,CXXTagFieldEndLine,buf);
 }
 
 // Make sure that the token chain contains only the specified keyword and eventually
@@ -840,12 +830,12 @@ static boolean cxxParserParseClassStructOrUnionInternal(
 
 		if(
 			g_cxx.pTemplateTokenChain && (g_cxx.pTemplateTokenChain->iCount > 0) &&
-			cxxTagCPPFieldEnabled(CXXTagCPPFieldTemplate)
+			cxxTagFieldEnabled(CXXTagCPPFieldTemplate)
 		)
 		{
 			cxxTokenChainNormalizeTypeNameSpacing(g_cxx.pTemplateTokenChain);
 			cxxTokenChainCondense(g_cxx.pTemplateTokenChain,0);
-			cxxTagSetCPPField(
+			cxxTagSetField(
 					CXXTagCPPFieldTemplate,
 					vStringValue(cxxTokenChainFirst(g_cxx.pTemplateTokenChain)->pszWord)
 				);
@@ -1212,8 +1202,8 @@ static rescanReason cxxParserMain(const unsigned int passCount)
 	int role_for_header_system = CR_HEADER_SYSTEM;
 	int role_for_header_local = CR_HEADER_LOCAL;
 	int end_field_type = cxxParserCurrentLanguageIsCPP()?
-		cxxTagGetCPPFieldSpecifiers () [CXXTagCPPFieldEndLine].ftype:
-		cxxTagGetCFieldSpecifiers ()   [CXXTagCFieldEndLine].ftype;
+		cxxTagGetCPPFieldSpecifiers () [CXXTagFieldEndLine].ftype:
+		cxxTagGetCFieldSpecifiers ()   [CXXTagFieldEndLine].ftype;
 
 	Assert(passCount < 3);
 

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -14,6 +14,7 @@
 #include "cxx_token.h"
 #include "cxx_token_chain.h"
 #include "cxx_scope.h"
+#include "cxx_tag.h"
 
 #include "parse.h"
 #include "vstring.h"
@@ -458,29 +459,32 @@ boolean cxxParserParseEnum(void)
 	{
 		// good.
 		// It may be qualified though.
-		CXXToken * pNamespaceBegin = pEnumName;
-		CXXToken * pPrev = pEnumName->pPrev;
-		while(pPrev)
+		if(cxxParserCurrentLanguageIsCPP())
 		{
-			if(!cxxTokenTypeIs(pPrev,CXXTokenTypeMultipleColons))
-				break;
-			pPrev = pPrev->pPrev;
-			if(!pPrev)
-				break;
-			if(!cxxTokenTypeIs(pPrev,CXXTokenTypeIdentifier))
-				break;
-			pNamespaceBegin = pPrev;
-			pPrev = pPrev->pPrev;
-		}
-
-		while(pNamespaceBegin != pEnumName)
-		{
-			CXXToken * pNext = pNamespaceBegin->pNext;
-			cxxTokenChainTake(g_cxx.pTokenChain,pNamespaceBegin);
-			// FIXME: We don't really know if it's a class!
-			cxxScopePush(pNamespaceBegin,CXXTagKindCLASS,CXXScopeAccessUnknown);
-			iPushedScopes++;
-			pNamespaceBegin = pNext->pNext;
+			CXXToken * pNamespaceBegin = pEnumName;
+			CXXToken * pPrev = pEnumName->pPrev;
+			while(pPrev)
+			{
+				if(!cxxTokenTypeIs(pPrev,CXXTokenTypeMultipleColons))
+					break;
+				pPrev = pPrev->pPrev;
+				if(!pPrev)
+					break;
+				if(!cxxTokenTypeIs(pPrev,CXXTokenTypeIdentifier))
+					break;
+				pNamespaceBegin = pPrev;
+				pPrev = pPrev->pPrev;
+			}
+	
+			while(pNamespaceBegin != pEnumName)
+			{
+				CXXToken * pNext = pNamespaceBegin->pNext;
+				cxxTokenChainTake(g_cxx.pTokenChain,pNamespaceBegin);
+				// FIXME: We don't really know if it's a class!
+				cxxScopePush(pNamespaceBegin,CXXScopeTypeClass,CXXScopeAccessUnknown);
+				iPushedScopes++;
+				pNamespaceBegin = pNext->pNext;
+			}
 		}
 
 		CXX_DEBUG_PRINT("Enum name is %s",vStringValue(pEnumName->pszWord));
@@ -505,7 +509,7 @@ boolean cxxParserParseEnum(void)
 		iCorkQueueIndex = cxxTagCommit();
 	}
 
-	cxxScopePush(pEnumName,CXXTagKindENUM,CXXScopeAccessPublic);
+	cxxScopePush(pEnumName,CXXScopeTypeEnum,CXXScopeAccessPublic);
 	iPushedScopes++;
 
 	vString * pScopeName = cxxScopeGetFullNameAsString();
@@ -573,7 +577,8 @@ boolean cxxParserParseEnum(void)
 
 static boolean cxxParserParseClassStructOrUnionInternal(
 		enum CXXKeyword eKeyword,
-		enum CXXTagKind eTagKind
+		unsigned int uTagKind,
+		unsigned int uScopeType
 	)
 {
 	CXX_DEBUG_ENTER();
@@ -610,7 +615,7 @@ static boolean cxxParserParseClassStructOrUnionInternal(
 			CXXTokenTypeSemicolon | CXXTokenTypeOpeningBracket |
 			CXXTokenTypeSmallerThanSign;
 
-	if(eTagKind != CXXTagKindCLASS)
+	if(uTagKind != CXXTagCPPKindCLASS)
 		uTerminatorTypes |= CXXTokenTypeParenthesisChain | CXXTokenTypeAssignment;
 
 	boolean bRet;
@@ -743,7 +748,7 @@ static boolean cxxParserParseClassStructOrUnionInternal(
 			CXXToken * pNext = pNamespaceBegin->pNext;
 			cxxTokenChainTake(g_cxx.pTokenChain,pNamespaceBegin);
 			// FIXME: We don't really know if it's a class!
-			cxxScopePush(pNamespaceBegin,CXXTagKindCLASS,CXXScopeAccessUnknown);
+			cxxScopePush(pNamespaceBegin,CXXScopeTypeClass,CXXScopeAccessUnknown);
 			iPushedScopes++;
 			pNamespaceBegin = pNext->pNext;
 		}
@@ -754,7 +759,7 @@ static boolean cxxParserParseClassStructOrUnionInternal(
 			);
 		cxxTokenChainTake(g_cxx.pTokenChain,pClassName);
 	} else {
-		pClassName = cxxTokenCreateAnonymousIdentifier(eTagKind);
+		pClassName = cxxTokenCreateAnonymousIdentifier(uTagKind);
 		CXX_DEBUG_PRINT(
 				"Class/struct/union name is %s (anonymous)",
 				vStringValue(pClassName->pszWord)
@@ -788,7 +793,7 @@ static boolean cxxParserParseClassStructOrUnionInternal(
 		cxxTokenChainClear(g_cxx.pTokenChain);
 	}
 
-	tagEntryInfo * tag = cxxTagBegin(eTagKind,pClassName);
+	tagEntryInfo * tag = cxxTagBegin(uTagKind,pClassName);
 
 	int iCorkQueueIndex = CORK_NIL;
 
@@ -853,8 +858,8 @@ static boolean cxxParserParseClassStructOrUnionInternal(
 
 	cxxScopePush(
 			pClassName,
-			eTagKind,
-			(eTagKind == CXXTagKindCLASS) ?
+			uScopeType,
+			(uTagKind == CXXTagCPPKindCLASS) ?
 				CXXScopeAccessPrivate : CXXScopeAccessPublic
 		);
 
@@ -894,7 +899,8 @@ static boolean cxxParserParseClassStructOrUnionInternal(
 
 boolean cxxParserParseClassStructOrUnion(
 		enum CXXKeyword eKeyword,
-		enum CXXTagKind eTagKind
+		unsigned int uTagKind,
+		unsigned int uScopeType
 	)
 {
 	// Trick for "smart" handling of public/protected/private keywords in .h files parsed as C++.
@@ -915,7 +921,7 @@ boolean cxxParserParseClassStructOrUnion(
 	// Enable public/protected/private keywords
 	g_cxx.bEnablePublicProtectedPrivateKeywords = TRUE;
 
-	boolean bRet = cxxParserParseClassStructOrUnionInternal(eKeyword,eTagKind);
+	boolean bRet = cxxParserParseClassStructOrUnionInternal(eKeyword,uTagKind,uScopeType);
 
 	g_cxx.bEnablePublicProtectedPrivateKeywords = bEnablePublicProtectedPrivateKeywords;
 
@@ -993,12 +999,12 @@ void cxxParserAnalyzeOtherStatement(void)
 		return;
 	}
 
-	enum CXXTagKind eScopeKind = cxxScopeGetKind();
+	enum CXXScopeType eScopeType = cxxScopeGetType();
 
 	CXXFunctionSignatureInfo oInfo;
 
 	// kinda looks like a function or variable instantiation... maybe
-	if(eScopeKind == CXXTagKindFUNCTION)
+	if(eScopeType == CXXScopeTypeFunction)
 	{
 		// prefer variable declarations.
 		// if none found then try function prototype
@@ -1075,19 +1081,19 @@ boolean cxxParserParseAccessSpecifier(void)
 {
 	CXX_DEBUG_ENTER();
 
-	enum CXXTagKind eScopeKind = cxxScopeGetKind();
+	enum CXXScopeType eScopeType = cxxScopeGetType();
 
 	if(
-			(eScopeKind != CXXTagKindCLASS) &&
-			(eScopeKind != CXXTagKindSTRUCT) &&
-			(eScopeKind != CXXTagKindUNION)
+			(eScopeType != CXXScopeTypeClass) &&
+			(eScopeType != CXXScopeTypeUnion) &&
+			(eScopeType != CXXScopeTypeStruct)
 		)
 	{
 		// this is a syntax error: we're in the wrong scope.
 		CXX_DEBUG_LEAVE_TEXT(
 				"Access specified in wrong context (%d): "
 					"bailing out to avoid reporting broken structure",
-				eScopeKind
+				eScopeType
 			);
 		return FALSE;
 	}
@@ -1200,8 +1206,8 @@ static rescanReason cxxParserMain(const unsigned int passCount)
 	cxxTokenAPINewFile();
 	cxxParserNewStatement();
 
-	kindOption * kind_for_define = cxxTagGetKindOptions() + CXXTagKindMACRO;
-	kindOption * kind_for_header = cxxTagGetKindOptions() + CXXTagKindINCLUDE;
+	kindOption * kind_for_define = g_cxx.pKindOptions + CXXTagKindMACRO;
+	kindOption * kind_for_header = g_cxx.pKindOptions + CXXTagKindINCLUDE;
 	int role_for_macro_undef = CR_MACRO_UNDEF;
 	int role_for_header_system = CR_HEADER_SYSTEM;
 	int role_for_header_local = CR_HEADER_LOCAL;
@@ -1246,7 +1252,7 @@ static rescanReason cxxParserMain(const unsigned int passCount)
 rescanReason cxxCParserMain(const unsigned int passCount)
 {
 	CXX_DEBUG_ENTER();
-	g_cxx.eLanguage = g_cxx.eCLanguage;
+	cxxTagInitForLanguage(g_cxx.eCLanguage);
 	rescanReason r = cxxParserMain(passCount);
 	CXX_DEBUG_LEAVE();
 	return r;
@@ -1255,7 +1261,7 @@ rescanReason cxxCParserMain(const unsigned int passCount)
 rescanReason cxxCppParserMain(const unsigned int passCount)
 {
 	CXX_DEBUG_ENTER();
-	g_cxx.eLanguage = g_cxx.eCPPLanguage;
+	cxxTagInitForLanguage(g_cxx.eCPPLanguage);
 
 	// In header files we disable processing of public/protected/private keywords
 	// until we either figure out that this is really C++ or we're start parsing

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -1102,13 +1102,13 @@ int cxxParserEmitFunctionTags(
 		if(
 			g_cxx.pTemplateTokenChain && (g_cxx.pTemplateTokenChain->iCount > 0) &&
 			cxxParserCurrentLanguageIsCPP() &&
-			cxxTagCPPFieldEnabled(CXXTagCPPFieldTemplate)
+			cxxTagFieldEnabled(CXXTagCPPFieldTemplate)
 		)
 		{
 			bIsEmptyTemplate = g_cxx.pTemplateTokenChain->iCount == 2;
 			cxxTokenChainNormalizeTypeNameSpacing(g_cxx.pTemplateTokenChain);
 			cxxTokenChainCondense(g_cxx.pTemplateTokenChain,0);
-			cxxTagSetCPPField(
+			cxxTagSetField(
 					CXXTagCPPFieldTemplate,
 					vStringValue(cxxTokenChainFirst(g_cxx.pTemplateTokenChain)->pszWord)
 				);
@@ -1116,10 +1116,7 @@ int cxxParserEmitFunctionTags(
 		
 		vString * pszProperties = NULL;
 		
-		if(
-			(cxxParserCurrentLanguageIsCPP() && cxxTagCPPFieldEnabled(CXXTagCPPFieldProperties)) ||
-			(cxxParserCurrentLanguageIsC() && cxxTagCFieldEnabled(CXXTagCFieldProperties))
-		)
+		if(cxxTagFieldEnabled(CXXTagFieldProperties))
 		{
 			unsigned int uProperties = 0;
 	

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -307,7 +307,7 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 			vStringValue(pIdentifier->pszWord)
 		);
 
-	cxxScopePush(pIdentifier,CXXTagKindFUNCTION,CXXScopeAccessUnknown);
+	cxxScopePush(pIdentifier,CXXScopeTypeFunction,CXXScopeAccessUnknown);
 
 	// emit parameters
 	if(cxxTagKindEnabled(CXXTagKindPARAMETER))
@@ -985,7 +985,7 @@ next_token:
 //
 int cxxParserEmitFunctionTags(
 		CXXFunctionSignatureInfo * pInfo,
-		enum CXXTagKind eTagKind,
+		unsigned int uTagKind,
 		unsigned int uOptions,
 		int * piCorkQueueIndex
 	)
@@ -997,7 +997,7 @@ int cxxParserEmitFunctionTags(
 	if(piCorkQueueIndex)
 		*piCorkQueueIndex = CORK_NIL;
 
-	enum CXXTagKind eOuterScopeKind = cxxScopeGetKind();
+	enum CXXScopeType eOuterScopeType = cxxScopeGetType();
 
 	boolean bPushScopes = uOptions & CXXEmitFunctionTagsPushScopes;
 
@@ -1024,7 +1024,7 @@ int cxxParserEmitFunctionTags(
 
 			cxxScopePush(
 					pScopeId,
-					CXXTagKindCLASS,
+					CXXScopeTypeClass,
 					// WARNING: We don't know if it's really a class! (FIXME?)
 					CXXScopeAccessUnknown
 				);
@@ -1049,7 +1049,7 @@ int cxxParserEmitFunctionTags(
 
 	CXX_DEBUG_PRINT("Identifier is '%s'",vStringValue(pIdentifier->pszWord));
 
-	tagEntryInfo * tag = cxxTagBegin(eTagKind,pIdentifier);
+	tagEntryInfo * tag = cxxTagBegin(uTagKind,pIdentifier);
 
 	if(tag)
 	{
@@ -1061,12 +1061,12 @@ int cxxParserEmitFunctionTags(
 			pInfo->pParenthesis->pChain->pTail->bFollowedBySpace = FALSE;
 		}
 
-		if(eTagKind == CXXTagKindPROTOTYPE)
+		if(uTagKind == CXXTagKindPROTOTYPE)
 		{
 			tag->isFileScope = !isInputHeaderFile();
 		} else {
 			// function definitions
-			if(eOuterScopeKind == CXXTagKindNAMESPACE)
+			if(eOuterScopeType == CXXScopeTypeNamespace)
 			{
 				// in a namespace only static stuff declared in cpp files is file scoped
 				tag->isFileScope = (
@@ -1174,7 +1174,7 @@ int cxxParserEmitFunctionTags(
 
 
 #ifdef CXX_DO_DEBUGGING
-	if(eTagKind == CXXTagKindFUNCTION)
+	if(uTagKind == CXXTagKindFUNCTION)
 		CXX_DEBUG_PRINT("Emitted function '%s'",vStringValue(pIdentifier->pszWord));
 	else
 		CXX_DEBUG_PRINT("Emitted prototype '%s'",vStringValue(pIdentifier->pszWord));
@@ -1182,7 +1182,7 @@ int cxxParserEmitFunctionTags(
 
 	if(bPushScopes)
 	{
-		cxxScopePush(pIdentifier,CXXTagKindFUNCTION,CXXScopeAccessUnknown);
+		cxxScopePush(pIdentifier,CXXScopeTypeFunction,CXXScopeAccessUnknown);
 		iScopesPushed++;
 	} else {
 		cxxTokenDestroy(pIdentifier);

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -150,7 +150,7 @@ enum CXXEmitFunctionTagsOptions
 
 int cxxParserEmitFunctionTags(
 		CXXFunctionSignatureInfo * pInfo,
-		enum CXXTagKind eTagKind,
+		unsigned int uTagKind,
 		unsigned int uOptions,
 		int * piCorkQueueIndex
 	);
@@ -171,7 +171,8 @@ boolean cxxParserParseNamespace(void);
 boolean cxxParserParseEnum(void);
 boolean cxxParserParseClassStructOrUnion(
 		enum CXXKeyword eKeyword,
-		enum CXXTagKind eTagKind
+		unsigned int uTagKind,
+		unsigned int uScopeType
 	);
 boolean cxxParserParseAndCondenseCurrentSubchain(
 		unsigned int uInitialSubchainMarkerTypes,
@@ -228,6 +229,11 @@ typedef struct _CXXParserState
 	langType eCPPLanguage;
 	// The identifier of the C language, as indicated by ctags core
 	langType eCLanguage;
+	
+	// The kind options associated to the current language
+	kindOption * pKindOptions;
+	// The number of kind options, used mainly for checking/debug purposes
+	unsigned int uKindOptionCount;
 
 	// The current token chain
 	CXXTokenChain * pTokenChain;

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -234,6 +234,11 @@ typedef struct _CXXParserState
 	kindOption * pKindOptions;
 	// The number of kind options, used mainly for checking/debug purposes
 	unsigned int uKindOptionCount;
+	
+	// The fields associated to the current language
+	fieldSpec * pFieldOptions;
+	// The number of field options, used mainly for checking/debug purposes
+	unsigned int uFieldOptionCount;
 
 	// The current token chain
 	CXXTokenChain * pTokenChain;

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -38,6 +38,8 @@ CXXToken * cxxParserOpeningBracketIsLambda(void)
 	// [ capture-list ] ( params ) { body }	(3)
 	// [ capture-list ] { body }	(4)
 
+	CXX_DEBUG_ASSERT(cxxParserCurrentLanguageIsCPP(),"C++ only");
+
 	CXXToken * t = g_cxx.pToken->pPrev;
 
 	if(!t)
@@ -90,6 +92,8 @@ CXXToken * cxxParserOpeningBracketIsLambda(void)
 boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 {
 	CXX_DEBUG_ENTER();
+	
+	CXX_DEBUG_ASSERT(cxxParserCurrentLanguageIsCPP(),"C++ only");
 
 	CXXToken * pIdentifier = cxxTokenCreateAnonymousIdentifier(CXXTagKindFUNCTION);
 
@@ -165,7 +169,7 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 		else
 			pTypeName = NULL;
 
-		if(pCaptureList && cxxTagCPPFieldEnabled(CXXTagCPPFieldLambdaCaptureList))
+		if(pCaptureList && cxxTagFieldEnabled(CXXTagCPPFieldLambdaCaptureList))
 		{
 			CXX_DEBUG_ASSERT(pCaptureList->pChain,"The capture list must be a chain");
 			cxxTokenChainCondense(pCaptureList->pChain,0);
@@ -173,7 +177,7 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 					cxxTokenChainFirst(pCaptureList->pChain),
 					"Condensation should have created a single token in the chain"
 				);
-			cxxTagSetCPPField(
+			cxxTagSetField(
 					CXXTagCPPFieldLambdaCaptureList,
 					vStringValue(cxxTokenChainFirst(pCaptureList->pChain)->pszWord)
 				);

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -14,6 +14,7 @@
 #include "cxx_token.h"
 #include "cxx_token_chain.h"
 #include "cxx_scope.h"
+#include "cxx_tag.h"
 
 #include "parse.h"
 #include "vstring.h"
@@ -198,7 +199,7 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 
 	cxxScopePush(
 			pIdentifier,
-			CXXTagKindFUNCTION,
+			CXXScopeTypeFunction,
 			CXXScopeAccessUnknown
 		);
 

--- a/parsers/cxx/cxx_parser_namespace.c
+++ b/parsers/cxx/cxx_parser_namespace.c
@@ -27,6 +27,8 @@
 boolean cxxParserParseNamespace(void)
 {
 	CXX_DEBUG_ENTER();
+	
+	CXX_DEBUG_ASSERT(cxxParserCurrentLanguageIsCPP(),"This should be called only in C++");
 
 	// FIXME: Do it better...
 
@@ -67,7 +69,7 @@ boolean cxxParserParseNamespace(void)
 		{
 			case CXXTokenTypeIdentifier:
 				CXX_DEBUG_PRINT("Got identifier %s",g_cxx.pToken->pszWord->buffer);
-				tagEntryInfo * tag = cxxTagBegin(CXXTagKindNAMESPACE,g_cxx.pToken);
+				tagEntryInfo * tag = cxxTagBegin(CXXTagCPPKindNAMESPACE,g_cxx.pToken);
 				if(tag)
 				{
 					// This is highly questionable but well.. it's how old ctags did, so we do.
@@ -76,7 +78,7 @@ boolean cxxParserParseNamespace(void)
 				}
 				cxxScopePush(
 						cxxTokenChainTakeLast(g_cxx.pTokenChain),
-						CXXTagKindNAMESPACE,
+						CXXScopeTypeNamespace,
 						CXXScopeAccessUnknown
 					);
 				iScopeCount++;
@@ -106,14 +108,14 @@ boolean cxxParserParseNamespace(void)
 				if(iScopeCount == 0)
 				{
 					// anonymous namespace!
-					CXXToken * t = cxxTokenCreateAnonymousIdentifier(CXXTagKindNAMESPACE);
-					tagEntryInfo * tag = cxxTagBegin(CXXTagKindNAMESPACE,t);
+					CXXToken * t = cxxTokenCreateAnonymousIdentifier(CXXTagCPPKindNAMESPACE);
+					tagEntryInfo * tag = cxxTagBegin(CXXTagCPPKindNAMESPACE,t);
 					if(tag)
 					{
 						tag->isFileScope = !isInputHeaderFile();
 						iCorkQueueIndex = cxxTagCommit();
 					}
-					cxxScopePush(t,CXXTagKindNAMESPACE,CXXScopeAccessUnknown);
+					cxxScopePush(t,CXXScopeTypeNamespace,CXXScopeAccessUnknown);
 					iScopeCount++;
 				}
 

--- a/parsers/cxx/cxx_parser_using.c
+++ b/parsers/cxx/cxx_parser_using.c
@@ -130,7 +130,7 @@ boolean cxxParserParseUsingClause(void)
 						"Found using clause '%s' which extends scope",
 						vStringValue(t->pszWord)
 					);
-				tag = cxxTagBegin(CXXTagKindUSING,t);
+				tag = cxxTagBegin(CXXTagCPPKindUSING,t);
 			} else {
 
 				t = cxxTokenChainLast(g_cxx.pTokenChain);
@@ -139,14 +139,14 @@ boolean cxxParserParseUsingClause(void)
 						"Found using clause '%s' which imports a name",
 						vStringValue(t->pszWord)
 					);
-				tag = cxxTagBegin(CXXTagKindNAME,t);
+				tag = cxxTagBegin(CXXTagCPPKindNAME,t);
 
 				// FIXME: We need something like "nameref:<condensed>" here!
 			}
 
 			if(tag)
 			{
-				tag->isFileScope = (cxxScopeGetKind() == CXXTagKindNAMESPACE) &&
+				tag->isFileScope = (cxxScopeGetType() == CXXScopeTypeNamespace) &&
 							(!isInputHeaderFile());
 				cxxTagCommit();
 			}

--- a/parsers/cxx/cxx_parser_variable.c
+++ b/parsers/cxx/cxx_parser_variable.c
@@ -556,10 +556,7 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 
 			vString * pszProperties = NULL;
 			
-			if(
-				(cxxParserCurrentLanguageIsCPP() && cxxTagCPPFieldEnabled(CXXTagCPPFieldProperties)) ||
-				(cxxParserCurrentLanguageIsC() && cxxTagCFieldEnabled(CXXTagCFieldProperties))
-			)
+			if(cxxTagFieldEnabled(CXXTagFieldProperties))
 			{
 				unsigned int uProperties = 0;
 		

--- a/parsers/cxx/cxx_parser_variable.c
+++ b/parsers/cxx/cxx_parser_variable.c
@@ -85,7 +85,7 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 
 	CXXToken * t = cxxTokenChainFirst(pChain);
 
-	enum CXXTagKind eScopeKind = cxxScopeGetKind();
+	enum CXXScopeType eScopeType = cxxScopeGetType();
 
 	CXX_DEBUG_ASSERT(t,"There should be an initial token here");
 
@@ -237,8 +237,8 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 				} else if(
 						cxxTokenTypeIs(t->pPrev,CXXTokenTypeIdentifier) &&
 						(
-							(eScopeKind == CXXTagKindNAMESPACE) ||
-							(eScopeKind == CXXTagKindFUNCTION)
+							(eScopeType == CXXScopeTypeNamespace) ||
+							(eScopeType == CXXScopeTypeFunction)
 						) &&
 						cxxParserCurrentLanguageIsCPP() &&
 						cxxParserTokenChainLooksLikeConstructorParameterSet(t->pChain)
@@ -476,7 +476,7 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 				CXXToken * pScopeId = cxxTokenChainExtractRange(pScopeStart,pPartEnd->pPrev,0);
 				cxxScopePush(
 						pScopeId,
-						CXXTagKindCLASS,
+						CXXScopeTypeClass,
 						// WARNING: We don't know if it's really a class! (FIXME?)
 						CXXScopeAccessUnknown
 					);
@@ -541,15 +541,15 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 					TRUE :
 					(
 						(
-							(eScopeKind == CXXTagKindNAMESPACE) &&
+							(eScopeType == CXXScopeTypeNamespace) &&
 							(g_cxx.uKeywordState & CXXParserKeywordStateSeenStatic) &&
 							(!isInputHeaderFile())
 						) ||
 						// locals are always hidden
-						(eScopeKind == CXXTagKindFUNCTION) ||
+						(eScopeType == CXXScopeTypeFunction) ||
 						(
-							(eScopeKind != CXXTagKindNAMESPACE) &&
-							(eScopeKind != CXXTagKindFUNCTION) &&
+							(eScopeType != CXXScopeTypeNamespace) &&
+							(eScopeType != CXXScopeTypeFunction) &&
 							(!isInputHeaderFile())
 						)
 					);

--- a/parsers/cxx/cxx_scope.h
+++ b/parsers/cxx/cxx_scope.h
@@ -12,7 +12,6 @@
 #include "general.h"
 
 #include "cxx_token.h"
-#include "cxx_tag.h"
 
 enum CXXScopeAccess
 {
@@ -20,6 +19,16 @@ enum CXXScopeAccess
 	CXXScopeAccessPublic,
 	CXXScopeAccessPrivate,
 	CXXScopeAccessProtected
+};
+
+enum CXXScopeType
+{
+	CXXScopeTypeFunction,
+	CXXScopeTypeNamespace,
+	CXXScopeTypeClass,
+	CXXScopeTypeEnum,
+	CXXScopeTypeUnion,
+	CXXScopeTypeStruct
 };
 
 void cxxScopeInit(void);
@@ -47,9 +56,10 @@ vString * cxxScopeGetFullNameAsString(void);
 // are less than two components. Ownership of the string is transferred.
 vString * cxxScopeGetFullNameExceptLastComponentAsString(void);
 
+enum CXXScopeType cxxScopeGetType(void);
 // Returns the current scope kind
-enum CXXTagKind cxxScopeGetKind(void);
-enum CXXTagKind cxxScopeGetVariableKind(void);
+unsigned int cxxScopeGetKind(void);
+unsigned int cxxScopeGetVariableKind(void);
 enum CXXScopeAccess cxxScopeGetAccess(void);
 // Are we in global scope?
 boolean cxxScopeIsGlobal(void);
@@ -57,7 +67,7 @@ boolean cxxScopeIsGlobal(void);
 // Add a token to the scope chain. The token ownership is transferred.
 void cxxScopePush(
 		CXXToken * t,
-		enum CXXTagKind eScopeKind,
+		enum CXXScopeType eScopeType,
 		enum CXXScopeAccess eInitialAccess
 	);
 void cxxScopeSetAccess(enum CXXScopeAccess eAccess);

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -18,26 +18,34 @@
 #include "routines.h"
 #include "xtag.h"
 
+#define CXX_COMMON_MACRO_ROLES(__langPrefix)		\
+    static roleDesc __langPrefix##MacroRoles [] = {	\
+	    RoleTemplateUndef,				\
+    }
 
-static roleDesc CMacroRoles [] = {
-	RoleTemplateUndef,
-};
-
-static roleDesc CHeaderRoles [] = {
-	RoleTemplateSystem,
-	RoleTemplateLocal,
-};
+CXX_COMMON_MACRO_ROLES(C);
+CXX_COMMON_MACRO_ROLES(CXX);
 
 
-#define CXX_COMMON_KINDS(_szMemberDescription) \
+#define CXX_COMMON_HEADER_ROLES(__langPrefix)		\
+    static roleDesc __langPrefix##HeaderRoles [] = {	\
+	    RoleTemplateSystem,				\
+	    RoleTemplateLocal,				\
+    }
+
+CXX_COMMON_HEADER_ROLES(C);
+CXX_COMMON_HEADER_ROLES(CXX);
+
+
+#define CXX_COMMON_KINDS(_langPrefix, _szMemberDescription) \
 	{ TRUE,  'd', "macro",      "macro definitions", \
-			.referenceOnly = FALSE, ATTACH_ROLES(CMacroRoles) \
+			.referenceOnly = FALSE, ATTACH_ROLES(_langPrefix##MacroRoles) \
 	}, \
 	{ TRUE,  'e', "enumerator", "enumerators (values inside an enumeration)" }, \
 	{ TRUE,  'f', "function",   "function definitions" }, \
 	{ TRUE,  'g', "enum",       "enumeration names" }, \
 	{ FALSE, 'h', "header",     "included header files", \
-			.referenceOnly = TRUE,  ATTACH_ROLES(CHeaderRoles) \
+			.referenceOnly = TRUE,  ATTACH_ROLES(_langPrefix##HeaderRoles) \
 	}, \
 	{ FALSE, 'l', "local",      "local variables" }, \
 	{ TRUE,  'm', "member",     _szMemberDescription }, \
@@ -51,11 +59,11 @@ static roleDesc CHeaderRoles [] = {
 	{ FALSE, 'L', "label",      "goto labels" }
 
 static kindOption g_aCXXCKinds [] = {
-	CXX_COMMON_KINDS("struct, and union members")
+	CXX_COMMON_KINDS(C,"struct, and union members")
 };
 
 static kindOption g_aCXXCPPKinds [] = {
-	CXX_COMMON_KINDS("class, struct, and union members"),
+	CXX_COMMON_KINDS(CXX,"class, struct, and union members"),
 	{ TRUE,  'c', "class",      "classes" },
 	{ TRUE,  'n', "namespace",  "namespaces" },
 	{ FALSE, 'N', "name",       "names imported via using scope::symbol" },

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -17,7 +17,7 @@
 #include "cxx_token.h"
 
 // Tag kinds common to all (sub)languages this parser supports
-enum CXXCommonTagKind
+enum CXXTagCommonKind
 {
 	CXXTagKindMACRO,
 	CXXTagKindENUMERATOR,
@@ -34,40 +34,41 @@ enum CXXCommonTagKind
 	CXXTagKindEXTERNVAR,
 	CXXTagKindPARAMETER,
 	CXXTagKindLABEL,
-	CXXCommonTagKindCount
+
+	CXXTagCommonKindCount
 };
 
 // Tags specific to the CPP language.
-enum CXXCPPTagKind
+enum CXXTagCPPKind
 {
-	CXXTagCPPKindCLASS = CXXCommonTagKindCount,
+	CXXTagCPPKindCLASS = CXXTagCommonKindCount,
 	CXXTagCPPKindNAMESPACE,
 	CXXTagCPPKindNAME,
 	CXXTagCPPKindUSING
 };
 
-typedef enum _CXXTagCPPField
+enum CXXTagCommonField
 {
-	CXXTagCPPFieldEndLine,
-	CXXTagCPPFieldTemplate,
-	CXXTagCPPFieldLambdaCaptureList,
-	CXXTagCPPFieldProperties
-} CXXTagCPPField;
+	CXXTagFieldEndLine,
+	CXXTagFieldProperties,
+	
+	CXXTagCommonFieldCount
+};
 
-typedef enum _CXXTagCField
+enum CXXTagCPPField
 {
-	CXXTagCFieldEndLine,
-	CXXTagCFieldProperties
-} CXXTagCField;
+	CXXTagCPPFieldTemplate = CXXTagCommonFieldCount,
+	CXXTagCPPFieldLambdaCaptureList
+};
 
 
 fieldSpec * cxxTagGetCPPFieldSpecifiers(void);
 int cxxTagGetCPPFieldSpecifierCount(void);
-int cxxTagCPPFieldEnabled(CXXTagCPPField eField);
 
 fieldSpec * cxxTagGetCFieldSpecifiers(void);
 int cxxTagGetCFieldSpecifierCount(void);
-int cxxTagCFieldEnabled(CXXTagCField eField);
+
+boolean cxxTagFieldEnabled(unsigned int uField);
 
 kindOption * cxxTagGetCKindOptions(void);
 int cxxTagGetCKindOptionCount(void);
@@ -76,14 +77,14 @@ kindOption * cxxTagGetCPPKindOptions(void);
 int cxxTagGetCPPKindOptionCount(void);
 
 // Returns true if the specified tag kind is enabled in the current language
-boolean cxxTagKindEnabled(unsigned int uTagKindId);
+boolean cxxTagKindEnabled(unsigned int uTagKind);
 
 // Begin composing a tag. The tag kind must correspond to the current language.
 // Returns NULL if the tag should *not* be included in the output
 // or the tag entry info that can be filled up with extension fields.
 // Must be followed by cxxTagCommit() if it returns a non-NULL value.
 // The pToken ownership is NOT transferred.
-tagEntryInfo * cxxTagBegin(unsigned int uKindId,CXXToken * pToken);
+tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken);
 
 // Set the type of the current tag from the specified token sequence
 // (which must belong to the same chain!).
@@ -136,39 +137,25 @@ typedef enum _CXXTagProperty
 // not enabled or similar...)
 vString * cxxTagSetProperties(unsigned int uProperties);
 
-// Set a parser-local CPP field. The szValue pointer must persist
+// Set a parser-local field. The szValue pointer must persist
 // until cxxTagCommit() is called.
-void cxxTagSetCPPField(CXXTagCPPField eField,const char * szValue);
+void cxxTagSetField(unsigned int uField,const char * szValue);
 
 // Set a parser-local CPP field for a tag in cork queue.
 // The szValue pointer is copied.
 // Make sure that the field is enabled before calling this function.
-void cxxTagSetCorkQueueCPPField(
+void cxxTagSetCorkQueueField(
 		int iIndex,
-		CXXTagCPPField eField,
+		unsigned int uField,
 		const char * szValue
 	);
-
-// Set a parser-local C field. The szValue pointer must persist
-// until cxxTagCommit() is called.
-void cxxTagSetCField(CXXTagCField eField,const char * szValue);
-
-// Set a parser-local C field for a tag in cork queue.
-// The szValue pointer is copied.
-// Make sure that the field is enabled before calling this function.
-void cxxTagSetCorkQueueCField(
-		int iIndex,
-		CXXTagCField eField,
-		const char * szValue
-	);
-
 
 // Commit the composed tag. Must follow a succesfull cxxTagBegin() call.
 // Returns the index of the tag in the cork queue.
 int cxxTagCommit(void);
 
 // Same as cxxTagBegin() eventually followed by cxxTagCommit()
-void cxxTag(unsigned int uKindId,CXXToken * pToken);
+void cxxTag(unsigned int uKind,CXXToken * pToken);
 
 typedef enum {
 	CR_MACRO_UNDEF,

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -47,6 +47,7 @@ enum CXXTagCPPKind
 	CXXTagCPPKindUSING
 };
 
+// The fields common to all (sub)languages this parser supports.
 enum CXXTagCommonField
 {
 	CXXTagFieldEndLine,
@@ -55,6 +56,7 @@ enum CXXTagCommonField
 	CXXTagCommonFieldCount
 };
 
+// The fields specific to the CPP language.
 enum CXXTagCPPField
 {
 	CXXTagCPPFieldTemplate = CXXTagCommonFieldCount,

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -16,9 +16,9 @@
 
 #include "cxx_token.h"
 
-enum CXXTagKind
+// Tag kinds common to all (sub)languages this parser supports
+enum CXXCommonTagKind
 {
-	CXXTagKindCLASS,
 	CXXTagKindMACRO,
 	CXXTagKindENUMERATOR,
 	CXXTagKindFUNCTION,
@@ -26,7 +26,6 @@ enum CXXTagKind
 	CXXTagKindINCLUDE,
 	CXXTagKindLOCAL,
 	CXXTagKindMEMBER,
-	CXXTagKindNAMESPACE,
 	CXXTagKindPROTOTYPE,
 	CXXTagKindSTRUCT,
 	CXXTagKindTYPEDEF,
@@ -35,8 +34,16 @@ enum CXXTagKind
 	CXXTagKindEXTERNVAR,
 	CXXTagKindPARAMETER,
 	CXXTagKindLABEL,
-	CXXTagKindNAME,
-	CXXTagKindUSING
+	CXXCommonTagKindCount
+};
+
+// Tags specific to the CPP language.
+enum CXXCPPTagKind
+{
+	CXXTagCPPKindCLASS = CXXCommonTagKindCount,
+	CXXTagCPPKindNAMESPACE,
+	CXXTagCPPKindNAME,
+	CXXTagCPPKindUSING
 };
 
 typedef enum _CXXTagCPPField
@@ -53,6 +60,7 @@ typedef enum _CXXTagCField
 	CXXTagCFieldProperties
 } CXXTagCField;
 
+
 fieldSpec * cxxTagGetCPPFieldSpecifiers(void);
 int cxxTagGetCPPFieldSpecifierCount(void);
 int cxxTagCPPFieldEnabled(CXXTagCPPField eField);
@@ -61,16 +69,21 @@ fieldSpec * cxxTagGetCFieldSpecifiers(void);
 int cxxTagGetCFieldSpecifierCount(void);
 int cxxTagCFieldEnabled(CXXTagCField eField);
 
-kindOption * cxxTagGetKindOptions(void);
-int cxxTagGetKindOptionCount(void);
-boolean cxxTagKindEnabled(enum CXXTagKind eKindId);
+kindOption * cxxTagGetCKindOptions(void);
+int cxxTagGetCKindOptionCount(void);
 
-// Begin composing a tag.
+kindOption * cxxTagGetCPPKindOptions(void);
+int cxxTagGetCPPKindOptionCount(void);
+
+// Returns true if the specified tag kind is enabled in the current language
+boolean cxxTagKindEnabled(unsigned int uTagKindId);
+
+// Begin composing a tag. The tag kind must correspond to the current language.
 // Returns NULL if the tag should *not* be included in the output
 // or the tag entry info that can be filled up with extension fields.
 // Must be followed by cxxTagCommit() if it returns a non-NULL value.
 // The pToken ownership is NOT transferred.
-tagEntryInfo * cxxTagBegin(enum CXXTagKind eKindId,CXXToken * pToken);
+tagEntryInfo * cxxTagBegin(unsigned int uKindId,CXXToken * pToken);
 
 // Set the type of the current tag from the specified token sequence
 // (which must belong to the same chain!).
@@ -155,7 +168,7 @@ void cxxTagSetCorkQueueCField(
 int cxxTagCommit(void);
 
 // Same as cxxTagBegin() eventually followed by cxxTagCommit()
-void cxxTag(enum CXXTagKind eKindId,CXXToken * pToken);
+void cxxTag(unsigned int uKindId,CXXToken * pToken);
 
 typedef enum {
 	CR_MACRO_UNDEF,
@@ -165,5 +178,9 @@ typedef enum {
 	CR_HEADER_SYSTEM,
 	CR_HEADER_LOCAL,
 } cHeaderRole;
+
+// Initialize the parser state for the specified language.
+// Must be called before attempting to access the kind options.
+void cxxTagInitForLanguage(langType eLanguage);
 
 #endif //!_cxxTag_h_

--- a/parsers/cxx/cxx_token.c
+++ b/parsers/cxx/cxx_token.c
@@ -125,11 +125,11 @@ CXXToken * cxxTokenCreateKeyword(int iLineNumber,MIOPos oFilePosition,enum CXXKe
 }
 
 
-CXXToken * cxxTokenCreateAnonymousIdentifier(enum CXXTagKind k)
+CXXToken * cxxTokenCreateAnonymousIdentifier(unsigned int uTagKind)
 {
 	CXXToken * t = cxxTokenCreate();
 
-	anonGenerate (t->pszWord, "__anon", k);
+	anonGenerate (t->pszWord, "__anon", uTagKind);
 	t->bFollowedBySpace = TRUE;
 	t->iLineNumber = getInputLineNumber();
 	t->oFilePosition = getInputFilePosition();

--- a/parsers/cxx/cxx_token.h
+++ b/parsers/cxx/cxx_token.h
@@ -81,7 +81,7 @@ typedef struct _CXXToken
 	// scope information. Only cxxScope* functions can make sense of it.
 	// In other contexts these are simply left
 	// uninitialized and must be treated as undefined.
-	unsigned char uInternalScopeKind;
+	unsigned char uInternalScopeType;
 	unsigned char uInternalScopeAccess;
 } CXXToken;
 
@@ -91,9 +91,7 @@ void cxxTokenDestroy(CXXToken * t);
 // A shortcut for quickly creating keyword tokens.
 CXXToken * cxxTokenCreateKeyword(int iLineNumber,MIOPos oFilePosition,enum CXXKeyword eKeyword);
 
-enum CXXTagKind;
-
-CXXToken * cxxTokenCreateAnonymousIdentifier(enum CXXTagKind k);
+CXXToken * cxxTokenCreateAnonymousIdentifier(unsigned int uTagKind);
 
 #define cxxTokenTypeIsOneOf(_pToken,_uTypes) (_pToken->eType & (_uTypes))
 #define cxxTokenTypeIs(_pToken,_eType) (_pToken->eType == _eType)


### PR DESCRIPTION
Split the C and C++ parser kinds. 
Use the "index sharing" splitting technique also for the fields.