### PR TITLE
Add pointer array and pool data structures

### DIFF
--- a/main/objpool.c
+++ b/main/objpool.c
@@ -1,0 +1,79 @@
+/*
+*   Copyright (c) 2016, Jiri Techet
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   Defines generic pool for object reuse reducing the amount of allocations
+*   and deallocations.
+*/
+
+/*
+*   INCLUDE FILES
+*/
+#include "general.h"  /* must always come first */
+
+#include "routines.h"
+#include "objpool.h"
+
+/*
+*   DATA DECLARATIONS
+*/
+
+struct sObjPool {
+	ptrArray *array;
+	unsigned int size;
+	objPoolCreateFunc createFunc;
+	objPoolDeleteFunc deleteFunc;
+	objPoolClearFunc clearFunc;
+};
+
+/*
+*   FUNCTION DEFINITIONS
+*/
+extern objPool *objPoolNew (unsigned int size,
+	objPoolCreateFunc createFunc, objPoolDeleteFunc deleteFunc, objPoolClearFunc clearFunc)
+{
+	objPool* const result = xMalloc (1, objPool);
+	result->array = ptrArrayNew (deleteFunc);
+	result->size = size;
+	result->createFunc = createFunc;
+	result->deleteFunc = deleteFunc;
+	result->clearFunc = clearFunc;
+	return result;
+}
+
+extern void objPoolDelete (objPool *pool)
+{
+	ptrArrayDelete (pool->array);
+	eFree (pool);
+}
+
+extern void *objPoolGet (objPool *pool)
+{
+	void *obj;
+
+	if (ptrArrayCount (pool->array) > 0)
+	{
+		obj = ptrArrayLast (pool->array);
+		ptrArrayRemoveLast (pool->array);
+	}
+	else
+		obj = pool->createFunc ();
+
+	if (pool->clearFunc)
+		pool->clearFunc (obj);
+
+	return obj;
+}
+
+extern void objPoolPut (objPool *pool, void *obj)
+{
+	if (obj == NULL)
+		return;
+
+	if (ptrArrayCount (pool->array) < pool->size)
+		ptrArrayAdd (pool->array, obj);
+	else
+		pool->deleteFunc (obj);
+}

--- a/main/objpool.h
+++ b/main/objpool.h
@@ -1,0 +1,39 @@
+/*
+*   Copyright (c) 2016, Jiri Techet
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   Defines generic pool for object reuse reducing the amount of allocations
+*   and deallocations.
+*/
+#ifndef CTAGS_MAIN_OBJPOOL_H
+#define CTAGS_MAIN_OBJPOOL_H
+
+/*
+*   INCLUDE FILES
+*/
+#include "general.h"  /* must always come first */
+
+#include "ptrarray.h"
+
+/*
+*   DATA DECLARATIONS
+*/
+typedef void * (*objPoolCreateFunc) (void);
+typedef void (*objPoolDeleteFunc) (void *data);
+typedef void (*objPoolClearFunc) (void *data);
+
+struct sObjPool;
+typedef struct sObjPool objPool;
+
+/*
+*   FUNCTION PROTOTYPES
+*/
+extern objPool *objPoolNew (unsigned int size,
+	objPoolCreateFunc createFunc, objPoolDeleteFunc deleteFunc, objPoolClearFunc clearFunc);
+extern void objPoolDelete (objPool *pool);
+extern void *objPoolGet (objPool *pool);
+extern void objPoolPut (objPool *pool, void *obj);
+
+#endif  /* CTAGS_MAIN_OBJPOOL_H */

--- a/main/ptrarray.h
+++ b/main/ptrarray.h
@@ -1,0 +1,46 @@
+/*
+*   Copyright (c) 1999-2002, Darren Hiebert
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   Defines external interface to resizable pointer arrays.
+*/
+#ifndef CTAGS_MAIN_PTRARRAY_H
+#define CTAGS_MAIN_PTRARRAY_H
+
+/*
+*   INCLUDE FILES
+*/
+#include "general.h"  /* must always come first */
+
+/*
+*   DATA DECLARATIONS
+*/
+
+typedef void (*ptrArrayDeleteFunc) (void *data);
+
+struct sPtrArray;
+typedef struct sPtrArray ptrArray;
+
+/*
+*   FUNCTION PROTOTYPES
+*/
+
+extern ptrArray *ptrArrayNew (ptrArrayDeleteFunc deleteFunc);
+extern void ptrArrayAdd (ptrArray *const current, void *ptr);
+extern void ptrArrayRemoveLast (ptrArray *const current);
+extern void ptrArrayCombine (ptrArray *const current, ptrArray *const from);
+extern void ptrArrayClear (ptrArray *const current);
+extern unsigned int ptrArrayCount (const ptrArray *const current);
+extern void* ptrArrayItem (const ptrArray *const current, const unsigned int indx);
+extern void* ptrArrayLast (const ptrArray *const current);
+extern void ptrArrayDelete (ptrArray *const current);
+extern bool ptrArrayHasInsensitive (const ptrArray *const current, const void *const ptr);
+extern bool ptrArrayHasTest (const ptrArray *const current,
+				  bool (*test)(const void *ptr, void *userData),
+				  void *userData);
+extern void ptrArrayReverse (const ptrArray *const current);
+extern void ptrArrayDeleteItem (ptrArray* const current, unsigned int indx);
+
+#endif  /* CTAGS_MAIN_PTRARRAY_H */

--- a/main/strlist.c
+++ b/main/strlist.c
@@ -26,53 +26,24 @@
 
 extern stringList *stringListNew (void)
 {
-	stringList* const result = xMalloc (1, stringList);
-	result->max   = 0;
-	result->count = 0;
-	result->list  = NULL;
-	return result;
+	return ptrArrayNew ((ptrArrayDeleteFunc)vStringDelete);
 }
 
 extern void stringListAdd (stringList *const current, vString *string)
 {
-	enum { incrementalIncrease = 10 };
-	Assert (current != NULL);
-	if (current->list == NULL)
-	{
-		Assert (current->max == 0);
-		current->count = 0;
-		current->max   = incrementalIncrease;
-		current->list  = xMalloc (current->max, vString*);
-	}
-	else if (current->count == current->max)
-	{
-		current->max += incrementalIncrease;
-		current->list = xRealloc (current->list, current->max, vString*);
-	}
-	current->list [current->count++] = string;
+	ptrArrayAdd (current, string);
 }
 
 extern void stringListRemoveLast (stringList *const current)
 {
-	Assert (current != NULL);
-	Assert (current->count > 0);
-	--current->count;
-	current->list [current->count] = NULL;
+	ptrArrayRemoveLast (current);
 }
 
 /* Combine list `from' into `current', deleting `from' */
 extern void stringListCombine (
 		stringList *const current, stringList *const from)
 {
-	unsigned int i;
-	Assert (current != NULL);
-	Assert (from != NULL);
-	for (i = 0  ;  i < from->count  ;  ++i)
-	{
-		stringListAdd (current, from->list [i]);
-		from->list [i] = NULL;
-	}
-	stringListDelete (from);
+	ptrArrayCombine (current, from);
 }
 
 extern stringList* stringListNewFromArgv (const char* const* const argv)
@@ -108,50 +79,28 @@ extern stringList* stringListNewFromFile (const char* const fileName)
 
 extern unsigned int stringListCount (const stringList *const current)
 {
-	Assert (current != NULL);
-	return current->count;
+	return ptrArrayCount (current);
 }
 
 extern vString* stringListItem (
 		const stringList *const current, const unsigned int indx)
 {
-	Assert (current != NULL);
-	return current->list [indx];
+	return ptrArrayItem (current, indx);
 }
 
 extern vString* stringListLast (const stringList *const current)
 {
-	Assert (current != NULL);
-	Assert (current->count > 0);
-	return current->list [current->count - 1];
+	return ptrArrayLast (current);
 }
 
 extern void stringListClear (stringList *const current)
 {
-	unsigned int i;
-	Assert (current != NULL);
-	for (i = 0  ;  i < current->count  ;  ++i)
-	{
-		vStringDelete (current->list [i]);
-		current->list [i] = NULL;
-	}
-	current->count = 0;
+	ptrArrayClear (current);
 }
 
 extern void stringListDelete (stringList *const current)
 {
-	if (current != NULL)
-	{
-		if (current->list != NULL)
-		{
-			stringListClear (current);
-			eFree (current->list);
-			current->list = NULL;
-		}
-		current->max   = 0;
-		current->count = 0;
-		eFree (current);
-	}
+	ptrArrayDelete (current);
 }
 
 static bool compareString (
@@ -176,8 +125,8 @@ static int stringListIndex (
 	Assert (current != NULL);
 	Assert (string != NULL);
 	Assert (test != NULL);
-	for (i = 0  ;  result == -1  &&  i < current->count  ;  ++i)
-		if ((*test)(string, current->list [i]))
+	for (i = 0  ;  result == -1  &&  i < ptrArrayCount (current)  ;  ++i)
+		if ((*test)(string, ptrArrayItem (current, i)))
 			result = i;
 	return result;
 }
@@ -224,15 +173,13 @@ extern bool stringListHasTest (const stringList *const current,
 	bool result = false;
 	unsigned int i;
 	Assert (current != NULL);
-	for (i = 0  ;  ! result  &&  i < current->count  ;  ++i)
-		result = (*test)(vStringValue (current->list [i]), userData);
+	for (i = 0  ;  ! result  &&  i < ptrArrayCount (current)  ;  ++i)
+		result = (*test)(vStringValue ((vString *)ptrArrayItem (current, i)), userData);
 	return result;
 }
 
 extern bool stringListDeleteItemExtension (stringList* const current, const char* const extension)
-
 {
-	bool result = false;
 	int where;
 #ifdef CASE_INSENSITIVE_FILENAMES
 	where = stringListIndex (current, extension, compareStringInsensitive);
@@ -240,15 +187,8 @@ extern bool stringListDeleteItemExtension (stringList* const current, const char
 	where = stringListIndex (current, extension, compareString);
 #endif
 	if (where != -1)
-	{
-		vStringDelete (current->list [where]);
-		memmove (current->list + where, current->list + where + 1,
-				(current->count - where) * sizeof (*current->list));
-		current->list [current->count - 1] = NULL;
-		--current->count;
-		result = true;
-	}
-	return result;
+		ptrArrayDeleteItem (current, where);
+	return where != -1;
 }
 
 extern bool stringListExtensionMatched (
@@ -302,20 +242,11 @@ extern void stringListPrint (const stringList *const current, FILE *fp)
 {
 	unsigned int i;
 	Assert (current != NULL);
-	for (i = 0  ;  i < current->count  ;  ++i)
-		fprintf (fp, "%s%s", (i > 0) ? ", " : "", vStringValue (current->list [i]));
+	for (i = 0  ;  i < ptrArrayCount (current)  ;  ++i)
+		fprintf (fp, "%s%s", (i > 0) ? ", " : "", vStringValue ((vString *)ptrArrayItem (current, i)));
 }
 
 extern void stringListReverse (const stringList *const current)
 {
-	unsigned int i, j;
-	vString *tmp;
-
-	Assert (current != NULL);
-	for (i = 0, j = current->count - 1 ; i <  (current->count / 2); ++i, --j)
-	{
-		tmp = current->list[i];
-		current->list[i] = current->list[j];
-		current->list[j] = tmp;
-	}
+	ptrArrayReverse (current);
 }

--- a/main/strlist.h
+++ b/main/strlist.h
@@ -15,17 +15,14 @@
 #include "general.h"  /* must always come first */
 
 #include "vstring.h"
+#include "ptrarray.h"
 
 #include <stdio.h>
 
 /*
 *   DATA DECLARATIONS
 */
-typedef struct sStringList {
-	unsigned int max;
-	unsigned int count;
-	vString    **list;
-} stringList;
+typedef ptrArray stringList;
 
 /*
 *   FUNCTION PROTOTYPES

--- a/source.mak
+++ b/source.mak
@@ -36,6 +36,7 @@ MAIN_HEADS =			\
 	main/pcoproc.h		\
 	main/promise.h		\
 	main/ptag.h		\
+	main/ptrarray.h		\
 	main/read.h		\
 	main/routines.h		\
 	main/selectors.h	\
@@ -74,6 +75,7 @@ MAIN_SRCS =				\
 	main/pcoproc.c			\
 	main/promise.c			\
 	main/ptag.c			\
+	main/ptrarray.c			\
 	main/read.c			\
 	main/routines.c			\
 	main/selectors.c		\

--- a/source.mak
+++ b/source.mak
@@ -29,6 +29,7 @@ MAIN_HEADS =			\
 	main/main.h		\
 	main/mbcs.h		\
 	main/nestlevel.h	\
+	main/objpool.h		\
 	main/options.h		\
 	main/output.h		\
 	main/parse.h		\
@@ -66,6 +67,7 @@ MAIN_SRCS =				\
 	main/main.c			\
 	main/mbcs.c			\
 	main/nestlevel.c		\
+	main/objpool.c			\
 	main/options.c			\
 	main/output-etags.c		\
 	main/output-ctags.c		\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -217,6 +217,7 @@
     <ClCompile Include="..\parsers\yumrepo.c" />
     <ClCompile Include="..\parsers\pythonloggingconfig.c" />
     <ClCompile Include="..\main\ptrarray.c" />
+    <ClCompile Include="..\main\objpool.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\fnmatch\fnmatch.h" />
@@ -267,6 +268,7 @@
     <ClInclude Include="..\parsers\iniconf.h" />
     <ClInclude Include="..\parsers\m4.h" />
     <ClInclude Include="..\main\ptrarray.h" />
+    <ClInclude Include="..\main\objpool.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -216,6 +216,7 @@
     <ClCompile Include="..\parsers\systemdunit.c" />
     <ClCompile Include="..\parsers\yumrepo.c" />
     <ClCompile Include="..\parsers\pythonloggingconfig.c" />
+    <ClCompile Include="..\main\ptrarray.c" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\fnmatch\fnmatch.h" />
@@ -265,6 +266,7 @@
     <ClInclude Include="..\parsers\make.h" />
     <ClInclude Include="..\parsers\iniconf.h" />
     <ClInclude Include="..\parsers\m4.h" />
+    <ClInclude Include="..\main\ptrarray.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -384,6 +384,9 @@
     <ClCompile Include="..\parsers\protobuf.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
+    <ClCompile Include="..\main\ptrarray.c">
+      <Filter>Source Files\Main</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\main\e_msoft.h">
@@ -525,6 +528,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
    <ClInclude Include="..\parsers\m4.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+   <ClInclude Include="..\main\ptrarray.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -387,6 +387,9 @@
     <ClCompile Include="..\main\ptrarray.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
+    <ClCompile Include="..\main\objpool.c">
+      <Filter>Source Files\Main</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\main\e_msoft.h">
@@ -531,6 +534,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
    <ClInclude Include="..\main\ptrarray.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+   <ClInclude Include="..\main\objpool.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
More details are in the individual commits.

To demonstrate the use of pool, I used it in the python parser for strings and tokens. The performance increase isn't much visible at this point because the bottlenecks are somewhere else (#1091, #1095) but once these are in, the pool increases the parser speed from 40MB/s to 46MB/s on my machine for django sources.