### PR TITLE
main: Don't print the same kinds repeatedly in --list-kinds output

### DIFF
--- a/Tmain/lregex-list-kinds-uniquely.d/run.sh
+++ b/Tmain/lregex-list-kinds-uniquely.d/run.sh
@@ -1,0 +1,10 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+${CTAGS} --quiet --options=NONE \
+		 --langdef=X \
+		 --regex-X='/./\0/l,label,labels/' \
+		 --regex-X='/./\0/l,label,labels/' \
+		 --list-kinds=X

--- a/Tmain/lregex-list-kinds-uniquely.d/stdout-expected.txt
+++ b/Tmain/lregex-list-kinds-uniquely.d/stdout-expected.txt
@@ -1,0 +1,1 @@
+l  labels


### PR DESCRIPTION
Close #1138.

When printing kinds in --list-kinds output, kinds hashtable of patternSet
should be traversed. However, mistakenly, patterns array was traversed.
As the result the same kind of a language is printed repeatedly.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>