### PR TITLE
python: Fix crash with dotted variables missing an explicit initializer

### DIFF
--- a/Units/parser-python.r/dotted-variable-leftovers.d/expected.tags
+++ b/Units/parser-python.r/dotted-variable-leftovers.d/expected.tags
@@ -1,0 +1,3 @@
+X	input.py	/^class X(list):$/;"	c
+a	input.py	/^a, x.a = x$/;"	v
+x	input.py	/^x = X()$/;"	v

--- a/Units/parser-python.r/dotted-variable-leftovers.d/input.py
+++ b/Units/parser-python.r/dotted-variable-leftovers.d/input.py
@@ -1,0 +1,8 @@
+class X(list):
+    pass
+
+x = X()
+x.append(1)
+x.append(2)
+
+a, x.a = x

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -1150,8 +1150,11 @@ static boolean parseVariable (tokenInfo *const token, const pythonKind kind)
 
 		/* if we got leftover to initialize, just make variables out of them.
 		 * This handles cases like `a, b, c = (c, d, e)` -- or worse */
-		while (i < nameCount)
-			makeSimplePythonTag (nameTokens[i++], kind);
+		for (; i < nameCount; i++)
+		{
+			if (nameTokens[i])
+				makeSimplePythonTag (nameTokens[i], kind);
+		}
 	}
 
 	while (nameCount > 0)


### PR DESCRIPTION
Fixes #1080.