### PR TITLE
main: don't print a tag of disabled kind

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -1092,6 +1092,8 @@ static void writeTagEntry (const tagEntryInfo *const tag)
 
 	if (tag->placeholder)
 		return;
+	if (! tag->kind->enabled)
+		return;
 
 	DebugStatement ( debugEntry (tag); )
 	Assert (writeEntry);


### PR DESCRIPTION
Even a kind is disabled, a tag with the kind could be printed in the case
the parser making the tag didn't verify the kind was enabled.

This commit adds the code for the verification to the main part side.
So even if a parser don't verify it, ctags doesn't print a tag of
disabled kind.

That means a parser doesn't have to verify the enablement.
However, verifying in a parser is still meaningful: it avoids
unnecessary performance overhead.