### PR TITLE
appveyor: Create MSVC packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you want to try the latest universal-ctags without building it yourself...
 
 ### Windows
 - Go to https://ci.appveyor.com/project/masatake/ctags
-  - Click the ```compiler=msvc, ARCH=x64``` (or ```compiler=msvc, ARCH=x86```) build.
+  - Click the ```compiler=msvc_msys2, ARCH=x64, ...``` (or ```compiler=msvc_msys2, ARCH=x86, ...```) build.
   - View the *Artifacts* tab and download ```ctags-XXXXXX-x64.zip``` (or ```ctags-XXXXXX-x86.zip```). (```XXXXXX``` is a version number or a commit ID.)
   - Add the binary folder to your PATH.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you want to try the latest universal-ctags without building it yourself...
 ### Windows
 - Go to https://ci.appveyor.com/project/masatake/ctags
   - Click the ```compiler=msvc, ARCH=x64``` (or ```compiler=msvc, ARCH=x86```) build.
-  - View the *Artifacts* tab and download ```ctags.exe```.
+  - View the *Artifacts* tab and download ```ctags-XXXXXX-x64.zip``` (or ```ctags-XXXXXX-x86.zip```). (```XXXXXX``` is a version number or a commit ID.)
   - Add the binary folder to your PATH.
 
 ### Mac

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,15 +4,17 @@ environment:
   matrix:
     - compiler: msbuild
       CONFIGURATION: Release
-    - compiler: msvc
+    - compiler: msvc_msys2
       ARCH: x64
-    - compiler: msvc
-      ARCH: x86
-    - compiler: mingw
-    - compiler: msys2
       MSYS2_ARCH: x86_64
       MSYS2_DIR: msys64
       MSYSTEM: MINGW64
+    - compiler: msvc_msys2
+      ARCH: x86
+      MSYS2_ARCH: x86
+      MSYS2_DIR: msys64
+      MSYSTEM: MINGW32
+    - compiler: mingw
     - compiler: cygwin
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,13 @@ environment:
     - compiler: cygwin
 
 build_script:
-  - '%APPVEYOR_BUILD_FOLDER%\win32\appveyor.bat'
+  - '%APPVEYOR_BUILD_FOLDER%\win32\appveyor.bat build'
+
+after_build:
+  - '%APPVEYOR_BUILD_FOLDER%\win32\appveyor.bat package'
 
 test_script:
   - '%APPVEYOR_BUILD_FOLDER%\win32\appveyor.bat test'
 
 artifacts:
-  - path: ctags.exe
+  - path: ctags-*.zip


### PR DESCRIPTION
This PR creates zip packages of MSVC builds (x86 and x64) on AppVeyor.
The zip packages contains ctags.exe, readtags.exe, iconv.dll and documents.

The build matrix is changed for testing both MSVC x86 and x64 binaries using bash on msys2.
The tests of MinGW-w64 binary are skipped instead.

Here is an example:
https://ci.appveyor.com/project/k-takata/ctags/build/1.0.129
Zip packages:
https://ci.appveyor.com/api/buildjobs/5fsf7doq4mhrh2n2/artifacts/ctags-787f95a-x64.zip
https://ci.appveyor.com/api/buildjobs/l3t1el9hkpdpu0g4/artifacts/ctags-787f95a-x86.zip
(When a tag is built, the zip filename becomes `ctags-<tagname>-<arch>.zip`.)

Unfortunately this makes the tests about 10 minutes longer.