### PR TITLE
Various minor optimizations

### DIFF
--- a/main/args.c
+++ b/main/args.c
@@ -108,7 +108,6 @@ static char* nextFileArg (FILE* const fp)
 				vStringPut (vs, c);
 				c = fgetc (fp);
 			} while (c != EOF  &&  ! isspace (c));
-			vStringTerminate (vs);
 			Assert (vStringLength (vs) > 0);
 			result = xMalloc (vStringLength (vs) + 1, char);
 			strcpy (result, vStringValue (vs));
@@ -144,7 +143,6 @@ static char* nextFileLine (FILE* const fp)
 				if (c != '\n')
 					c = ungetc (c, fp);
 			}
-			vStringTerminate (vs);
 			vStringStripTrailing (vs);
 			result = xMalloc (vStringLength (vs) + 1, char);
 			vStringStripLeading (vs);

--- a/main/lcpp.c
+++ b/main/lcpp.c
@@ -232,7 +232,6 @@ static void readIdentifier (int c, vString *const name)
 		c = getcFromInputFile ();
 	} while (c != EOF  && cppIsident (c));
 	ungetcToInputFile (c);
-	vStringTerminate (name);
 }
 
 static void readFilename (int c, vString *const name)
@@ -243,8 +242,6 @@ static void readFilename (int c, vString *const name)
 
 	while (c = getcFromInputFile (), (c != EOF && c != c_end && c != '\n'))
 		vStringPut (name, c);
-
-	vStringTerminate (name);
 }
 
 static conditionalInfo *currentConditional (void)

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -602,7 +602,6 @@ static vString* substitute (
 		else if (*p != '\n'  &&  *p != '\r')
 			vStringPut (result, *p);
 	}
-	vStringTerminate (result);
 	return result;
 }
 

--- a/main/mbcs.c
+++ b/main/mbcs.c
@@ -89,8 +89,8 @@ retry:
 	dest_len = dest_ptr - dest;
 
 	vStringClear (string);
-	while (vStringSize (string) <= dest_len + 1)
-		vStringAutoResize (string);
+	if (vStringSize (string) < dest_len + 1)
+		vStringResize (string, dest_len + 1);
 	memcpy (vStringValue (string), dest, dest_len + 1);
 	vStringLength (string) = dest_len;
 	eFree (dest);

--- a/main/parse.c
+++ b/main/parse.c
@@ -418,7 +418,6 @@ static vString* determineInterpreter (const char* const cmd)
 			;  /* no-op */
 		for ( ;  *p != '\0'  &&  ! isspace ((int) *p)  ;  ++p)
 			vStringPut (interpreter, (int) *p);
-		vStringTerminate (interpreter);
 	} while (strcmp (vStringValue (interpreter), "env") == 0);
 	return interpreter;
 }
@@ -473,7 +472,6 @@ static vString* determineEmacsModeAtFirstLine (const char* const line)
 			;  /* no-op */
 		for ( ;  *p != '\0'  &&  (isalnum ((int) *p)  || *p == '-')  ;  ++p)
 			vStringPut (mode, (int) *p);
-		vStringTerminate (mode);
 	}
 	else
 	{
@@ -485,7 +483,6 @@ static vString* determineEmacsModeAtFirstLine (const char* const line)
 
 		for ( ;  p < end &&  (isalnum ((int) *p) || *p == '-')  ;  ++p)
 			vStringPut (mode, (int) *p);
-		vStringTerminate (mode);
 
 		for ( ;  isspace ((int) *p)  ;  ++p)
 			;  /* no-op */
@@ -537,7 +534,6 @@ static vString* determineEmacsModeAtEOF (MIO* const fp)
 				;  /* no-op */
 			for ( ;  *p != '\0'  &&  (isalnum ((int) *p)  || *p == '-')  ;  ++p)
 				vStringPut (mode, (int) *p);
-			vStringTerminate (mode);
 		}
 		else if (headerFound && (p = strstr(line, "End:")))
 			headerFound = false;
@@ -591,7 +587,6 @@ static vString* determineVimFileType (const char *const modeline)
 		p += strlen(filetype_prefix[i]);
 		for ( ;  *p != '\0'  &&  isalnum ((int) *p)  ;  ++p)
 			vStringPut (filetype, (int) *p);
-		vStringTerminate (filetype);
 		break;
 	}
 	return filetype;

--- a/main/read.c
+++ b/main/read.c
@@ -880,11 +880,9 @@ extern char *readLineRaw (vString *const vLine, MIO *const mio)
 					 *pLastChar != '\n'  &&  *pLastChar != '\r')
 			{
 				/*  buffer overflow */
-				reReadLine = vStringAutoResize (vLine);
-				if (reReadLine)
-					mio_seek (mio, startOfLine, SEEK_SET);
-				else
-					error (FATAL | PERROR, "input line too big; out of memory");
+				vStringResize (vLine, vStringSize (vLine) * 2);
+				mio_seek (mio, startOfLine, SEEK_SET);
+				reReadLine = true;
 			}
 			else
 			{

--- a/main/read.c
+++ b/main/read.c
@@ -753,8 +753,6 @@ static vString *iFileGetLine (void)
 			vStringPut (File.line, c);
 		if (c == '\n'  ||  (c == EOF  &&  vStringLength (File.line) > 0))
 		{
-			vStringTerminate (File.line);
-
 			if (vStringLength (File.line) > 0)
 				matchRegex (File.line, getInputLanguage ());
 

--- a/main/routines.c
+++ b/main/routines.c
@@ -671,10 +671,7 @@ extern char *combinePathAndFile (
 
 	vStringCopyS (filePath, path);
 	if (! terminated)
-	{
 		vStringPut (filePath, OUTPUT_PATH_SEPARATOR);
-		vStringTerminate (filePath);
-	}
 	vStringCatS (filePath, file);
 
 	return vStringDeleteUnwrap (filePath);

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -63,11 +63,6 @@ extern void vStringTruncate (vString *const string, const size_t length)
 	                         string->size - string->length); )
 }
 
-extern void vStringClear (vString *const string)
-{
-	vStringTruncate (string, 0);
-}
-
 extern void vStringDelete (vString *const string)
 {
 	if (string != NULL)

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -58,7 +58,7 @@ extern void vStringTruncate (vString *const string, const size_t length)
 {
 	Assert (length <= string->length);
 	string->length = length;
-	vStringTerminate (string);
+	string->buffer[string->length] = '\0';
 	DebugStatement ( memset (string->buffer + string->length, 0,
 	                         string->size - string->length); )
 }
@@ -145,7 +145,7 @@ extern void vStringNCatS (
 		--remain;
 		++p;
 	}
-	vStringTerminate (string);
+	vStringPut (string, '\0');
 }
 
 /*  Strip trailing newline from string.

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -43,6 +43,12 @@
 #define vStringChar(vs,i)     ((vs)->buffer[i])
 #define vStringLower(vs)      toLowerString((vs)->buffer)
 #define vStringUpper(vs)      toUpperString((vs)->buffer)
+#define vStringClear(string) \
+	do { \
+		vString *vStringClear_s = (string); \
+		vStringClear_s->length = 0; \
+		vStringClear_s->buffer[0] = '\0'; \
+	} while (false)
 
 /*
 *   DATA DECLARATIONS
@@ -58,7 +64,6 @@ typedef struct sVString {
 *   FUNCTION PROTOTYPES
 */
 extern bool vStringAutoResize (vString *const string);
-extern void vStringClear (vString *const string);
 extern vString *vStringNew (void);
 extern void vStringDelete (vString *const string);
 #ifndef VSTRING_PUTC_MACRO

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -40,10 +40,6 @@
 #define vStringLast(vs)       ((vs)->buffer[(vs)->length - 1])
 #define vStringLength(vs)     ((vs)->length)
 #define vStringSize(vs)       ((vs)->size)
-#define vStringCat(vs,s)      vStringCatS((vs), vStringValue((s)))
-#define vStringNCat(vs,s,l)   vStringNCatS((vs), vStringValue((s)), (l))
-#define vStringCopy(vs,s)     vStringCopyS((vs), vStringValue((s)))
-#define vStringNCopy(vs,s,l)  vStringNCopyS((vs), vStringValue((s)), (l))
 #define vStringChar(vs,i)     ((vs)->buffer[i])
 #define vStringLower(vs)      toLowerString((vs)->buffer)
 #define vStringUpper(vs)      toUpperString((vs)->buffer)
@@ -72,11 +68,15 @@ extern void vStringStripNewline (vString *const string);
 extern void vStringStripLeading (vString *const string);
 extern void vStringChop (vString *const string);
 extern void vStringStripTrailing (vString *const string);
+extern void vStringCat (vString *const string, const vString *const s);
 extern void vStringCatS (vString *const string, const char *const s);
+extern void vStringNCat (vString *const string, const vString *const s, const size_t length);
 extern void vStringNCatS (vString *const string, const char *const s, const size_t length);
 extern vString *vStringNewCopy (const vString *const string);
 extern vString *vStringNewInit (const char *const s);
+extern void vStringCopy (vString *const string, const vString *const s);
 extern void vStringCopyS (vString *const string, const char *const s);
+extern void vStringNCopy (vString *const string, const vString *const s, const size_t length);
 extern void vStringNCopyS (vString *const string, const char *const s, const size_t length);
 extern void vStringCopyToLower (vString *const dest, const vString *const src);
 extern void vStringSetLength (vString *const string);

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -45,7 +45,6 @@
 #define vStringCopy(vs,s)     vStringCopyS((vs), vStringValue((s)))
 #define vStringNCopy(vs,s,l)  vStringNCopyS((vs), vStringValue((s)), (l))
 #define vStringChar(vs,i)     ((vs)->buffer[i])
-#define vStringTerminate(vs)  vStringPut(vs, '\0')
 #define vStringLower(vs)      toLowerString((vs)->buffer)
 #define vStringUpper(vs)      toUpperString((vs)->buffer)
 

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -30,7 +30,7 @@
 #endif
 #ifdef VSTRING_PUTC_MACRO
 #define vStringPut(s,c) \
-	(void)(((s)->length + 1 == (s)->size ? vStringAutoResize (s) : 0), \
+	(void)(((s)->length + 1 == (s)->size ? vStringResize ((s), (s)->size * 2) : 0), \
 	((s)->buffer [(s)->length] = (c)), \
 	((c) == '\0' ? 0 : ((s)->buffer [++(s)->length] = '\0')))
 #endif
@@ -63,7 +63,7 @@ typedef struct sVString {
 /*
 *   FUNCTION PROTOTYPES
 */
-extern bool vStringAutoResize (vString *const string);
+extern void vStringResize (vString *const string, const size_t newSize);
 extern vString *vStringNew (void);
 extern void vStringDelete (vString *const string);
 #ifndef VSTRING_PUTC_MACRO

--- a/old-docs/EXTENDING.html
+++ b/old-docs/EXTENDING.html
@@ -242,7 +242,6 @@ static void findSwineTags (void)
                 vStringPut (name, (int) *cp);
                 ++cp;
             }
-            vStringTerminate (name);
             makeSimpleTag (name, SwineKinds, K_DEFINE);
             vStringClear (name);
         }

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -142,7 +142,6 @@ static bool readPreProc (const unsigned char *const line)
 		vStringPut (name, *cp);
 		++cp;
 	}
-	vStringTerminate (name);
 	result = (bool) (strcmp (vStringValue (name), "define") == 0);
 	if (result)
 	{
@@ -154,7 +153,6 @@ static bool readPreProc (const unsigned char *const line)
 			vStringPut (name, *cp);
 			++cp;
 		}
-		vStringTerminate (name);
 		makeSimpleTag (name, AsmKinds, K_DEFINE);
 	}
 	vStringDelete (name);
@@ -233,7 +231,6 @@ static const unsigned char *readSymbol (
 			vStringPut (sym, *cp);
 			++cp;
 		}
-		vStringTerminate (sym);
 	}
 	return cp;
 }
@@ -249,7 +246,6 @@ static const unsigned char *readOperator (
 		vStringPut (operator, *cp);
 		++cp;
 	}
-	vStringTerminate (operator);
 	return cp;
 }
 

--- a/parsers/asp.c
+++ b/parsers/asp.c
@@ -130,7 +130,6 @@ static void findAspTags (void)
 						    vStringPut (name, (int) *cp);
 						    ++cp;
 					    }
-					    vStringTerminate (name);
 					    makeSimpleTag (name, AspKinds, K_FUNCTION);
 					    vStringClear (name);
 					}
@@ -144,7 +143,6 @@ static void findAspTags (void)
 						    vStringPut (name, (int) *cp);
 						    ++cp;
 					    }
-					    vStringTerminate (name);
 					    makeSimpleTag (name, AspKinds, K_SUB);
 					    vStringClear (name);
 					}
@@ -154,7 +152,6 @@ static void findAspTags (void)
 						    vStringPut (name, (int) *cp);
 						    ++cp;
 					    }
-					    vStringTerminate (name);
 					    makeSimpleTag (name, AspKinds, K_DIM);
 					    vStringClear (name);
 					}
@@ -177,7 +174,6 @@ static void findAspTags (void)
 						    vStringPut (name, (int) *cp);
 						    ++cp;
 					    }
-					    vStringTerminate (name);
 					    makeSimpleTag (name, AspKinds, K_FUNCTION);
 					    vStringClear (name);
 					}
@@ -191,7 +187,6 @@ static void findAspTags (void)
 						    vStringPut (name, (int) *cp);
 						    ++cp;
 					    }
-					    vStringTerminate (name);
 					    makeSimpleTag (name, AspKinds, K_SUB);
 					    vStringClear (name);
 					}
@@ -201,7 +196,6 @@ static void findAspTags (void)
 						    vStringPut (name, (int) *cp);
 						    ++cp;
 					    }
-					    vStringTerminate (name);
 					    makeSimpleTag (name, AspKinds, K_DIM);
 					    vStringClear (name);
 					}
@@ -222,7 +216,6 @@ static void findAspTags (void)
 						vStringPut (name, (int) *cp);
 						++cp;
 					}
-					vStringTerminate (name);
 					makeSimpleTag (name, AspKinds, K_FUNCTION);
 					vStringClear (name);
 				}
@@ -241,7 +234,6 @@ static void findAspTags (void)
 						vStringPut (name, (int) *cp);
 						++cp;
 					}
-					vStringTerminate (name);
 					makeSimpleTag (name, AspKinds, K_SUB);
 					vStringClear (name);
 				}
@@ -260,7 +252,6 @@ static void findAspTags (void)
 						vStringPut (name, (int) *cp);
 						++cp;
 					}
-					vStringTerminate (name);
 					makeSimpleTag (name, AspKinds, K_DIM);
 					vStringClear (name);
 				}
@@ -279,7 +270,6 @@ static void findAspTags (void)
 						vStringPut (name, (int) *cp);
 						++cp;
 					}
-					vStringTerminate (name);
 					makeSimpleTag (name, AspKinds, K_CLASS);
 					vStringClear (name);
 				}
@@ -298,7 +288,6 @@ static void findAspTags (void)
 						vStringPut (name, (int) *cp);
 						++cp;
 					}
-					vStringTerminate (name);
 					makeSimpleTag (name, AspKinds, K_CONST);
 					vStringClear (name);
 				}

--- a/parsers/automake.c
+++ b/parsers/automake.c
@@ -249,7 +249,6 @@ static void directiveFoundAM (struct makeParserClient *client,
 		}
 		if (c == '\n')
 			ungetcToInputFile (c);
-		vStringTerminate (condition);
 		vStringStripTrailing (condition);
 		if (vStringLength (condition) > 0 )
 			refCondtionAM (condition);

--- a/parsers/awk.c
+++ b/parsers/awk.c
@@ -53,7 +53,6 @@ static void findAwkTags (void)
 				vStringPut (name, (int) *cp);
 				++cp;
 			}
-			vStringTerminate (name);
 			while (isspace ((int) *cp))
 				++cp;
 			if (*cp == '(')

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -97,7 +97,6 @@ static char const *extract_name (char const *pos, vString * name)
 	vStringClear (name);
 	for (; *pos && !isspace (*pos) && *pos != '(' && *pos != ','; pos++)
 		vStringPut (name, *pos);
-	vStringTerminate (name);
 	return pos;
 }
 

--- a/parsers/beta.c
+++ b/parsers/beta.c
@@ -96,8 +96,6 @@ static void findBetaTags (void)
 		while ((c = getcFromInputFile ()) != EOF && c != '\n' && c != '\r')
 			vStringPut (line, c);
 
-		vStringTerminate (line);
-
 		last = vStringLength (line) - 1;
 		first = 0;
 		/* skip white space at start and end of line */

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -1909,7 +1909,6 @@ static void readIdentifier (tokenInfo *const token, const int firstChar)
 		}
 		c = cppGetc ();
 	} while (cppIsident (c) || ((isInputLanguage (Lang_java) || isInputLanguage (Lang_csharp)) && (isHighChar (c) || c == '.')));
-	vStringTerminate (name);
 	cppUngetc (c);        /* unget non-identifier character */
 
 	analyzeIdentifier (token);
@@ -1927,7 +1926,6 @@ static void readPackageName (tokenInfo *const token, const int firstChar, bool a
 		vStringPut (name, c);
 		c = cppGetc ();
 	}
-	vStringTerminate (name);
 	cppUngetc (c);        /* unget non-package character */
 }
 
@@ -1964,7 +1962,6 @@ static void readVersionName (tokenInfo *const token, const int firstChar)
 		vStringPut (name, c);
 		c = cppGetc ();
 	}
-	vStringTerminate (name);
     cppGetc ();
 }
 
@@ -2040,7 +2037,6 @@ static void readOperator (statementInfo *const st)
 			}
 			c = cppGetc ();
 		} while (! isOneOf (c, "(;")  &&  c != EOF);
-		vStringTerminate (name);
 	}
 	else if (isOneOf (c, acceptable))
 	{
@@ -2050,7 +2046,6 @@ static void readOperator (statementInfo *const st)
 			vStringPut (name, c);
 			c = cppGetc ();
 		} while (isOneOf (c, acceptable));
-		vStringTerminate (name);
 	}
 
 	cppUngetc (c);
@@ -2796,7 +2791,6 @@ static int parseParens (statementInfo *const st, parenInfo *const info)
 	if (! info->isNameCandidate)
 		initToken (token);
 
-	vStringTerminate (Signature);
 	if (info->isKnrParamList)
 		vStringClear (Signature);
 	CollectingSignature = false;

--- a/parsers/clojure.c
+++ b/parsers/clojure.c
@@ -58,7 +58,6 @@ static void functionName (vString * const name, const char *dbp)
 	for (p = dbp; *p != '\0' && *p != '(' && !isspace ((int) *p) && *p != ')';
 		p++)
 		vStringPut (name, *p);
-	vStringTerminate (name);
 }
 
 static int makeNamespaceTag (vString * const name, const char *dbp)

--- a/parsers/css.c
+++ b/parsers/css.c
@@ -61,7 +61,6 @@ static void parseSelector (vString *const string, const int firstChar)
 		c = getcFromInputFile ();
 	} while (isSelectorChar (c));
 	ungetcToInputFile (c);
-	vStringTerminate (string);
 }
 
 static void readToken (tokenInfo *const token)
@@ -222,7 +221,6 @@ static void findCssTags (void)
 			/* we already consumed the next token, don't read it twice */
 			readNextToken = false;
 
-			vStringTerminate (selector);
 			if (CssKinds[kind].enabled)
 			{
 				tagEntryInfo e;

--- a/parsers/css.c
+++ b/parsers/css.c
@@ -14,6 +14,21 @@
 #include "read.h" 
 #include "routines.h"
 
+#define isSelectorChar(c) \
+	/* attribute selectors are handled separately */ \
+	(isalnum (c) || \
+		(c) == '_' || /* allowed char */ \
+		(c) == '-' || /* allowed char */ \
+		(c) == '+' || /* allow all sibling in a single tag */ \
+		(c) == '>' || /* allow all child in a single tag */ \
+		(c) == '|' || /* allow namespace separator */ \
+		(c) == '(' || /* allow pseudo-class arguments */ \
+		(c) == ')' || \
+		(c) == '.' || /* allow classes and selectors */ \
+		(c) == ':' || /* allow pseudo classes */ \
+		(c) == '*' || /* allow globs as P + * */ \
+		(c) == '#')   /* allow ids */
+
 typedef enum eCssKinds {
 	K_CLASS, K_SELECTOR, K_ID
 } cssKind;
@@ -36,23 +51,6 @@ typedef struct {
 	vString *string;
 } tokenInfo;
 
-
-static bool isSelectorChar (const int c)
-{
-	/* attribute selectors are handled separately */
-	return (isalnum (c) ||
-			c == '_' || // allowed char
-			c == '-' || // allowed char
-			c == '+' || // allow all sibling in a single tag
-			c == '>' || // allow all child in a single tag
-			c == '|' || // allow namespace separator
-			c == '(' || // allow pseudo-class arguments
-			c == ')' ||
-			c == '.' || // allow classes and selectors
-			c == ':' || // allow pseudo classes
-			c == '*' || // allow globs as P + *
-			c == '#');  // allow ids
-}
 
 static void parseSelector (vString *const string, const int firstChar)
 {

--- a/parsers/diff.c
+++ b/parsers/diff.c
@@ -169,7 +169,6 @@ static void findDiffTags (void)
 					tmp++;
 				}
 
-				vStringTerminate(filename);
 				if (delim == DIFF_DELIM_PLUS)
 					kind = K_NEW_FILE;
 				else

--- a/parsers/eiffel.c
+++ b/parsers/eiffel.c
@@ -345,7 +345,6 @@ static vString *parseInteger (int c)
 		vStringPut (string, c);
 		c = getcFromInputFile ();
 	}
-	vStringTerminate (string);
 	ungetcToInputFile (c);
 
 	return string;
@@ -376,8 +375,6 @@ static vString *parseNumeric (int c)
 	}
 	else if (!isspace (c))
 		ungetcToInputFile (c);
-
-	vStringTerminate (string);
 
 	return string;
 }
@@ -501,14 +498,10 @@ static void parseString (vString *const string)
 		{
 			vStringPut (string, c);
 			if (verbatim)
-			{
 				vStringPut (lastLine, c);
-				vStringTerminate (lastLine);
-			}
 			prev = c;
 		}
 	}
-	vStringTerminate (string);
 	vStringDelete (lastLine);
 	vStringDelete (verbatimCloser);
 }
@@ -525,7 +518,6 @@ static void parseIdentifier (vString *const string, const int firstChar)
 		c = getcFromInputFile ();
 	} while (isident (c));
 
-	vStringTerminate (string);
 	if (!isspace (c))
 		ungetcToInputFile (c);  /* unget non-identifier character */
 }
@@ -540,7 +532,6 @@ static void parseFreeOperator (vString *const string, const int firstChar)
 		c = getcFromInputFile ();
 	} while (c > ' ');
 
-	vStringTerminate (string);
 	if (!isspace (c))
 		ungetcToInputFile (c);  /* unget non-identifier character */
 }

--- a/parsers/erlang.c
+++ b/parsers/erlang.c
@@ -69,7 +69,6 @@ static const unsigned char *parseIdentifier (
 		vStringPut (identifier, (int) *cp);
 		++cp;
 	}
-	vStringTerminate (identifier);
 	return cp;
 }
 

--- a/parsers/falcon.c
+++ b/parsers/falcon.c
@@ -84,7 +84,6 @@ static void findFalconTags (void)
                 vStringPut (name, (int) *cp);
                 ++cp;
             }
-            vStringTerminate (name);
             makeSimpleTag (name, FalconKinds, K_FUNCTION);
             vStringClear (name);
         }
@@ -98,7 +97,6 @@ static void findFalconTags (void)
                 vStringPut (name, (int) *cp);
                 ++cp;
             }
-            vStringTerminate (name);
             makeSimpleTag (name, FalconKinds, K_CLASS);
             vStringClear (name);
         }
@@ -112,7 +110,6 @@ static void findFalconTags (void)
                 vStringPut (name, (int) *cp);
                 ++cp;
             }
-            vStringTerminate (name);
             makeSimpleTag (name, FalconKinds, K_NAMESPACE);
             vStringClear (name);
         }
@@ -126,7 +123,6 @@ static void findFalconTags (void)
                 vStringPut (name, (int) *cp);
                 ++cp;
             }
-            vStringTerminate (name);
             makeSimpleTag (name, FalconKinds, K_NAMESPACE);
             vStringClear (name);
         }

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -36,6 +36,10 @@
  */
 #define isType(token,t)		(bool) ((token)->type == (t))
 #define isKeyword(token,k)	(bool) ((token)->keyword == (k))
+#define isEOF(token) (isType ((token), TOKEN_EOF))
+#define isIdentChar(c) \
+	(isalpha (c) || isdigit (c) || (c) == '$' || \
+		(c) == '@' || (c) == '_' || (c) == '#')
 
 /*
  *	 DATA DECLARATIONS
@@ -193,18 +197,6 @@ static bool parseBlock (tokenInfo *const token, tokenInfo *const parent);
 static bool parseLine (tokenInfo *const token);
 static bool parseActionScript (tokenInfo *const token);
 static bool parseMXML (tokenInfo *const token);
-
-static bool isEOF (tokenInfo *const token)
-{
-	return isType (token, TOKEN_EOF);
-}
-
-static bool isIdentChar (const int c)
-{
-	return (bool)
-		(isalpha (c) || isdigit (c) || c == '$' || 
-		 c == '@' || c == '_' || c == '#');
-}
 
 static tokenInfo *newToken (void)
 {

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -269,7 +269,6 @@ static void makeFlexTag (tokenInfo *const token, flexKind kind)
 			vStringCopy(fulltag, token->scope);
 			vStringCatS (fulltag, ".");
 			vStringCatS (fulltag, vStringValue(token->string));
-			vStringTerminate(fulltag);
 			vStringCopy(token->string, fulltag);
 			vStringDelete (fulltag);
 		}
@@ -294,7 +293,6 @@ static void makeClassTag (tokenInfo *const token)
 		{
 			vStringCopy(fulltag, token->string);
 		}
-		vStringTerminate(fulltag);
 		if ( ! stringListHas(ClassNames, vStringValue (fulltag)) )
 		{
 			stringListAdd (ClassNames, vStringNewCopy (fulltag));
@@ -321,7 +319,6 @@ static void makeMXTag (tokenInfo *const token)
 		{
 			vStringCopy(fulltag, token->string);
 		}
-		vStringTerminate(fulltag);
 		makeFlexTag (token, FLEXTAG_MXTAG);
 		vStringDelete (fulltag);
 	}
@@ -344,7 +341,6 @@ static void makeFunctionTag (tokenInfo *const token)
 		{
 			vStringCopy(fulltag, token->string);
 		}
-		vStringTerminate(fulltag);
 		if ( ! stringListHas(FunctionNames, vStringValue (fulltag)) )
 		{
 			stringListAdd (FunctionNames, vStringNewCopy (fulltag));
@@ -376,7 +372,6 @@ static void parseString (vString *const string, const int delimiter)
 		else
 			vStringPut (string, c);
 	}
-	vStringTerminate (string);
 }
 
 /*	Read a C identifier beginning with "firstChar" and places it into
@@ -391,7 +386,6 @@ static void parseIdentifier (vString *const string, const int firstChar)
 		vStringPut (string, c);
 		c = getcFromInputFile ();
 	} while (isIdentChar (c));
-	vStringTerminate (string);
 	if (!isspace (c))
 		ungetcToInputFile (c);		/* unget non-identifier character */
 }
@@ -807,7 +801,6 @@ static void addContext (tokenInfo* const parent, const tokenInfo* const child)
 		vStringCatS (parent->string, ".");
 	}
 	vStringCatS (parent->string, vStringValue(child->string));
-	vStringTerminate(parent->string);
 }
 
 static void addToScope (tokenInfo* const token, vString* const extra)
@@ -817,7 +810,6 @@ static void addToScope (tokenInfo* const token, vString* const extra)
 		vStringCatS (token->scope, ".");
 	}
 	vStringCatS (token->scope, vStringValue(extra));
-	vStringTerminate(token->scope);
 }
 
 /*
@@ -1871,7 +1863,6 @@ static bool parseStatement (tokenInfo *const token)
 				{
 					vStringCopy(fulltag, token->string);
 				}
-				vStringTerminate(fulltag);
 				if ( ! stringListHas(FunctionNames, vStringValue (fulltag)) &&
 						! stringListHas(ClassNames, vStringValue (fulltag)) )
 				{

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -646,10 +646,7 @@ static lineType getLineType (void)
 	Assert (type != LTYPE_UNDETERMINED);
 
 	if (vStringLength (label) > 0)
-	{
-		vStringTerminate (label);
 		makeLabelTag (label);
-	}
 	vStringDelete (label);
 	return type;
 }
@@ -843,7 +840,6 @@ static vString *parseInteger (int c)
 		vStringPut (string, c);
 		c = getChar ();
 	}
-	vStringTerminate (string);
 
 	if (c == '_')
 	{
@@ -879,8 +875,6 @@ static vString *parseNumeric (int c)
 	else
 		ungetChar (c);
 
-	vStringTerminate (string);
-
 	return string;
 }
 
@@ -902,7 +896,6 @@ static void parseString (vString *const string, const int delimiter)
 		if (c != EOF && ! FreeSourceForm)
 			FreeSourceFormFound = true;
 	}
-	vStringTerminate (string);
 	ParsingString = false;
 }
 
@@ -918,7 +911,6 @@ static void parseIdentifier (vString *const string, const int firstChar)
 		c = getChar ();
 	} while (isident (c));
 
-	vStringTerminate (string);
 	ungetChar (c);  /* unget non-identifier character */
 }
 
@@ -944,7 +936,6 @@ static void checkForLabel (void)
 	}
 	if (length > 0  &&  token != NULL)
 	{
-		vStringTerminate (token->string);
 		makeFortranTag (token, TAG_LABEL);
 		deleteToken (token);
 	}
@@ -1025,7 +1016,6 @@ getNextChar:
 				c = getChar ();
 			} while (strchr (operatorChars, c) != NULL);
 			ungetChar (c);
-			vStringTerminate (token->string);
 			token->type = TOKEN_OPERATOR;
 			break;
 		}
@@ -1055,7 +1045,6 @@ getNextChar:
 			if (c == '.')
 			{
 				vStringPut (token->string, c);
-				vStringTerminate (token->string);
 				token->type = TOKEN_OPERATOR;
 			}
 			else

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -180,7 +180,6 @@ static void parseString (vString *const string, const int delimiter)
 		else
 			vStringPut (string, c);
 	}
-	vStringTerminate (string);
 }
 
 static void parseIdentifier (vString *const string, const int firstChar)
@@ -191,7 +190,6 @@ static void parseIdentifier (vString *const string, const int firstChar)
 		vStringPut (string, c);
 		c = getcFromInputFile ();
 	} while (isIdentChar (c));
-	vStringTerminate (string);
 	ungetcToInputFile (c);		/* always unget, LF might add a semicolon */
 }
 

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -22,6 +22,8 @@
 #define MAX_SIGNATURE_LENGTH 512
 #define isType(token,t) (bool) ((token)->type == (t))
 #define isKeyword(token,k) (bool) ((token)->keyword == (k))
+#define isStartIdentChar(c) (isalpha (c) ||  (c) == '_' || (c) > 128) /* XXX UTF-8 */
+#define isIdentChar(c) (isStartIdentChar (c) || isdigit (c))
 
 /*
  *	 DATA DECLARATIONS
@@ -117,19 +119,6 @@ static const keywordTable GoKeywordTable[] = {
 /*
 *   FUNCTION DEFINITIONS
 */
-
-// XXX UTF-8
-static bool isStartIdentChar (const int c)
-{
-	return (bool)
-		(isalpha (c) ||  c == '_' || c > 128);
-}
-
-static bool isIdentChar (const int c)
-{
-	return (bool)
-		(isStartIdentChar (c) || isdigit (c));
-}
 
 static void initialize (const langType language)
 {

--- a/parsers/iniconf.c
+++ b/parsers/iniconf.c
@@ -124,7 +124,6 @@ extern void runIniconfParser (const iniconfCallback callback, void* userData)
 				vStringPut (name, (int) *cp);
 				++cp;
 			}
-			vStringTerminate (name);
 
 			if (isLanguageEnabled (iniconf))
 				makeIniconfTagMaybe (iniconf, vStringValue (name), NULL, NULL,
@@ -144,7 +143,6 @@ extern void runIniconfParser (const iniconfCallback callback, void* userData)
 				cb (vStringValue (name), NULL, NULL, userData);
 
 			vStringCopy (scope, name);
-			vStringTerminate (scope);
 			vStringClear (name);
 			continue;
 		}
@@ -159,7 +157,6 @@ extern void runIniconfParser (const iniconfCallback callback, void* userData)
 					vStringPut (name, (int) *cp);
 					++cp;
 				}
-				vStringTerminate (name);
 				vStringStripTrailing (name);
 				while (isspace ((int) *cp))
 					++cp;
@@ -174,7 +171,6 @@ extern void runIniconfParser (const iniconfCallback callback, void* userData)
 						vStringPut (val, (int) *cp);
 						++cp;
 					}
-					vStringTerminate (val);
 					vStringStripTrailing (val);
 
 					if (isLanguageEnabled (iniconf))

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -294,7 +294,6 @@ static void makeClassTag (tokenInfo *const token, vString *const signature)
 		{
 			vStringCopy(fulltag, token->string);
 		}
-		vStringTerminate(fulltag);
 		if ( ! stringListHas(ClassNames, vStringValue (fulltag)) )
 		{
 			stringListAdd (ClassNames, vStringNewCopy (fulltag));
@@ -321,7 +320,6 @@ static void makeFunctionTag (tokenInfo *const token, vString *const signature)
 		{
 			vStringCopy(fulltag, token->string);
 		}
-		vStringTerminate(fulltag);
 		if ( ! stringListHas(FunctionNames, vStringValue (fulltag)) )
 		{
 			stringListAdd (FunctionNames, vStringNewCopy (fulltag));
@@ -374,7 +372,6 @@ static void parseString (vString *const string, const int delimiter)
 		else
 			vStringPut (string, c);
 	}
-	vStringTerminate (string);
 }
 
 static void parseRegExp (void)
@@ -421,7 +418,6 @@ static void parseIdentifier (vString *const string, const int firstChar)
 		vStringPut (string, c);
 		c = getcFromInputFile ();
 	} while (isIdentChar (c));
-	vStringTerminate (string);
 	ungetcToInputFile (c);		/* unget non-identifier character */
 }
 
@@ -466,7 +462,6 @@ static void parseTemplateString (vString *const string)
 		}
 	}
 	while (c != EOF);
-	vStringTerminate (string);
 }
 
 static void readTokenFull (tokenInfo *const token, bool include_newlines, vString *const repr)
@@ -792,7 +787,6 @@ static void addContext (tokenInfo* const parent, const tokenInfo* const child)
 		vStringCatS (parent->string, ".");
 	}
 	vStringCatS (parent->string, vStringValue(child->string));
-	vStringTerminate(parent->string);
 }
 
 static void addToScope (tokenInfo* const token, vString* const extra)
@@ -802,7 +796,6 @@ static void addToScope (tokenInfo* const token, vString* const extra)
 		vStringCatS (token->scope, ".");
 	}
 	vStringCatS (token->scope, vStringValue(extra));
-	vStringTerminate(token->scope);
 }
 
 /*
@@ -1677,7 +1670,6 @@ nextVar:
 					{
 						vStringCopy(fulltag, token->string);
 					}
-					vStringTerminate(fulltag);
 					if ( ! stringListHas(FunctionNames, vStringValue (fulltag)) &&
 							! stringListHas(ClassNames, vStringValue (fulltag)) )
 					{
@@ -1768,7 +1760,6 @@ nextVar:
 				{
 					vStringCopy(fulltag, token->string);
 				}
-				vStringTerminate(fulltag);
 				if ( ! stringListHas(FunctionNames, vStringValue (fulltag)) &&
 						! stringListHas(ClassNames, vStringValue (fulltag)) )
 				{

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -38,6 +38,9 @@
  */
 #define isType(token,t)		(bool) ((token)->type == (t))
 #define isKeyword(token,k)	(bool) ((token)->keyword == (k))
+#define isIdentChar(c) \
+	(isalpha (c) || isdigit (c) || (c) == '$' || \
+		(c) == '@' || (c) == '_' || (c) == '#')
 
 /*
  *	 DATA DECLARATIONS
@@ -172,13 +175,6 @@ static void parseFunction (tokenInfo *const token);
 static bool parseBlock (tokenInfo *const token, tokenInfo *const orig_parent);
 static bool parseLine (tokenInfo *const token, tokenInfo *const parent, bool is_inside_class);
 static void parseUI5 (tokenInfo *const token);
-
-static bool isIdentChar (const int c)
-{
-	return (bool)
-		(isalpha (c) || isdigit (c) || c == '$' ||
-		 c == '@' || c == '_' || c == '#');
-}
 
 static tokenInfo *newToken (void)
 {

--- a/parsers/json.c
+++ b/parsers/json.c
@@ -25,6 +25,9 @@
 #include "routines.h"
 #include "vstring.h"
 
+#define isIdentChar(c) \
+	(isalnum (c) || (c) == '+' || (c) == '-' || (c) == '.')
+
 typedef enum {
 	TOKEN_EOF,
 	TOKEN_UNDEFINED,
@@ -136,11 +139,6 @@ static void makeJsonTag (tokenInfo *const token, const jsonKind kind)
 	}
 
 	makeTagEntry (&e);
-}
-
-static bool isIdentChar (int c)
-{
-	return (isalnum (c) || c == '+' || c == '-' || c == '.');
 }
 
 static void readTokenFull (tokenInfo *const token,

--- a/parsers/json.c
+++ b/parsers/json.c
@@ -185,7 +185,6 @@ static void readTokenFull (tokenInfo *const token,
 				if (includeStringRepr)
 					vStringPut (token->string, c);
 			}
-			vStringTerminate (token->string);
 			break;
 		}
 
@@ -200,7 +199,6 @@ static void readTokenFull (tokenInfo *const token,
 					c = getcFromInputFile ();
 				}
 				while (c != EOF && isIdentChar (c));
-				vStringTerminate (token->string);
 				ungetcToInputFile (c);
 				switch (lookupKeyword (vStringValue (token->string), Lang_json))
 				{
@@ -223,7 +221,6 @@ static void pushScope (tokenInfo *const token,
 	if (vStringLength (token->scope) > 0)
 		vStringPut (token->scope, '.');
 	vStringCat (token->scope, parent->string);
-	vStringTerminate (token->scope);
 	token->scopeKind = parentKind;
 }
 

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -67,7 +67,6 @@ static void L_getit (vString *const name, const unsigned char *dbp)
 	}
 	for (p=dbp ; *p!='\0' && *p!='(' && !isspace ((int) *p) && *p!=')' ; p++)
 		vStringPut (name, *p);
-	vStringTerminate (name);
 
 	if (vStringLength (name) > 0)
 		makeSimpleTag (name, LispKinds, K_FUNCTION);

--- a/parsers/lua.c
+++ b/parsers/lua.c
@@ -90,7 +90,6 @@ static void extract_next_token (const char *begin, const char *end_sentinel, vSt
 
 	if (found)
 	{
-		vStringTerminate (name);
 		makeSimpleTag (name, LuaKinds, K_FUNCTION);
 		vStringClear (name);
 	}

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -183,7 +183,6 @@ static void readIdentifier (const int first, vString *const id)
 		c = nextChar ();
 	}
 	ungetcToInputFile (c);
-	vStringTerminate (id);
 }
 
 extern void runMakeParser (struct makeParserClient *client, void *data)
@@ -295,7 +294,6 @@ extern void runMakeParser (struct makeParserClient *client, void *data)
 					}
 					if (c == '\n')
 						ungetcToInputFile (c);
-					vStringTerminate (name);
 					vStringStripTrailing (name);
 					newMacro (name, true, false, client, data);
 				}

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -246,8 +246,6 @@ static void readIdentifier (lexingState * st)
 		vStringPut (st->name, (int) *p);
 
 	st->cp = p;
-
-	vStringTerminate (st->name);
 }
 
 /* read the @something directives */
@@ -265,8 +263,6 @@ static void readIdentifierObjcDirective (lexingState * st)
 		vStringPut (st->name, (int) *p);
 
 	st->cp = p;
-
-	vStringTerminate (st->name);
 }
 
 /* The lexer is in charge of reading the file.

--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -336,8 +336,6 @@ static void readIdentifier (lexingState * st)
 		vStringPut (st->name, (int) *p);
 
 	st->cp = p;
-
-	vStringTerminate (st->name);
 }
 
 static ocamlKeyword eatNumber (lexingState * st)
@@ -361,8 +359,6 @@ static ocamlKeyword eatOperator (lexingState * st)
 		vStringPut (st->name, st->cp[count]);
 		count++;
 	}
-
-	vStringTerminate (st->name);
 
 	st->cp += count;
 	if (count <= 1)
@@ -1813,7 +1809,6 @@ static void computeModuleName ( void )
 	}
 
 	vStringNCopyS (moduleName, &filename[beginIndex], endIndex - beginIndex);
-	vStringTerminate (moduleName);
 
 	if (isLowerAlpha (moduleName->buffer[0]))
 		moduleName->buffer[0] += ('A' - 'a');

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -473,7 +473,6 @@ static void findPerlTags (void)
 				vStringCatS (name, "STDOUT");
 			}
 
-			vStringTerminate (name);
 			TRACE("name: %s\n", name->buffer);
 
 			if (0 == vStringLength(name)) {

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -20,6 +20,7 @@
 #include "routines.h"
 #include "debug.h"
 
+#define isIdentChar(c) (isalnum (c) || (c) == '_' || (c) >= 0x80)
 
 enum {
 	KEYWORD_abstract,
@@ -520,11 +521,6 @@ static void addToScope (tokenInfo *const token, const vString *const extra,
 	}
 	vStringCat (token->scope, extra);
 	vStringTerminate(token->scope);
-}
-
-static bool isIdentChar (const int c)
-{
-	return (isalnum (c) || c == '_' || c >= 0x80);
 }
 
 static int skipToCharacter (const int c)

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -331,7 +331,6 @@ static void initPhpEntry (tagEntryInfo *const e, const tokenInfo *const token,
 	{
 		Assert (parentKind >= 0);
 
-		vStringTerminate (FullScope);
 		e->extensionFields.scopeKind = &(PhpKinds[parentKind]);
 		e->extensionFields.scopeName = vStringValue (FullScope);
 	}
@@ -520,7 +519,6 @@ static void addToScope (tokenInfo *const token, const vString *const extra,
 		vStringCatS (token->scope, sep);
 	}
 	vStringCat (token->scope, extra);
-	vStringTerminate(token->scope);
 }
 
 static int skipToCharacter (const int c)
@@ -546,7 +544,6 @@ static void parseString (vString *const string, const int delimiter)
 		else
 			vStringPut (string, (char) c);
 	}
-	vStringTerminate (string);
 }
 
 /* reads an HereDoc or a NowDoc (the part after the <<<).
@@ -664,8 +661,6 @@ static void parseHeredoc (vString *const string)
 	}
 	while (c != EOF);
 
-	vStringTerminate (string);
-
 	return;
 
 error:
@@ -681,7 +676,6 @@ static void parseIdentifier (vString *const string, const int firstChar)
 		c = getcFromInputFile ();
 	} while (isIdentChar (c));
 	ungetcToInputFile (c);
-	vStringTerminate (string);
 }
 
 static bool isSpace (int c)
@@ -1235,8 +1229,6 @@ static bool parseFunction (tokenInfo *const token, const tokenInfo *name)
 		}
 		while (token->type != TOKEN_EOF && depth > 0);
 
-		vStringTerminate (arglist);
-
 		makeFunctionTag (name, arglist, access, impl);
 		vStringDelete (arglist);
 
@@ -1524,7 +1516,6 @@ static bool parseNamespace (tokenInfo *const token)
 		   token->type != TOKEN_SEMICOLON &&
 		   token->type != TOKEN_OPEN_CURLY);
 
-	vStringTerminate (CurrentNamesapce);
 	if (vStringLength (CurrentNamesapce) > 0)
 		makeNamespacePhpTag (nsToken, CurrentNamesapce);
 

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -439,7 +439,6 @@ static void readIdentifier (vString *const string, const int firstChar)
 	}
 	while (isIdentifierChar (c));
 	ungetcToInputFile (c);
-	vStringTerminate (string);
 }
 
 static void ungetToken (tokenInfo *const token)
@@ -697,8 +696,6 @@ static bool skipOverPair (tokenInfo *const token, int tOpen, int tClose,
 		}
 		while (token->type != TOKEN_EOF && depth > 0);
 	}
-	if (repr)
-		vStringTerminate (repr);
 
 	return token->type == tClose;
 }
@@ -902,8 +899,6 @@ static bool parseClassOrDef (tokenInfo *const token,
 			}
 		}
 		while (token->type != TOKEN_EOF && depth > 0);
-
-		vStringTerminate (arglist);
 	}
 
 	if (kind == K_CLASS)

--- a/parsers/r.c
+++ b/parsers/r.c
@@ -105,7 +105,6 @@ static void createRTags (void)
 						vStringPut (name, (int) *cp);
 						cp++;
 					}
-					vStringTerminate (name);
 
 					/* if the string really exists, make a tag of it */
 					if (vStringLength (name) > 0)
@@ -154,7 +153,6 @@ static void createRTags (void)
 					{
 						/* it's a function: ident <- function(args) */
 						cp += 8;
-						vStringTerminate (name);
 						/* if the string really exists, make a tag of it */
 						if (vStringLength (name) > 0)
 							makeRTag (name, K_FUNCTION);
@@ -166,7 +164,6 @@ static void createRTags (void)
 					else
 					{
 						/* it's a variable: ident <- value */
-						vStringTerminate (name);
 						/* if the string really exists, make a tag of it */
 						if (vStringLength (name) > 0)
 						{

--- a/parsers/rst.c
+++ b/parsers/rst.c
@@ -252,7 +252,6 @@ static void findRstTags (void)
 			vStringCatS(name, (const char*)line);
 			filepos = getInputFilePosition();
 		}
-		vStringTerminate(name);
 	}
 	/* Force popping all nesting levels */
 	getNestingLevel (K_EOF);

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -192,7 +192,6 @@ static void emitRubyTag (vString* name, rubyKind kind)
             return;
         }
 
-	vStringTerminate (name);
 	scope = nestingLevelsToScope (nesting);
 	lvl = nestingLevelsGetCurrent (nesting);
 	parent = getEntryOfNestingLevel (lvl);
@@ -315,7 +314,6 @@ static rubyKind parseIdentifier (
 			/* Recognize singleton methods. */
 			if (last_char == '.')
 			{
-				vStringTerminate (name);
 				vStringClear (name);
 				return parseIdentifier (cp, name, K_SINGLETON);
 			}

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -26,6 +26,11 @@
 #include "vstring.h"
 
 /*
+ *	 MACROS
+ */
+#define isIdentChar(c) (isalnum (c) || (c) == '_')
+
+/*
 *   DATA DECLARATIONS
 */
 typedef enum {
@@ -110,11 +115,6 @@ static bool canMatch (const unsigned char** s, const char* literal,
 	}
 	*s += literal_length;
 	return true;
-}
-
-static bool isIdentChar (int c)
-{
-	return (isalnum (c) || c == '_');
 }
 
 static bool notIdentChar (int c)

--- a/parsers/scheme.c
+++ b/parsers/scheme.c
@@ -50,7 +50,6 @@ static void readIdentifier (vString *const name, const unsigned char *cp)
 	/* Go till you get to white space or a syntactic break */
 	for (p = cp; *p != '\0' && *p != '(' && *p != ')' && !isspace (*p); p++)
 		vStringPut (name, (int) *p);
-	vStringTerminate (name);
 }
 
 static void findSchemeTags (void)

--- a/parsers/sh.c
+++ b/parsers/sh.c
@@ -248,7 +248,6 @@ static void findShTags (void)
 				vStringPut (name, (int) *cp);
 				++cp;
 			}
-			vStringTerminate (name);
 
 			while (isspace ((int) *cp))
 				++cp;

--- a/parsers/sml.c
+++ b/parsers/sml.c
@@ -133,7 +133,6 @@ static const unsigned char *parseIdentifier (
 		vStringPut (identifier, (int) *cp);
 		cp++;
 	}
-	vStringTerminate (identifier);
 	return cp;
 }
 

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -42,6 +42,17 @@
  */
 #define isType(token,t)		(bool) ((token)->type == (t))
 #define isKeyword(token,k)	(bool) ((token)->keyword == (k))
+#define isIdentChar1(c) \
+	/*
+	 * Other databases are less restrictive on the first character of
+	 * an identifier.
+	 * isIdentChar1 is used to identify the first character of an 
+	 * identifier, so we are removing some restrictions.
+	 */ \
+	(isalpha (c) || (c) == '@' || (c) == '_' )
+#define isIdentChar(c) \
+	(isalpha (c) || isdigit (c) || (c) == '$' || \
+		(c) == '@' || (c) == '_' || (c) == '#')
 
 /*
  *	 DATA DECLARATIONS
@@ -314,25 +325,6 @@ static tokenType parseSqlFile (tokenInfo *const token);
 /*
  *	 FUNCTION DEFINITIONS
  */
-
-static bool isIdentChar1 (const int c)
-{
-	/*
-	 * Other databases are less restrictive on the first character of
-	 * an identifier.
-	 * isIdentChar1 is used to identify the first character of an 
-	 * identifier, so we are removing some restrictions.
-	 */
-	return (bool)
-		(isalpha (c) || c == '@' || c == '_' );
-}
-
-static bool isIdentChar (const int c)
-{
-	return (bool)
-		(isalpha (c) || isdigit (c) || c == '$' || 
-		 c == '@' || c == '_' || c == '#');
-}
 
 static bool isCmdTerm (tokenInfo *const token)
 {

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -457,7 +457,6 @@ static void parseString (vString *const string, const int delimiter)
 		else
 			vStringPut (string, c);
 	}
-	vStringTerminate (string);
 }
 
 /*	Read a C identifier beginning with "firstChar" and places it into "name".
@@ -471,7 +470,6 @@ static void parseIdentifier (vString *const string, const int firstChar)
 		vStringPut (string, c);
 		c = getcFromInputFile ();
 	} while (isIdentChar (c));
-	vStringTerminate (string);
 	if (!isspace (c))
 		ungetcToInputFile (c);		/* unget non-identifier character */
 }
@@ -659,7 +657,6 @@ static void readIdentifier (tokenInfo *const token)
  *		   vStringCatS (parent->string, ".");
  *	   }
  *	   vStringCatS (parent->string, vStringValue(child->string));
- *	   vStringTerminate(parent->string);
  * }
  */
 
@@ -670,7 +667,6 @@ static void addToScope (tokenInfo* const token, vString* const extra, sqlKind ki
 		vStringCatS (token->scope, ".");
 	}
 	vStringCatS (token->scope, vStringValue(extra));
-	vStringTerminate(token->scope);
 	token->scopeKind = kind;
 }
 

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -47,7 +47,6 @@ static const unsigned char *makeTclTag (
 		vStringPut (name, (int) *cp);
 		++cp;
 	}
-	vStringTerminate (name);
 	makeSimpleTag (name, TclKinds, kind);
 	return cp;
 }

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -35,6 +35,9 @@
  */
 #define isType(token,t)		(bool) ((token)->type == (t))
 #define isKeyword(token,k)	(bool) ((token)->keyword == (k))
+#define isIdentChar(c) \
+	(isalpha (c) || isdigit (c) || (c) == '$' || \
+		(c) == '_' || (c) == '#' || (c) == '-' || (c) == '.' || (c) == ':')
 
 /*
  *	 DATA DECLARATIONS
@@ -139,13 +142,6 @@ static const keywordTable TexKeywordTable [] = {
 /*
  *	 FUNCTION DEFINITIONS
  */
-
-static bool isIdentChar (const int c)
-{
-	return (bool)
-		(isalpha (c) || isdigit (c) || c == '$' ||
-		  c == '_' || c == '#' || c == '-' || c == '.' || c == ':');
-}
 
 static tokenInfo *newToken (void)
 {

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -281,7 +281,6 @@ static void parseIdentifier (vString *const string, const int firstChar)
 		c = getcFromInputFile ();
 	} while (isIdentChar (c));
 
-	vStringTerminate (string);
 	if (!isspace (c))
 		ungetcToInputFile (c);		/* unget non-identifier character */
 }
@@ -410,7 +409,6 @@ static bool parseTag (tokenInfo *const token, texKind kind)
 			}
 			readToken (token);
 		}
-		vStringTerminate (fullname);
 		vStringCopy (name->string, fullname);
 		makeTexTag (name, kind);
 	}
@@ -436,7 +434,6 @@ static bool parseTag (tokenInfo *const token, texKind kind)
 		}
 		if (useLongName)
 		{
-			vStringTerminate (fullname);
 			if (vStringLength (fullname) > 0)
 			{
 				vStringCopy (name->string, fullname);

--- a/parsers/ttcn.c
+++ b/parsers/ttcn.c
@@ -522,10 +522,6 @@ static ttcnToken_t * getToken (void)
         vStringDelete(pTtcnToken->value);
         pTtcnToken->value = NULL;
     }
-    else
-    {
-        vStringTerminate(pTtcnToken->value);
-    }
     return pTtcnToken;
 } 
 

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -448,7 +448,6 @@ static bool readIdentifier (tokenInfo *const token, int c)
 			c = vGetc ();
 		}
 		vUngetc (c);
-		vStringTerminate (token->name);
 		token->lineNumber = getInputLineNumber ();
 		token->filePosition = getInputFilePosition ();
 	}

--- a/parsers/vhdl.c
+++ b/parsers/vhdl.c
@@ -361,7 +361,6 @@ static void parseString (vString * const string, const int delimiter)
 		else
 			vStringPut (string, c);
 	}
-	vStringTerminate (string);
 }
 
 /*  Read a VHDL identifier beginning with "firstChar" and place it into "name".
@@ -375,7 +374,6 @@ static void parseIdentifier (vString * const string, const int firstChar)
 		vStringPut (string, c);
 		c = getcFromInputFile ();
 	} while (isIdentChar (c));
-	vStringTerminate (string);
 	if (!isspace (c))
 		ungetcToInputFile (c);	/* unget non-identifier character */
 }
@@ -538,7 +536,6 @@ static void makeVhdlTag (tokenInfo * const token, const vhdlKind kind)
 			vStringCopy (fulltag, token->scope);
 			vStringCatS (fulltag, ".");
 			vStringCatS (fulltag, vStringValue (token->string));
-			vStringTerminate (fulltag);
 			vStringCopy (token->string, fulltag);
 			vStringDelete (fulltag);
 		}

--- a/parsers/vhdl.c
+++ b/parsers/vhdl.c
@@ -28,6 +28,8 @@
  */
 #define isType(token,t)     (bool) ((token)->type == (t))
 #define isKeyword(token,k)  (bool) ((token)->keyword == (k))
+#define isIdentChar1(c) (isalpha (c) || (c) == '_')
+#define isIdentChar(c) (isalpha (c) || isdigit (c) || (c) == '_')
 
 /*
  *   DATA DECLARATIONS
@@ -299,17 +301,6 @@ static void parseKeywords (tokenInfo * const token, bool local);
 /*
  *   FUNCTION DEFINITIONS
  */
-
-static bool isIdentChar1 (const int c)
-{
-	return (bool) (isalpha (c) || c == '_');
-}
-
-static bool isIdentChar (const int c)
-{
-	return (bool) (isalpha (c) || isdigit (c) || c == '_');
-}
-
 static bool isIdentifierMatch (const tokenInfo * const token,
 	const vString * const name)
 {

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -258,7 +258,6 @@ static void parseFunction (const unsigned char *line)
 					vStringPut (name, (int) *cp);
 					++cp;
 				} while (isalnum ((int) *cp) || *cp == '_' || *cp == '.' || *cp == '#');
-				vStringTerminate (name);
 				index = makeSimpleTag (name, VimKinds, K_FUNCTION);
 				vStringClear (name);
 			}
@@ -303,7 +302,6 @@ static void parseAutogroup (const unsigned char *line)
 			if (end > cp && strncasecmp ((const char *) cp, "end", end - cp) != 0)
 			{
 				vStringNCatS (name, (const char *) cp, end - cp);
-				vStringTerminate (name);
 				makeSimpleTag (name, VimKinds, K_AUGROUP);
 				vStringClear (name);
 			}
@@ -428,7 +426,6 @@ static bool parseCommand (const unsigned char *line)
 		++cp;
 	} while (isalnum ((int) *cp) || *cp == '_');
 
-	vStringTerminate (name);
 	makeSimpleTag (name, VimKinds, K_COMMAND);
 	vStringClear (name);
 
@@ -488,7 +485,6 @@ static void parseLet (const unsigned char *line, int infunction)
 			vStringPut (name, (int) *cp);
 			++cp;
 		} while (isalnum ((int) *cp) || *cp == '_' || *cp == '#' || *cp == ':' || *cp == '$');
-		vStringTerminate (name);
 		makeSimpleTag (name, VimKinds, K_VARIABLE);
 		vStringClear (name);
 	}
@@ -568,7 +564,6 @@ static bool parseMap (const unsigned char *line)
 		++cp;
 	} while (*cp && *cp != ' ');
 
-	vStringTerminate (name);
 	makeSimpleTag (name, VimKinds, K_MAP);
 	vStringClear (name);
 
@@ -664,7 +659,6 @@ static void parseVimBallFile (const unsigned char *line)
 				vStringPut (fname, (int) *cp);
 				++cp;
 			} while (isalnum ((int) *cp) || *cp == '.' || *cp == '/' || *cp == '\\');
-			vStringTerminate (fname);
 			makeSimpleTag (fname, VimKinds, K_FILENAME);
 			vStringClear (fname);
 		}

--- a/parsers/windres.c
+++ b/parsers/windres.c
@@ -55,7 +55,6 @@ typedef enum _WindResParserState
 
 static void makeResTag(vString *name, ResKind kind)
 {
-	vStringTerminate(name);
 	vStringStripTrailing(name);
 	makeSimpleTag(name, ResKinds, kind);
 	vStringClear(name);
@@ -72,7 +71,6 @@ static ResParserState parseResDefinition(const unsigned char *line)
 		vStringPut(name, (int) *line);
 		line++;
 	}
-	vStringTerminate(name);
 
 	while (*line && isspace((int) *line))
 		line++;
@@ -83,7 +81,6 @@ static ResParserState parseResDefinition(const unsigned char *line)
 		vStringPut(type, (int) *line);
 		line++;
 	}
-	vStringTerminate(type);
 
 	if (strcmp(vStringValue(type), "DIALOG") == 0 || strcmp(vStringValue(type), "DIALOGEX") == 0)
 	{


### PR DESCRIPTION
The biggest optimization from these is the isIdentChar() conversion to macros. The second (though much smaller improvement) is the conversion of vStringClear() to macro.

The remaining two patches should improve performance too but the improvement is almost invisible and these are more cleanups than anything else.

This should be the last of my general performance patches - the rest should be done parser by parser.