### PR TITLE
Improve reStructuredText coverage

### DIFF
--- a/Units/iso8859-1-restructuredtext.d/expected.tags
+++ b/Units/iso8859-1-restructuredtext.d/expected.tags
@@ -1,0 +1,4 @@
+Chàptèr 1	input.rst	/^Chàptèr 1$/;"	c
+Subsubsection 1.1.1.1	input.rst	/^Subsubsection 1.1.1.1$/;"	t	subsection:Sùbs
+Séçtiön 1.1	input.rst	/^Séçtiön 1.1$/;"	s	chapter:Chàptèr 1
+Sùbs	input.rst	/^Sùbs$/;"	S	section:Séçtiön 1.1

--- a/Units/iso8859-1-restructuredtext.d/input.rst
+++ b/Units/iso8859-1-restructuredtext.d/input.rst
@@ -1,0 +1,17 @@
+Chàptèr 1
+=========
+
+Intro text of chapter 1
+
+Séçtiön 1.1
+-----------
+
+Text of section 1.1
+
+Sùbs
+++++
+
+Text of subsection 1.1.1
+
+Subsubsection 1.1.1.1
+~~~~~~~~~~~~~~~~~~~~~

--- a/Units/utf8-restructuredtext.d/expected.tags
+++ b/Units/utf8-restructuredtext.d/expected.tags
@@ -1,0 +1,4 @@
+@Ѐ–𐀀	input.rst	/^@Ѐ–𐀀$/;"	S	section:Šéçtiön 1.1
+Chàptěr 1	input.rst	/^Chàptěr 1$/;"	c
+Subsubsection 1.1.1.1	input.rst	/^Subsubsection 1.1.1.1$/;"	t	subsection:@Ѐ–𐀀
+Šéçtiön 1.1	input.rst	/^Šéçtiön 1.1$/;"	s	chapter:Chàptěr 1

--- a/Units/utf8-restructuredtext.d/input.rst
+++ b/Units/utf8-restructuredtext.d/input.rst
@@ -1,0 +1,17 @@
+Chàptěr 1
+=========
+
+Intro text of chapter 1
+
+Šéçtiön 1.1
+-----------
+
+Text of section 1.1
+
+@Ѐ–𐀀
+++++
+
+Text of subsection 1.1.1
+
+Subsubsection 1.1.1.1
+~~~~~~~~~~~~~~~~~~~~~

--- a/parsers/rst.c
+++ b/parsers/rst.c
@@ -234,6 +234,9 @@ static void findRstTags (void)
 	{
 		int line_len = strlen((const char*) line);
 		int name_len_bytes = vStringLength(name);
+		/* FIXME: this isn't right, actually we need the real display width,
+		 * taking into account double-width characters and stuff like that.
+		 * But duh. */
 		int name_len = utf8_strlen(vStringValue(name), name_len_bytes);
 
 		/* if the name doesn't look like UTF-8, assume one-byte charset */


### PR DESCRIPTION
…and add a note that heading width computation isn't actually accurate (according to Docutils' *rst2html* at least), but that's way too tricky to fix just now, and possibly ever (requires full Unicode character width understanding).