### PR TITLE
Vim: fix matching of global variables in functions

### DIFF
--- a/Units/parser-vim.r/vim-let-in-function.d/expected.tags
+++ b/Units/parser-vim.r/vim-let-in-function.d/expected.tags
@@ -1,0 +1,2 @@
+Func	input.vim	/^function Func()$/;"	f
+g:global_var	input.vim	/^  let g:global_var = 42$/;"	v

--- a/Units/parser-vim.r/vim-let-in-function.d/input.vim
+++ b/Units/parser-vim.r/vim-let-in-function.d/input.vim
@@ -1,0 +1,4 @@
+function Func()
+  let g:global_var = 42
+  let g_local_var = 42
+endfunction

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -482,7 +482,7 @@ static void parseLet (const unsigned char *line, int infunction)
 			goto cleanUp;
 
 		/* Skip non-global vars in functions */
-		if (infunction && (int) *cp != 'g')
+		if (infunction && ((int) *np != ':' || (int) *cp != 'g'))
 			goto cleanUp;
 
 		/* deal with spaces, $, @ and & */


### PR DESCRIPTION
Don't match local variables without a scope prefix named g* as global
variables.