### PR TITLE
Geany sync, part 1

### DIFF
--- a/docs/input-text-stream.svg
+++ b/docs/input-text-stream.svg
@@ -10,8 +10,8 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="167.89255mm"
-   height="100.40414mm"
-   viewBox="0 0 594.89486 355.76271"
+   height="99.839706mm"
+   viewBox="0 0 594.89486 353.76276"
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -108,22 +108,6 @@
          style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:#666666;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)" />
     </marker>
-    <marker
-       inkscape:stockid="Arrow1Lend"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="marker6735-6-6-4"
-       style="overflow:visible"
-       inkscape:isstock="true"
-       inkscape:collect="always">
-      <path
-         inkscape:connector-curvature="0"
-         id="path6737-7-1-1"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:#666666;stroke-width:1pt;stroke-opacity:1"
-         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
-    </marker>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -132,37 +116,37 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.4142136"
-     inkscape:cx="180.83561"
-     inkscape:cy="212.91231"
+     inkscape:zoom="2.0000001"
+     inkscape:cx="234.25314"
+     inkscape:cy="183.38668"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1016"
-     inkscape:window-x="4080"
-     inkscape:window-y="27"
+     inkscape:window-width="2880"
+     inkscape:window-height="1583"
+     inkscape:window-x="1200"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0">
     <sodipodi:guide
-       position="426.1203,334.2506"
+       position="426.1203,332.25068"
        orientation="1,0"
        id="guide7768" />
     <sodipodi:guide
-       position="276.92077,59.18606"
+       position="276.92077,57.186122"
        orientation="1,0"
        id="guide6795" />
     <sodipodi:guide
-       position="524.61361,29.425131"
+       position="524.61361,27.425191"
        orientation="0,1"
        id="guide6910" />
     <sodipodi:guide
-       position="473.14292,281.9247"
+       position="473.14292,279.92477"
        orientation="0,1"
        id="guide7227" />
   </sodipodi:namedview>
@@ -187,17 +171,17 @@
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="67.530678"
-       y="337.67322"
+       y="335.67322"
        id="text9293"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan9295"
          x="67.530678"
-         y="337.67322"
+         y="335.67322"
          style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';text-align:start;writing-mode:lr-tb;text-anchor:start">File</tspan></text>
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker6735-6)"
-       d="m 92.08532,336.79905 26.03301,15.03449"
+       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
+       d="m 92.08532,334.79905 26.03301,15.03449"
        id="path7947-9"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
@@ -207,130 +191,130 @@
        width="115.17915"
        height="143.60025"
        x="120.64043"
-       y="352.61703" />
+       y="350.61703" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="192.03923"
-       y="439.42728"
+       y="437.42728"
        id="text4751-9"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4753-3"
          x="192.03923"
-         y="439.42728">inputFileInfo</tspan></text>
+         y="437.42728">inputFileInfo</tspan></text>
     <rect
        style="opacity:1;fill:none;fill-opacity:1;stroke:#666666;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect5890-3-2"
        width="74.179138"
        height="26.850252"
        x="284.89038"
-       y="468.61703" />
+       y="466.61707" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="289.03918"
-       y="487.67728"
+       y="485.67725"
        id="text4751-9-5"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4753-3-3"
          x="289.03918"
-         y="487.67728">MIO</tspan></text>
+         y="485.67725">MIO</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="183.0112"
-       y="377.04214"
+       y="375.04214"
        id="text4723-9"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4725-6"
          x="183.0112"
-         y="377.04214">.<tspan
+         y="375.04214">.<tspan
    style="fill:#ff0000"
    id="tspan7233">input</tspan></tspan></text>
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker6735-6-6-4)"
-       d="m 230.37899,480.45864 53.88481,-12.1455"
+       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
+       d="m 229.87899,474.95864 54.38481,-8.6455"
        id="path7947-9-5-1"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="210.2612"
-       y="480.54218"
+       x="202.2612"
+       y="478.54218"
        id="text4723-9-3"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4725-6-5"
-         x="210.2612"
-         y="480.54218">.fp</tspan></text>
+         x="202.2612"
+         y="478.54218">.mio</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="182.54245"
-       y="417.66718"
+       y="415.66718"
        id="text4723-9-37"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4725-6-9"
          x="182.54245"
-         y="417.66718">.source</tspan></text>
+         y="415.66718">.source</tspan></text>
     <rect
        style="opacity:1;fill:none;fill-opacity:1;stroke:#666666;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect5890-3-2-0"
        width="227.67914"
        height="37.35025"
        x="188.89038"
-       y="363.86703" />
+       y="361.86703" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="114.66747"
-       y="494.16714"
+       x="122.66747"
+       y="492.16711"
        id="text4751-9-2"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4753-3-7"
-         x="114.66747"
-         y="494.16714">inputFile</tspan></text>
+         x="122.66747"
+         y="492.16711">inputFile</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="192.0737"
-       y="396.16714"
+       y="394.16714"
        id="text4751-9-7"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4753-3-6"
          x="192.0737"
-         y="396.16714">inputFileInfo</tspan></text>
+         y="394.16714">inputFileInfo</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="379.04248"
-       y="378.66718"
+       y="376.66718"
        id="text4723-9-6"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4725-6-0"
          x="379.04248"
-         y="378.66718">.name</tspan></text>
+         y="376.66718">.name</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="343.10495"
-       y="392.54218"
+       y="390.54218"
        id="text4723-9-6-5"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4725-6-0-8"
          x="343.10495"
-         y="392.54218">.lineNumber</tspan></text>
+         y="390.54218">.lineNumber</tspan></text>
     <rect
-       y="407.86703"
+       y="405.86703"
        x="188.89038"
        height="37.35025"
        width="227.67914"
@@ -340,26 +324,26 @@
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="380.82373"
-       y="423.10468"
+       y="421.10468"
        id="text4723-9-6-8"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4725-6-0-7"
          x="380.82373"
-         y="423.10468">.name</tspan></text>
+         y="421.10468">.name</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="344.8862"
-       y="436.97968"
+       y="434.97968"
        id="text4723-9-6-5-1"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4725-6-0-8-3"
          x="344.8862"
-         y="436.97968">.lineNumber</tspan></text>
+         y="434.97968">.lineNumber</tspan></text>
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.56267413"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.56267413;marker-end:"
        d="m 326.78713,483.28606 43.13352,-43.84062 0,-61.51829 -43.13352,-24.90314 0,-105.20449"
        id="path6819"
        inkscape:connector-curvature="0"
@@ -420,13 +404,13 @@
          x="174.36806"
          y="150.95457">native parser written in C</tspan></text>
     <path
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="m 318.88942,215.03846 -0.022,-12.39295 -10.0459,0.0207 18.1028,-15.43867 17.82841,15.42523 -10.00691,0.01 0.043,12.41063 z"
        id="path5618-0-6-14-4"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccccc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.47632315"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.47632315;marker-end:"
        d="m 326.78713,482.57895 149.35029,-37.18376 -0.5,-204.93964"
        id="path6945"
        inkscape:connector-curvature="0"
@@ -450,20 +434,20 @@
        width="74.179138"
        height="26.850252"
        x="585.39044"
-       y="469.36703" />
+       y="467.36707" />
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="589.53925"
-       y="488.42728"
+       y="486.42725"
        id="text4751-9-5-6"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4753-3-3-7"
          x="589.53925"
-         y="488.42728">MIO</tspan></text>
+         y="486.42725">MIO</tspan></text>
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.72144847"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.72144847;marker-end:"
        d="m 624.47997,476.79215 c 0,-237 0,-237 0,-237"
        id="path7025"
        inkscape:connector-curvature="0" />
@@ -481,13 +465,13 @@
    style="fill:#008000"
    id="tspan7237">Raw</tspan>()</tspan></text>
     <path
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="m 465.58226,215.68015 -0.022,-12.39295 -10.0459,0.0207 18.1028,-15.43867 17.82841,15.42523 -10.00691,0.01 0.043,12.41063 z"
        id="path5618-0-6-14-4-4"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccccc" />
     <path
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="m 613.58226,214.68015 -0.022,-12.39295 -10.0459,0.0207 18.1028,-15.43867 17.82841,15.42523 -10.00691,0.01 0.043,12.41063 z"
        id="path5618-0-6-14-4-4-4"
        inkscape:connector-curvature="0"

--- a/docs/internal.rst
+++ b/docs/internal.rst
@@ -167,9 +167,9 @@ is a marker of C code area.
 
 .. code-block:: c
 
-    static void enter_c_prologue (const char *line __unused__,
-				 const regexMatch *matches __unused__,
-				 unsigned int count __unused__,
+    static void enter_c_prologue (const char *line CTAGS_ATTR_UNUSED,
+				 const regexMatch *matches CTAGS_ATTR_UNUSED,
+				 unsigned int count CTAGS_ATTR_UNUSED,
 				 void *data)
     {
 	   struct cStart *cstart = data;
@@ -190,9 +190,9 @@ the end marker of C code area is found in the current input text stream.
 
 .. code-block:: c
 
-    static void leave_c_prologue (const char *line __unused__,
-				 const regexMatch *matches __unused__,
-				 unsigned int count __unused__,
+    static void leave_c_prologue (const char *line CTAGS_ATTR_UNUSED,
+				 const regexMatch *matches CTAGS_ATTR_UNUSED,
+				 unsigned int count CTAGS_ATTR_UNUSED,
 				 void *data)
     {
 	   struct cStart *cstart = data;

--- a/docs/output-tag-stream.svg
+++ b/docs/output-tag-stream.svg
@@ -9,9 +9,9 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="171.44594mm"
+   width="172.93948mm"
    height="136.06023mm"
-   viewBox="0 0 607.48561 482.10316"
+   viewBox="0 0 612.7777 482.10316"
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -32,22 +32,6 @@
          d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
          style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:#666666;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker11825"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lend"
-       inkscape:collect="always">
-      <path
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:#666666;stroke-width:1pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         id="path11827"
-         inkscape:connector-curvature="0" />
     </marker>
     <marker
        inkscape:isstock="true"
@@ -124,22 +108,6 @@
          style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:#666666;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)" />
     </marker>
-    <marker
-       inkscape:stockid="Arrow1Lend"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="marker6735-6-6"
-       style="overflow:visible"
-       inkscape:isstock="true"
-       inkscape:collect="always">
-      <path
-         inkscape:connector-curvature="0"
-         id="path6737-7-1"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 Z"
-         style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:#666666;stroke-width:1pt;stroke-opacity:1"
-         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
-    </marker>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -148,25 +116,25 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.4142136"
-     inkscape:cx="291.05441"
-     inkscape:cy="336.56608"
+     inkscape:zoom="2.0000001"
+     inkscape:cx="339.67169"
+     inkscape:cy="291.80905"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1016"
-     inkscape:window-x="4080"
-     inkscape:window-y="27"
+     inkscape:window-width="2880"
+     inkscape:window-height="1583"
+     inkscape:window-x="1200"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
      fit-margin-bottom="0">
     <sodipodi:guide
-       position="471.57362,182.14424"
+       position="476.86572,182.14423"
        orientation="1,0"
        id="guide7768" />
   </sodipodi:namedview>
@@ -186,21 +154,21 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-65.479966,-21.688993)">
+     transform="translate(-60.187851,-21.688993)">
     <path
-       style="fill:#b3b3b3;fill-rule:evenodd;stroke:#e2e4e4;stroke-width:10.10000038;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#b3b3b3;fill-rule:evenodd;stroke:#e2e4e4;stroke-width:10.10000038;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:"
        d="M 79.07377,244.30479 455.92005,245.719"
        id="path4279-5-7"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:#b3b3b3;fill-rule:evenodd;stroke:#e2e4e4;stroke-width:10.10000038;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#b3b3b3;fill-rule:evenodd;stroke:#e2e4e4;stroke-width:10.10000038;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:"
        d="m 197.3414,195.06721 406.58639,1.41421"
        id="path4279-5"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:#b3b3b3;fill-rule:evenodd;stroke:#e2e4e4;stroke-width:10.10000038;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#b3b3b3;fill-rule:evenodd;stroke:#e2e4e4;stroke-width:10.10000038;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:"
        d="m 269.83382,153.0672 274.35743,1.41421"
        id="path4279"
        inkscape:connector-curvature="0"
@@ -213,19 +181,19 @@
        x="306.42352"
        y="71.447166" />
     <path
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="m 396.15383,115.31842 -0.0223,12.39295 -10.0459,-0.0207 18.10275,15.43867 17.8284,-15.42523 -10.00683,-0.01 0.0434,-12.41063 z"
        id="path5618-0"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccccc" />
     <path
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="m 245.31691,159.54564 -0.0223,12.39295 -10.0459,-0.0207 18.10275,15.43867 17.8284,-15.42523 -10.00683,-0.01 0.0434,-12.41063 z"
        id="path5618-0-6"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccccc" />
     <path
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="m 245.61629,208.33404 -0.0223,12.39295 -10.0459,-0.0207 18.10275,15.43867 17.8284,-15.42523 -10.00683,-0.01 0.0434,-12.41063 z"
        id="path5618-0-6-1"
        inkscape:connector-curvature="0"
@@ -235,13 +203,13 @@
        inkscape:connector-curvature="0"
        id="path5825"
        d="m 379.61629,208.33404 -0.0223,12.39295 -10.0459,-0.0207 18.10275,15.43867 17.8284,-15.42523 -10.00683,-0.01 0.0434,-12.41063 z"
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:" />
     <path
        sodipodi:nodetypes="cccccccc"
        inkscape:connector-curvature="0"
        id="path5835"
        d="m 115.61629,208.33404 -0.0223,12.39295 -10.0459,-0.0207 18.10275,15.43867 17.8284,-15.42523 -10.00683,-0.01 0.0434,-12.41063 z"
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:" />
     <rect
        y="290.8757"
        x="280.06638"
@@ -254,15 +222,15 @@
        inkscape:connector-curvature="0"
        id="path5845"
        d="m 263.84566,267.14873 8.03233,9.43755 -7.65191,6.50913 23.79205,-0.0189 3.53717,-23.30833 -7.61526,6.49189 -8.02777,-9.46469 z"
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:" />
     <path
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="m 375.5553,267.14873 -8.03233,9.43755 7.65191,6.50913 -23.79205,-0.0189 -3.53717,-23.30833 7.61526,6.49189 8.02777,-9.46469 z"
        id="path5862"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccccc" />
     <path
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="m 115.61629,256.33404 -0.0223,12.39295 -10.0459,-0.0207 18.10275,15.43867 17.8284,-15.42523 -10.00683,-0.01 0.0434,-12.41063 z"
        id="path5888"
        inkscape:connector-curvature="0"
@@ -275,7 +243,7 @@
        x="86.066391"
        y="290.8757" />
     <path
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="m 208.58379,329.56106 12.39295,0.0223 -0.0207,10.0459 15.43867,-18.10275 -15.42523,-17.8284 -0.01,10.00683 -12.41063,-0.0434 z"
        id="path5618-0-6-1-3"
        inkscape:connector-curvature="0"
@@ -285,7 +253,7 @@
        inkscape:connector-curvature="0"
        id="path5927"
        d="m 539.31691,159.54564 -0.0223,12.39295 -10.0459,-0.0207 18.10275,15.43867 17.8284,-15.42523 -10.00683,-0.01 0.0434,-12.41063 z"
-       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#666666;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#666666;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:" />
     <rect
        y="233.49739"
        x="467.19669"
@@ -360,27 +328,27 @@
        inkscape:connector-curvature="0"
        id="path5927-4"
        d="m 561.78831,210.16742 -0.0223,12.39295 -10.0459,-0.0207 18.10275,15.43867 17.8284,-15.42523 -10.00683,-0.01 0.0434,-12.41063 z"
-       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#666666;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#666666;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:4, 8;stroke-dashoffset:0;stroke-opacity:1"
+       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:4, 8;stroke-dashoffset:0;stroke-opacity:1;marker-end:"
        d="m 537.11399,286.32865 -0.0514,25.25382 118.05104,0 -0.82197,-287.893477 -401.03056,0 0,130.309677"
        id="path6643"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccc" />
     <path
-       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="m 647.10262,99.7502 -0.0223,-12.39295 -10.0459,0.0207 18.10275,-15.43867 17.8284,15.42523 -10.00683,0.01 0.0434,12.41063 z"
        id="path5618-0-6-14"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccccccc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker6735)"
+       style="fill:none;fill-rule:evenodd;stroke:#ff0000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="m 465,103.86221 c 25,135.5 25,135.5 25,135.5"
        id="path7947"
        inkscape:connector-curvature="0" />
     <rect
        y="430.44189"
-       x="240.85831"
+       x="204.85831"
        height="72.35025"
        width="77.679146"
        id="rect5837-8"
@@ -398,23 +366,17 @@
          y="419.50165"
          style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';text-align:start;writing-mode:lr-tb;text-anchor:start">TagFile</tspan></text>
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker6735-6)"
-       d="m 159.9491,413.12748 78.03301,19.53449"
+       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
+       d="m 159.9491,413.12748 45.53301,18.53449"
        id="path7947-9"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker6735-6-6)"
-       d="m 314.03294,457.74274 43.38478,-92.8955"
+       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
+       d="m 279.53294,444.74274 77.88478,-79.8955"
        id="path7947-9-5"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
-    <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path11057"
-       d="M 280.79892,433.70111 161.9027,363.43303"
-       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker11059)" />
     <rect
        style="opacity:1;fill:none;fill-opacity:1;stroke:#666666;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect11783"
@@ -426,10 +388,10 @@
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
        id="path11823"
-       d="M 311.98416,476.24883 432.44359,430.7295"
-       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker11825)" />
+       d="M 278.98416,464.24883 432.44359,430.7295"
+       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker12257)"
+       style="fill:none;fill-rule:evenodd;stroke:#666666;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:"
        d="M 504.24466,438.2973 465.60506,272.92337"
        id="path12255"
        inkscape:connector-curvature="0"
@@ -448,47 +410,36 @@
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="257.45773"
-       y="444.0766"
-       id="text4533"
-       sodipodi:linespacing="0%"><tspan
-         sodipodi:role="line"
-         id="tspan4535"
-         x="257.45773"
-         y="444.0766">.etags.fp</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="292.69174"
-       y="461.36951"
+       x="256.69174"
+       y="449.36951"
        id="text4723"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4725"
-         x="292.69174"
-         y="461.36951">.fp</tspan></text>
+         x="256.69174"
+         y="449.36951">.fp</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="248.93439"
-       y="478.0766"
+       x="212.93439"
+       y="466.0766"
        id="text4727"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4729"
-         x="248.93439"
-         y="478.0766">.corkQueue</tspan></text>
+         x="212.93439"
+         y="466.0766">.corkQueue</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="244.12556"
-       y="495.6976"
+       x="208.12556"
+       y="497.6976"
        id="text4731"
        sodipodi:linespacing="0%"><tspan
          sodipodi:role="line"
          id="tspan4733"
-         x="244.12556"
-         y="495.6976">inputFile</tspan></text>
+         x="208.12556"
+         y="497.6976">tagFile</tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
@@ -676,5 +627,17 @@
          id="tspan4289"
          x="472.24466"
          y="266.97083">tagEntryInfo</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:'VL Gothic';-inkscape-font-specification:'VL Gothic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="59.61412"
+       y="375.24063"
+       id="text9293-3"
+       sodipodi:linespacing="0%"><tspan
+         sodipodi:role="line"
+         id="tspan9295-6"
+         x="59.61412"
+         y="375.24063"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'sans-serif, Italic';text-align:start;writing-mode:lr-tb;text-anchor:start">output-tags.c private</tspan></text>
   </g>
 </svg>

--- a/main/debug.h
+++ b/main/debug.h
@@ -71,7 +71,7 @@ enum eDebugLevels {
 *   Function prototypes
 */
 extern void lineBreak (void);
-extern void debugPrintf (const enum eDebugLevels level, const char *const format, ...) __printf__ (2, 3);
+extern void debugPrintf (const enum eDebugLevels level, const char *const format, ...) CTAGS_ATTR_PRINTF (2, 3);
 extern void debugPutc (const int level, const int c);
 extern void debugParseNest (const boolean increase, const unsigned int level);
 extern void debugCppNest (const boolean begin, const unsigned int level);

--- a/main/entry.c
+++ b/main/entry.c
@@ -1,4 +1,3 @@
-
 /*
 *   Copyright (c) 1996-2002, Darren Hiebert
 *

--- a/main/entry.c
+++ b/main/entry.c
@@ -78,7 +78,7 @@
 typedef struct eTagFile {
 	char *name;
 	char *directory;
-	MIO *fp;
+	MIO *mio;
 	struct sNumTags { unsigned long added, prev; } numTags;
 	struct sMax { size_t line, tag; } max;
 	vString *vLine;
@@ -146,9 +146,9 @@ extern const char *tagFileName (void)
 *   Pseudo tag support
 */
 
-extern void abort_if_ferror(MIO *const fp)
+extern void abort_if_ferror(MIO *const mio)
 {
-	if (mio_error (fp))
+	if (mio_error (mio))
 		error (FATAL | PERROR, "cannot write tag file");
 }
 
@@ -212,7 +212,7 @@ extern void makeFileTag (const char *const fileName)
 }
 
 static void updateSortedFlag (
-		const char *const line, MIO *const fp, MIOPos startOfLine)
+		const char *const line, MIO *const mio, MIOPos startOfLine)
 {
 	const char *const tab = strchr (line, '\t');
 
@@ -224,7 +224,7 @@ static void updateSortedFlag (
 		{
 			MIOPos nextLine;
 
-			if (mio_getpos (fp, &nextLine) == -1 || mio_getpos (fp, &startOfLine) == -1)
+			if (mio_getpos (mio, &nextLine) == -1 || mio_getpos (mio, &startOfLine) == -1)
 				error (WARNING, "Failed to update 'sorted' pseudo-tag");
 			else
 			{
@@ -232,18 +232,18 @@ static void updateSortedFlag (
 				int c, d;
 
 				do
-					c = mio_getc (fp);
+					c = mio_getc (mio);
 				while (c != '\t'  &&  c != '\n');
-				mio_getpos (fp, &flagLocation);
-				d = mio_getc (fp);
+				mio_getpos (mio, &flagLocation);
+				d = mio_getc (mio);
 				if (c == '\t'  &&  (d == '0'  ||  d == '1')  &&
 					d != (int) Option.sorted)
 				{
-					mio_setpos (fp, &flagLocation);
-					mio_putc (fp, Option.sorted == SO_FOLDSORTED ? '2' :
+					mio_setpos (mio, &flagLocation);
+					mio_putc (mio, Option.sorted == SO_FOLDSORTED ? '2' :
 						(Option.sorted == SO_SORTED ? '1' : '0'));
 				}
-				mio_setpos (fp, &nextLine);
+				mio_setpos (mio, &nextLine);
 			}
 		}
 	}
@@ -252,7 +252,7 @@ static void updateSortedFlag (
 /*  Look through all line beginning with "!_TAG_FILE", and update those which
  *  require it.
  */
-static long unsigned int updatePseudoTags (MIO *const fp)
+static long unsigned int updatePseudoTags (MIO *const mio)
 {
 	enum { maxEntryLength = 20 };
 	char entry [maxEntryLength + 1];
@@ -265,8 +265,8 @@ static long unsigned int updatePseudoTags (MIO *const fp)
 	entryLength = strlen (entry);
 	Assert (entryLength < maxEntryLength);
 
-	mio_getpos (fp, &startOfLine);
-	line = readLineRaw (TagFile.vLine, fp);
+	mio_getpos (mio, &startOfLine);
+	line = readLineRaw (TagFile.vLine, mio);
 	while (line != NULL  &&  line [0] == entry [0])
 	{
 		++linesRead;
@@ -278,16 +278,16 @@ static long unsigned int updatePseudoTags (MIO *const fp)
 				tab == '\t')
 			{
 				if (strcmp (classType, "_SORTED") == 0)
-					updateSortedFlag (line, fp, startOfLine);
+					updateSortedFlag (line, mio, startOfLine);
 			}
-			mio_getpos (fp, &startOfLine);
+			mio_getpos (mio, &startOfLine);
 		}
-		line = readLineRaw (TagFile.vLine, fp);
+		line = readLineRaw (TagFile.vLine, mio);
 	}
 	while (line != NULL)  /* skip to end of file */
 	{
 		++linesRead;
-		line = readLineRaw (TagFile.vLine, fp);
+		line = readLineRaw (TagFile.vLine, mio);
 	}
 	return linesRead;
 }
@@ -364,19 +364,19 @@ static boolean isEtagsLine (const char *const line)
 static boolean isTagFile (const char *const filename)
 {
 	boolean ok = FALSE;  /* we assume not unless confirmed */
-	MIO *const fp = mio_new_file (filename, "rb");
+	MIO *const mio = mio_new_file (filename, "rb");
 
-	if (fp == NULL  &&  errno == ENOENT)
+	if (mio == NULL  &&  errno == ENOENT)
 		ok = TRUE;
-	else if (fp != NULL)
+	else if (mio != NULL)
 	{
-		const char *line = readLineRaw (TagFile.vLine, fp);
+		const char *line = readLineRaw (TagFile.vLine, mio);
 
 		if (line == NULL)
 			ok = TRUE;
 		else
 			ok = (boolean) (isCtagsLine (line) || isEtagsLine (line));
-		mio_free (fp);
+		mio_free (mio);
 	}
 	return ok;
 }
@@ -395,7 +395,7 @@ extern void openTagFile (void)
 	{
 		/* Open a tempfile with read and write mode. Read mode is used when
 		 * write the result to stdout. */
-		TagFile.fp = tempFile ("w+", &TagFile.name);
+		TagFile.mio = tempFile ("w+", &TagFile.name);
 		if (isXtagEnabled (XTAG_PSEUDO_TAGS))
 			addCommonPseudoTags ();
 	}
@@ -413,30 +413,30 @@ extern void openTagFile (void)
 		if (Option.etags)
 		{
 			if (Option.append  &&  fileExists)
-				TagFile.fp = mio_new_file (TagFile.name, "a+b");
+				TagFile.mio = mio_new_file (TagFile.name, "a+b");
 			else
-				TagFile.fp = mio_new_file (TagFile.name, "w+b");
+				TagFile.mio = mio_new_file (TagFile.name, "w+b");
 		}
 		else
 		{
 			if (Option.append  &&  fileExists)
 			{
-				TagFile.fp = mio_new_file (TagFile.name, "r+");
-				if (TagFile.fp != NULL)
+				TagFile.mio = mio_new_file (TagFile.name, "r+");
+				if (TagFile.mio != NULL)
 				{
-					TagFile.numTags.prev = updatePseudoTags (TagFile.fp);
-					mio_free (TagFile.fp);
-					TagFile.fp = mio_new_file (TagFile.name, "a+");
+					TagFile.numTags.prev = updatePseudoTags (TagFile.mio);
+					mio_free (TagFile.mio);
+					TagFile.mio = mio_new_file (TagFile.name, "a+");
 				}
 			}
 			else
 			{
-				TagFile.fp = mio_new_file (TagFile.name, "w");
-				if (TagFile.fp != NULL && isXtagEnabled (XTAG_PSEUDO_TAGS))
+				TagFile.mio = mio_new_file (TagFile.name, "w");
+				if (TagFile.mio != NULL && isXtagEnabled (XTAG_PSEUDO_TAGS))
 					addCommonPseudoTags ();
 			}
 		}
-		if (TagFile.fp == NULL)
+		if (TagFile.mio == NULL)
 			error (FATAL | PERROR, "cannot open tag file");
 	}
 	if (TagsToStdout)
@@ -447,7 +447,7 @@ extern void openTagFile (void)
 
 #ifdef USE_REPLACEMENT_TRUNCATE
 
-static void copyBytes (MIO* const fromFp, MIO* const toFp, const long size)
+static void copyBytes (MIO* const fromMio, MIO* const toMio, const long size)
 {
 	enum { BufferSize = 1000 };
 	long toRead, numRead;
@@ -457,8 +457,8 @@ static void copyBytes (MIO* const fromFp, MIO* const toFp, const long size)
 	{
 		toRead = (0 < remaining && remaining < BufferSize) ?
 					remaining : (long) BufferSize;
-		numRead = mio_read (fromFp, buffer, (size_t) 1, (size_t) toRead);
-		if (mio_write (toFp, buffer, (size_t)1, (size_t)numRead) < (size_t)numRead)
+		numRead = mio_read (fromMio, buffer, (size_t) 1, (size_t) toRead);
+		if (mio_write (toMio, buffer, (size_t)1, (size_t)numRead) < (size_t)numRead)
 			error (FATAL | PERROR, "cannot complete write");
 		if (remaining > 0)
 			remaining -= numRead;
@@ -468,20 +468,20 @@ static void copyBytes (MIO* const fromFp, MIO* const toFp, const long size)
 
 static void copyFile (const char *const from, const char *const to, const long size)
 {
-	MIO* const fromFp = mio_new_file (from, "rb");
-	if (fromFp == NULL)
+	MIO* const fromMio = mio_new_file_full (from, "rb", g_fopen, fclose);
+	if (fromMio == NULL)
 		error (FATAL | PERROR, "cannot open file to copy");
 	else
 	{
-		MIO* const toFp = mio_new_file (to, "wb");
-		if (toFp == NULL)
+		MIO* const toMio = mio_new_file_full (to, "wb", g_fopen, fclose);
+		if (toMio == NULL)
 			error (FATAL | PERROR, "cannot open copy destination");
 		else
 		{
-			copyBytes (fromFp, toFp, size);
-			mio_free (toFp);
+			copyBytes (fromMio, toMio, size);
+			mio_free (toMio);
 		}
-		mio_free (fromFp);
+		mio_free (fromMio);
 	}
 }
 
@@ -490,8 +490,8 @@ static void copyFile (const char *const from, const char *const to, const long s
 static int replacementTruncate (const char *const name, const long size)
 {
 	char *tempName = NULL;
-	MIO *fp = tempFile ("w", &tempName);
-	mio_free (fp);
+	MIO *mio = tempFile ("w", &tempName);
+	mio_free (mio);
 	copyFile (name, tempName, size);
 	copyFile (tempName, name, WHOLE_FILE);
 	remove (tempName);
@@ -505,28 +505,28 @@ static int replacementTruncate (const char *const name, const long size)
 #ifndef EXTERNAL_SORT
 static void internalSortTagFile (void)
 {
-	MIO *fp;
+	MIO *mio;
 
 	/*  Open/Prepare the tag file and place its lines into allocated buffers.
 	 */
 	if (TagsToStdout)
 	{
-		fp = TagFile.fp;
-		mio_seek (fp, 0, SEEK_SET);
+		mio = TagFile.mio;
+		mio_seek (mio, 0, SEEK_SET);
 	}
 	else
 	{
-		fp = mio_new_file (tagFileName (), "r");
-		if (fp == NULL)
-			failedSort (fp, NULL);
+		mio = mio_new_file (tagFileName (), "r");
+		if (mio == NULL)
+			failedSort (mio, NULL);
 	}
 
 	internalSortTags (TagsToStdout,
-			  fp,
+			  mio,
 			  TagFile.numTags.added + TagFile.numTags.prev);
 
 	if (! TagsToStdout)
-		mio_free (fp);
+		mio_free (mio);
 }
 #endif
 
@@ -538,13 +538,13 @@ static void sortTagFile (void)
 		{
 			verbose ("sorting tag file\n");
 #ifdef EXTERNAL_SORT
-			externalSortTags (TagsToStdout, TagFile.fp);
+			externalSortTags (TagsToStdout, TagFile.mio);
 #else
 			internalSortTagFile ();
 #endif
 		}
 		else if (TagsToStdout)
-			catFile (TagFile.fp);
+			catFile (TagFile.mio);
 	}
 }
 
@@ -579,7 +579,7 @@ static void resizeTagFile (const long newSize)
 		fprintf (stderr, "Cannot shorten tag file: errno = %d\n", errno);
 }
 
-static void writeEtagsIncludes (MIO *const fp)
+static void writeEtagsIncludes (MIO *const mio)
 {
 	if (Option.etagsInclude)
 	{
@@ -587,7 +587,7 @@ static void writeEtagsIncludes (MIO *const fp)
 		for (i = 0  ;  i < stringListCount (Option.etagsInclude)  ;  ++i)
 		{
 			vString *item = stringListItem (Option.etagsInclude, i);
-			mio_printf (fp, "\f\n%s,include\n", vStringValue (item));
+			mio_printf (mio, "\f\n%s,include\n", vStringValue (item));
 		}
 	}
 }
@@ -597,15 +597,15 @@ extern void closeTagFile (const boolean resize)
 	long desiredSize, size;
 
 	if (Option.etags)
-		writeEtagsIncludes (TagFile.fp);
-	mio_flush (TagFile.fp);
-	abort_if_ferror (TagFile.fp);
-	desiredSize = mio_tell (TagFile.fp);
-	mio_seek (TagFile.fp, 0L, SEEK_END);
-	size = mio_tell (TagFile.fp);
+		writeEtagsIncludes (TagFile.mio);
+	mio_flush (TagFile.mio);
+	abort_if_ferror (TagFile.mio);
+	desiredSize = mio_tell (TagFile.mio);
+	mio_seek (TagFile.mio, 0L, SEEK_END);
+	size = mio_tell (TagFile.mio);
 	if (! TagsToStdout)
 		/* The tag file should be closed before resizing. */
-		if (mio_free (TagFile.fp) != 0)
+		if (mio_free (TagFile.mio) != 0)
 			error (FATAL | PERROR, "cannot close tag file");
 
 	if (resize  &&  desiredSize < size)
@@ -618,7 +618,7 @@ extern void closeTagFile (const boolean resize)
 	sortTagFile ();
 	if (TagsToStdout)
 	{
-		if (mio_free (TagFile.fp) != 0)
+		if (mio_free (TagFile.mio) != 0)
 			error (FATAL | PERROR, "cannot close tag file");
 		remove (tagFileName ());  /* remove temporary file */
 	}
@@ -1069,7 +1069,7 @@ extern boolean outpuFormatUsedStdoutByDefault (void)
 extern void setupWriter (void)
 {
 	if (preWriteEntry)
-		writerData = preWriteEntry (TagFile.fp);
+		writerData = preWriteEntry (TagFile.mio);
 	else
 		writerData = NULL;
 }
@@ -1077,7 +1077,7 @@ extern void setupWriter (void)
 extern void teardownWriter (const char *filename)
 {
 	if (postWriteEntry)
-		postWriteEntry (TagFile.fp, filename, writerData);
+		postWriteEntry (TagFile.mio, filename, writerData);
 }
 
 static void buildFqTagCache (const tagEntryInfo *const tag)
@@ -1106,13 +1106,13 @@ static void writeTagEntry (const tagEntryInfo *const tag)
 	    && doesInputLanguageRequestAutomaticFQTag ())
 		buildFqTagCache (tag);
 
-	length = (* writeEntry) (TagFile.fp, tag, writerData);
+	length = (* writeEntry) (TagFile.mio, tag, writerData);
 
 	++TagFile.numTags.added;
 	rememberMaxLengths (strlen (tag->name), (size_t) length);
-	DebugStatement ( mio_flush (TagFile.fp); )
+	DebugStatement ( mio_flush (TagFile.mio); )
 
-	abort_if_ferror (TagFile.fp);
+	abort_if_ferror (TagFile.mio);
 }
 
 extern boolean writePseudoTag (const ptagDesc *desc,
@@ -1125,8 +1125,8 @@ extern boolean writePseudoTag (const ptagDesc *desc,
 	if (writePtagEntry == NULL)
 		return FALSE;
 
-	length = (* writePtagEntry) (TagFile.fp, desc, fileName, pattern, parserName, writerData);
-	abort_if_ferror (TagFile.fp);
+	length = (* writePtagEntry) (TagFile.mio, desc, fileName, pattern, parserName, writerData);
+	abort_if_ferror (TagFile.mio);
 
 	++TagFile.numTags.added;
 	rememberMaxLengths (strlen (desc->name), (size_t) length);
@@ -1402,12 +1402,12 @@ extern void invalidatePatternCache(void)
 
 extern void tagFilePosition (MIOPos *p)
 {
-	mio_getpos (TagFile.fp, p);
+	mio_getpos (TagFile.mio, p);
 }
 
 extern void setTagFilePosition (MIOPos *p)
 {
-	mio_setpos (TagFile.fp, p);
+	mio_setpos (TagFile.mio, p);
 }
 
 extern const char* getTagFileDirectory (void)

--- a/main/error.c
+++ b/main/error.c
@@ -27,7 +27,7 @@ extern void setErrorPrinter (errorPrintFunc printer, void *data)
 
 extern boolean stderrDefaultErrorPrinter (const errorSelection selection,
 					  const char *const format,
-					  va_list ap, void *data __unused__)
+					  va_list ap, void *data CTAGS_ATTR_UNUSED)
 {
 	fprintf (stderr, "%s: %s", getExecutableName (),
 		 selected (selection, WARNING) ? "Warning: " : "");

--- a/main/field.c
+++ b/main/field.c
@@ -377,13 +377,13 @@ extern void printFields (int language)
 	}
 }
 
-static const char *renderAsIs (vString* b __unused__, const char *s)
+static const char *renderAsIs (vString* b CTAGS_ATTR_UNUSED, const char *s)
 {
 	return s;
 }
 
 static const char *renderEscapedString (const char *s,
-					const tagEntryInfo *const tag __unused__,
+					const tagEntryInfo *const tag CTAGS_ATTR_UNUSED,
 					vString* b)
 {
 	vStringCatSWithEscaping (b, s);
@@ -421,12 +421,12 @@ static const char *renderEscapedName (const char* s,
 	return renderEscapedString (s, tag, b);
 }
 
-static const char *renderFieldName (const tagEntryInfo *const tag, const char *value __unused__, vString* b)
+static const char *renderFieldName (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	return renderEscapedName (tag->name, tag, b);
 }
 
-static const char *renderFieldInput (const tagEntryInfo *const tag, const char *value __unused__, vString* b)
+static const char *renderFieldInput (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	const char *f = tag->inputFileName;
 
@@ -435,13 +435,13 @@ static const char *renderFieldInput (const tagEntryInfo *const tag, const char *
 	return renderEscapedString (f, tag, b);
 }
 
-static const char *renderFieldSignature (const tagEntryInfo *const tag, const char *value __unused__, vString* b)
+static const char *renderFieldSignature (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	return renderEscapedString (WITH_DEFUALT_VALUE (tag->extensionFields.signature),
 				    tag, b);
 }
 
-static const char *renderFieldScope (const tagEntryInfo *const tag, const char *value __unused__, vString* b)
+static const char *renderFieldScope (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	const char* scope;
 
@@ -449,13 +449,13 @@ static const char *renderFieldScope (const tagEntryInfo *const tag, const char *
 	return scope? renderEscapedName (scope, tag, b): NULL;
 }
 
-static const char *renderFieldInherits (const tagEntryInfo *const tag, const char *value __unused__, vString* b)
+static const char *renderFieldInherits (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	return renderEscapedString (WITH_DEFUALT_VALUE (tag->extensionFields.inheritance),
 				    tag, b);
 }
 
-static const char *renderFieldTyperef (const tagEntryInfo *const tag, const char *value __unused__, vString* b)
+static const char *renderFieldTyperef (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	return renderEscapedName (WITH_DEFUALT_VALUE (tag->extensionFields.typeRef [1]), tag, b);
 }
@@ -516,13 +516,13 @@ static const char* renderCompactInputLine (vString *b,  const char *const line)
 	return vStringValue (b);
 }
 
-static const char *renderFieldKindName (const tagEntryInfo *const tag, const char *value __unused__, vString* b)
+static const char *renderFieldKindName (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	return renderAsIs (b, tag->kind->name);
 }
 
 static const char *renderFieldCompactInputLine (const tagEntryInfo *const tag,
-						const char *value __unused__,
+						const char *value CTAGS_ATTR_UNUSED,
 						 vString* b)
 {
 	const char *line;
@@ -546,7 +546,7 @@ static const char *renderFieldCompactInputLine (const tagEntryInfo *const tag,
 }
 
 static const char *renderFieldLineNumber (const tagEntryInfo *const tag,
-					  const char *value __unused__,
+					  const char *value CTAGS_ATTR_UNUSED,
 					  vString* b)
 {
 	long ln = tag->lineNumber;
@@ -560,7 +560,7 @@ static const char *renderFieldLineNumber (const tagEntryInfo *const tag,
 }
 
 static const char *renderFieldRole (const tagEntryInfo *const tag,
-				    const char *value __unused__,
+				    const char *value CTAGS_ATTR_UNUSED,
 				    vString* b)
 {
 	int rindex = tag->extensionFields.roleIndex;
@@ -579,7 +579,7 @@ static const char *renderFieldRole (const tagEntryInfo *const tag,
 }
 
 static const char *renderFieldLanguage (const tagEntryInfo *const tag,
-					const char *value __unused__,
+					const char *value CTAGS_ATTR_UNUSED,
 					vString* b)
 {
 	const char *l = tag->language;
@@ -598,7 +598,7 @@ static const char *renderFieldAccess (const tagEntryInfo *const tag,
 }
 
 static const char *renderFieldKindLetter (const tagEntryInfo *const tag,
-					  const char *value __unused__,
+					  const char *value CTAGS_ATTR_UNUSED,
 					  vString* b)
 {
 	static char c[2] = { [1] = '\0' };
@@ -609,21 +609,21 @@ static const char *renderFieldKindLetter (const tagEntryInfo *const tag,
 }
 
 static const char *renderFieldImplementation (const tagEntryInfo *const tag,
-					      const char *value __unused__,
+					      const char *value CTAGS_ATTR_UNUSED,
 					      vString* b)
 {
 	return renderAsIs (b, WITH_DEFUALT_VALUE (tag->extensionFields.implementation));
 }
 
 static const char *renderFieldFile (const tagEntryInfo *const tag,
-				    const char *value __unused__,
+				    const char *value CTAGS_ATTR_UNUSED,
 				    vString* b)
 {
 	return renderAsIs (b, tag->isFileScope? "file": "-");
 }
 
 static const char *renderFieldPattern (const tagEntryInfo *const tag,
-				       const char *value __unused__,
+				       const char *value CTAGS_ATTR_UNUSED,
 				       vString* b)
 {
 	char* tmp = makePatternString (tag);
@@ -633,7 +633,7 @@ static const char *renderFieldPattern (const tagEntryInfo *const tag,
 }
 
 static const char *renderFieldRefMarker (const tagEntryInfo *const tag,
-					 const char *value __unused__,
+					 const char *value CTAGS_ATTR_UNUSED,
 					 vString* b)
 {
 	static char c[2] = { [1] = '\0' };
@@ -644,7 +644,7 @@ static const char *renderFieldRefMarker (const tagEntryInfo *const tag,
 }
 
 static const char *renderFieldExtra (const tagEntryInfo *const tag,
-				     const char *value __unused__,
+				     const char *value CTAGS_ATTR_UNUSED,
 				     vString* b)
 {
 	int i;

--- a/main/fmt.c
+++ b/main/fmt.c
@@ -34,7 +34,7 @@ struct sFmtElement {
 	struct sFmtElement *next;
 };
 
-static int printLiteral (fmtSpec* fspec, MIO* fp, const tagEntryInfo * tag __unused__)
+static int printLiteral (fmtSpec* fspec, MIO* fp, const tagEntryInfo * tag CTAGS_ATTR_UNUSED)
 {
 	return mio_puts (fp, fspec->const_str);
 }

--- a/main/gcc-attr.h
+++ b/main/gcc-attr.h
@@ -15,15 +15,15 @@
 /*  Prevent warnings about unused variables in GCC. */
 #if defined (__GNUC__) && !defined (__GNUG__)
 # ifdef __MINGW32__
-#  define __unused__
+#  define CTAGS_ATTR_UNUSED
 # else
-#  define __unused__ __attribute__((unused))
+#  define CTAGS_ATTR_UNUSED __attribute__((unused))
 # endif
-# define __printf__(s,f)  __attribute__((format (printf, s, f)))
+# define CTAGS_ATTR_PRINTF(s,f)  __attribute__((format (printf, s, f)))
 # define attr__noreturn __attribute__((__noreturn__))
 #else
-# define __unused__
-# define __printf__(s,f)
+# define CTAGS_ATTR_UNUSED
+# define CTAGS_ATTR_PRINTF(s,f)
 # define attr__noreturn
 #endif
 

--- a/main/htable.c
+++ b/main/htable.c
@@ -196,7 +196,7 @@ extern void       hashTableForeachItem (hashTable *htable, hashTableForeachFunc 
 		entry_foreach(htable->table[i], proc, user_data);
 }
 
-static void count (void *key __unused__, void *value __unused__, void *data)
+static void count (void *key CTAGS_ATTR_UNUSED, void *value CTAGS_ATTR_UNUSED, void *data)
 {
 	int *c = data;
 	++*c;

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -563,15 +563,15 @@ static void processLanguageRegex (const langType language,
 	else
 	{
 		const char* regexfile = parameter + 1;
-		MIO* const fp = mio_new_file (regexfile, "r");
-		if (fp == NULL)
+		MIO* const mio = mio_new_file (regexfile, "r");
+		if (mio == NULL)
 			error (WARNING | PERROR, "%s", regexfile);
 		else
 		{
 			vString* const regex = vStringNew ();
-			while (readLineRaw (regex, fp))
+			while (readLineRaw (regex, mio))
 				addLanguageRegex (language, vStringValue (regex));
-			mio_free (fp);
+			mio_free (mio);
 			vStringDelete (regex);
 		}
 	}

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -251,13 +251,13 @@ static boolean parseTagRegex (
 }
 
 
-static void pre_ptrn_flag_exclusive_short (char c __unused__, void* data)
+static void pre_ptrn_flag_exclusive_short (char c CTAGS_ATTR_UNUSED, void* data)
 {
 	boolean *exclusive = data;
 	*exclusive = TRUE;
 }
 
-static void pre_ptrn_flag_exclusive_long (const char* const s __unused__, const char* const unused __unused__, void* data)
+static void pre_ptrn_flag_exclusive_long (const char* const s CTAGS_ATTR_UNUSED, const char* const unused CTAGS_ATTR_UNUSED, void* data)
 {
 	pre_ptrn_flag_exclusive_short ('x', data);
 }
@@ -267,7 +267,7 @@ static flagDefinition prePtrnFlagDef[] = {
 	  NULL, "skip testing the other patterns if a line is matched to this pattern"},
 };
 
-static void scope_ptrn_flag_eval (const char* const f  __unused__,
+static void scope_ptrn_flag_eval (const char* const f  CTAGS_ATTR_UNUSED,
 				  const char* const v, void* data)
 {
 	unsigned long *bfields = data;
@@ -286,8 +286,8 @@ static void scope_ptrn_flag_eval (const char* const f  __unused__,
 		error (FATAL, "Unexpected value for scope flag in regex definition: scope=%s", v);
 }
 
-static void placeholder_ptrn_flag_eval (const char* const f  __unused__,
-				     const char* const v  __unused__, void* data)
+static void placeholder_ptrn_flag_eval (const char* const f  CTAGS_ATTR_UNUSED,
+				     const char* const v  CTAGS_ATTR_UNUSED, void* data)
 {
 	unsigned long *bfields = data;
 	*bfields |= SCOPE_PLACEHOLDER;
@@ -442,34 +442,34 @@ static void addCompiledCallbackPattern (const langType language, regex_t* const 
 }
 
 
-static void regex_flag_basic_short (char c __unused__, void* data)
+static void regex_flag_basic_short (char c CTAGS_ATTR_UNUSED, void* data)
 {
 	int* cflags = data;
 	*cflags &= ~REG_EXTENDED;
 }
-static void regex_flag_basic_long (const char* const s __unused__, const char* const unused __unused__, void* data)
+static void regex_flag_basic_long (const char* const s CTAGS_ATTR_UNUSED, const char* const unused CTAGS_ATTR_UNUSED, void* data)
 {
 	regex_flag_basic_short ('b', data);
 }
 
-static void regex_flag_extend_short (char c __unused__, void* data)
+static void regex_flag_extend_short (char c CTAGS_ATTR_UNUSED, void* data)
 {
 	int* cflags = data;
 	*cflags |= REG_EXTENDED;
 }
 
-static void regex_flag_extend_long (const char* const c __unused__, const char* const unused __unused__, void* data)
+static void regex_flag_extend_long (const char* const c CTAGS_ATTR_UNUSED, const char* const unused CTAGS_ATTR_UNUSED, void* data)
 {
 	regex_flag_extend_short('e', data);
 }
 
-static void regex_flag_icase_short (char c __unused__, void* data)
+static void regex_flag_icase_short (char c CTAGS_ATTR_UNUSED, void* data)
 {
 	int* cflags = data;
 	*cflags |= REG_ICASE;
 }
 
-static void regex_flag_icase_long (const char* s __unused__, const char* const unused __unused__, void* data)
+static void regex_flag_icase_long (const char* s CTAGS_ATTR_UNUSED, const char* const unused CTAGS_ATTR_UNUSED, void* data)
 {
 	regex_flag_icase_short ('i', data);
 }
@@ -810,20 +810,20 @@ static regexPattern *addTagRegexInternal (const langType language,
 	return rptr;
 }
 
-extern void addTagRegex (const langType language __unused__,
-			 const char* const regex __unused__,
-			 const char* const name __unused__,
-			 const char* const kinds __unused__,
-			 const char* const flags __unused__,
+extern void addTagRegex (const langType language CTAGS_ATTR_UNUSED,
+			 const char* const regex CTAGS_ATTR_UNUSED,
+			 const char* const name CTAGS_ATTR_UNUSED,
+			 const char* const kinds CTAGS_ATTR_UNUSED,
+			 const char* const flags CTAGS_ATTR_UNUSED,
 			 boolean *disabled)
 {
 	addTagRegexInternal (language, regex, name, kinds, flags, disabled);
 }
 
-extern void addCallbackRegex (const langType language __unused__,
-			      const char* const regex __unused__,
-			      const char* const flags __unused__,
-			      const regexCallback callback __unused__,
+extern void addCallbackRegex (const langType language CTAGS_ATTR_UNUSED,
+			      const char* const regex CTAGS_ATTR_UNUSED,
+			      const char* const flags CTAGS_ATTR_UNUSED,
+			      const regexCallback callback CTAGS_ATTR_UNUSED,
 			      boolean *disabled,
 			      void * userData)
 {
@@ -838,7 +838,7 @@ extern void addCallbackRegex (const langType language __unused__,
 }
 
 extern void addLanguageRegex (
-		const langType language __unused__, const char* const regex __unused__)
+		const langType language CTAGS_ATTR_UNUSED, const char* const regex CTAGS_ATTR_UNUSED)
 {
 	if (regexAvailable)
 	{
@@ -858,7 +858,7 @@ extern void addLanguageRegex (
 */
 
 extern boolean processRegexOption (const char *const option,
-				   const char *const parameter __unused__)
+				   const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	langType language;
 

--- a/main/lxcmd.c
+++ b/main/lxcmd.c
@@ -570,10 +570,10 @@ static boolean printXcmdKind (kindOption *kind, void *user_data)
 }
 #endif
 
-extern void printXcmdKinds (const langType language __unused__,
-			    boolean allKindFields __unused__,
-			    boolean indent __unused__,
-			    boolean tabSeparated __unused__)
+extern void printXcmdKinds (const langType language CTAGS_ATTR_UNUSED,
+			    boolean allKindFields CTAGS_ATTR_UNUSED,
+			    boolean indent CTAGS_ATTR_UNUSED,
+			    boolean tabSeparated CTAGS_ATTR_UNUSED)
 {
 #ifdef HAVE_COPROC
 	if (language <= SetUpper  &&  Sets [language].count > 0)
@@ -657,7 +657,7 @@ extern void addTagXcmd (const langType language, vString* pathvstr, const char* 
 #endif
 }
 extern void addLanguageXcmd (
-	const langType language __unused__, const char* const parameter __unused__)
+	const langType language CTAGS_ATTR_UNUSED, const char* const parameter CTAGS_ATTR_UNUSED)
 {
 #ifdef HAVE_COPROC
 	char *path;

--- a/main/lxpath.c
+++ b/main/lxpath.c
@@ -64,7 +64,7 @@ out:
 	xmlFree (str);
 }
 
-extern void addTagXpath (const langType language __unused__, tagXpathTable *xpathTable)
+extern void addTagXpath (const langType language CTAGS_ATTR_UNUSED, tagXpathTable *xpathTable)
 {
 	Assert (xpathTable->xpath);
 	Assert (!xpathTable->xpathCompiled);
@@ -127,7 +127,7 @@ static void findXMLTagsCore (xmlXPathContext *ctx, xmlNode *root,
 	}
 }
 
-static void suppressWarning (void *ctx __unused__, const char *msg __unused__, ...)
+static void suppressWarning (void *ctx CTAGS_ATTR_UNUSED, const char *msg CTAGS_ATTR_UNUSED, ...)
 {
 }
 

--- a/main/main.c
+++ b/main/main.c
@@ -433,7 +433,7 @@ static void runMainLoop (cookedArgs *args)
 	(* mainLoop) (args, mainData);
 }
 
-static void batchMakeTags (cookedArgs *args, void *user __unused__)
+static void batchMakeTags (cookedArgs *args, void *user CTAGS_ATTR_UNUSED)
 {
 	clock_t timeStamps [3];
 	boolean resize = FALSE;
@@ -542,7 +542,7 @@ static void sanitizeEnviron (void)
  *		Start up code
  */
 
-extern int main (int __unused__ argc, char **argv)
+extern int main (int argc CTAGS_ATTR_UNUSED, char **argv)
 {
 	cookedArgs *args;
 

--- a/main/mio.h
+++ b/main/mio.h
@@ -143,8 +143,8 @@ int mio_ungetc (MIO *mio, int ch);
 int mio_putc (MIO *mio, int c);
 int mio_puts (MIO *mio, const char *s);
 
-int mio_vprintf (MIO *mio, const char *format, va_list ap) __printf__ (2, 0);
-int mio_printf (MIO *mio, const char *format, ...) __printf__ (2, 3);
+int mio_vprintf (MIO *mio, const char *format, va_list ap) CTAGS_ATTR_PRINTF (2, 0);
+int mio_printf (MIO *mio, const char *format, ...) CTAGS_ATTR_PRINTF (2, 3);
 
 void mio_clearerr (MIO *mio);
 int mio_eof (MIO *mio);

--- a/main/options.c
+++ b/main/options.c
@@ -1004,7 +1004,7 @@ extern boolean isIncludeFile (const char *const fileName)
  */
 
  static void processConfigFilenameOption (
-		const char *const option __unused__, const char *const parameter)
+		const char *const option CTAGS_ATTR_UNUSED, const char *const parameter)
  {
 	freeString (&Option.configFilename);
 	Option.configFilename = stringCopy (parameter);
@@ -1026,7 +1026,7 @@ static void processEtagsInclude (
 }
 
 static void processExcludeOption (
-		const char *const option __unused__, const char *const parameter)
+		const char *const option CTAGS_ATTR_UNUSED, const char *const parameter)
 {
 	const char *const fileName = parameter + 1;
 	if (parameter [0] == '\0')
@@ -1251,7 +1251,7 @@ static void processFieldsOption (
 }
 
 static void processFilterTerminatorOption (
-		const char *const option __unused__, const char *const parameter)
+		const char *const option CTAGS_ATTR_UNUSED, const char *const parameter)
 {
 	freeString (&Option.filterTerminator);
 	Option.filterTerminator = stringCopy (parameter);
@@ -1328,8 +1328,8 @@ static void printFeatureList (void)
 }
 
 
-static void processListFeaturesOption(const char *const option __unused__,
-				      const char *const parameter __unused__)
+static void processListFeaturesOption(const char *const option CTAGS_ATTR_UNUSED,
+				      const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	int i;
 
@@ -1341,7 +1341,7 @@ static void processListFeaturesOption(const char *const option __unused__,
 	exit (0);
 }
 
-static void processListFieldsOption(const char *const option __unused__,
+static void processListFieldsOption(const char *const option CTAGS_ATTR_UNUSED,
 				    const char *const parameter)
 {
 	if (parameter [0] == '\0' || strcasecmp (parameter, "all") == 0)
@@ -1385,8 +1385,8 @@ static void printProgramIdentification (void)
 }
 
 static void processHelpOption (
-		const char *const option __unused__,
-		const char *const parameter __unused__)
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	printProgramIdentification ();
 	putchar ('\n');
@@ -1703,8 +1703,8 @@ extern boolean processMapOption (
 }
 
 static void processLicenseOption (
-		const char *const option __unused__,
-		const char *const parameter __unused__)
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	printProgramIdentification ();
 	puts ("");
@@ -1730,7 +1730,7 @@ static void processListAliasesOption (
 }
 
 static void processListExtraOption (
-		const char *const option __unused__, const char *const parameter __unused__)
+		const char *const option CTAGS_ATTR_UNUSED, const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	printXtags ();
 	exit (0);
@@ -1770,7 +1770,7 @@ static void processListKindsOption (
 	exit (0);
 }
 
-static void processListMapsOptionForType (const char *const __unused__ option,
+static void processListMapsOptionForType (const char *const option CTAGS_ATTR_UNUSED,
 					  const char *const  parameter,
 					  langmapType type)
 {
@@ -1800,23 +1800,23 @@ static void processListPatternsOption (const char *const option,
 }
 
 static void processListMapsOption (
-		const char *const __unused__ option,
-		const char *const __unused__ parameter)
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	processListMapsOptionForType (option, parameter, LMAP_ALL);
 }
 
 static void processListLanguagesOption (
-		const char *const option __unused__,
-		const char *const parameter __unused__)
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	printLanguageList ();
 	exit (0);
 }
 
 static void processListPseudoTagsOptions (
-		const char *const option __unused__,
-		const char *const parameter __unused__)
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	int i;
 	for (i = 0; i < PTAG_COUNT; i++)
@@ -1825,14 +1825,14 @@ static void processListPseudoTagsOptions (
 }
 
 static void processListRegexFlagsOptions (
-		const char *const option __unused__,
-		const char *const parameter __unused__)
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	printRegexFlags ();
 	exit (0);
 }
 
-static void processListRolesOptions (const char *const option __unused__,
+static void processListRolesOptions (const char *const option CTAGS_ATTR_UNUSED,
 				     const char *const parameter)
 {
 	const char* sep;
@@ -1999,7 +1999,7 @@ static void processOptionFile (
 		vStringDelete (vpath);
 }
 
-static void processOutputFormat (const char *const option __unused__,
+static void processOutputFormat (const char *const option CTAGS_ATTR_UNUSED,
 				 const char *const parameter)
 {
 	if (parameter [0] == '\0')
@@ -2019,7 +2019,7 @@ static void processOutputFormat (const char *const option __unused__,
 		error (FATAL, "unknown output format name supplied for \"%s=%s\"", option, parameter);
 }
 
-static void processPseudoTags (const char *const option __unused__,
+static void processPseudoTags (const char *const option CTAGS_ATTR_UNUSED,
 			       const char *const parameter)
 {
 	const char *p = parameter;
@@ -2229,7 +2229,7 @@ static void processEchoOption (const char *const option, const char *const param
 	notice ("%s", parameter);
 }
 
-static void processForceQuitOption (const char *const option __unused__,
+static void processForceQuitOption (const char *const option CTAGS_ATTR_UNUSED,
 				    const char *const parameter)
 {
 	int s;
@@ -2239,14 +2239,14 @@ static void processForceQuitOption (const char *const option __unused__,
 }
 
 static void processVersionOption (
-		const char *const option __unused__,
-		const char *const parameter __unused__)
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	printProgramIdentification ();
 	exit (0);
 }
 
-static void processXformatOption (const char *const option __unused__,
+static void processXformatOption (const char *const option CTAGS_ATTR_UNUSED,
 				  const char *const parameter)
 {
 	if (Option.customXfmt)

--- a/main/options.h
+++ b/main/options.h
@@ -127,8 +127,8 @@ extern CONST_OPTION optionValues		Option;
 /*
 *   FUNCTION PROTOTYPES
 */
-extern void notice (const char *const format, ...) __printf__ (1, 2);
-extern void verbose (const char *const format, ...) __printf__ (1, 2);
+extern void notice (const char *const format, ...) CTAGS_ATTR_PRINTF (1, 2);
+extern void verbose (const char *const format, ...) CTAGS_ATTR_PRINTF (1, 2);
 #define BEGIN_VERBOSE(VFP) do { if (Option.verbose) { \
                                 FILE* VFP = stderr
 #define END_VERBOSE()      } } while (0)

--- a/main/output-ctags.c
+++ b/main/output-ctags.c
@@ -168,7 +168,7 @@ static int writePatternEntry (MIO *mio, const tagEntryInfo *const tag)
 	return makePatternStringCommon (tag, file_putc, file_puts, mio);
 }
 
-extern int writeCtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)
+extern int writeCtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data CTAGS_ATTR_UNUSED)
 {
 	int length = mio_printf (mio, "%s\t%s\t",
 			      escapeFieldValue (tag, FIELD_NAME),
@@ -195,7 +195,7 @@ extern int writeCtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data
 extern int writeCtagsPtagEntry (MIO * mio, const ptagDesc *desc,
 				const char *const fileName,
 				const char *const pattern,
-				const char *const parserName, void *data __unused__)
+				const char *const parserName, void *data CTAGS_ATTR_UNUSED)
 {
 	return parserName
 

--- a/main/output-json.c
+++ b/main/output-json.c
@@ -95,7 +95,7 @@ static void addExtensionFields (json_t *response, const tagEntryInfo *const tag)
 		renderExtensionFieldMaybe (k, tag, response);
 }
 
-extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)
+extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data CTAGS_ATTR_UNUSED)
 {
 	json_t *response = json_pack ("{ss ss ss ss}",
 		"_type", "tag",
@@ -123,7 +123,7 @@ extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data 
 extern int writeJsonPtagEntry (MIO * mio, const ptagDesc *desc,
 			       const char *const fileName,
 			       const char *const pattern,
-			       const char *const parserName, void *data __unused__)
+			       const char *const parserName, void *data CTAGS_ATTR_UNUSED)
 {
 #define OPT(X) ((X)?(X):"")
 	json_t *response;
@@ -155,7 +155,7 @@ extern int writeJsonPtagEntry (MIO * mio, const ptagDesc *desc,
 #undef OPT
 }
 
-extern boolean ptagMakeJsonOutputVersion (ptagDesc *desc, void *data __unused__)
+extern boolean ptagMakeJsonOutputVersion (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED)
 {
 	return writePseudoTag (desc,
 			       "0.0",
@@ -164,19 +164,19 @@ extern boolean ptagMakeJsonOutputVersion (ptagDesc *desc, void *data __unused__)
 }
 
 #else /* HAVE_JANSSON */
-extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)
+extern int writeJsonEntry (MIO * mio, const tagEntryInfo *const tag, void *data CTAGS_ATTR_UNUSED)
 {
 	return 0;
 }
 extern int writeJsonPtagEntry (MIO * mio, const ptagDesc *desc,
 			       const char *const fileName,
 			       const char *const pattern,
-			       const char *const parserName, void *data __unused__)
+			       const char *const parserName, void *data CTAGS_ATTR_UNUSED)
 {
 	return 0;
 }
 
-extern boolean ptagMakeJsonOutputVersion (ptagDesc *desc, void *data __unused__)
+extern boolean ptagMakeJsonOutputVersion (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED)
 {
 	return FALSE;
 }

--- a/main/output-xref.c
+++ b/main/output-xref.c
@@ -14,7 +14,7 @@
 #include "mio.h"
 #include "options.h"
 
-extern int writeXrefEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__)
+extern int writeXrefEntry (MIO * mio, const tagEntryInfo *const tag, void *data CTAGS_ATTR_UNUSED)
 {
 	int length;
 	static fmtElement *fmt1;

--- a/main/output.h
+++ b/main/output.h
@@ -36,18 +36,18 @@ extern int writeEtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data
 extern void *beginEtagsFile (MIO * mio);
 extern void  endEtagsFile   (MIO * mio, const char* filename, void *data);
 
-extern int writeCtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data __unused__);
-extern int writeXrefEntry  (MIO * mio, const tagEntryInfo *const tag, void *data __unused__);
-extern int writeJsonEntry  (MIO * mio, const tagEntryInfo *const tag, void *data __unused__);
+extern int writeCtagsEntry (MIO * mio, const tagEntryInfo *const tag, void *data CTAGS_ATTR_UNUSED);
+extern int writeXrefEntry  (MIO * mio, const tagEntryInfo *const tag, void *data CTAGS_ATTR_UNUSED);
+extern int writeJsonEntry  (MIO * mio, const tagEntryInfo *const tag, void *data CTAGS_ATTR_UNUSED);
 
 extern int writeCtagsPtagEntry (MIO * mio, const ptagDesc *desc,
 				const char *const fileName,
 				const char *const pattern,
-				const char *const parserName, void *data __unused__);
+				const char *const parserName, void *data CTAGS_ATTR_UNUSED);
 extern int writeJsonPtagEntry (MIO * mio, const ptagDesc *desc,
 				const char *const fileName,
 				const char *const pattern,
-				const char *const parserName, void *data __unused__);
+				const char *const parserName, void *data CTAGS_ATTR_UNUSED);
 
 extern int makePatternStringCommon (const tagEntryInfo *const tag,
 				    int putc_func (char , void *),
@@ -57,6 +57,6 @@ extern void truncateTagLine (char *const line, const char *const token,
 			     const boolean discardNewline);
 extern void abort_if_ferror(MIO *const fp);
 
-extern boolean ptagMakeJsonOutputVersion (ptagDesc *desc, void *data __unused__);
+extern boolean ptagMakeJsonOutputVersion (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED);
 
 #endif 

--- a/main/parse.c
+++ b/main/parse.c
@@ -340,7 +340,7 @@ found:
 	return result;
 }
 
-static parserCandidate* parserCandidateNew(unsigned int count __unused__)
+static parserCandidate* parserCandidateNew(unsigned int count CTAGS_ATTR_UNUSED)
 {
 	parserCandidate* candidates;
 	unsigned int i;
@@ -1568,7 +1568,7 @@ static flagDefinition LangDefFlagDef [] = {
 };
 
 extern void processLanguageDefineOption (
-		const char *const option, const char *const parameter __unused__)
+		const char *const option, const char *const parameter CTAGS_ATTR_UNUSED)
 {
 	if (parameter [0] == '\0')
 		error (WARNING, "No language specified for \"%s\" option", option);

--- a/main/ptag.c
+++ b/main/ptag.c
@@ -29,7 +29,7 @@ static boolean writePseudoTagForXcmdData (ptagDesc *desc,
 			       pdata->fileName,  pdata->pattern, pdata->language);
 }
 
-static boolean ptagMakeFormat (ptagDesc *desc, void *data __unused__)
+static boolean ptagMakeFormat (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED)
 {
 	char format [11];
 	const char *formatComment = "unknown format";
@@ -43,7 +43,7 @@ static boolean ptagMakeFormat (ptagDesc *desc, void *data __unused__)
 	return writePseudoTag (desc, format, formatComment, NULL);
 }
 
-static boolean ptagMakeHowSorted (ptagDesc *desc, void *data __unused__)
+static boolean ptagMakeHowSorted (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED)
 {
 	return writePseudoTag (desc,
 			       Option.sorted == SO_FOLDSORTED ? "2" :
@@ -85,14 +85,14 @@ static boolean ptagMakeProgURL (ptagDesc *desc, void *data)
 				       PROGRAM_URL, "official site", NULL);
 }
 
-static boolean ptagMakeProgVersion (ptagDesc *desc, void *data __unused__)
+static boolean ptagMakeProgVersion (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED)
 {
 	const char* repoinfo = ctags_repoinfo? ctags_repoinfo: "";
 	return writePseudoTag (desc, PROGRAM_VERSION, repoinfo, NULL);
 }
 
 #ifdef HAVE_ICONV
-static boolean ptagMakeFileEncoding (ptagDesc *desc, void *data __unused__)
+static boolean ptagMakeFileEncoding (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED)
 {
 	if (! Option.outputEncoding)
 		return FALSE;

--- a/main/read.c
+++ b/main/read.c
@@ -759,7 +759,7 @@ static vString *iFileGetLine (void)
 	return result;
 }
 
-/*  Do not mix use of fileReadLine () and getcFromInputFile () for the same file.
+/*  Do not mix use of readLineFromInputFile () and getcFromInputFile () for the same file.
  */
 extern int getcFromInputFile (void)
 {
@@ -820,7 +820,7 @@ extern int skipToCharacterInInputFile (int c)
 	return d;
 }
 
-/*  An alternative interface to getcFromInputFile (). Do not mix use of fileReadLine()
+/*  An alternative interface to getcFromInputFile (). Do not mix use of readLineFromInputFile()
  *  and getcFromInputFile() for the same file. The returned string does not contain
  *  the terminating newline. A NULL return value means that all lines in the
  *  file have been read and we are at the end of file.

--- a/main/read.c
+++ b/main/read.c
@@ -82,7 +82,7 @@ typedef struct sInputFile {
 	vString    *path;          /* path of input file (if any) */
 	vString    *line;          /* last line read from file */
 	const unsigned char* currentLine;  /* current line being worked on */
-	MIO        *fp;            /* stream used for reading the file */
+	MIO        *mio;           /* MIO stream used for reading the file */
 	MIOPos      filePosition;  /* file position of current line */
 	unsigned int ungetchIdx;
 	int         ungetchBuf[3]; /* characters that were ungotten */
@@ -237,7 +237,7 @@ extern void freeInputFileResources (void)
 
 extern const unsigned char *getInputFileData (size_t *size)
 {
-	return mio_memory_get_data (File.fp, size);
+	return mio_memory_get_data (File.mio, size);
 }
 
 /*
@@ -394,7 +394,7 @@ static int skipWhite (void)
 {
 	int c;
 	do
-		c = mio_getc (File.fp);
+		c = mio_getc (File.mio);
 	while (c == ' '  ||  c == '\t');
 	return c;
 }
@@ -406,9 +406,9 @@ static unsigned long readLineNumber (void)
 	while (c != EOF  &&  isdigit (c))
 	{
 		lNum = (lNum * 10) + (c - '0');
-		c = mio_getc (File.fp);
+		c = mio_getc (File.mio);
 	}
-	mio_ungetc (File.fp, c);
+	mio_ungetc (File.mio, c);
 	if (c != ' '  &&  c != '\t')
 		lNum = 0;
 
@@ -431,17 +431,17 @@ static vString *readFileName (void)
 
 	if (c == '"')
 	{
-		c = mio_getc (File.fp);  /* skip double-quote */
+		c = mio_getc (File.mio);  /* skip double-quote */
 		quoteDelimited = TRUE;
 	}
 	while (c != EOF  &&  c != '\n'  &&
 			(quoteDelimited ? (c != '"') : (c != ' '  &&  c != '\t')))
 	{
 		vStringPut (fileName, c);
-		c = mio_getc (File.fp);
+		c = mio_getc (File.mio);
 	}
 	if (c == '\n')
-		mio_ungetc (File.fp, c);
+		mio_ungetc (File.mio, c);
 	vStringPut (fileName, '\0');
 
 	return fileName;
@@ -455,13 +455,13 @@ static boolean parseLineDirective (void)
 
 	if (isdigit (c))
 	{
-		mio_ungetc (File.fp, c);
+		mio_ungetc (File.mio, c);
 		result = TRUE;
 	}
-	else if (c == 'l'  &&  mio_getc (File.fp) == 'i'  &&
-			 mio_getc (File.fp) == 'n'  &&  mio_getc (File.fp) == 'e')
+	else if (c == 'l'  &&  mio_getc (File.mio) == 'i'  &&
+			 mio_getc (File.mio) == 'n'  &&  mio_getc (File.mio) == 'e')
 	{
-		c = mio_getc (File.fp);
+		c = mio_getc (File.mio);
 		if (c == ' '  ||  c == '\t')
 		{
 			DebugStatement ( lineStr = "line"; )
@@ -538,7 +538,7 @@ extern MIO *getMio (const char *const fileName, const char *const openMode,
 }
 
 /*  This function opens an input file, and resets the line counter.  If it
- *  fails, it will display an error message and leave the File.fp set to NULL.
+ *  fails, it will display an error message and leave the File.mio set to NULL.
  */
 extern boolean openInputFile (const char *const fileName, const langType language,
 			      MIO *mio)
@@ -549,10 +549,10 @@ extern boolean openInputFile (const char *const fileName, const langType languag
 
 	/*	If another file was already open, then close it.
 	 */
-	if (File.fp != NULL)
+	if (File.mio != NULL)
 	{
-		mio_free (File.fp);  /* close any open input file */
-		File.fp = NULL;
+		mio_free (File.mio);  /* close any open input file */
+		File.mio = NULL;
 	}
 
 	/* File position is used as key for checking the availability of
@@ -575,17 +575,17 @@ extern boolean openInputFile (const char *const fileName, const langType languag
 			mio_rewind (mio);
 	}
 
-	File.fp = mio? mio_ref (mio): getMio (fileName, openMode, memStreamRequired);
+	File.mio = mio? mio_ref (mio): getMio (fileName, openMode, memStreamRequired);
 
-	if (File.fp == NULL)
+	if (File.mio == NULL)
 		error (WARNING | PERROR, "cannot open \"%s\"", fileName);
 	else
 	{
 		opened = TRUE;
 
 		setOwnerDirectoryOfInputFile (fileName);
-		mio_getpos (File.fp, &StartOfLine);
-		mio_getpos (File.fp, &File.filePosition);
+		mio_getpos (File.mio, &StartOfLine);
+		mio_getpos (File.mio, &File.filePosition);
 		File.currentLine  = NULL;
 		File.eof          = FALSE;
 		File.newLine      = TRUE;
@@ -610,11 +610,11 @@ extern boolean openInputFile (const char *const fileName, const langType languag
 
 extern void resetInputFile (const langType language)
 {
-	Assert (File.fp);
+	Assert (File.mio);
 
-	mio_rewind (File.fp);
-	mio_getpos (File.fp, &StartOfLine);
-	mio_getpos (File.fp, &File.filePosition);
+	mio_rewind (File.mio);
+	mio_getpos (File.mio, &StartOfLine);
+	mio_getpos (File.mio, &File.filePosition);
 	File.currentLine  = NULL;
 	File.eof          = FALSE;
 	File.newLine      = TRUE;
@@ -630,7 +630,7 @@ extern void resetInputFile (const langType language)
 
 extern void closeInputFile (void)
 {
-	if (File.fp != NULL)
+	if (File.mio != NULL)
 	{
 		clearLangOnStack (& (File.input.langInfo));
 
@@ -642,15 +642,15 @@ extern void closeInputFile (void)
 			fileStatus *status = eStat (vStringValue (File.input.name));
 			addTotals (0, File.input.lineNumber - 1L, status->size);
 		}
-		mio_free (File.fp);
-		File.fp = NULL;
+		mio_free (File.mio);
+		File.mio = NULL;
 		freeLineFposMap (&File.lineFposMap);
 	}
 }
 
 extern void *getInputFileUserData(void)
 {
-	return mio_get_user_data (File.fp);
+	return mio_get_user_data (File.mio);
 }
 
 /*  Action to take for each encountered input newline.
@@ -659,7 +659,7 @@ static void fileNewline (void)
 {
 	File.filePosition = StartOfLine;
 
-	if (BackupFile.fp == NULL)
+	if (BackupFile.mio == NULL)
 		appendLineFposMap (&File.lineFposMap, File.filePosition);
 
 	File.newLine = FALSE;
@@ -676,7 +676,7 @@ static int iFileGetc (void)
 {
 	int	c;
 readnext:
-	c = mio_getc (File.fp);
+	c = mio_getc (File.mio);
 
 	/*	If previous character was a newline, then we're starting a line.
 	 */
@@ -689,8 +689,8 @@ readnext:
 				goto readnext;
 			else
 			{
-				mio_setpos (File.fp, &StartOfLine);
-				c = mio_getc (File.fp);
+				mio_setpos (File.mio, &StartOfLine);
+				c = mio_getc (File.mio);
 			}
 		}
 	}
@@ -700,7 +700,7 @@ readnext:
 	else if (c == NEWLINE)
 	{
 		File.newLine = TRUE;
-		mio_getpos (File.fp, &StartOfLine);
+		mio_getpos (File.mio, &StartOfLine);
 	}
 	else if (c == CRETURN)
 	{
@@ -709,15 +709,15 @@ readnext:
 		 * and CR-LF (MS-DOS) are converted into a generic newline.
 		 */
 #ifndef macintosh
-		const int next = mio_getc (File.fp);  /* is CR followed by LF? */
+		const int next = mio_getc (File.mio);  /* is CR followed by LF? */
 		if (next != NEWLINE)
-			mio_ungetc (File.fp, next);
+			mio_ungetc (File.mio, next);
 		else
 #endif
 		{
 			c = NEWLINE;  /* convert CR into newline */
 			File.newLine = TRUE;
-			mio_getpos (File.fp, &StartOfLine);
+			mio_getpos (File.mio, &StartOfLine);
 		}
 	}
 	DebugStatement ( debugPutc (DEBUG_RAW, c); )
@@ -841,12 +841,12 @@ extern const unsigned char *readLineFromInputFile (void)
 /*
  *   Raw file line reading with automatic buffer sizing
  */
-extern char *readLineRaw (vString *const vLine, MIO *const fp)
+extern char *readLineRaw (vString *const vLine, MIO *const mio)
 {
 	char *result = NULL;
 
 	vStringClear (vLine);
-	if (fp == NULL)  /* to free memory allocated to buffer */
+	if (mio == NULL)  /* to free memory allocated to buffer */
 		error (FATAL, "NULL file pointer");
 	else
 	{
@@ -862,13 +862,13 @@ extern char *readLineRaw (vString *const vLine, MIO *const fp)
 			char *const pLastChar = vStringValue (vLine) + vStringSize (vLine) -2;
 			long startOfLine;
 
-			startOfLine = mio_tell(fp);
+			startOfLine = mio_tell(mio);
 			reReadLine = FALSE;
 			*pLastChar = '\0';
-			result = mio_gets (fp, vStringValue (vLine), (int) vStringSize (vLine));
+			result = mio_gets (mio, vStringValue (vLine), (int) vStringSize (vLine));
 			if (result == NULL)
 			{
-				if (! mio_eof (fp))
+				if (! mio_eof (mio))
 					error (FATAL | PERROR, "Failure on attempt to read file");
 			}
 			else if (*pLastChar != '\0'  &&
@@ -877,14 +877,14 @@ extern char *readLineRaw (vString *const vLine, MIO *const fp)
 				/*  buffer overflow */
 				reReadLine = vStringAutoResize (vLine);
 				if (reReadLine)
-					mio_seek (fp, startOfLine, SEEK_SET);
+					mio_seek (mio, startOfLine, SEEK_SET);
 				else
 					error (FATAL | PERROR, "input line too big; out of memory");
 			}
 			else
 			{
 				char* eol;
-				vStringLength(vLine) = mio_tell(fp) - startOfLine;
+				vStringLength(vLine) = mio_tell(mio) - startOfLine;
 				/* canonicalize new line */
 				eol = vStringValue (vLine) + vStringLength (vLine) - 1;
 				if (*eol == '\r')
@@ -915,12 +915,12 @@ extern char *readLineFromBypass (
 	MIOPos orignalPosition;
 	char *result;
 
-	mio_getpos (File.fp, &orignalPosition);
-	mio_setpos (File.fp, &location);
+	mio_getpos (File.mio, &orignalPosition);
+	mio_setpos (File.mio, &location);
 	if (pSeekValue != NULL)
-		*pSeekValue = mio_tell (File.fp);
-	result = readLineRaw (vLine, File.fp);
-	mio_setpos (File.fp, &orignalPosition);
+		*pSeekValue = mio_tell (File.mio);
+	result = readLineRaw (vLine, File.mio);
+	mio_setpos (File.mio, &orignalPosition);
 	/* If the file is empty, we can't get the line
 	   for location 0. readLineFromBypass doesn't know
 	   what itself should do; just report it to the caller. */
@@ -979,14 +979,14 @@ extern char *readLineFromBypassSlow (vString *const vLine,
 	{
 		unsigned long n;
 
-		mio_getpos (File.fp, &originalPosition);
-		mio_rewind (File.fp);
+		mio_getpos (File.mio, &originalPosition);
+		mio_rewind (File.mio);
 		line = NULL;
 		pos = 0;
 		for (n = 0; n < lineNumber; n++)
 		{
-			pos = mio_tell (File.fp);
-			line = readLineRaw (vLine, File.fp);
+			pos = mio_tell (File.mio);
+			line = readLineRaw (vLine, File.mio);
 			if (line == NULL)
 				break;
 		}
@@ -1023,7 +1023,7 @@ extern char *readLineFromBypassSlow (vString *const vLine,
 
 out:
 	regfree (&patbuf);
-	mio_setpos (File.fp, &originalPosition);
+	mio_setpos (File.mio, &originalPosition);
 	return result;
 }
 
@@ -1081,23 +1081,23 @@ extern void   pushNarrowedInputStream (const langType language,
 	original = getInputFilePosition ();
 
 	tmp = getInputFilePositionForLine (startLine);
-	mio_setpos (File.fp, &tmp);
-	mio_seek (File.fp, startCharOffset, SEEK_CUR);
-	p = mio_tell (File.fp);
+	mio_setpos (File.mio, &tmp);
+	mio_seek (File.mio, startCharOffset, SEEK_CUR);
+	p = mio_tell (File.mio);
 
 	tmp = getInputFilePositionForLine (endLine);
-	mio_setpos (File.fp, &tmp);
-	mio_seek (File.fp, endCharOffset, SEEK_CUR);
-	q = mio_tell (File.fp);
+	mio_setpos (File.mio, &tmp);
+	mio_seek (File.mio, endCharOffset, SEEK_CUR);
+	q = mio_tell (File.mio);
 
-	mio_setpos (File.fp, &original);
+	mio_setpos (File.mio, &original);
 
-	subio = mio_new_mio (File.fp, p, q - p);
+	subio = mio_new_mio (File.mio, p, q - p);
 
 
 	BackupFile = File;
 
-	File.fp = subio;
+	File.mio = subio;
 	File.nestedInputStreamInfo.startLine = startLine;
 	File.nestedInputStreamInfo.startCharOffset = startCharOffset;
 	File.nestedInputStreamInfo.endLine = endLine;
@@ -1130,7 +1130,7 @@ extern unsigned int getNestedInputBoundaryInfo (unsigned long lineNumber)
 }
 extern void   popNarrowedInputStream  (void)
 {
-	mio_free (File.fp);
+	mio_free (File.mio);
 	File = BackupFile;
 	memset (&BackupFile, 0, sizeof (BackupFile));
 }

--- a/main/read.h
+++ b/main/read.h
@@ -99,7 +99,7 @@ extern const char *getSourceLanguageName (void);
 extern unsigned long getSourceLineNumber (void);
 
 /* Raw: reading from given a parameter, fp */
-extern char *readLineRaw           (vString *const vLine, MIO *const fp);
+extern char *readLineRaw           (vString *const vLine, MIO *const mio);
 extern char* readLineRawWithNoSeek (vString *const vline, FILE *const pp);
 
 /* Bypass: reading from fp in inputFile WITHOUT updating fields in input fields */

--- a/main/routines.c
+++ b/main/routines.c
@@ -686,15 +686,15 @@ extern char *combinePathAndFile (
  */
 static char* concat (const char *s1, const char *s2, const char *s3)
 {
-  int len1 = strlen (s1), len2 = strlen (s2), len3 = strlen (s3);
-  char *result = xMalloc (len1 + len2 + len3 + 1, char);
+	int len1 = strlen (s1), len2 = strlen (s2), len3 = strlen (s3);
+	char *result = xMalloc (len1 + len2 + len3 + 1, char);
 
-  strcpy (result, s1);
-  strcpy (result + len1, s2);
-  strcpy (result + len1 + len2, s3);
-  result [len1 + len2 + len3] = '\0';
+	strcpy (result, s1);
+	strcpy (result + len1, s2);
+	strcpy (result + len1 + len2, s3);
+	result [len1 + len2 + len3] = '\0';
 
-  return result;
+	return result;
 }
 
 /* Return a newly allocated string containing the absolute file name of FILE

--- a/main/routines.c
+++ b/main/routines.c
@@ -524,7 +524,7 @@ static boolean isPathSeparator (const int c)
 
 #if ! defined (HAVE_STAT_ST_INO)
 
-static void canonicalizePath (char *const path __unused__)
+static void canonicalizePath (char *const path CTAGS_ATTR_UNUSED)
 {
 # if defined (MSDOS_STYLE_PATH)
 	char *p;

--- a/main/routines.h
+++ b/main/routines.h
@@ -94,7 +94,7 @@ extern void freeRoutineResources (void);
 extern void setExecutableName (const char *const path);
 extern const char *getExecutableName (void);
 extern const char *getExecutablePath (void);
-extern void error (const errorSelection selection, const char *const format, ...) __printf__ (2, 3);
+extern void error (const errorSelection selection, const char *const format, ...) CTAGS_ATTR_PRINTF (2, 3);
 
 /* Memory allocation functions */
 #ifdef NEED_PROTO_MALLOC

--- a/main/selectors.c
+++ b/main/selectors.c
@@ -53,7 +53,7 @@ static const char *selectByLines (MIO *input,
 
 /* Returns "Perl" or "Perl6" or NULL if it does not taste like anything */
 static const char *
-tastePerlLine (const char *line, void *data __unused__)
+tastePerlLine (const char *line, void *data CTAGS_ATTR_UNUSED)
 {
     while (isspace(*line))
         ++line;
@@ -126,7 +126,7 @@ selectByPickingPerlVersion (MIO *input)
 }
 
 static const char *
-tasteObjectiveCOrMatLabLines (const char *line, void *data __unused__)
+tasteObjectiveCOrMatLabLines (const char *line, void *data CTAGS_ATTR_UNUSED)
 {
     if (startsWith (line, "% ")
 	|| startsWith (line, "%{"))
@@ -167,7 +167,7 @@ selectByObjectiveCAndMatLabKeywords (MIO * input)
 }
 
 static const char *
-tasteObjectiveC (const char *line, void *data __unused__)
+tasteObjectiveC (const char *line, void *data CTAGS_ATTR_UNUSED)
 {
     if (startsWith (line, "#import")
 	|| startsWith (line, "@interface ")
@@ -205,7 +205,7 @@ selectByObjectiveCKeywords (MIO * input)
 }
 
 static const char *
-tasteR (const char *line, void *data __unused__)
+tasteR (const char *line, void *data CTAGS_ATTR_UNUSED)
 {
 	/* As far as reading test cases in GNU assembler,
 	   assembly language for d10v and d30v processors
@@ -296,7 +296,7 @@ selectByRexxCommentAndDosbatchLabelPrefix (MIO *input)
 #include <libxml/xpath.h>
 #include <libxml/tree.h>
 
-static void suppressWarning (void *ctx __unused__, const char *msg __unused__, ...)
+static void suppressWarning (void *ctx CTAGS_ATTR_UNUSED, const char *msg CTAGS_ATTR_UNUSED, ...)
 {
 }
 

--- a/main/sort.c
+++ b/main/sort.c
@@ -35,13 +35,13 @@
 *   FUNCTION DEFINITIONS
 */
 
-extern void catFile (MIO *fp)
+extern void catFile (MIO *mio)
 {
-	if (fp != NULL)
+	if (mio != NULL)
 	{
 		int c;
-		mio_seek (fp, 0, SEEK_SET);
-		while ((c = mio_getc (fp)) != EOF)
+		mio_seek (mio, 0, SEEK_SET);
+		while ((c = mio_getc (mio)) != EOF)
 			putchar (c);
 		fflush (stdout);
 	}
@@ -127,11 +127,11 @@ extern void externalSortTags (const boolean toStdout, MIO *tagFile)
  *  so have lots of memory if you have large tag files.
  */
 
-extern void failedSort (MIO *const fp, const char* msg)
+extern void failedSort (MIO *const mio, const char* msg)
 {
 	const char* const cannotSort = "cannot sort tag file";
-	if (fp != NULL)
-		mio_free (fp);
+	if (mio != NULL)
+		mio_free (mio);
 	if (msg == NULL)
 		error (FATAL | PERROR, "%s", cannotSort);
 	else
@@ -157,18 +157,18 @@ static int compareTags (const void *const one, const void *const two)
 static void writeSortedTags (
 		char **const table, const size_t numTags, const boolean toStdout)
 {
-	MIO *fp;
+	MIO *mio;
 	size_t i;
 
 	/*  Write the sorted lines back into the tag file.
 	 */
 	if (toStdout)
-		fp = mio_new_fp (stdout, NULL);
+		mio = mio_new_fp (stdout, NULL);
 	else
 	{
-		fp = mio_new_file (tagFileName (), "w");
-		if (fp == NULL)
-			failedSort (fp, NULL);
+		mio = mio_new_file (tagFileName (), "w");
+		if (mio == NULL)
+			failedSort (mio, NULL);
 	}
 	for (i = 0 ; i < numTags ; ++i)
 	{
@@ -176,15 +176,15 @@ static void writeSortedTags (
 		 *  pattern) if this is not an xref file.
 		 */
 		if (i == 0  ||  Option.xref  ||  strcmp (table [i], table [i-1]) != 0)
-			if (mio_puts (fp, table [i]) == EOF)
-				failedSort (fp, NULL);
+			if (mio_puts (mio, table [i]) == EOF)
+				failedSort (mio, NULL);
 	}
 	if (toStdout)
-		mio_flush (fp);
-	mio_free (fp);
+		mio_flush (mio);
+	mio_free (mio);
 }
 
-extern void internalSortTags (const boolean toStdout, MIO* fp, size_t numTags)
+extern void internalSortTags (const boolean toStdout, MIO* mio, size_t numTags)
 {
 	vString *vLine = vStringNew ();
 	const char *line;
@@ -200,15 +200,15 @@ extern void internalSortTags (const boolean toStdout, MIO* fp, size_t numTags)
 
 	cmpFunc = Option.sorted == SO_FOLDSORTED ? compareTagsFolded : compareTags;
 	if (table == NULL)
-		failedSort (fp, "out of memory");
+		failedSort (mio, "out of memory");
 
-	for (i = 0  ;  i < numTags  &&  ! mio_eof (fp)  ;  )
+	for (i = 0  ;  i < numTags  &&  ! mio_eof (mio)  ;  )
 	{
-		line = readLineRaw (vLine, fp);
+		line = readLineRaw (vLine, mio);
 		if (line == NULL)
 		{
-			if (! mio_eof (fp))
-				failedSort (fp, NULL);
+			if (! mio_eof (mio))
+				failedSort (mio, NULL);
 			break;
 		}
 		else if (*line == '\0'  ||  strcmp (line, "\n") == 0)
@@ -219,7 +219,7 @@ extern void internalSortTags (const boolean toStdout, MIO* fp, size_t numTags)
 
 			table [i] = (char *) malloc (stringSize);
 			if (table [i] == NULL)
-				failedSort (fp, "out of memory");
+				failedSort (mio, "out of memory");
 			DebugStatement ( mallocSize += stringSize; )
 			strcpy (table [i], line);
 			++i;

--- a/main/sort.h
+++ b/main/sort.h
@@ -21,17 +21,17 @@
 /*
 *   FUNCTION PROTOTYPES
 */
-extern void catFile (MIO *fp);
+extern void catFile (MIO *mio);
 
 #ifdef EXTERNAL_SORT
 extern void externalSortTags (const boolean toStdout, MIO *tagFile);
 #else
 extern void internalSortTags (const boolean toStdout,
-			      MIO *fp,
+			      MIO *mio,
 			      size_t numTags);
 #endif
 
-/* fp is closed in this function. */
-extern void failedSort (MIO *const fp, const char* msg);
+/* mio is closed in this function. */
+extern void failedSort (MIO *const mio, const char* msg);
 
 #endif  /* CTAGS_MAIN_SORT_H */

--- a/main/strlist.c
+++ b/main/strlist.c
@@ -88,14 +88,14 @@ extern stringList* stringListNewFromArgv (const char* const* const argv)
 extern stringList* stringListNewFromFile (const char* const fileName)
 {
 	stringList* result = NULL;
-	MIO* const fp = mio_new_file (fileName, "r");
-	if (fp != NULL)
+	MIO* const mio = mio_new_file (fileName, "r");
+	if (mio != NULL)
 	{
 		result = stringListNew ();
-		while (! mio_eof (fp))
+		while (! mio_eof (mio))
 		{
 			vString* const str = vStringNew ();
-			readLineRaw (str, fp);
+			readLineRaw (str, mio);
 			vStringStripTrailing (str);
 			if (vStringLength (str) > 0)
 				stringListAdd (result, str);

--- a/main/xtag.c
+++ b/main/xtag.c
@@ -20,7 +20,7 @@
 #include <string.h>
 
 
-static boolean isPseudoTagsEnabled (xtagDesc *pdesc __unused__)
+static boolean isPseudoTagsEnabled (xtagDesc *pdesc CTAGS_ATTR_UNUSED)
 {
 	return ! isDestinationStdout ();
 }

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -259,7 +259,7 @@ EOF
 
 sub emit_initializer {
     my $opts = shift;
-    my $may_unused = (@{$opts->{'xcmds'}} || @{$opts->{'disabledKinds'}}) ? "": " __unused__";
+    my $may_unused = (@{$opts->{'xcmds'}} || @{$opts->{'disabledKinds'}}) ? "": " CTAGS_ATTR_UNUSED";
 
     print <<EOF;
 static void initialize$opts->{'Clangdef'}Parser (const langType language$may_unused)

--- a/optlib/ctags-optlib.c
+++ b/optlib/ctags-optlib.c
@@ -6,7 +6,7 @@
 #include "routines.h"
 
 
-static void initializeCtagsParser (const langType language __unused__)
+static void initializeCtagsParser (const langType language CTAGS_ATTR_UNUSED)
 {
 }
 

--- a/optlib/man.c
+++ b/optlib/man.c
@@ -6,7 +6,7 @@
 #include "routines.h"
 
 
-static void initializeManParser (const langType language __unused__)
+static void initializeManParser (const langType language CTAGS_ATTR_UNUSED)
 {
 }
 

--- a/optlib/pod.c
+++ b/optlib/pod.c
@@ -6,7 +6,7 @@
 #include "routines.h"
 
 
-static void initializePodParser (const langType language __unused__)
+static void initializePodParser (const langType language CTAGS_ATTR_UNUSED)
 {
 }
 

--- a/parsers/ant.c
+++ b/parsers/ant.c
@@ -137,9 +137,9 @@ static const tagRegexTable antTagRegexTable [] = {
 
 static void
 antFindTagsUnderProject (xmlNode *node,
-			 const struct sTagXpathRecurSpec *spec __unused__,
+			 const struct sTagXpathRecurSpec *spec CTAGS_ATTR_UNUSED,
 			 xmlXPathContext *ctx,
-			 void *userData __unused__)
+			 void *userData CTAGS_ATTR_UNUSED)
 {
 	int corkIndex = CORK_NIL;
 
@@ -166,8 +166,8 @@ static void antFindTagsUnderTask (xmlNode *node,
 		     &corkIndex);
 }
 
-static void makeTagForProjectName (xmlNode *node __unused__,
-				   const struct sTagXpathMakeTagSpec *spec __unused__,
+static void makeTagForProjectName (xmlNode *node CTAGS_ATTR_UNUSED,
+				   const struct sTagXpathMakeTagSpec *spec CTAGS_ATTR_UNUSED,
 				   struct sTagEntryInfo *tag,
 				   void *userData)
 {
@@ -176,8 +176,8 @@ static void makeTagForProjectName (xmlNode *node __unused__,
 	*corkIndex = makeTagEntry (tag);
 }
 
-static void makeTagForTargetName (xmlNode *node __unused__,
-				  const struct sTagXpathMakeTagSpec *spec __unused__,
+static void makeTagForTargetName (xmlNode *node CTAGS_ATTR_UNUSED,
+				  const struct sTagXpathMakeTagSpec *spec CTAGS_ATTR_UNUSED,
 				  struct sTagEntryInfo *tag,
 				  void *userData)
 {
@@ -191,8 +191,8 @@ static void makeTagForTargetName (xmlNode *node __unused__,
 	*corkIndex = makeTagEntry (tag);
 }
 
-static void makeTagWithScope (xmlNode *node __unused__,
-			      const struct sTagXpathMakeTagSpec *spec __unused__,
+static void makeTagWithScope (xmlNode *node CTAGS_ATTR_UNUSED,
+			      const struct sTagXpathMakeTagSpec *spec CTAGS_ATTR_UNUSED,
 			      struct sTagEntryInfo *tag,
 			      void *userData)
 {

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -1,6 +1,4 @@
 /*
- *   $Id:$
- *
  *   Copyright (c) 2000-2006, Darren Hiebert, Elias Pschernig
  *
  *   This source code is released for free distribution under the terms of the

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -795,7 +795,7 @@ static const char *keywordString (const keywordId keyword)
 	return name;
 }
 
-static void __unused__ pt (tokenInfo *const token)
+static void CTAGS_ATTR_UNUSED pt (tokenInfo *const token)
 {
 	if (isType (token, TOKEN_NAME))
 		printf ("type: %-12s: %-13s   line: %lu\n",
@@ -810,7 +810,7 @@ static void __unused__ pt (tokenInfo *const token)
 			tokenString (token->type), token->lineNumber);
 }
 
-static void __unused__ ps (statementInfo *const st)
+static void CTAGS_ATTR_UNUSED ps (statementInfo *const st)
 {
 #define P	"[%-7u]"
 	static unsigned int id = 0;

--- a/parsers/css.c
+++ b/parsers/css.c
@@ -258,12 +258,12 @@ static void findCssTags (void)
 /* parser definition */
 extern parserDefinition* CssParser (void)
 {
-    static const char *const extensions [] = { "css", NULL };
-    parserDefinition* def = parserNew ("CSS");
-    def->kinds      = CssKinds;
-    def->kindCount  = ARRAY_SIZE (CssKinds);
-    def->extensions = extensions;
-    def->parser     = findCssTags;
-    return def;
+	static const char *const extensions [] = { "css", NULL };
+	parserDefinition* def = parserNew ("CSS");
+	def->kinds      = CssKinds;
+	def->kindCount  = ARRAY_SIZE (CssKinds);
+	def->extensions = extensions;
+	def->parser     = findCssTags;
+	return def;
 }
 

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1386,7 +1386,7 @@ void cxxCParserInitialize(const langType language)
 	cxxBuildKeywordHash(language,FALSE);
 }
 
-void cxxParserCleanup (langType language __unused__, boolean initialized __unused__)
+void cxxParserCleanup (langType language CTAGS_ATTR_UNUSED, boolean initialized CTAGS_ATTR_UNUSED)
 {
 	if(g_bFirstRun)
 		return; // didn't run at all

--- a/parsers/dbusintrospect.c
+++ b/parsers/dbusintrospect.c
@@ -91,9 +91,9 @@ static tagXpathTableTable dbusIntrospectXpathTableTable[] = {
 };
 
 static void dbusIntrospectFindTagsUnderInterface (xmlNode *node,
-						  const struct sTagXpathRecurSpec *spec __unused__,
+						  const struct sTagXpathRecurSpec *spec CTAGS_ATTR_UNUSED,
 						  xmlXPathContext *ctx,
-						  void *userData __unused__)
+						  void *userData CTAGS_ATTR_UNUSED)
 {
 	int corkIndex = CORK_NIL;
 
@@ -107,8 +107,8 @@ static void dbusIntrospectFindTagsUnderInterface (xmlNode *node,
 		     &corkIndex);
 }
 
-static void makeTagWithScope (xmlNode *node __unused__,
-			      const struct sTagXpathMakeTagSpec *spec __unused__,
+static void makeTagWithScope (xmlNode *node CTAGS_ATTR_UNUSED,
+			      const struct sTagXpathMakeTagSpec *spec CTAGS_ATTR_UNUSED,
 			      struct sTagEntryInfo *tag,
 			      void *userData)
 {
@@ -119,8 +119,8 @@ static void makeTagWithScope (xmlNode *node __unused__,
 	makeTagEntry (tag);
 }
 
-static void makeTagForInterfaceName (xmlNode *node __unused__,
-				     const struct sTagXpathMakeTagSpec *spec __unused__,
+static void makeTagForInterfaceName (xmlNode *node CTAGS_ATTR_UNUSED,
+				     const struct sTagXpathMakeTagSpec *spec CTAGS_ATTR_UNUSED,
 				     struct sTagEntryInfo *tag,
 				     void *userData)
 {

--- a/parsers/eiffel.c
+++ b/parsers/eiffel.c
@@ -743,7 +743,7 @@ static boolean findKeyword (tokenInfo *const token, const keywordId keyword)
 
 static boolean parseType (tokenInfo *const token);
 
-static void parseGeneric (tokenInfo *const token, boolean declaration __unused__)
+static void parseGeneric (tokenInfo *const token, boolean declaration CTAGS_ATTR_UNUSED)
 {
 	unsigned int depth = 0;
 

--- a/parsers/erlang.c
+++ b/parsers/erlang.c
@@ -79,7 +79,7 @@ static void makeMemberTag (
 	if (ErlangKinds [kind].enabled  &&  vStringLength (identifier) > 0)
 	{
 		tagEntryInfo tag;
-		initTagEntry (&tag, vStringValue (identifier), & (ErlangKinds[kind]));
+		initTagEntry (&tag, vStringValue (identifier), &(ErlangKinds[kind]));
 
 		if (module != NULL  &&  vStringLength (module) > 0)
 		{

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -1,6 +1,4 @@
 /*
- *	 $Id: flex.c 666 2008-05-15 17:47:31Z dfishburn $
- *
  *	 Copyright (c) 2008, David Fishburn
  *
  *	 This source code is released for free distribution under the terms of the

--- a/parsers/iniconf.c
+++ b/parsers/iniconf.c
@@ -61,7 +61,7 @@ struct probeData {
 
 };
 
-static void mayRunProbe (void *key __unused__, void *value, void *user_data)
+static void mayRunProbe (void *key CTAGS_ATTR_UNUSED, void *value, void *user_data)
 {
 	struct probeData *probe_data = user_data;
 	struct iniconfParserClient *client = value;

--- a/parsers/m4.c
+++ b/parsers/m4.c
@@ -175,7 +175,7 @@ struct probeData {
 	const char* token;
 };
 
-static void mayRunProbe (void *key __unused__, void *value, void* user_data)
+static void mayRunProbe (void *key CTAGS_ATTR_UNUSED, void *value, void* user_data)
 {
 	struct probeData *probe_data = user_data;
 	struct m4ParserClient *client = value;

--- a/parsers/maven2.c
+++ b/parsers/maven2.c
@@ -71,9 +71,9 @@ static void makeTagRecursively (xmlNode *node,
 				void *userData);
 
 static void makeTagForProperties (xmlNode *node,
-				  const struct sTagXpathRecurSpec *spec __unused__,
-				  xmlXPathContext *ctx __unused__,
-				  void *userData __unused__)
+				  const struct sTagXpathRecurSpec *spec CTAGS_ATTR_UNUSED,
+				  xmlXPathContext *ctx CTAGS_ATTR_UNUSED,
+				  void *userData CTAGS_ATTR_UNUSED)
 {
 	const xmlChar* str;
 	tagEntryInfo tag;
@@ -233,7 +233,7 @@ findMaven2TagsForTable (enum maven2XpathTable tindex,
 static void makeTagRecursively (xmlNode *node,
 				  const struct sTagXpathRecurSpec *spec,
 				  xmlXPathContext *ctx,
-				  void *userData __unused__)
+				  void *userData CTAGS_ATTR_UNUSED)
 {
 	findMaven2TagsForTable (spec->nextTable, node, ctx);
 }

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -23,17 +23,6 @@
 #include "selectors.h"
 #include "vstring.h"
 
-/* To get rid of unused parameter warning in
- * -Wextra */
-#ifdef UNUSED
-#elif defined(__GNUC__)
-# define UNUSED(x) UNUSED_ ## x __attribute__((unused))
-#elif defined(__LCLINT__)
-# define UNUSED(x) /*@unused@*/ x
-#else
-# define UNUSED(x) x
-#endif
-
 typedef enum {
 	K_INTERFACE,
 	K_IMPLEMENTATION,
@@ -477,13 +466,13 @@ static objcToken waitedToken, fallBackToken;
 /* Ignore everything till waitedToken and jump to comeAfter.
  * If the "end" keyword is encountered break, doesn't remember
  * why though. */
-static void tillToken (vString * const UNUSED (ident), objcToken what)
+static void tillToken (vString * const ident CTAGS_ATTR_UNUSED, objcToken what)
 {
 	if (what == waitedToken)
 		toDoNext = comeAfter;
 }
 
-static void tillTokenOrFallBack (vString * const UNUSED (ident), objcToken what)
+static void tillTokenOrFallBack (vString * const ident CTAGS_ATTR_UNUSED, objcToken what)
 {
 	if (what == waitedToken)
 		toDoNext = comeAfter;
@@ -494,7 +483,7 @@ static void tillTokenOrFallBack (vString * const UNUSED (ident), objcToken what)
 }
 
 static int ignoreBalanced_count = 0;
-static void ignoreBalanced (vString * const UNUSED (ident), objcToken what)
+static void ignoreBalanced (vString * const ident CTAGS_ATTR_UNUSED, objcToken what)
 {
 
 	switch (what)
@@ -696,7 +685,7 @@ static void parseProperty (vString * const ident, objcToken what)
 	}
 }
 
-static void parseMethods (vString * const UNUSED (ident), objcToken what)
+static void parseMethods (vString * const ident CTAGS_ATTR_UNUSED, objcToken what)
 {
 	switch (what)
 	{
@@ -955,7 +944,7 @@ static void parseTypedef (vString * const ident, objcToken what)
 }
 
 static boolean ignorePreprocStuff_escaped = FALSE;
-static void ignorePreprocStuff (vString * const UNUSED (ident), objcToken what)
+static void ignorePreprocStuff (vString * const ident CTAGS_ATTR_UNUSED, objcToken what)
 {
 	switch (what)
 	{

--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -21,16 +21,6 @@
 #include "routines.h"
 #include "vstring.h"
 
-/* To get rid of unused parameter warning in
- * -Wextra */
-#ifdef UNUSED
-#elif defined(__GNUC__)
-# define UNUSED(x) UNUSED_ ## x __attribute__((unused))
-#elif defined(__LCLINT__)
-# define UNUSED(x) /*@unused@*/ x
-#else
-# define UNUSED(x) x
-#endif
 #define OCAML_MAX_STACK_SIZE 256
 
 typedef enum {
@@ -744,7 +734,7 @@ static contextType popStrongContext ( void )
 /* Ignore everything till waitedToken and jump to comeAfter.
  * If the "end" keyword is encountered break, doesn't remember
  * why though. */
-static void tillToken (vString * const UNUSED (ident), ocaToken what)
+static void tillToken (vString * const ident CTAGS_ATTR_UNUSED, ocaToken what)
 {
 	if (what == waitedToken)
 		toDoNext = comeAfter;
@@ -757,7 +747,7 @@ static void tillToken (vString * const UNUSED (ident), ocaToken what)
 
 /* Ignore everything till a waitedToken is seen, but
  * take care of balanced parentheses/bracket use */
-static void contextualTillToken (vString * const UNUSED (ident), ocaToken what)
+static void contextualTillToken (vString * const ident CTAGS_ATTR_UNUSED, ocaToken what)
 {
 	static int parentheses = 0;
 	static int bracket = 0;
@@ -824,7 +814,7 @@ static void tillTokenOrTerminatingOrFallback (vString * const ident,
 
 /* ignore the next token in the stream and jump to the
  * given comeAfter state */
-static void ignoreToken (vString * const UNUSED (ident), ocaToken UNUSED (what))
+static void ignoreToken (vString * const ident CTAGS_ATTR_UNUSED, ocaToken what CTAGS_ATTR_UNUSED)
 {
 	toDoNext = comeAfter;
 }
@@ -1419,7 +1409,7 @@ static void letParam (vString * const ident, ocaToken what)
 /* parse object ...
  * used to be sure the class definition is not a type
  * alias */
-static void classSpecif (vString * const UNUSED (ident), ocaToken what)
+static void classSpecif (vString * const ident CTAGS_ATTR_UNUSED, ocaToken what)
 {
 	switch (what)
 	{
@@ -1614,7 +1604,7 @@ static void globalLet (vString * const ident, ocaToken what)
 
 /* Handle the "strong" top levels, all 'big' declarations
  * happen here */
-static void globalScope (vString * const UNUSED (ident), ocaToken what)
+static void globalScope (vString * const ident CTAGS_ATTR_UNUSED, ocaToken what)
 {
 	/* Do not touch, this is used only by the global scope
 	 * to handle an 'and' */

--- a/parsers/relaxng.c
+++ b/parsers/relaxng.c
@@ -210,8 +210,8 @@ findRelaxNGTags (void)
 }
 
 static void
-makeTagWithScope (xmlNode *node __unused__,
-		  const struct sTagXpathMakeTagSpec *spec __unused__,
+makeTagWithScope (xmlNode *node CTAGS_ATTR_UNUSED,
+		  const struct sTagXpathMakeTagSpec *spec CTAGS_ATTR_UNUSED,
 		  struct sTagEntryInfo *tag,
 		  void *userData)
 {

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -1,6 +1,4 @@
 /*
-*   $Id: ruby.c 571 2007-06-24 23:32:14Z elliotth $
-*
 *   Copyright (c) 2000-2001, Thaddeus Covert <sahuagin@mediaone.net>
 *   Copyright (c) 2002 Matthias Veit <matthias_veit@yahoo.de>
 *   Copyright (c) 2004 Elliott Hughes <enh@acm.org>

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -1,6 +1,4 @@
 /*
- *	 $Id: tex.c 666 2008-05-15 17:47:31Z dfishburn $
- *
  *	 Copyright (c) 2008, David Fishburn
  *	 Copyright (c) 2012, Jan Larres
  *

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -544,7 +544,7 @@ static void initialize (const langType language)
 	lastSubSubS = vStringNew();
 }
 
-static void finalize (const langType language __unused__,
+static void finalize (const langType language CTAGS_ATTR_UNUSED,
 		      boolean initialized)
 {
 	if (initialized)

--- a/parsers/vhdl.c
+++ b/parsers/vhdl.c
@@ -1,6 +1,4 @@
 /*
-*   $Id: vhdl.c 652 2008-04-18 03:51:47Z elliotth $
-*
 *   Copyright (c) 2008, Nicolas Vincent
 *
 *   This source code is released for free distribution under the terms of the

--- a/parsers/yacc.c
+++ b/parsers/yacc.c
@@ -33,10 +33,10 @@ struct cStart {
 	unsigned long source;
 };
 
-static  void change_section (const char *line __unused__,
-			     const regexMatch *matches __unused__,
-			     unsigned int count __unused__,
-			     void *data __unused__)
+static  void change_section (const char *line CTAGS_ATTR_UNUSED,
+			     const regexMatch *matches CTAGS_ATTR_UNUSED,
+			     unsigned int count CTAGS_ATTR_UNUSED,
+			     void *data CTAGS_ATTR_UNUSED)
 {
 	not_in_grammar_rules = !not_in_grammar_rules;
 
@@ -60,9 +60,9 @@ static  void change_section (const char *line __unused__,
 	}
 }
 
-static void enter_c_prologue (const char *line __unused__,
-			      const regexMatch *matches __unused__,
-			      unsigned int count __unused__,
+static void enter_c_prologue (const char *line CTAGS_ATTR_UNUSED,
+			      const regexMatch *matches CTAGS_ATTR_UNUSED,
+			      unsigned int count CTAGS_ATTR_UNUSED,
 			      void *data)
 {
 	struct cStart *cstart = data;
@@ -73,9 +73,9 @@ static void enter_c_prologue (const char *line __unused__,
 	cstart->source = getSourceLineNumber ();
 }
 
-static void leave_c_prologue (const char *line __unused__,
-			      const regexMatch *matches __unused__,
-			      unsigned int count __unused__,
+static void leave_c_prologue (const char *line CTAGS_ATTR_UNUSED,
+			      const regexMatch *matches CTAGS_ATTR_UNUSED,
+			      unsigned int count CTAGS_ATTR_UNUSED,
 			      void *data)
 {
 	struct cStart *cstart = data;
@@ -86,9 +86,9 @@ static void leave_c_prologue (const char *line __unused__,
 	memset (cstart, 0, sizeof (*cstart));
 }
 
-static void enter_union (const char *line __unused__,
+static void enter_union (const char *line CTAGS_ATTR_UNUSED,
 			 const regexMatch *matches,
-			 unsigned int count __unused__,
+			 unsigned int count CTAGS_ATTR_UNUSED,
 			 void *data)
 {
 	struct cStart *cstart = data;
@@ -100,9 +100,9 @@ static void enter_union (const char *line __unused__,
 	}
 }
 
-static void leave_union (const char *line __unused__,
+static void leave_union (const char *line CTAGS_ATTR_UNUSED,
 			 const regexMatch *matches,
-			 unsigned int count __unused__,
+			 unsigned int count CTAGS_ATTR_UNUSED,
 			 void *data)
 {
 	struct cStart *cstart = data;


### PR DESCRIPTION
These are small fixes brought from Geany which I noticed when working on https://github.com/geany/geany/pull/1160 or which resulted as a reaction to review comments. Mostly just variable renames, whitespace changes and comment fixes.

The last patch however is something we need for Geany. The macro `__unused__` unfortunately clashes with the same macro defined in glib which we use in Geany and we need to rename it to something else. In Geany UNUSED and PRINTF were used so I kept these but I can rename them to whatever else.