### PR TITLE
Fix whitespace and warning

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,4 +89,3 @@ include $(top_srcdir)/makefiles/testing.mak
 include $(top_srcdir)/makefiles/test-cases.mak
 
 include $(top_srcdir)/makefiles/help.mak
-

--- a/main/output.h
+++ b/main/output.h
@@ -40,4 +40,4 @@ extern void truncateTagLine (char *const line, const char *const token,
 			     const boolean discardNewline);
 extern void abort_if_ferror(MIO *const fp);
 
-#endif 
+#endif

--- a/main/parse.c
+++ b/main/parse.c
@@ -1635,7 +1635,7 @@ static boolean enableLanguageKind (
 }
 
 static boolean enableLanguageKindLong (
-	const langType language, const const char *kindLong, const boolean mode)
+	const langType language, const char *kindLong, const boolean mode)
 {
 	boolean result = FALSE;
 	kindOption* const opt = langKindLongOption (language, kindLong);

--- a/main/parse.c
+++ b/main/parse.c
@@ -1080,7 +1080,7 @@ getFileLanguageInternal (const char *const fileName, MIO **mio)
 	    if (Option.guessLanguageEagerly)
 	    {
 		    GLC_FOPEN_IF_NECESSARY(&glc, cleanup, FALSE);
-		    language = tasteLanguage(&glc, 
+		    language = tasteLanguage(&glc,
 					     eager_tasters + 1,
 					     ARRAY_SIZE(eager_tasters) - 1,
 					     fallback + HINT_OTHER);

--- a/source.mak
+++ b/source.mak
@@ -94,7 +94,7 @@ PARSER_HEADS = \
 	parsers/cxx/cxx_tag.h \
 	parsers/cxx/cxx_token.h \
 	parsers/cxx/cxx_token_chain.h
-	
+
 PARSER_SRCS =				\
 	parsers/ada.c			\
 	parsers/ant.c			\


### PR DESCRIPTION
```
main/parse.c:1638:33: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
        const langType language, const const char *kindLong, const boolean mode)
                                       ^
1 warning generated.
```
