### PR TITLE
lxcmd: use path arranged by ctags main side as %{input}

### DIFF
--- a/Tmain/xcmd-tag-relative-option.d/input.dog
+++ b/Tmain/xcmd-tag-relative-option.d/input.dog
@@ -1,0 +1,2 @@
+define: dog
+define: cat

--- a/Tmain/xcmd-tag-relative-option.d/run.sh
+++ b/Tmain/xcmd-tag-relative-option.d/run.sh
@@ -1,0 +1,28 @@
+# Copyright: 2016 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+. ../utils.sh
+exit_if_no_coproc ${CTAGS}
+
+rm -f ./tags
+d=$(basename $(pwd))
+cd ..
+{
+    for r in yes no; do
+	${CTAGS} --quiet --options=NONE --tag-relative=$r \
+		 --langdef=dog \
+		 --langmap=dog:.dog \
+		 --xcmd-dog=$d/xcmd-dog \
+		 --extra=+f \
+		 --fields=+n \
+		 -o $d/tags \
+		 --append=yes \
+		 $d/input.dog
+    done
+    cat $d/tags | grep -v '^!'
+    rm -f $d/tags
+}
+
+exit $?

--- a/Tmain/xcmd-tag-relative-option.d/stdout-expected.txt
+++ b/Tmain/xcmd-tag-relative-option.d/stdout-expected.txt
@@ -1,0 +1,6 @@
+cat	input.dog	/^define: cat/;"	d	line:2
+cat	xcmd-tag-relative-option.d/input.dog	/^define: cat/;"	d	line:2
+dog	input.dog	/^define: dog$/;"	d	line:1
+dog	xcmd-tag-relative-option.d/input.dog	/^define: dog$/;"	d	line:1
+input.dog	input.dog	1;"	F	line:1
+input.dog	xcmd-tag-relative-option.d/input.dog	1;"	F	line:1

--- a/Tmain/xcmd-tag-relative-option.d/xcmd-dog
+++ b/Tmain/xcmd-tag-relative-option.d/xcmd-dog
@@ -1,0 +1,17 @@
+#!/bin/sh
+if test "z$1" = "z--list-kinds=dog"; then
+    echo "d  definition"
+else
+    cat <<EOF
+!_TAG_FILE_FORMAT	2	/extended format/
+!_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Masatake YAMATO	/yamato@redhat.com/
+!_TAG_PROGRAM_NAME	xcmd-dog	//
+!_TAG_PROGRAM_URL	https://github.com/fishman/ctags/tree/deploy/Units	//
+!_TAG_PROGRAM_VERSION	Development	//
+dog	Units/xcmd-simple.d/input.dog	/^define: dog$/;"	d	line:1
+cat	Units/xcmd-simple.d/input.dog	/^define: cat/;"	d	line:2
+input.dog	Units/xcmd-simple.d/input.dog	1;"	F	line:1
+EOF
+fi
+exit 0

--- a/main/lxcmd.c
+++ b/main/lxcmd.c
@@ -1167,6 +1167,12 @@ static boolean invokeXcmdPath (const char* const fileName, xcmdPath* path, const
 			if (parseXcmdPath (line, path, &entry) )
 			{
 				entryAddField (&entry, "language", getLanguageName (language));
+
+				/* Throw away the input file name returned from the xcmd.
+				   Instead we use the input file name arranged
+				   (relative or absolute) by ctags main side. */
+				entry.file = getInputFileTagPath ();
+
 				if (makeTagEntryFromTagEntry (path, &entry))
 					result = TRUE;
 				freeTagEntry (&entry);


### PR DESCRIPTION
Close #1122.

--tag-relative option passed to ctags command was ignore when
xcmd is used because ctags prints the name of input files (%{input})
returned from the xcmd directly. (ctags doesn't pass --tag-relative option
to the xcmd).

This commit is for reflecting the specification of --tag-relative option
to tags files; instead of using the value returned from xcmd directly,
use the path arranged by ctags main side.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>