### PR TITLE
main: Only generate reference tags when they are enabled

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -1094,6 +1094,9 @@ static void writeTagEntry (const tagEntryInfo *const tag)
 		return;
 	if (! tag->kind->enabled)
 		return;
+	if (tag->extensionFields.roleIndex != ROLE_INDEX_DEFINITION
+	    && ! isXtagEnabled (XTAG_REFERENCE_TAGS))
+		return;
 
 	DebugStatement ( debugEntry (tag); )
 	Assert (writeEntry);


### PR DESCRIPTION
This commit is inspired by 102b735b2e50664888e5f1c61bfb6ec4052c9b27 and
88202471d37f29037744b3c358202a50b105d130.

Rule: when reference extra tag feature enabled with --extra=+r is
disabled, a tag attached with a role other than ROLE_INDEX_DEFINITION
should not be printed.

This change forces the rule in the main part level. A lazy parser developer
can ignore the rule in her/his parser; the main part drops the tag emission.

However, it will be better to follow the rule in the parser level because it
will gain the performance when ctags is called without --extra=+r.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>