### PR TITLE
readtags: don't use general.h

### DIFF
--- a/main/gcc-attr.h
+++ b/main/gcc-attr.h
@@ -1,0 +1,30 @@
+/*
+*   Copyright (c) 1998-2003, Darren Hiebert
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*/
+
+/* This is derived from general.h.
+   Only readtags related source file should include this.
+   ctags related source file should include genera.h instead. */
+
+#ifndef CTAGS_MAIN_GCC_ATTR_H
+#define CTAGS_MAIN_GCC_ATTR_H
+
+/*  Prevent warnings about unused variables in GCC. */
+#if defined (__GNUC__) && !defined (__GNUG__)
+# ifdef __MINGW32__
+#  define __unused__
+# else
+#  define __unused__ __attribute__((unused))
+# endif
+# define __printf__(s,f)  __attribute__((format (printf, s, f)))
+# define attr__noreturn __attribute__((__noreturn__))
+#else
+# define __unused__
+# define __printf__(s,f)
+# define attr__noreturn
+#endif
+
+#endif	/* CTAGS_MAIN_GCC_ATTR_H */

--- a/main/general.h
+++ b/main/general.h
@@ -25,21 +25,7 @@
 /*
 *   MACROS
 */
-
-/*  Prevent warnings about unused variables in GCC. */
-#if defined (__GNUC__) && !defined (__GNUG__)
-# ifdef __MINGW32__
-#  define __unused__
-# else
-#  define __unused__ __attribute__((unused))
-# endif
-# define __printf__(s,f)  __attribute__((format (printf, s, f)))
-# define attr__noreturn __attribute__((__noreturn__))
-#else
-# define __unused__
-# define __printf__(s,f)
-# define attr__noreturn
-#endif
+#include "gcc-attr.h"
 
 /*
  *  Portability macros
@@ -68,15 +54,7 @@
 # include <stdbool.h>
 #endif
 
-#undef FALSE
-#undef TRUE
-#ifdef __cplusplus
-typedef bool boolean;
-#define FALSE false
-#define TRUE true
-#else
-typedef enum { FALSE, TRUE } boolean;
-#endif
+#include "mybool.h"
 
 /*
 *   FUNCTION PROTOTYPES

--- a/main/mio.c
+++ b/main/mio.c
@@ -23,6 +23,8 @@
 
 #include "routines.h"
 #include "debug.h"
+#else
+#include "mybool.h"
 #endif
 
 #include "mio.h"

--- a/main/mio.h
+++ b/main/mio.h
@@ -21,7 +21,11 @@
 #ifndef MIO_H
 #define MIO_H
 
+#ifndef QUALIFIER
 #include "general.h"  /* must always come first */
+#else
+#include "gcc-attr.h"
+#endif
 
 #include <stdio.h>
 #include <stdarg.h>

--- a/main/mybool.h
+++ b/main/mybool.h
@@ -1,0 +1,26 @@
+/*
+*   Copyright (c) 1998-2003, Darren Hiebert
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*/
+
+/* This is derived from general.h.
+   Only readtags related source file should include this.
+   ctags related source file should include genera.h instead. */
+
+#ifndef CTAGS_MAIN_MYBOOL_H
+#define CTAGS_MAIN_MYBOOL_H
+
+#undef FALSE
+#undef TRUE
+#ifdef __cplusplus
+typedef bool boolean;
+#define FALSE false
+#define TRUE true
+#else
+typedef enum { FALSE, TRUE } boolean;
+#endif
+
+#endif	/* CTAGS_MAIN_MYBOOL_H */

--- a/source.mak
+++ b/source.mak
@@ -20,6 +20,7 @@ MAIN_HEADS =			\
 	main/field.h		\
 	main/flags.h		\
 	main/fmt.h		\
+	main/gcc-attr.h		\
 	main/general.h		\
 	main/htable.h		\
 	main/keyword.h		\
@@ -27,6 +28,7 @@ MAIN_HEADS =			\
 	main/lcpp.h		\
 	main/main.h		\
 	main/mbcs.h		\
+	main/mybool.h		\
 	main/nestlevel.h	\
 	main/options.h		\
 	main/output.h		\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -222,6 +222,8 @@
     <ClInclude Include="..\main\flags.h" />
     <ClInclude Include="..\main\fmt.h" />
     <ClInclude Include="..\main\general.h" />
+    <ClInclude Include="..\main\gcc-attr.h" />
+    <ClInclude Include="..\main\mybool.h" />
     <ClInclude Include="..\gnu_regex\regex.h" />
     <ClInclude Include="..\main\htable.h" />
     <ClInclude Include="..\main\keyword.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -438,6 +438,12 @@
     <ClInclude Include="..\main\general.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\main\gcc-attr.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\main\mybool.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\main\routines.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
Close #1035.

To make readtags.c stand-alone, we cannot include
general.h to make readtags command.

Though, in following chain, general.h is included
from readtags-cmd.c.

    In file included from ./main/general.h:16:0,
		     from ./main/mio.h:24,
		     from ./dsl/es-lang-c-stdc99.h:30,
		     from ./dsl/qualifier.h:18,
		     from read/readtags-cmd.c:21:

The other *.c files being part of readtags command don't
include general.h. They are guarded with
'#ifndef QUALIFIER/#endif.

This becomes an issue in #1035.  configure script running on solaris
sets _FILE_OFFSET_BITS in config.h. config.h is included from
general.h. That means the value of _FILE_OFFSET_BITS is different
between *.c files including general.h and *.c files not including it.

readtags-cmd.c should not include general.h.
This commit introduces two sub header files(gcc-attr.h and mybool.h)
derived from general.h. Instead of include general.h, readtags-cmd.c
includes gcc-attr.h and mybool.h. So readtags-cmd.c doesn't have to
include config.h.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>