### PR TITLE
Cxx: fix anon identifier related memleak

### DIFF
--- a/parsers/cxx/cxx_token.c
+++ b/parsers/cxx/cxx_token.c
@@ -130,6 +130,7 @@ CXXToken * cxxTokenCreateAnonymousIdentifier(unsigned int uTagKind)
 	CXXToken * t = cxxTokenCreate();
 
 	anonGenerate (t->pszWord, "__anon", uTagKind);
+	t->eType = CXXTokenTypeIdentifier;
 	t->bFollowedBySpace = TRUE;
 	t->iLineNumber = getInputLineNumber();
 	t->oFilePosition = getInputFilePosition();


### PR DESCRIPTION
Valgrind reports memory errors for following cases:

    $ make units VG=1 LANGUAGES=C
    ...
    Summary (see CMDLINE.tmp to reproduce without test harness)
    ------------------------------------------------------------
      #passed:                                52
      #FIXED:                                 0
      #FAILED (unexpected-exit-status):       0
      #FAILED (unexpected-output):            0
      #TIMED-OUT (10s)                        0
      #skipped (features):                    0
      #skipped (languages):                   0
      #known-bugs:                            0
      #valgrind-error:                        3
	    parser-c.r/bug1491666.c
	    parser-c.r/bug556646.c
	    parser-c.r/using-cxx-keyword-in-c-code

This is because a token type is specified when generating an anonymous
identifier.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>