### PR TITLE
python: Fix recorded indentation after a continuation line

### DIFF
--- a/Units/parser-python.r/multiline-class-def.d/expected.tags
+++ b/Units/parser-python.r/multiline-class-def.d/expected.tags
@@ -1,0 +1,4 @@
+A	input.py	/^class A(Foo,$/;"	c
+B	input.py	/^class B():$/;"	c
+a	input.py	/^    a = 1$/;"	v	class:A
+b	input.py	/^    b = 2$/;"	v	class:B

--- a/Units/parser-python.r/multiline-class-def.d/input.py
+++ b/Units/parser-python.r/multiline-class-def.d/input.py
@@ -1,0 +1,6 @@
+class A(Foo,
+        Bar):
+    a = 1
+
+class B():
+    b = 2

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -569,6 +569,8 @@ getNextChar:
 		case '#': /* comment */
 		case '\r': /* newlines for indent */
 		case '\n':
+		{
+			int indent = 0;
 			do
 			{
 				if (c == '#')
@@ -583,16 +585,15 @@ getNextChar:
 					if (d != '\n')
 						ungetcToInputFile (d);
 				}
-				token->type = TOKEN_INDENT;
-				token->indent = 0;
+				indent = 0;
 				while ((c = getcFromInputFile ()) == ' ' || c == '\t' || c == '\f')
 				{
 					if (c == '\t')
-						token->indent += 8 - (token->indent % 8);
+						indent += 8 - (indent % 8);
 					else if (c == '\f') /* yeah, it's weird */
-						token->indent = 0;
+						indent = 0;
 					else
-						token->indent++;
+						indent++;
 				}
 			} /* skip completely empty lines, so retry */
 			while (c == '\r' || c == '\n' || c == '#');
@@ -607,7 +608,13 @@ getNextChar:
 				else
 					goto getNextChar;
 			}
+			else
+			{
+				token->type = TOKEN_INDENT;
+				token->indent = indent;
+			}
 			break;
+		}
 
 		default:
 			if (! isIdentifierChar (c))


### PR DESCRIPTION
The token's indentation was set to the line indentation even inside
continuation lines, which leads to incorrect indentation recorded in
the token, breaking hierarchy if the incorrect indentation is on a
token used to create a scope and greater than the indentation of the
scope's body.

Fixes #1103.