### PR TITLE
CXX: Improve variable parsing

### DIFF
--- a/Units/parser-cxx.r/variable-declarations.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/variable-declarations.cpp.d/expected.tags
@@ -19,14 +19,25 @@ l18	input.cpp	/^	struct Struct1 * l16, l17, l18[10];$/;"	l	function:main	typeref
 l19	input.cpp	/^	Struct1 l19 = {};$/;"	l	function:main	typeref:typename:Struct1	file:
 l20	input.cpp	/^	std::string ** l20[SIZE];$/;"	l	function:main	typeref:typename:std::string ** []	file:
 l21	input.cpp	/^	std::string l21[1 << 2];$/;"	l	function:main	typeref:typename:std::string[]	file:
-l22	input.cpp	/^	std::string * const l22[SIZE][SIZE];$/;"	l	function:main	typeref:typename:std::string * const[][]	file:
+l22	input.cpp	/^	std::string * l22[SIZE][SIZE];$/;"	l	function:main	typeref:typename:std::string * [][]	file:
 l23	input.cpp	/^	std::string l23[5][2];$/;"	l	function:main	typeref:typename:std::string[5][2]	file:
+l24	input.cpp	/^	std::string * const l24 = 0;$/;"	l	function:main	typeref:typename:std::string * const	file:
+l25	input.cpp	/^	wchar_t l25[] = { L"кошка" };$/;"	l	function:main	typeref:typename:wchar_t[]	file:
+l26	input.cpp	/^	wchar_t l26[] { L'к', L'о', L'ш', L'к', L'а', L'\\0' };$/;"	l	function:main	typeref:typename:wchar_t[]	file:
+l27	input.cpp	/^	std::string l27[] = { std::string("one"),"two",{'t', 'h', 'r', 'e', 'e'} };$/;"	l	function:main	typeref:typename:std::string[]	file:
+l28	input.cpp	/^	int l28 {};$/;"	l	function:main	typeref:typename:int	file:
 m01	input.cpp	/^	unsigned int m01;$/;"	m	struct:Struct1	typeref:typename:unsigned int	file:
 m02	input.cpp	/^	std::string m02;$/;"	m	struct:Struct1	typeref:typename:std::string	file:
 m03	input.cpp	/^	std::string ** m03, m04;$/;"	m	struct:Struct1	typeref:typename:std::string **	file:
 m04	input.cpp	/^	std::string ** m03, m04;$/;"	m	struct:Struct1	typeref:typename:std::string **	file:
 m05	input.cpp	/^	std::string & (*m05)(int a,int b);$/;"	m	struct:Struct1	typeref:typename:std::string & (*)(int a,int b)	file:
 m06	input.cpp	/^	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > m06[10];$/;"	m	struct:Struct1	typeref:typename:std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>[10]	file:
+m07	input.cpp	/^	std::string m07 { "test" }; \/\/ C++11$/;"	m	struct:Struct1	typeref:typename:std::string	file:
+m08	input.cpp	/^	std::string m08[2] { "a", "b" };$/;"	m	struct:Struct1	typeref:typename:std::string[2]	file:
+m09	input.cpp	/^	int m09 {};$/;"	m	struct:Struct1	typeref:typename:int	file:
+m10	input.cpp	/^	int m10[2][2]{{1, 2}, {3, 4}};$/;"	m	struct:Struct1	typeref:typename:int[2][2]	file:
+m11	input.cpp	/^	std::array<int, 3> m11 { {1,2,3} };$/;"	m	struct:Struct1	typeref:typename:std::array<int,3>	file:
+m12	input.cpp	/^	std::string m12[3] { std::string("one"),"two",{'t', 'h', 'r', 'e', 'e'} };$/;"	m	struct:Struct1	typeref:typename:std::string[3]	file:
 v01	input.cpp	/^} v01, v02[10];$/;"	v	typeref:struct:Struct1
 v02	input.cpp	/^} v01, v02[10];$/;"	v	typeref:struct:Struct1[10]
 v03	input.cpp	/^} v03, * v04;$/;"	v	typeref:enum:Enum1

--- a/Units/parser-cxx.r/variable-declarations.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/variable-declarations.cpp.d/input.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <array>
 
 // All of these are valid variable declarations
 
@@ -9,6 +10,12 @@ struct Struct1
 	std::string ** m03, m04;
 	std::string & (*m05)(int a,int b);
 	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > m06[10];
+	std::string m07 { "test" }; // C++11
+	std::string m08[2] { "a", "b" };
+	int m09 {};
+	int m10[2][2]{{1, 2}, {3, 4}};
+	std::array<int, 3> m11 { {1,2,3} };
+	std::string m12[3] { std::string("one"),"two",{'t', 'h', 'r', 'e', 'e'} };
 } v01, v02[10];
 
 enum Enum1
@@ -45,8 +52,14 @@ int main(int argc,char ** argv)
 #define SIZE 25
 	std::string ** l20[SIZE];
 	std::string l21[1 << 2];
-	std::string * const l22[SIZE][SIZE];
+	std::string * l22[SIZE][SIZE];
 	std::string l23[5][2];
+	std::string * const l24 = 0;
+
+	wchar_t l25[] = { L"кошка" };
+	wchar_t l26[] { L'к', L'о', L'ш', L'к', L'а', L'\0' };
+	std::string l27[] = { std::string("one"),"two",{'t', 'h', 'r', 'e', 'e'} };
+	int l28 {};
 
 	return 0;
 }

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -478,7 +478,28 @@ bool cxxParserTokenChainLooksLikeConstructorParameterSet(
 	// ending parenthesis.
 
 	if(pChain->iCount < 3)
+	{
+		CXX_DEBUG_ASSERT(
+				pChain->iCount == 2,
+				"This function should be called only on parenthesis and bracket chains"
+			);
+
+		if(cxxTokenTypeIs(cxxTokenChainFirst(pChain),CXXTokenTypeOpeningBracket))
+		{
+			CXX_DEBUG_ASSERT(
+					cxxTokenTypeIs(cxxTokenChainLast(pChain),CXXTokenTypeClosingBracket),
+					"The last token should have been a closing bracket here"
+				);
+			return true; // type var {} is valid in C++11
+		}
+
+		CXX_DEBUG_ASSERT(
+				cxxTokenTypeIs(cxxTokenChainFirst(pChain),CXXTokenTypeOpeningParenthesis),
+				"This function should be called only on parenthesis and bracket chains"
+			);
+
 		return false; // type var() is NOT valid C++
+	}
 
 	return cxxParserTokenChainLooksLikeFunctionCallParameterSet(pChain);
 }

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -37,6 +37,9 @@ CXXToken * cxxParserOpeningBracketIsLambda(void)
 	// [ capture-list ] ( params ) -> ret { body }	(2)
 	// [ capture-list ] ( params ) { body }	(3)
 	// [ capture-list ] { body }	(4)
+	
+	// Exclude the case of array bracket initialization
+	//  type var[] { ... } (5 - not lambda)
 
 	CXX_DEBUG_ASSERT(cxxParserCurrentLanguageIsCPP(),"C++ only");
 
@@ -47,9 +50,14 @@ CXXToken * cxxParserOpeningBracketIsLambda(void)
 
 	// Check simple cases first
 
-	// case 4
+	// case 4?
 	if(cxxTokenTypeIs(t,CXXTokenTypeSquareParenthesisChain))
 	{
+		if(t->pPrev && cxxTokenTypeIs(t->pPrev,CXXTokenTypeIdentifier))
+		{
+			// case 5
+			return NULL;
+		}
 		// very likely parameterless lambda
 		return t;
 	}

--- a/parsers/cxx/cxx_parser_variable.c
+++ b/parsers/cxx/cxx_parser_variable.c
@@ -335,7 +335,7 @@ bool cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int uF
 							))
 					)
 				{
-					CXX_DEBUG_LEAVE_TEXT("No comma, semicolon, = or {} after [] (got %x)",t->pNext->eType);
+					CXX_DEBUG_LEAVE_TEXT("No comma, semicolon, = or {} after []");
 					return bGotVariable;
 				}
 

--- a/parsers/cxx/cxx_parser_variable.c
+++ b/parsers/cxx/cxx_parser_variable.c
@@ -331,11 +331,11 @@ bool cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int uF
 						(!cxxTokenTypeIsOneOf(
 								t->pNext,
 								CXXTokenTypeComma | CXXTokenTypeSemicolon |
-								CXXTokenTypeAssignment
+								CXXTokenTypeAssignment | CXXTokenTypeBracketChain
 							))
 					)
 				{
-					CXX_DEBUG_LEAVE_TEXT("No comma, semicolon or assignment after array specifier");
+					CXX_DEBUG_LEAVE_TEXT("No comma, semicolon, = or {} after [] (got %x)",t->pNext->eType);
 					return bGotVariable;
 				}
 


### PR DESCRIPTION
Handle C++11
    type var {};
    type var[] { ... };
bracket initializers.

Fixes issue #1149 .

(PS. Commit messages should contain 'type var' instead of 'var type'... but I'm too lazy to redo them :D)