### PR TITLE
lcpp, OldC, Cxx, DTS, Vera: enable header kind by default

### DIFF
--- a/Tmain/list-kinds-full.d/stdout-expected.txt
+++ b/Tmain/list-kinds-full.d/stdout-expected.txt
@@ -3,7 +3,7 @@ d	macro	on	FALSE	1	C	macro definitions
 e	enumerator	on	FALSE	0	C	enumerators (values inside an enumeration)
 f	function	on	FALSE	0	C	function definitions
 g	enum	on	FALSE	0	C	enumeration names
-h	header	off	TRUE	2	C	included header files
+h	header	on	TRUE	2	C	included header files
 l	local	off	FALSE	0	C	local variables
 m	member	on	FALSE	0	C	struct, and union members
 p	prototype	off	FALSE	0	C	function prototypes
@@ -19,7 +19,7 @@ d	macro	on	FALSE	1	C	macro definitions
 e	enumerator	on	FALSE	0	C	enumerators (values inside an enumeration)
 f	function	on	FALSE	0	C	function definitions
 g	enum	on	FALSE	0	C	enumeration names
-h	header	off	TRUE	2	C	included header files
+h	header	on	TRUE	2	C	included header files
 l	local	off	FALSE	0	C	local variables
 m	member	on	FALSE	0	C	class, struct, and union members
 p	prototype	off	FALSE	0	C	function prototypes

--- a/main/lcpp.c
+++ b/main/lcpp.c
@@ -384,7 +384,8 @@ static void makeIncludeTag (const  char *const name, boolean systemHeader)
 	if (role_index == ROLE_INDEX_DEFINITION)
 		return;
 
-	if (Cpp.headerKind && isXtagEnabled (XTAG_REFERENCE_TAGS)
+	if (Cpp.headerKind && Cpp.headerKind->enabled
+	    && isXtagEnabled (XTAG_REFERENCE_TAGS)
 	    && Cpp.headerKind->roles [ role_index ].enabled)
 	{
 		initRefTagEntry (&e, name, Cpp.headerKind, role_index);

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -339,7 +339,7 @@ static kindOption CKinds [] = {
 	{ TRUE,  'e', "enumerator", "enumerators (values inside an enumeration)"},
 	{ TRUE,  'f', "function",   "function definitions"},
 	{ TRUE,  'g', "enum",       "enumeration names"},
-	{ FALSE, 'h', "header",     "included header files",
+	{ TRUE,  'h', "header",     "included header files",
 	  .referenceOnly = TRUE,  ATTACH_ROLES(CHeaderRoles)},
 	{ FALSE, 'l', "local",      "local variables"},
 	{ TRUE,  'm', "member",     "class, struct, and union members"},
@@ -479,8 +479,8 @@ static kindOption VeraKinds [] = {
 	{ TRUE,  'T', "typedef",    "typedefs"},
 	{ TRUE,  'v', "variable",   "variable definitions"},
 	{ FALSE, 'x', "externvar",  "external variable declarations"},
-	{ FALSE, 'h', "header",     "included header files",
-	  .referenceOnly = FALSE, ATTACH_ROLES(VeraHeaderRoles)},
+	{ TRUE,  'h', "header",     "included header files",
+	  .referenceOnly = TRUE, ATTACH_ROLES(VeraHeaderRoles)},
 };
 
 static const keywordDesc KeywordTable [] = {

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -44,7 +44,7 @@ CXX_COMMON_HEADER_ROLES(CXX);
 	{ TRUE,  'e', "enumerator", "enumerators (values inside an enumeration)", .syncWith = _syncWith }, \
 	{ TRUE,  'f', "function",   "function definitions", .syncWith = _syncWith },		\
 	{ TRUE,  'g', "enum",       "enumeration names", .syncWith = _syncWith },		\
-	{ FALSE, 'h', "header",     "included header files", \
+	{ TRUE, 'h', "header",     "included header files", \
 			.referenceOnly = TRUE,  ATTACH_ROLES(_langPrefix##HeaderRoles), .syncWith = _syncWith \
 	}, \
 	{ FALSE, 'l', "local",      "local variables", .syncWith = _syncWith },   \

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -43,8 +43,8 @@ typedef enum {
 static kindOption DTSKinds [] = {
 	{ TRUE,  'd', "macro",      "macro definitions",
 	  .referenceOnly = FALSE, ATTACH_ROLES(DTSMacroRoles)},
-	{ FALSE, 'h', "header",     "included header files",
-	  .referenceOnly = FALSE, ATTACH_ROLES(DTSHeaderRoles)},
+	{ TRUE, 'h', "header",     "included header files",
+	  .referenceOnly = TRUE, ATTACH_ROLES(DTSHeaderRoles)},
 };
 
 static tagRegexTable dtsTagRegexTable [] = {


### PR DESCRIPTION
"header" kinds for OldC, Cxx, DTS, Vera were disabled by default.
However, a tag for the kinds is printed always because lcpp calls
makeTagsEnty without verifying the value of `enabled' field of the
kind.

This commit does two things:

(1) verifying the value of the `enabled' field of the "header" kind in lcpp, and
(2) enabling the "header" kinds by default.