### PR TITLE
Don't compare foreign values to enumeration type

### DIFF
--- a/parsers/c.c
+++ b/parsers/c.c
@@ -65,7 +65,7 @@ typedef enum eException {
 
 /*  Used to specify type of keyword.
  */
-typedef enum eKeywordId {
+enum eKeywordId {
 	KEYWORD_ALIAS, KEYWORD_ATTRIBUTE, KEYWORD_ABSTRACT,
 	KEYWORD_BOOLEAN, KEYWORD_BYTE, KEYWORD_BAD_STATE, KEYWORD_BAD_TRANS,
 	KEYWORD_BIND, KEYWORD_BIND_VAR, KEYWORD_BIT,
@@ -113,7 +113,8 @@ typedef enum eKeywordId {
 	KEYWORD_SUPER, KEYWORD_TRUE, KEYWORD_TYPEID, KEYWORD_TYPEOF,
 	KEYWORD_UBYTE, KEYWORD_UCENT, KEYWORD_UNITTEST, KEYWORD_VERSION,
 	KEYWORD_WCHAR, KEYWORD_WITH
-} keywordId;
+};
+typedef int keywordId; /* to allow KEYWORD_NONE */
 
 /*  Used to determine whether keyword is valid for the current language and
  *  what its ID is.

--- a/parsers/eiffel.c
+++ b/parsers/eiffel.c
@@ -42,7 +42,7 @@
 
 /*  Used to specify type of keyword.
  */
-typedef enum eKeywordId {
+enum eKeywordId {
 	KEYWORD_across,
 	KEYWORD_alias,
 	KEYWORD_all,
@@ -106,7 +106,8 @@ typedef enum eKeywordId {
 	KEYWORD_variant,
 	KEYWORD_when,
 	KEYWORD_xor
-} keywordId;
+};
+typedef int keywordId; /* to allow KEYWORD_NONE */
 
 typedef enum eTokenType {
 	TOKEN_EOF,

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -49,7 +49,7 @@ static stringList *FunctionNames;
 
 /*	Used to specify type of keyword.
 */
-typedef enum eKeywordId {
+enum eKeywordId {
 	KEYWORD_function,
 	KEYWORD_capital_function,
 	KEYWORD_object,
@@ -78,7 +78,8 @@ typedef enum eKeywordId {
 	KEYWORD_mx,
 	KEYWORD_fx,
 	KEYWORD_override
-} keywordId;
+};
+typedef int keywordId; /* to allow KEYWORD_NONE */
 
 typedef enum eTokenType {
 	TOKEN_UNDEFINED,

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -54,7 +54,7 @@ typedef enum eFortranLineType {
 
 /*  Used to specify type of keyword.
  */
-typedef enum eKeywordId {
+enum eKeywordId {
 	KEYWORD_abstract,
 	KEYWORD_allocatable,
 	KEYWORD_assignment,
@@ -140,7 +140,8 @@ typedef enum eKeywordId {
 	KEYWORD_volatile,
 	KEYWORD_where,
 	KEYWORD_while
-} keywordId;
+};
+typedef int keywordId; /* to allow KEYWORD_NONE */
 
 typedef enum eTokenType {
 	TOKEN_UNDEFINED,

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -27,7 +27,7 @@
  *	 DATA DECLARATIONS
  */
 
-typedef enum eKeywordId {
+enum eKeywordId {
 	KEYWORD_package,
 	KEYWORD_import,
 	KEYWORD_const,
@@ -38,7 +38,8 @@ typedef enum eKeywordId {
 	KEYWORD_interface,
 	KEYWORD_map,
 	KEYWORD_chan
-} keywordId;
+};
+typedef int keywordId; /* to allow KEYWORD_NONE */
 
 typedef enum eTokenType {
 	TOKEN_NONE = -1,

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -51,7 +51,7 @@ static stringList *FunctionNames;
 
 /*	Used to specify type of keyword.
 */
-typedef enum eKeywordId {
+enum eKeywordId {
 	KEYWORD_function,
 	KEYWORD_capital_function,
 	KEYWORD_capital_object,
@@ -72,7 +72,8 @@ typedef enum eKeywordId {
 	KEYWORD_finally,
 	KEYWORD_sap,
 	KEYWORD_return
-} keywordId;
+};
+typedef int keywordId; /* to allow KEYWORD_NONE */
 
 typedef enum eTokenType {
 	TOKEN_UNDEFINED,

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -21,7 +21,7 @@
 #include "debug.h"
 
 
-typedef enum {
+enum {
 	KEYWORD_abstract,
 	KEYWORD_and,
 	KEYWORD_as,
@@ -81,7 +81,8 @@ typedef enum {
 	KEYWORD_while,
 	KEYWORD_xor,
 	KEYWORD_yield
-} keywordId;
+};
+typedef int keywordId; /* to allow KEYWORD_NONE */
 
 typedef enum {
 	ACCESS_UNDEFINED,

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -25,7 +25,7 @@
 #include "xtag.h"
 
 
-typedef enum {
+enum {
 	KEYWORD_as,
 	KEYWORD_cdef,
 	KEYWORD_class,
@@ -38,7 +38,8 @@ typedef enum {
 	KEYWORD_lambda,
 	KEYWORD_pass,
 	KEYWORD_return,
-} keywordId;
+};
+typedef int keywordId; /* to allow KEYWORD_NONE */
 
 typedef enum {
 	ACCESS_PRIVATE,

--- a/parsers/rpmspec.c
+++ b/parsers/rpmspec.c
@@ -37,9 +37,10 @@ typedef enum {
 	K_GLOBAL,
 } rpmSpecKind;
 
-typedef enum rpmSpecMacroRole {
+enum rpmSpecMacroRole {
 	R_MACRO_UNDEF,
-} rpmSpecMacroRole;
+};
+typedef int rpmSpecMacroRole; /* to allow ROLE_INDEX_* */;
 
 static roleDesc RpmSpecMacroRoles [] = {
 	{ TRUE, "undef", "undefined" },

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -52,7 +52,7 @@ typedef enum eException { ExceptionNone, ExceptionEOF } exception_t;
 /*
  * Used to specify type of keyword.
  */
-typedef enum eKeywordId {
+enum eKeywordId {
 	KEYWORD_is,
 	KEYWORD_begin,
 	KEYWORD_body,
@@ -125,7 +125,8 @@ typedef enum eKeywordId {
 	KEYWORD_comment,
 	KEYWORD_create,
 	KEYWORD_go
-} keywordId;
+};
+typedef int keywordId; /* to allow KEYWORD_NONE */
 
 typedef enum eTokenType {
 	TOKEN_UNDEFINED,

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -45,7 +45,7 @@ typedef enum eException { ExceptionNone, ExceptionEOF } exception_t;
 /*
  * Used to specify type of keyword.
  */
-typedef enum eKeywordId {
+enum eKeywordId {
 	KEYWORD_part,
 	KEYWORD_chapter,
 	KEYWORD_section,
@@ -55,7 +55,8 @@ typedef enum eKeywordId {
 	KEYWORD_subparagraph,
 	KEYWORD_label,
 	KEYWORD_include
-} keywordId;
+};
+typedef int keywordId; /* to allow KEYWORD_NONE */
 
 typedef enum eTokenType {
 	TOKEN_UNDEFINED,

--- a/parsers/vhdl.c
+++ b/parsers/vhdl.c
@@ -36,7 +36,7 @@
 /*
  * Used to specify type of keyword.
  */
-typedef enum eKeywordId {
+enum eKeywordId {
 	KEYWORD_ABS,
 	KEYWORD_ACCESS,
 	KEYWORD_AFTER,
@@ -132,7 +132,8 @@ typedef enum eKeywordId {
 	KEYWORD_WITH,
 	KEYWORD_XNOR,
 	KEYWORD_XOR
-} keywordId;
+};
+typedef int keywordId; /* to allow KEYWORD_NONE */
 
 typedef enum eTokenType {
 	TOKEN_NONE,		/* none */


### PR DESCRIPTION
Clang warns when comparing an enumeration type with a value not found
in this enumeration:

```clang
warning: comparison of constant VALUE with expression of type 'TYPE' is
      always false [-Wtautological-constant-out-of-range-compare]
```

If then the compiler then decides to optimize the test away because it
assumes the test is indeed always false, it can lead to pretty subtle
and nasty issues.

Closes #1115.