### PR TITLE
buildsys: enable c99 mode in C compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -274,6 +274,7 @@ AM_CONDITIONAL(ENABLE_DEBUGGING, [test "x$enable_debugging" = "xyes"])
 # -------------------
 
 AC_PROG_CC
+AC_PROG_CC_C99
 
 if test "${with_sparse_cgcc}" = "yes"; then
 	REAL_CC="${CC}"


### PR DESCRIPTION
As [requested](https://github.com/universal-ctags/ctags/pull/1005/files/3d771976b29b1ea06987237b17385ead746bf5a4..0664f8396cd64edc59ecfb9a75b9433b52c949cc#r69405469) by @masatake, put C compiler into C99 mode (if that's not the default).

There's probably some other stuff that could be removed from Autoconf, like checking for `stdlib.h` and `stdbool.h` and other stuff that is required by some C standard, but I didn't want to mess with it.