### PR TITLE
Fix typo in help string for --fields option

### DIFF
--- a/main/options.c
+++ b/main/options.c
@@ -247,7 +247,7 @@ static optionDescription LongOptionDescription [] = {
  {1,"      Include selected extension fields (flags: \"afmikKlnsStzZ\") [fks]."},
  {1,"  --fields-<LANG|*>=[+|-]flags"},
  {1,"      Include selected <LANG> own extension fields"},
- {1,"      (flags: --list-flags=<LANG>)."},
+ {1,"      (flags: --list-fields=<LANG>)."},
  {1,"  --file-scope=[yes|no]"},
  {1,"       Should tags scoped only for a single file (e.g. \"static\" tags)"},
  {1,"       be included in the output [yes]?"},


### PR DESCRIPTION
@masatake As discussed here: https://github.com/universal-ctags/ctags/commit/9135e21d4833d104ddf50b7fbc0a77ab9d21e766#commitcomment-18866858