### PR TITLE
main: update column header of --list-fields output

### DIFF
--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -1,13 +1,13 @@
-r       UCTAGSrole      off     NONE             TRUE     Role                          
-Z       UCTAGSscope     off     NONE             TRUE     Include the "scope:" key in scope field (use s) in tags output, scope name in xref output
-E       UCTAGSextra     off     NONE             TRUE     Extra tag type information    
-x       UCTAGSxpath     off     NONE             TRUE     xpath for the tag             
-p       UCTAGSscopeKind off     NONE             TRUE     Kind of scope as full name    
-e       UCTAGSend       off     NONE             TRUE     end lines of various items    
--       UCTAGSproperties off     C                TRUE     properties (static, inline, mutable,...)
--       UCTAGSproperties off     C++              TRUE     properties (static, inline, mutable,...)
--       UCTAGStemplate  off     C++              TRUE     template parameters           
--       UCTAGScaptures  off     C++              TRUE     lambda capture list           
--       UCTAGSname      on      C++              TRUE     aliased names                 
--       UCTAGSdecorators off     Python           TRUE     decorators on functions and classes
--       UCTAGSsectionMarker off     reStructuredText TRUE     character used for declaring section
+r       UCTAGSrole      off     NONE             TRUE   Role                          
+Z       UCTAGSscope     off     NONE             TRUE   Include the "scope:" key in scope field (use s) in tags output, scope name in xref output
+E       UCTAGSextra     off     NONE             TRUE   Extra tag type information    
+x       UCTAGSxpath     off     NONE             TRUE   xpath for the tag             
+p       UCTAGSscopeKind off     NONE             TRUE   Kind of scope as full name    
+e       UCTAGSend       off     NONE             TRUE   end lines of various items    
+-       UCTAGSproperties off     C                TRUE   properties (static, inline, mutable,...)
+-       UCTAGSproperties off     C++              TRUE   properties (static, inline, mutable,...)
+-       UCTAGStemplate  off     C++              TRUE   template parameters           
+-       UCTAGScaptures  off     C++              TRUE   lambda capture list           
+-       UCTAGSname      on      C++              TRUE   aliased names                 
+-       UCTAGSdecorators off     Python           TRUE   decorators on functions and classes
+-       UCTAGSsectionMarker off     reStructuredText TRUE   character used for declaring section

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -1,4 +1,4 @@
-#LETTER	NAME	ENABLED	LANGUAGE	XFMTCHAR	DESCRIPTION
+#LETTER	NAME	ENABLED	LANGUAGE	XFMT	DESCRIPTION
 N	name	on	NONE	TRUE	tag name (fixed field)
 F	input	on	NONE	TRUE	input file (fixed field)
 P	pattern	on	NONE	TRUE	pattern (fixed field)

--- a/Tmain/list-language-fields.d/stdout-expected.txt
+++ b/Tmain/list-language-fields.d/stdout-expected.txt
@@ -1,2 +1,2 @@
-#LETTER	NAME	ENABLED	LANGUAGE	XFMTCHAR	DESCRIPTION
+#LETTER	NAME	ENABLED	LANGUAGE	XFMT	DESCRIPTION
 -	sectionMarker	off	reStructuredText	TRUE	character used for declaring section

--- a/Tmain/wildcard-in-lang-of-fields-option.d/stdout-expected.txt
+++ b/Tmain/wildcard-in-lang-of-fields-option.d/stdout-expected.txt
@@ -1,2 +1,2 @@
-S       signature       on      NONE             TRUE     Signature of routine (e.g. prototype or parameter list)
-t       typeref         off     NONE             TRUE     Type and name of a variable or typedef
+S       signature       on      NONE             TRUE   Signature of routine (e.g. prototype or parameter list)
+t       typeref         off     NONE             TRUE   Type and name of a variable or typedef

--- a/Tmain/xformat-and-parser-own-field.d/stdout-expected.txt
+++ b/Tmain/xformat-and-parser-own-field.d/stdout-expected.txt
@@ -25,4 +25,4 @@ subsection reStructuredText
 #
 # LIST: ENABLING COMMON FIELD BY SPECIFYING WILDCARD
 #
-l       language        on      NONE             TRUE     Language of input file containing tag
+l       language        on      NONE             TRUE   Language of input file containing tag

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -789,16 +789,16 @@ in the `LANGUAGE` column:
 .. code-block:: console
 
 	$ ./ctags --list-fields
-	#LETTER NAME            ENABLED LANGUAGE         XFMTCHAR DESCRIPTION
+	#LETTER NAME            ENABLED LANGUAGE         XFMT  DESCRIPTION
 	...
-	-       end             off     C                TRUE     end lines of various constructs
-	-       properties      off     C                TRUE     properties (static, inline, mutable,...)
-	-       end             off     C++              TRUE     end lines of various constructs
-	-       template        off     C++              TRUE     template parameters
-	-       captures        off     C++              TRUE     lambda capture list
-	-       properties      off     C++              TRUE     properties (static, virtual, inline, mutable,...)
-	-       sectionMarker   off     reStructuredText TRUE     character used for declaring section
-	-       version         off     Maven2           TRUE     version of artifact
+	-       end             off     C                TRUE   end lines of various constructs
+	-       properties      off     C                TRUE   properties (static, inline, mutable,...)
+	-       end             off     C++              TRUE   end lines of various constructs
+	-       template        off     C++              TRUE   template parameters
+	-       captures        off     C++              TRUE   lambda capture list
+	-       properties      off     C++              TRUE   properties (static, virtual, inline, mutable,...)
+	-       sectionMarker   off     reStructuredText TRUE   character used for declaring section
+	-       version         off     Maven2           TRUE   version of artifact
 
 e.g. reStructuredText is the owner of the sectionMarker field and
 both C and C++ own the end field.
@@ -809,8 +809,8 @@ given, ``--list-fields`` prints only the fields for that parser:
 .. code-block:: console
 
 	$ ./ctags --list-fields=Maven2
-	#LETTER NAME            ENABLED LANGUAGE        XFMTCHAR DESCRIPTION
-	-       version         off     Maven2          TRUE     version of artifact
+	#LETTER NAME            ENABLED LANGUAGE        XFMT  DESCRIPTION
+	-       version         off     Maven2          TRUE  version of artifact
 
 A parser own field only has a long name, no letter. For
 enabling/disabling such fields, the name must be passed to

--- a/main/field.c
+++ b/main/field.c
@@ -314,7 +314,7 @@ extern boolean doesFieldHaveValue (fieldType type, const tagEntryInfo *tag)
 #define PR_FIELD_WIDTH_NAME      15
 #define PR_FIELD_WIDTH_LANGUAGE  16
 #define PR_FIELD_WIDTH_DESC      30
-#define PR_FIELD_WIDTH_XFMTCHAR  8
+#define PR_FIELD_WIDTH_XFMT      6
 #define PR_FIELD_WIDTH_ENABLED   7
 
 #define PR_FIELD_STR(X) PR_FIELD_WIDTH_##X
@@ -329,7 +329,7 @@ extern boolean doesFieldHaveValue (fieldType type, const tagEntryInfo *tag)
 	" "					\
 	PR_FIELD_FMT (LANGUAGE,s)		\
 	" "					\
-	PR_FIELD_FMT (XFMTCHAR,s)		\
+	PR_FIELD_FMT (XFMT,s)		\
 	" "					\
 	PR_FIELD_FMT (DESC,s)			\
 	"\n"
@@ -368,7 +368,7 @@ extern void printFields (int language)
 
 	if (Option.withListHeader)
 		printf ((Option.machinable? "%s\t%s\t%s\t%s\t%s\t%s\n": MAKE_FIELD_FMT(s)),
-			"#LETTER", "NAME", "ENABLED", "LANGUAGE", "XFMTCHAR", "DESCRIPTION");
+			"#LETTER", "NAME", "ENABLED", "LANGUAGE", "XFMT", "DESCRIPTION");
 
 	for (i = 0; i < fieldDescUsed; i++)
 	{


### PR DESCRIPTION
Now we can specify a field with not only field char but also field
name. "XFMTCHR" used in the column header of --list-fields output
is suitable name for the column. This commit changes it to "XFMT".

Signed-off-by: Masatake YAMATO <yamato@redhat.com>