### PR TITLE
Support JSX files

### DIFF
--- a/Units/simple-jsx.d/expected.tags
+++ b/Units/simple-jsx.d/expected.tags
@@ -1,0 +1,1 @@
+foo	input.jsx	/^function foo() {$/;"	f

--- a/Units/simple-jsx.d/input.jsx
+++ b/Units/simple-jsx.d/input.jsx
@@ -1,0 +1,7 @@
+function foo() {
+  var x = <div>
+    <Menu />
+  <div>;
+
+  return x;
+}

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -1979,7 +1979,9 @@ static void findJsTags (void)
 /* Create parser definition structure */
 extern parserDefinition* JavaScriptParser (void)
 {
-	static const char *const extensions [] = { "js", NULL };
+	// .jsx files are JSX: https://facebook.github.io/jsx/
+	// which have JS function definitions, so we just use the JS parser
+	static const char *const extensions [] = { "js", "jsx", NULL };
 	static const char *const aliases [] = { "js", "node", "nodejs",
 	                                        "seed", "gjs", NULL };
 	parserDefinition *const def = parserNew ("JavaScript");


### PR DESCRIPTION
Fixes #1086. I've tested it and as far as I can see, the jscript parser Just Works with .jsx files.