### PR TITLE
main: change the separator between parser name and kind name in --_list-roles

### DIFF
--- a/Tmain/list-roles.d/run.sh
+++ b/Tmain/list-roles.d/run.sh
@@ -29,14 +29,14 @@ ignore_old()
 title ''
 ${CTAGS} --quiet --options=NONE --_list-roles= | ignore_xml | ignore_old
 
-title 'all:*'
-${CTAGS} --quiet --options=NONE --_list-roles='all:*' | ignore_xml | ignore_old
+title 'all.*'
+${CTAGS} --quiet --options=NONE --_list-roles='all.*' | ignore_xml | ignore_old
 
-title 'C:*'
-${CTAGS} --quiet --options=NONE --_list-roles='C:*'
+title 'C.*'
+${CTAGS} --quiet --options=NONE --_list-roles='C.*'
 
-title 'all:h'
-${CTAGS} --quiet --options=NONE --_list-roles='all:h' | ignore_xml | ignore_old
+title 'all.h'
+${CTAGS} --quiet --options=NONE --_list-roles='all.h' | ignore_xml | ignore_old
 
-title 'Sh:s'
-${CTAGS} --quiet --options=NONE --_list-roles='Sh:s'
+title 'Sh.s'
+${CTAGS} --quiet --options=NONE --_list-roles='Sh.s'

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -35,7 +35,7 @@ Vera	h	system	system header	on
 Vera	h	local	local header	on
 
 #
-# all:*
+# all.*
 #
 Automake	I	included	included	on
 Automake	I	optional	optionally included	on
@@ -70,14 +70,14 @@ Vera	h	system	system header	on
 Vera	h	local	local header	on
 
 #
-# C:*
+# C.*
 #
 C	d	undef	undefined	on
 C	h	system	system header	on
 C	h	local	local header	on
 
 #
-# all:h
+# all.h
 #
 C	h	system	system header	on
 C	h	local	local header	on
@@ -89,6 +89,6 @@ Vera	h	system	system header	on
 Vera	h	local	local header	on
 
 #
-# Sh:s
+# Sh.s
 #
 Sh	s	loaded	loaded	on

--- a/main/options.c
+++ b/main/options.c
@@ -1833,20 +1833,20 @@ static void processListRolesOptions (const char *const option __unused__,
 		exit (0);
 	}
 
-	sep = strchr (parameter, ':');
+	sep = strchr (parameter, '.');
 
 	if (sep == NULL || sep [1] == '\0')
 	{
 		vString* vstr = vStringNewInit (parameter);
-		vStringCatS (vstr, (sep? "*": ":*"));
+		vStringCatS (vstr, (sep? "*": ".*"));
 		processListRolesOptions (option, vStringValue (vstr));
 		/* The control should never reache here. */
 	}
 
 	kindletters = sep + 1;
-	if (strncmp (parameter, "all:", 4) == 0
-	    || strncmp (parameter, "*:", 1) == 0
-	    || strncmp (parameter, ":", 1) == 0)
+	if (strncmp (parameter, "all.", 4) == 0
+	    || strncmp (parameter, "*.", 1) == 0
+	    || strncmp (parameter, ".", 1) == 0)
 		lang = LANG_AUTO;
 	else
 	{


### PR DESCRIPTION
`:` is used. It is changed to `.` to be consistent with format notation
in which `.` is used as separator.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>