### PR TITLE
Fix empty field handling in xformat

### DIFF
--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -2,7 +2,7 @@ r       UCTAGSrole      off     NONE             TRUE     Role
 Z       UCTAGSscope     off     NONE             TRUE     Include the "scope:" key in scope field (use s) in tags output, scope name in xref output
 E       UCTAGSextra     off     NONE             TRUE     Extra tag type information    
 x       UCTAGSxpath     off     NONE             TRUE     xpath for the tag             
-p       UCTAGSscopeKind on      NONE             TRUE     Kind of scope as full name    
+p       UCTAGSscopeKind off     NONE             TRUE     Kind of scope as full name    
 e       UCTAGSend       off     NONE             TRUE     end lines of various items    
 -       UCTAGSproperties off     C                TRUE     properties (static, inline, mutable,...)
 -       UCTAGSproperties off     C++              TRUE     properties (static, inline, mutable,...)

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -20,7 +20,7 @@ R	NONE	off	NONE	TRUE	Marker (R or D) representing whether tag is definition or r
 Z	scope	off	NONE	TRUE	Include the "scope:" key in scope field (use s) in tags output, scope name in xref output
 E	extra	off	NONE	TRUE	Extra tag type information
 x	xpath	off	NONE	TRUE	xpath for the tag
-p	scopeKind	on	NONE	TRUE	Kind of scope as full name
+p	scopeKind	off	NONE	TRUE	Kind of scope as full name
 e	end	off	NONE	TRUE	end lines of various items
 -	properties	off	C	TRUE	properties (static, inline, mutable,...)
 -	properties	off	C++	TRUE	properties (static, inline, mutable,...)

--- a/Tmain/xformat-common-fields.d/input.py
+++ b/Tmain/xformat-common-fields.d/input.py
@@ -1,0 +1,3 @@
+class Foo:
+    def doIt():
+        pass

--- a/Tmain/xformat-common-fields.d/run.sh
+++ b/Tmain/xformat-common-fields.d/run.sh
@@ -1,0 +1,13 @@
+# Copyright: 2016 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+${CTAGS} --quiet --options=NONE --list-fields | while read K REST; do
+    if ! [ "$K" = '-' ]; then
+	echo "field: $K"
+	${CTAGS} --quiet --options=NONE -x --_xformat="output: %N %${K}" -o - input.py
+	echo "status: $?"
+	echo
+    fi
+done

--- a/Tmain/xformat-common-fields.d/stdout-expected.txt
+++ b/Tmain/xformat-common-fields.d/stdout-expected.txt
@@ -1,0 +1,116 @@
+field: #LETTER
+status: 1
+
+field: N
+output: Foo Foo
+output: doIt doIt
+status: 0
+
+field: F
+output: Foo input.py
+output: doIt input.py
+status: 0
+
+field: P
+output: Foo /^class Foo:$/
+output: doIt /^    def doIt():$/
+status: 0
+
+field: C
+output: Foo class Foo:
+output: doIt def doIt():
+status: 0
+
+field: a
+output: Foo public
+output: doIt public
+status: 0
+
+field: f
+output: Foo -
+output: doIt -
+status: 0
+
+field: i
+output: Foo 
+output: doIt -
+status: 0
+
+field: K
+output: Foo class
+output: doIt member
+status: 0
+
+field: k
+output: Foo c
+output: doIt m
+status: 0
+
+field: l
+output: Foo Python
+output: doIt Python
+status: 0
+
+field: m
+output: Foo -
+output: doIt -
+status: 0
+
+field: n
+output: Foo 1
+output: doIt 2
+status: 0
+
+field: S
+output: Foo -
+output: doIt ()
+status: 0
+
+field: s
+output: Foo 
+output: doIt Foo
+status: 0
+
+field: t
+output: Foo -
+output: doIt -
+status: 0
+
+field: z
+status: 1
+
+field: r
+output: Foo 
+output: doIt 
+status: 0
+
+field: R
+output: Foo D
+output: doIt D
+status: 0
+
+field: Z
+output: Foo 
+output: doIt Foo
+status: 0
+
+field: E
+output: Foo 
+output: doIt 
+status: 0
+
+field: x
+output: Foo 
+output: doIt 
+status: 0
+
+field: p
+output: Foo 
+output: doIt class
+status: 0
+
+field: e
+output: Foo 
+output: doIt 
+status: 0
+

--- a/main/field.c
+++ b/main/field.c
@@ -143,7 +143,7 @@ static fieldSpec fieldSpecsUniversal [] = {
 	DEFINE_FIELD_SPEC ('x', "xpath",   FALSE,
 			   "xpath for the tag",
 			   renderFieldXpath),
-	DEFINE_FIELD_SPEC ('p', "scopeKind", TRUE,
+	DEFINE_FIELD_SPEC ('p', "scopeKind", FALSE,
 			   "Kind of scope as full name",
 			   renderFieldScopeKindName),
 	DEFINE_FIELD_SPEC ('e', "end", FALSE,

--- a/main/fmt.c
+++ b/main/fmt.c
@@ -54,7 +54,7 @@ static int printTagField (fmtSpec* fspec, MIO* fp, const tagEntryInfo * tag)
 	int i;
 	int width = fspec->field.width;
 	int ftype;
-	const char* str;
+	const char* str = NULL;
 
 	ftype = fspec->field.ftype;
 
@@ -75,9 +75,10 @@ static int printTagField (fmtSpec* fspec, MIO* fp, const tagEntryInfo * tag)
 		else if (isFieldEnabled (tag->parserFields [findex].ftype))
 			str = renderFieldEscaped (tag->parserFields [findex].ftype,
 						  tag, findex);
-		else
-			str = "";
 	}
+
+	if (str == NULL)
+		str = "";
 
 	if (width < 0)
 		i = mio_printf (fp, "%-*s", -1 * width, str);


### PR DESCRIPTION
This is fixing for following crash.

```
[yamato@x201]~/var/ctags-github% cat /tmp/foo.py 
class Foo:
    def doIt():
        pass
[yamato@x201]~/var/ctags-github% ./ctags -x --_xformat=%p /tmp/foo.py
zsh: segmentation fault (core dumped)  ./ctags -x --_xformat=%p /tmp/foo.py
```