### PR TITLE
Fix compilation error in CentOS 6.

### DIFF
--- a/main/lxpath.c
+++ b/main/lxpath.c
@@ -118,9 +118,9 @@ static void findXMLTagsCore (xmlXPathContext *ctx, xmlNode *root,
 			{
 				node = set->nodeTab[j];
 				if (elt->specType == LXPATH_TABLE_DO_MAKE)
-					simpleXpathMakeTag (node, &(elt->makeTagSpec), kinds, userData);
+					simpleXpathMakeTag (node, &(elt->spec.makeTagSpec), kinds, userData);
 				else
-					elt->recurSpec.enter (node, &(elt->recurSpec), ctx, userData);
+					elt->spec.recurSpec.enter (node, &(elt->spec.recurSpec), ctx, userData);
 			}
 		}
 		xmlXPathFreeObject (object);

--- a/main/parse.h
+++ b/main/parse.h
@@ -107,7 +107,7 @@ typedef struct sTagXpathTable
 	union {
 		tagXpathMakeTagSpec makeTagSpec;
 		tagXpathRecurSpec   recurSpec;
-	};
+	} spec;
 	xmlXPathCompExpr* xpathCompiled;
 } tagXpathTable;
 

--- a/parsers/plist.c
+++ b/parsers/plist.c
@@ -43,7 +43,7 @@ static void makeTagWithScope (xmlNode *node,
 static tagXpathTable plistXpathMainTable[] = {
 	{ "///plist//dict/key",
 	  LXPATH_TABLE_DO_RECUR,
-	  .recurSpec = {
+	  .spec.recurSpec = {
 			plistFindTagsUnderKey
 		}
 	},
@@ -52,7 +52,7 @@ static tagXpathTable plistXpathMainTable[] = {
 static tagXpathTable plistXpathTextTable[] = {
 	{ "text()",
 	  LXPATH_TABLE_DO_MAKE,
-	  .makeTagSpec = {
+	  .spec.makeTagSpec = {
 			K_KEY,  ROLE_INDEX_DEFINITION,
 			makeTagWithScope
 		}


### PR DESCRIPTION
According to c11 6.7.9p9 http://www.iso-9899.info/n1570.html#6.7.9p9
[Initialization] Except where explicitly stated otherwise, for the
purposes of this subclause unnamed members of objects of structure and
union type do not | participate in initialization. Unnamed members of
structure objects have indeterminate value even after initialization.

This is also mentioned in #999.