### PR TITLE
Eiffel: add support for Liberty Eiffel's "insert"

### DIFF
--- a/Units/parser-eiffel.r/inherit-rename.e.d/expected.tags
+++ b/Units/parser-eiffel.r/inherit-rename.e.d/expected.tags
@@ -1,0 +1,3 @@
+INHERIT_RENAME_TEST	input.e	/^class INHERIT_RENAME_TEST$/;"	c
+feat2	input.e	/^         feat1 as feat2$/;"	f	class:INHERIT_RENAME_TEST
+feat4	input.e	/^         feat3 as feat4$/;"	f	class:INHERIT_RENAME_TEST

--- a/Units/parser-eiffel.r/inherit-rename.e.d/input.e
+++ b/Units/parser-eiffel.r/inherit-rename.e.d/input.e
@@ -1,0 +1,17 @@
+class INHERIT_RENAME_TEST
+
+inherit
+
+   FOO
+      rename
+         feat1 as feat2
+      end
+
+insert
+
+   BAR
+      rename
+         feat3 as feat4
+      end
+
+end

--- a/parsers/eiffel.c
+++ b/parsers/eiffel.c
@@ -149,6 +149,7 @@ static const keywordTable EiffelKeywordTable [] = {
 	{ "indexing",       KEYWORD_indexing   },
 	{ "infix",          KEYWORD_infix      },
 	{ "inherit",        KEYWORD_inherit    },
+	{ "insert",         KEYWORD_inherit    },
 	{ "inspect",        KEYWORD_inspect    },
 	{ "invariant",      KEYWORD_invariant  },
 	{ "is",             KEYWORD_is         },


### PR DESCRIPTION
Liberty Eiffel uses the "insert" keyword for non-conforming inheritance.