### PR TITLE
Be verbose when allocating too large string

### DIFF
--- a/main/read.c
+++ b/main/read.c
@@ -882,11 +882,9 @@ extern char *readLineRaw (vString *const vLine, MIO *const mio)
 					 *pLastChar != '\n'  &&  *pLastChar != '\r')
 			{
 				/*  buffer overflow */
-				reReadLine = vStringAutoResize (vLine);
-				if (reReadLine)
-					mio_seek (mio, startOfLine, SEEK_SET);
-				else
-					error (FATAL | PERROR, "input line too big; out of memory");
+				vStringAutoResize (vLine);
+				mio_seek (mio, startOfLine, SEEK_SET);
+				reReadLine = TRUE;
 			}
 			else
 			{

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -12,7 +12,6 @@
 */
 #include "general.h"  /* must always come first */
 
-#include <limits.h>  /* to define INT_MAX */
 #include <string.h>
 #include <ctype.h>
 
@@ -41,17 +40,9 @@ static void vStringResize (vString *const string, const size_t newSize)
 *   External interface
 */
 
-extern boolean vStringAutoResize (vString *const string)
+extern void vStringAutoResize (vString *const string)
 {
-	boolean ok = TRUE;
-
-	if (string->size <= INT_MAX / 2)
-	{
-		const size_t newSize = string->size * 2;
-
-		vStringResize (string, newSize);
-	}
-	return ok;
+	vStringResize (string, string->size * 2);
 }
 
 extern void vStringTruncate (vString *const string, const size_t length)

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -62,7 +62,7 @@ typedef struct sVString {
 /*
 *   FUNCTION PROTOTYPES
 */
-extern boolean vStringAutoResize (vString *const string);
+extern void vStringAutoResize (vString *const string);
 extern void vStringClear (vString *const string);
 extern vString *vStringNew (void);
 extern void vStringDelete (vString *const string);


### PR DESCRIPTION
Previously if the string got too large, string resizing just silently
didn't happen. End with a fatal error in this case so it's clear what
happens.

We could relay on the xMalloc() behaviour here but it's better to
terminate earlier than running out of memory (before the system tries
to find enough memory and starts swapping). Strings should never be
too large and it always means there's some bug in ctags so the patch
lowers the maximum string memory to 100MB which should be more than
enough for anything non-buggy.