### PR TITLE
CXX: Mitigate problem with preprocessor macros when emitting types.

### DIFF
--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -1090,7 +1090,7 @@ int cxxParserEmitFunctionTags(
 		CXXToken * pTypeName;
 
 		if(pInfo->pTypeStart)
-			pTypeName = cxxTagSetTypeField(pInfo->pTypeStart,pInfo->pTypeEnd);
+			pTypeName = cxxTagCheckAndSetTypeField(pInfo->pTypeStart,pInfo->pTypeEnd);
 		else
 			pTypeName = NULL;
 
@@ -1296,7 +1296,7 @@ void cxxParserEmitFunctionParameterTags(CXXFunctionParameterInfo * pInfo)
 
 				cxxTokenChainTakeRecursive(pInfo->pChain,pInfo->aIdentifiers[i]);
 
-				pTypeName = cxxTagSetTypeField(
+				pTypeName = cxxTagCheckAndSetTypeField(
 						pTypeStart,
 						pTypeEnd
 					);

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -165,7 +165,7 @@ boolean cxxParserHandleLambda(CXXToken * pParenthesis)
 		CXXToken * pTypeName;
 
 		if(pTypeStart)
-			pTypeName = cxxTagSetTypeField(pTypeStart,pTypeEnd);
+			pTypeName = cxxTagCheckAndSetTypeField(pTypeStart,pTypeEnd);
 		else
 			pTypeName = NULL;
 

--- a/parsers/cxx/cxx_parser_typedef.c
+++ b/parsers/cxx/cxx_parser_typedef.c
@@ -249,7 +249,7 @@ skip_to_comma_or_end:
 						"There should be at least another token here!"
 					);
 
-				pTypeName = cxxTagSetTypeField(
+				pTypeName = cxxTagCheckAndSetTypeField(
 							cxxTokenChainFirst(pChain),
 							pComma ? pComma->pPrev : cxxTokenChainLast(pChain)
 						);

--- a/parsers/cxx/cxx_parser_variable.c
+++ b/parsers/cxx/cxx_parser_variable.c
@@ -535,7 +535,7 @@ boolean cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int
 			}
 
 			// anything that remains is part of type
-			CXXToken * pTypeToken = cxxTagSetTypeField(cxxTokenChainFirst(pChain),t->pPrev);
+			CXXToken * pTypeToken = cxxTagCheckAndSetTypeField(cxxTokenChainFirst(pChain),t->pPrev);
 
 			tag->isFileScope = bKnRStyleParameters ?
 					TRUE :

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -91,9 +91,12 @@ tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken);
 
 // Set the type of the current tag from the specified token sequence
 // (which must belong to the same chain!).
-// Returns a token that must be destroyed after cxxTagCommit() has
-// been called.
-CXXToken * cxxTagSetTypeField(
+// Before setting the type this function will check that the specified
+// range of tokens looks reasonable for a type name and if it looks
+// suspicious will refuse to emit it.
+// If the type is effectively set then the return value is a token that must
+// be destroyed after cxxTagCommit() has been called.
+CXXToken * cxxTagCheckAndSetTypeField(
 		CXXToken * pTypeStart,
 		CXXToken * pTypeEnd
 	);


### PR DESCRIPTION
Attempt to filter out types that contain too many macros or other oddities gathered by mistake.