### PR TITLE
Make more areas plug able

### DIFF
--- a/Tmain/output-format-option.d/input.c
+++ b/Tmain/output-format-option.d/input.c
@@ -1,0 +1,5 @@
+int
+main(void)
+{
+  return 0;
+}

--- a/Tmain/output-format-option.d/run.sh
+++ b/Tmain/output-format-option.d/run.sh
@@ -1,0 +1,15 @@
+# Copyright: 2016 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+run_with_format()
+{
+    echo '#' $1
+    ${CTAGS} --quiet --options=NONE --output-format=$1 -o - input.c
+}
+
+
+run_with_format ctags
+run_with_format etags
+run_with_format xref

--- a/Tmain/output-format-option.d/stdout-expected.txt
+++ b/Tmain/output-format-option.d/stdout-expected.txt
@@ -1,0 +1,8 @@
+# ctags
+main	input.c	/^main(void)$/;"	f	typeref:typename:int
+# etags
+
+input.c,20
+main(void)main2,4
+# xref
+main             function      2 input.c          main(void)

--- a/main/entry.h
+++ b/main/entry.h
@@ -108,8 +108,8 @@ extern void freeTagFileResources (void);
 extern const char *tagFileName (void);
 extern void openTagFile (void);
 extern void closeTagFile (const boolean resize);
-extern void beginEtagsFile (void);
-extern void endEtagsFile (const char *const name);
+extern void  setupWriter (void);
+extern void  teardownWriter (const char *inputFilename);
 extern int makeTagEntry (const tagEntryInfo *const tag);
 extern void initTagEntry (tagEntryInfo *const e, const char *const name,
 			  const kindOption *kind);

--- a/main/error.c
+++ b/main/error.c
@@ -1,0 +1,59 @@
+/*
+*   Copyright (c) 2002-2003, Darren Hiebert
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   This module contains a lose assortment of shared functions.
+*/
+
+#include "general.h"  /* must always come first */
+#include <string.h>
+#include <errno.h>
+
+#include "error.h"
+#include "options.h"
+
+#define selected(var,feature)	(((int)(var) & (int)(feature)) == (int)feature)
+
+static errorPrintFunc errorPrinter;
+static void *errorPrinterData;
+
+extern void setErrorPrinter (errorPrintFunc printer, void *data)
+{
+	errorPrinter = printer;
+	errorPrinterData = data;
+}
+
+extern boolean stderrDefaultErrorPrinter (const errorSelection selection,
+					  const char *const format,
+					  va_list ap, void *data __unused__)
+{
+	fprintf (stderr, "%s: %s", getExecutableName (),
+		 selected (selection, WARNING) ? "Warning: " : "");
+	vfprintf (stderr, format, ap);
+	if (selected (selection, PERROR))
+#ifdef HAVE_STRERROR
+		fprintf (stderr, " : %s", strerror (errno));
+#else
+	perror (" ");
+#endif
+	fputs ("\n", stderr);
+
+	return (selected (selection, FATAL) || Option.fatalWarnings)? TRUE: FALSE;
+}
+
+extern void error (const errorSelection selection,
+		   const char *const format, ...)
+{
+	va_list ap;
+	boolean shouldExit;
+
+	va_start (ap, format);
+	shouldExit = (* errorPrinter) (selection, format, ap, errorPrinterData);
+	va_end (ap);
+
+	if (shouldExit)
+		exit (1);
+}
+

--- a/main/error.h
+++ b/main/error.h
@@ -1,0 +1,26 @@
+/*
+*   Copyright (c) 2002-2003, Darren Hiebert
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   This module contains a lose assortment of shared functions.
+*/
+
+#ifndef CTAGS_MAIN_ERORR_H
+#define CTAGS_MAIN_ERORR_H
+
+#include "general.h"  /* must always come first */
+
+#include <stdarg.h>
+#include "routines.h"
+
+typedef boolean (* errorPrintFunc) (const errorSelection selection, const char *const format,
+				    va_list ap, void *data);
+
+extern void setErrorPrinter (errorPrintFunc printer, void *data);
+
+extern boolean stderrDefaultErrorPrinter (const errorSelection selection, const char *const format, va_list ap,
+					  void *data);
+
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -71,6 +71,7 @@
 #include "keyword.h"
 #include "main.h"
 #include "options.h"
+#include "output.h"
 #include "read.h"
 #include "routines.h"
 
@@ -530,6 +531,8 @@ static void sanitizeEnviron (void)
 extern int main (int __unused__ argc, char **argv)
 {
 	cookedArgs *args;
+
+	setTagWriter (writeCtagsEntry, NULL, NULL);
 
 	setCurrentDirectory ();
 	setExecutableName (*argv++);

--- a/main/main.c
+++ b/main/main.c
@@ -67,6 +67,7 @@
 
 #include "debug.h"
 #include "entry.h"
+#include "error.h"
 #include "field.h"
 #include "keyword.h"
 #include "main.h"
@@ -545,6 +546,7 @@ extern int main (int __unused__ argc, char **argv)
 {
 	cookedArgs *args;
 
+	setErrorPrinter (stderrDefaultErrorPrinter, NULL);
 	setMainLoop (batchMakeTags, NULL);
 	setTagWriter (writeCtagsEntry, NULL, NULL);
 

--- a/main/main.h
+++ b/main/main.h
@@ -16,8 +16,6 @@
 
 #include <stdio.h>
 
-#include "vstring.h"
-
 /*
 *   FUNCTION PROTOTYPES
 */

--- a/main/options.c
+++ b/main/options.c
@@ -346,6 +346,8 @@ static optionDescription LongOptionDescription [] = {
  {1,"      The encoding to write the tag file in. Defaults to UTF-8 if --input-encoding"},
  {1,"      is specified, otherwise no conversion is performed."},
 #endif
+ {0,"  --output-format=ctags|etags|xref"},
+ {0,"      Specify the output format. [ctags]"},
  {0,"  --print-language"},
  {0,"       Don't make tags file but just print the guessed language name for"},
  {0,"       input file."},
@@ -1933,6 +1935,22 @@ static void processOptionFile (
 		vStringDelete (vpath);
 }
 
+static void processOutputFormat (const char *const option __unused__,
+				 const char *const parameter)
+{
+	if (parameter [0] == '\0')
+		error (FATAL, "no output format name supplied for \"%s\"", option);
+
+	if (strcmp (parameter, "ctags") == 0)
+		;
+	else if (strcmp (parameter, "etags") == 0)
+		setEtagsMode ();
+	else if (strcmp (parameter, "xref") == 0)
+		setXrefMode ();
+	else
+		error (FATAL, "unknown output format name supplied for \"%s=%s\"", option, parameter);
+}
+
 static void processPseudoTags (const char *const option __unused__,
 			       const char *const parameter)
 {
@@ -2348,6 +2366,7 @@ static parametricOption ParametricOptions [] = {
 	{ "_list-roles",            processListRolesOptions,        TRUE,   STAGE_ANY },
 	{ "maxdepth",               processMaxRecursionDepthOption, TRUE,   STAGE_ANY },
 	{ "options",                processOptionFile,              FALSE,  STAGE_ANY },
+	{ "output-format",          processOutputFormat,            TRUE,   STAGE_ANY},
 	{ "pseudo-tags",            processPseudoTags,              FALSE,  STAGE_ANY },
 	{ "sort",                   processSortOption,              TRUE,   STAGE_ANY },
 	{ "version",                processVersionOption,           TRUE,   STAGE_ANY },

--- a/main/options.c
+++ b/main/options.c
@@ -28,6 +28,7 @@
 #include "main.h"
 #define OPTION_WRITE
 #include "options.h"
+#include "output.h"
 #include "parse.h"
 #include "ptag.h"
 #include "routines.h"
@@ -696,6 +697,7 @@ static void setEtagsMode (void)
 	Option.sorted = SO_UNSORTED;
 	Option.lineDirectives = FALSE;
 	Option.tagRelative = TRUE;
+	setTagWriter (writeEtagsEntry, beginEtagsFile, endEtagsFile);
 }
 
 extern void testEtagsInvocation (void)
@@ -2596,6 +2598,7 @@ static void processShortOption (
 		case 'x':
 			checkOptionOrder (option, FALSE);
 			Option.xref = TRUE;
+			setTagWriter (writeXrefEntry, NULL, NULL);
 			break;
 		default:
 			error (FATAL, "Unknown option: -%s", option);

--- a/main/options.c
+++ b/main/options.c
@@ -717,6 +717,12 @@ extern void testEtagsInvocation (void)
 	eFree (etags);
 }
 
+static void setXrefMode (void)
+{
+	Option.xref = TRUE;
+	setTagWriter (writeXrefEntry, NULL, NULL);
+}
+
 /*
  *  Cooked argument parsing
  */
@@ -2597,8 +2603,7 @@ static void processShortOption (
 			break;
 		case 'x':
 			checkOptionOrder (option, FALSE);
-			Option.xref = TRUE;
-			setTagWriter (writeXrefEntry, NULL, NULL);
+			setXrefMode ();
 			break;
 		default:
 			error (FATAL, "Unknown option: -%s", option);

--- a/main/options.h
+++ b/main/options.h
@@ -181,6 +181,9 @@ extern boolean processLanguageEncodingOption (const char *const option, const ch
 extern boolean processRegexOption (const char *const option, const char *const parameter);
 extern boolean processXcmdOption (const char *const option, const char *const parameter, OptionLoadingStage stage);
 
+typedef void (* mainLoopFunc) (cookedArgs *args, void *data);
+extern void setMainLoop (mainLoopFunc func, void *data);
+
 #endif  /* CTAGS_MAIN_OPTIONS_H */
 
 /* vi:set tabstop=4 shiftwidth=4: */

--- a/main/output-ctags.c
+++ b/main/output-ctags.c
@@ -1,0 +1,217 @@
+/*
+*   Copyright (c) 1998-2002, Darren Hiebert
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   External interface to entry.c
+*/
+
+#include "general.h"  /* must always come first */
+
+#include "entry.h"
+#include "mio.h"
+#include "options.h"
+#include "output.h"
+#include "read.h"
+
+
+#define includeExtensionFlags()         (Option.tagFileFormat > 1)
+
+
+static const char* escapeName (const tagEntryInfo * tag, fieldType ftype)
+{
+	return renderFieldEscaped (ftype, tag, NO_PARSER_FIELD);
+}
+
+static int addParserFields (MIO * mio, const tagEntryInfo *const tag)
+{
+	unsigned int i;
+	unsigned int ftype;
+	int length = 0;
+
+	for (i = 0; i < tag->usedParserFields; i++)
+	{
+		ftype = tag->parserFields [i].ftype;
+		if (! isFieldEnabled (ftype))
+			continue;
+
+		length += mio_printf(mio, "\t%s:%s",
+				     getFieldName (ftype),
+				     renderFieldEscaped (tag->parserFields [i].ftype, tag, i));
+	}
+	return length;
+}
+
+static int writeLineNumberEntry (MIO * mio, const tagEntryInfo *const tag)
+{
+	if (Option.lineDirectives)
+		return mio_printf (mio, "%s", escapeName (tag, FIELD_LINE_NUMBER));
+	else
+		return mio_printf (mio, "%lu", tag->lineNumber);
+}
+
+static int file_putc (char c, void *data)
+{
+	MIO *fp = data;
+	mio_putc (fp, c);
+	return 1;
+}
+
+static int file_puts (const char* s, void *data)
+{
+	MIO *fp = data;
+	return mio_puts (fp, s);
+}
+
+static int addExtensionFields (MIO *mio, const tagEntryInfo *const tag)
+{
+	boolean isKindKeyEnabled = isFieldEnabled (FIELD_KIND_KEY);
+	boolean isScopeEnabled = isFieldEnabled   (FIELD_SCOPE_KEY);
+
+	const char* const kindKey = isKindKeyEnabled
+		?getFieldName (FIELD_KIND_KEY)
+		:"";
+	const char* const kindFmt = isKindKeyEnabled
+		?"%s\t%s:%s"
+		:"%s\t%s%s";
+	const char* const scopeKey = isScopeEnabled
+		?getFieldName (FIELD_SCOPE_KEY)
+		:"";
+	const char* const scopeFmt = isScopeEnabled
+		?"%s\t%s:%s:%s"
+		:"%s\t%s%s:%s";
+
+	boolean first = TRUE;
+	const char* separator = ";\"";
+	const char* const empty = "";
+	int length = 0;
+
+	boolean making_fq_tag =  (doesInputLanguageRequestAutomaticFQTag ()
+				  && isXtagEnabled (XTAG_QUALIFIED_TAGS));
+
+/* "sep" returns a value only the first time it is evaluated */
+#define sep (first ? (first = FALSE, separator) : empty)
+
+	if (tag->kind->name != NULL && (isFieldEnabled (FIELD_KIND_LONG)  ||
+		 (isFieldEnabled (FIELD_KIND)  && tag->kind == '\0')))
+		length += mio_printf (mio, kindFmt, sep, kindKey, tag->kind->name);
+	else if (tag->kind != '\0'  && (isFieldEnabled (FIELD_KIND) ||
+			(isFieldEnabled (FIELD_KIND_LONG) &&  tag->kind->name == NULL)))
+	{
+		char str[2] = {tag->kind->letter, '\0'};
+		length += mio_printf (mio, kindFmt, sep, kindKey, str);
+	}
+
+	if (isFieldEnabled (FIELD_LINE_NUMBER))
+		length += mio_printf (mio, "%s\t%s:%ld", sep,
+				   getFieldName (FIELD_LINE_NUMBER),
+				   tag->lineNumber);
+
+	if (isFieldEnabled (FIELD_LANGUAGE)  &&  tag->language != NULL)
+		length += mio_printf (mio, "%s\t%s:%s", sep,
+				   getFieldName (FIELD_LANGUAGE),
+				   escapeName (tag, FIELD_LANGUAGE));
+
+	if (isFieldEnabled (FIELD_SCOPE) || making_fq_tag)
+	{
+		const char* k = NULL, *v = NULL;
+
+		k = escapeName (tag, FIELD_SCOPE_KIND_LONG);
+		v = escapeName (tag, FIELD_SCOPE);
+
+		if (isFieldEnabled (FIELD_SCOPE) && k && v)
+			length += mio_printf (mio, scopeFmt, sep, scopeKey, k, v);
+	}
+
+	if (isFieldEnabled (FIELD_TYPE_REF) &&
+	    tag->extensionFields.typeRef [0] != NULL  &&
+	    tag->extensionFields.typeRef [1] != NULL)
+		length += mio_printf (mio, "%s\t%s:%s:%s", sep,
+				      getFieldName (FIELD_TYPE_REF),
+				      tag->extensionFields.typeRef [0],
+				      escapeName (tag, FIELD_TYPE_REF));
+
+	if (isFieldEnabled (FIELD_FILE_SCOPE) &&  tag->isFileScope)
+		length += mio_printf (mio, "%s\t%s:", sep,
+				      getFieldName (FIELD_FILE_SCOPE));
+
+	if (isFieldEnabled (FIELD_INHERITANCE) &&
+			tag->extensionFields.inheritance != NULL)
+		length += mio_printf (mio, "%s\t%s:%s", sep,
+				   getFieldName (FIELD_INHERITANCE),
+				   escapeName (tag, FIELD_INHERITANCE));
+
+	if (isFieldEnabled (FIELD_ACCESS) &&  tag->extensionFields.access != NULL)
+		length += mio_printf (mio, "%s\t%s:%s", sep,
+				   getFieldName (FIELD_ACCESS),
+				   tag->extensionFields.access);
+
+	if (isFieldEnabled (FIELD_IMPLEMENTATION) &&
+			tag->extensionFields.implementation != NULL)
+		length += mio_printf (mio, "%s\t%s:%s", sep,
+				   getFieldName (FIELD_IMPLEMENTATION),
+				   tag->extensionFields.implementation);
+
+	if (isFieldEnabled (FIELD_SIGNATURE) &&
+			tag->extensionFields.signature != NULL)
+		length += mio_printf (mio, "%s\t%s:%s", sep,
+				   getFieldName (FIELD_SIGNATURE),
+				   escapeName (tag, FIELD_SIGNATURE));
+	if (isFieldEnabled (FIELD_ROLE) && tag->extensionFields.roleIndex != ROLE_INDEX_DEFINITION)
+		length += mio_printf (mio, "%s\t%s:%s", sep,
+				   getFieldName (FIELD_ROLE),
+				   escapeName (tag, FIELD_ROLE));
+
+	if (isFieldEnabled (FIELD_EXTRA))
+	{
+		const char *value = escapeName (tag, FIELD_EXTRA);
+		if (value)
+			length += mio_printf (mio, "%s\t%s:%s", sep,
+					   getFieldName (FIELD_EXTRA),
+					   escapeName (tag, FIELD_EXTRA));
+	}
+
+#ifdef HAVE_LIBXML
+	if (isFieldEnabled(FIELD_XPATH))
+	{
+		const char *value = escapeName (tag, FIELD_XPATH);
+		if (value)
+			length += mio_printf (mio, "%s\t%s:%s", sep,
+					      getFieldName (FIELD_XPATH),
+					      escapeName (tag, FIELD_XPATH));
+
+	}
+#endif
+
+	return length;
+#undef sep
+}
+
+static int writePatternEntry (MIO *mio, const tagEntryInfo *const tag)
+{
+	return makePatternStringCommon (tag, file_putc, file_puts, mio);
+}
+
+extern int writeCtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)
+{
+	int length = mio_printf (mio, "%s\t%s\t",
+			      escapeName (tag, FIELD_NAME),
+			      escapeName (tag, FIELD_INPUT_FILE));
+
+	if (tag->lineNumberEntry)
+		length += writeLineNumberEntry (mio, tag);
+	else if (tag->pattern)
+		length += mio_printf(mio, "%s", tag->pattern);
+	else
+		length += writePatternEntry (mio, tag);
+
+	if (includeExtensionFlags ())
+		length += addExtensionFields (mio, tag);
+
+	length += addParserFields (mio, tag);
+
+	length += mio_printf (mio, "\n");
+
+	return length;
+}

--- a/main/output-etags.c
+++ b/main/output-etags.c
@@ -1,0 +1,95 @@
+/*
+*   Copyright (c) 1998-2002, Darren Hiebert
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   External interface to entry.c
+*/
+
+#include "general.h"  /* must always come first */
+
+#include <string.h>
+
+#include "debug.h"
+#include "entry.h"
+#include "mio.h"
+#include "options.h"
+#include "output.h"
+#include "read.h"
+#include "vstring.h"
+
+struct sEtags {
+	char *name;
+	MIO *fp;
+	size_t byteCount;
+	vString *vLine;
+};
+
+
+
+extern void *beginEtagsFile (MIO *mio)
+{
+	static struct sEtags etags = { NULL, NULL, 0, NULL };
+
+	etags.fp = tempFile ("w+b", &etags.name);
+	etags.byteCount = 0;
+	etags.vLine = vStringNew ();
+	return &etags;
+}
+
+extern void endEtagsFile (MIO *mainfp, const char *filename, void *data)
+{
+	const char *line;
+	struct sEtags *etags = data;
+
+	mio_printf (mainfp, "\f\n%s,%ld\n", filename, (long) etags->byteCount);
+	abort_if_ferror (mainfp);
+
+	if (etags->fp != NULL)
+	{
+		mio_rewind (etags->fp);
+
+		while ((line = readLineRaw (etags->vLine, etags->fp)) != NULL)
+			mio_puts (mainfp, line);
+
+		vStringDelete (etags->vLine);
+		mio_free (etags->fp);
+		remove (etags->name);
+		eFree (etags->name);
+		etags->vLine = NULL;
+		etags->fp = NULL;
+		etags->name = NULL;
+	}
+}
+
+extern int writeEtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data)
+{
+	int length;
+	struct sEtags *etags = data;
+
+	mio = etags->fp;
+
+	if (tag->isFileEntry)
+		length = mio_printf (mio, "\177%s\001%lu,0\n",
+				tag->name, tag->lineNumber);
+	else
+	{
+		long seekValue;
+		char *const line =
+				readLineFromBypassAnyway (etags->vLine, tag, &seekValue);
+		if (line == NULL)
+			return 0;
+
+		if (tag->truncateLine)
+			truncateTagLine (line, tag->name, TRUE);
+		else
+			line [strlen (line) - 1] = '\0';
+
+		length = mio_printf (mio, "%s\177%s\001%lu,%ld\n", line,
+				tag->name, tag->lineNumber, seekValue);
+	}
+	etags->byteCount += length;
+
+	return length;
+}

--- a/main/output-xref.c
+++ b/main/output-xref.c
@@ -1,0 +1,48 @@
+/*
+*   Copyright (c) 1998-2002, Darren Hiebert
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   External interface to entry.c
+*/
+
+#include "general.h"  /* must always come first */
+
+#include "entry.h"
+#include "fmt.h"
+#include "mio.h"
+#include "options.h"
+
+extern int writeXrefEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)
+{
+	int length;
+	static fmtElement *fmt1;
+	static fmtElement *fmt2;
+
+	if (Option.customXfmt)
+		length = fmtPrint (Option.customXfmt, mio, tag);
+	else
+	{
+		if (tag->isFileEntry)
+			return 0;
+
+		if (Option.tagFileFormat == 1)
+		{
+			if (fmt1 == NULL)
+				fmt1 = fmtNew ("%-16N %4n %-16F %C");
+			length = fmtPrint (fmt1, mio, tag);
+		}
+		else
+		{
+			if (fmt2 == NULL)
+				fmt2 = fmtNew ("%-16N %-10K %4n %-16F %C");
+			length = fmtPrint (fmt2, mio, tag);
+		}
+	}
+
+	mio_putc (mio, '\n');
+	length++;
+
+	return length;
+}

--- a/main/output.h
+++ b/main/output.h
@@ -1,0 +1,43 @@
+/*
+*   Copyright (c) 2016, Red Hat, Inc.
+*   Copyright (c) 2016, Masatake YAMATO
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*/
+#ifndef CTAGS_MAIN_OUTPUT_H
+#define CTAGS_MAIN_OUTPUT_H
+
+#include "general.h"  /* must always come first */
+
+/* preFuc and Postfunc can be NULL.
+   The value returned from preWriteEntryFunc is passed to writeEntryFunc,
+   and postWriteEntryFunc. If resource is a resource is allocated in
+   preWriteEntryFunc, it should be freed in postWriteEntryFunc. */
+
+typedef int (* writeEntryFunc) (MIO * mio, const tagEntryInfo *const tag, void *data);
+typedef void * (* preWriteEntryFunc) (MIO * mio);
+typedef void (* postWriteEntryFunc)  (MIO * mio, const char* filename, void *data);
+
+extern void setTagWriter (writeEntryFunc func,
+			  preWriteEntryFunc preFunc,
+			  postWriteEntryFunc postFunc);
+
+
+extern int writeEtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data);
+extern void *beginEtagsFile (MIO * mio);
+extern void  endEtagsFile   (MIO * mio, const char* filename, void *data);
+
+extern int writeCtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__);
+extern int writeXrefEntry  (MIO * mio, const tagEntryInfo *const tag, void *data __unused__);
+
+extern int makePatternStringCommon (const tagEntryInfo *const tag,
+				    int putc_func (char , void *),
+				    int puts_func (const char* , void *),
+				    void *output);
+extern void truncateTagLine (char *const line, const char *const token,
+			     const boolean discardNewline);
+extern void abort_if_ferror(MIO *const fp);
+
+#endif 

--- a/main/parse.c
+++ b/main/parse.c
@@ -2243,8 +2243,7 @@ extern boolean parseFile (const char *const fileName)
 					EncodingMap[language] : Option.inputEncoding, Option.outputEncoding);
 #endif
 
-		if (Option.etags)
-			beginEtagsFile ();
+		setupWriter ();
 
 		tagFileResized = createTagsWithFallback (fileName, language, mio);
 #ifdef HAVE_COPROC
@@ -2252,8 +2251,8 @@ extern boolean parseFile (const char *const fileName)
 			tagFileResized = createTagsWithXcmd (fileName, language, mio)? TRUE: tagFileResized;
 #endif
 
-		if (Option.etags)
-			endEtagsFile (fileName);
+		teardownWriter (fileName);
+
 		if (Option.filter)
 			closeTagFile (tagFileResized);
 		addTotals (1, 0L, 0L);

--- a/main/routines.c
+++ b/main/routines.c
@@ -17,8 +17,6 @@
 #endif
 #include <ctype.h>
 #include <string.h>
-#include <stdarg.h>
-#include <errno.h>
 #include <stdio.h>  /* to declare tempnam(), and SEEK_SET (hopefully) */
 
 #ifdef HAVE_FCNTL_H
@@ -149,7 +147,7 @@
 /*
  *  Miscellaneous macros
  */
-#define selected(var,feature)	(((int)(var) & (int)(feature)) == (int)feature)
+
 
 /*
 *   DATA DEFINITIONS
@@ -200,27 +198,6 @@ extern const char *getExecutableName (void)
 extern const char *getExecutablePath (void)
 {
 	return ExecutableProgram;
-}
-
-extern void error (
-		const errorSelection selection, const char *const format, ...)
-{
-	va_list ap;
-
-	va_start (ap, format);
-	fprintf (stderr, "%s: %s", getExecutableName (),
-			selected (selection, WARNING) ? "Warning: " : "");
-	vfprintf (stderr, format, ap);
-	if (selected (selection, PERROR))
-#ifdef HAVE_STRERROR
-		fprintf (stderr, " : %s", strerror (errno));
-#else
-		perror (" ");
-#endif
-	fputs ("\n", stderr);
-	va_end (ap);
-	if (selected (selection, FATAL) || Option.fatalWarnings)
-		exit (1);
 }
 
 /*

--- a/source.mak
+++ b/source.mak
@@ -15,6 +15,7 @@ MAIN_HEADS =			\
 	main/args.h		\
 	main/ctags.h		\
 	main/entry.h		\
+	main/error.h		\
 	main/field.h		\
 	main/flags.h		\
 	main/fmt.h		\
@@ -46,6 +47,7 @@ MAIN_HEADS =			\
 MAIN_SRCS =				\
 	main/args.c			\
 	main/entry.c			\
+	main/error.c			\
 	main/field.c			\
 	main/flags.c			\
 	main/fmt.c			\

--- a/source.mak
+++ b/source.mak
@@ -27,6 +27,7 @@ MAIN_HEADS =			\
 	main/mbcs.h		\
 	main/nestlevel.h	\
 	main/options.h		\
+	main/output.h		\
 	main/parse.h		\
 	main/parsers.h		\
 	main/pcoproc.h		\
@@ -59,6 +60,9 @@ MAIN_SRCS =				\
 	main/mbcs.c			\
 	main/nestlevel.c		\
 	main/options.c			\
+	main/output-etags.c		\
+	main/output-ctags.c		\
+	main/output-xref.c		\
 	main/parse.c			\
 	main/pcoproc.c			\
 	main/promise.c			\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="..\parsers\dts.c" />
     <ClCompile Include="..\parsers\eiffel.c" />
     <ClCompile Include="..\main\entry.c" />
+    <ClCompile Include="..\main\error.c" />
     <ClCompile Include="..\parsers\erlang.c" />
     <ClCompile Include="..\parsers\falcon.c" />
     <ClCompile Include="..\main\field.c" />
@@ -213,6 +214,7 @@
     <ClInclude Include="..\main\ctags.h" />
     <ClInclude Include="..\main\debug.h" />
     <ClInclude Include="..\main\entry.h" />
+    <ClInclude Include="..\main\error.h" />
     <ClInclude Include="..\main\e_msoft.h" />
     <ClInclude Include="..\main\field.h" />
     <ClInclude Include="..\main\flags.h" />

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -146,6 +146,9 @@
     <ClCompile Include="..\parsers\objc.c" />
     <ClCompile Include="..\parsers\ocaml.c" />
     <ClCompile Include="..\main\options.c" />
+    <ClCompile Include="..\main\output-ctags.c" />
+    <ClCompile Include="..\main\output-etags.c" />
+    <ClCompile Include="..\main\output-xref.c" />
     <ClCompile Include="..\main\parse.c" />
     <ClCompile Include="..\parsers\pascal.c" />
     <ClCompile Include="..\parsers\perl.c" />
@@ -223,6 +226,7 @@
     <ClInclude Include="..\main\main.h" />
     <ClInclude Include="..\main\nestlevel.h" />
     <ClInclude Include="..\main\options.h" />
+    <ClInclude Include="..\main\output.h" />
     <ClInclude Include="..\main\parse.h" />
     <ClInclude Include="..\main\parsers.h" />
     <ClInclude Include="..\main\ptag.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -241,6 +241,15 @@
     <ClCompile Include="..\main\options.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
+    <ClCompile Include="..\main\output-ctags.c">
+      <Filter>Source Files\Main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\main\output-etags.c">
+      <Filter>Source Files\Main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\main\output-xref.c">
+      <Filter>Source Files\Main</Filter>
+    </ClCompile>
     <ClCompile Include="..\main\parse.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
@@ -380,6 +389,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\options.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\main\output.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\parse.h">

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -201,6 +201,9 @@
     <ClCompile Include="..\main\entry.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
+    <ClCompile Include="..\main\error.c">
+      <Filter>Source Files\Main</Filter>
+    </ClCompile>
     <ClCompile Include="..\main\field.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
@@ -362,6 +365,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\entry.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\main\error.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\field.h">


### PR DESCRIPTION
This is for #994.

Interface for three hooks (plug able areas) are introduced.

* handler for printing a tag entry
```
typedef int (* writeEntryFunc) (MIO * mio, const tagEntryInfo *const tag, void *data);
typedef void * (* preWriteEntryFunc) (MIO * mio);
typedef void (* postWriteEntryFunc)  (MIO * mio, const char* filename, void *data);

extern void setTagWriter (writeEntryFunc func,
			  preWriteEntryFunc preFunc,
			  postWriteEntryFunc postFunc);

```

* function for main loop
```
typedef void (* mainLoopFunc) (cookedArgs *args, void *data);
extern void setMainLoop (mainLoopFunc func, void *data);
```

* handler for printing an error message
```
typedef boolean (* errorPrintFunc) (const errorSelection selection, const char *const format,
				    va_list ap, void *data);
extern void setErrorPrinter (errorPrintFunc printer, void *data);
```

An example:
```
extern int main (int __unused__ argc, char **argv)
{
	cookedArgs *args;

	setErrorPrinter (stderrDefaultErrorPrinter, NULL);
	setMainLoop (batchMakeTags, NULL);
	setTagWriter (writeCtagsEntry, NULL, NULL);


```

In addition `--output-format` option is introduced.
