### PR TITLE
main: warn when a kind letter is reused in a regex parser definition

### DIFF
--- a/Tmain/warn-reusing-kind-letter.d/run.sh
+++ b/Tmain/warn-reusing-kind-letter.d/run.sh
@@ -1,0 +1,13 @@
+# Copyright: 2016 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+${CTAGS} --quiet --options=NONE \
+	 --langdef=X \
+	 --regex-X='/./\0/a,anyobject/' \
+	 --regex-X='/./\0/a,anyitem/' \
+	 --langdef=Y \
+	 --regex-Y='/./\0/b,any' \
+	 --regex-Y='/./\0/b,any' \
+	 --_force-quit=0 2>&1 | sed -e 's/.*ctags\(.exe\)\{0,1\}: //'

--- a/Tmain/warn-reusing-kind-letter.d/stdout-expected.txt
+++ b/Tmain/warn-reusing-kind-letter.d/stdout-expected.txt
@@ -1,0 +1,1 @@
+Warning: Don't reuse the kind letter `a' in a language X (old: "anyobject", new: "anyitem")

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -413,6 +413,14 @@ static regexPattern *addCompiledTagPattern (const langType language, regex_t* co
 		ptrn->u.tag.kind->name    = kindName? eStrdup (kindName): NULL;
 		ptrn->u.tag.kind->description = description? eStrdup (description): NULL;
 	}
+	else if (ptrn->u.tag.kind->name && kindName && strcmp(ptrn->u.tag.kind->name, kindName))
+	{
+		/* When using a same kind letter for multiple regex patterns, the name of kind
+		   should be the same. */
+		error  (WARNING, "Don't reuse the kind letter `%c' in a language %s (old: \"%s\", new: \"%s\")",
+			ptrn->u.tag.kind->letter, getLanguageName (language),
+			ptrn->u.tag.kind->name, kindName);
+	}
 
 	return ptrn;
 }


### PR DESCRIPTION
u-ctags doesn't allow using a same letter for different log names.

e.g. (taken from #1062)

    --langdef=pascal
    --regex-pascal=/(uses|interface|implementation)[[:space:]]*/\1/s,Section/
    --regex-pascal=/unit[[:space:]]+([a-zA-Z0-9_<>,][a-zA-Z0-9_<>, ]+)[;(]/\1/s,unit/

In both "Section" and "unit" `s' is used as a kind letter. u-ctags
threw later one, "unit", away silently.

As reported in #1062, user can reuse a letter accidentally.
With this commit ctags can make warnrnings when detecting such reuses.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>