### PR TITLE
Cxx: fix debuggging build

### DIFF
--- a/parsers/cxx/cxx_scope.c
+++ b/parsers/cxx/cxx_scope.c
@@ -16,6 +16,10 @@
 #include "cxx_debug.h"
 #include "cxx_token_chain.h"
 
+#ifdef CXX_DO_DEBUGGING
+#include "cxx_parser_internal.h"
+#endif
+
 // The tokens defining current scope
 static CXXTokenChain * g_pScope = NULL;
 static vString * g_szScopeName = NULL;


### PR DESCRIPTION
Building with setting  CXX_DEBUGGING_ENABLED 1, gcc reports an error when
compiling cxx_scope.c.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>