### PR TITLE
Some more uses of pool and other optimizations

### DIFF
--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -582,10 +582,11 @@ static void makeLabelTag (vString *const label)
 
 static lineType getLineType (void)
 {
-	vString *label = vStringNew ();
+	static vString *label = NULL;
 	int column = 0;
 	lineType type = LTYPE_UNDETERMINED;
 
+	label = vStringNewOrClear (label);
 	do  /* read in first 6 "margin" characters */
 	{
 		int c = getcFromInputFile ();
@@ -647,7 +648,6 @@ static lineType getLineType (void)
 
 	if (vStringLength (label) > 0)
 		makeLabelTag (label);
-	vStringDelete (label);
 	return type;
 }
 

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -136,15 +136,13 @@ static tokenInfo *newToken (void)
 	return token;
 }
 
-static tokenInfo *copyToken (tokenInfo *other)
+static void copyToken (tokenInfo *const dest, const tokenInfo *const other)
 {
-	tokenInfo *const token = xMalloc (1, tokenInfo);
-	token->type = other->type;
-	token->keyword = other->keyword;
-	token->string = vStringNewCopy (other->string);
-	token->lineNumber = other->lineNumber;
-	token->filePosition = other->filePosition;
-	return token;
+	dest->type = other->type;
+	dest->keyword = other->keyword;
+	vStringCopy(dest->string, other->string);
+	dest->lineNumber = other->lineNumber;
+	dest->filePosition = other->filePosition;
 }
 
 static void deleteToken (tokenInfo * const token)
@@ -570,7 +568,9 @@ static void parseFunctionOrMethod (tokenInfo *const token)
 
 	if (isType (token, TOKEN_IDENTIFIER))
 	{
-		tokenInfo *functionToken = copyToken (token);
+		tokenInfo *functionToken = newToken ();
+
+		copyToken (functionToken, token);
 
 		// Start recording signature
 		signature = vStringNew ();
@@ -623,7 +623,8 @@ static void parseStructMembers (tokenInfo *const token, tokenInfo *const parent_
 				if (first)
 				{
 					// could be anonymous field like in 'struct {int}' - we don't know yet
-					memberCandidate = copyToken (token);
+					memberCandidate = newToken ();
+					copyToken (memberCandidate, token);
 					first = false;
 				}
 				else
@@ -698,7 +699,8 @@ static void parseConstTypeVar (tokenInfo *const token, goKind kind)
 			{
 				if (kind == GOTAG_TYPE)
 				{
-					typeToken = copyToken (token);
+					typeToken = newToken ();
+					copyToken (typeToken, token);
 					readToken (token);
 					if (isKeyword (token, KEYWORD_struct))
 						makeTag (typeToken, GOTAG_STRUCT, NULL, GOTAG_UNDEFINED, NULL);

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -25,6 +25,8 @@
 #include "xtag.h"
 #include "objpool.h"
 
+#define isIdentifierChar(c) \
+	(isalnum (c) || (c) == '_' || (c) >= 0x80)
 
 enum {
 	KEYWORD_as,
@@ -372,11 +374,6 @@ static void copyToken (tokenInfo *const dest, const tokenInfo *const src)
 	dest->keyword = src->keyword;
 	dest->indent = src->indent;
 	vStringCopy(dest->string, src->string);
-}
-
-static bool isIdentifierChar (const int c)
-{
-	return (isalnum (c) || c == '_' || c >= 0x80);
 }
 
 /* Skip a single or double quoted string. */

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -27,6 +27,8 @@
 
 #define isIdentifierChar(c) \
 	(isalnum (c) || (c) == '_' || (c) >= 0x80)
+#define newToken() (objPoolGet (TokenPool))
+#define deleteToken(t) (objPoolPut (TokenPool, (t)))
 
 enum {
 	KEYWORD_as,
@@ -343,21 +345,24 @@ static int makeSimplePythonRefTag (const tokenInfo *const token,
 	return CORK_NIL;
 }
 
-static tokenInfo *newToken (void)
+static void *newPoolToken (void)
 {
-	tokenInfo *const token = xMalloc (1, tokenInfo);
-	token->string		= vStringNew ();
+	tokenInfo *token = xMalloc (1, tokenInfo);
+	token->string = vStringNew ();
 	return token;
 }
 
-static void deleteToken (tokenInfo *const token)
+static void deletePoolToken (void *data)
 {
+	tokenInfo *token = data;
 	vStringDelete (token->string);
 	eFree (token);
 }
 
-static void clearToken (tokenInfo *const token)
+static void clearPoolToken (void *data)
 {
+	tokenInfo *token = data;
+
 	token->type			= TOKEN_UNDEFINED;
 	token->keyword		= KEYWORD_NONE;
 	token->indent		= 0;
@@ -446,7 +451,7 @@ static void readIdentifier (vString *const string, const int firstChar)
 static void ungetToken (tokenInfo *const token)
 {
 	Assert (NextToken == NULL);
-	NextToken = objPoolGet (TokenPool);
+	NextToken = newToken ();
 	copyToken (NextToken, token);
 }
 
@@ -459,7 +464,7 @@ static void readTokenFull (tokenInfo *const token, bool inclWhitespaces)
 	if (NextToken)
 	{
 		copyToken (token, NextToken);
-		objPoolPut (TokenPool, NextToken);
+		deleteToken (NextToken);
 		NextToken = NULL;
 		return;
 	}
@@ -746,7 +751,7 @@ static void readQualifiedName (tokenInfo *const nameToken)
 	    nameToken->type == '.')
 	{
 		vString *qualifiedName = vStringNew ();
-		tokenInfo *token = objPoolGet (TokenPool);
+		tokenInfo *token = newToken ();
 
 		while (nameToken->type == TOKEN_IDENTIFIER ||
 		       nameToken->type == '.')
@@ -763,7 +768,7 @@ static void readQualifiedName (tokenInfo *const nameToken)
 		nameToken->type = TOKEN_IDENTIFIER;
 		vStringCopy (nameToken->string, qualifiedName);
 
-		objPoolPut (TokenPool, token);
+		deleteToken (token);
 		vStringDelete (qualifiedName);
 	}
 }
@@ -789,7 +794,7 @@ static bool readCDefName (tokenInfo *const token, pythonKind *kind)
 	{
 		/* skip the optional type declaration -- everything on the same line
 		 * until an identifier followed by "(". */
-		tokenInfo *candidate = objPoolGet (TokenPool);
+		tokenInfo *candidate = newToken ();
 
 		while (token->type != TOKEN_EOF &&
 		       token->type != TOKEN_INDENT &&
@@ -823,7 +828,7 @@ static bool readCDefName (tokenInfo *const token, pythonKind *kind)
 				readToken (token);
 		}
 
-		objPoolPut (TokenPool, candidate);
+		deleteToken (candidate);
 	}
 
 	return token->type == TOKEN_IDENTIFIER;
@@ -852,7 +857,7 @@ static bool parseClassOrDef (tokenInfo *const token,
 			return false;
 	}
 
-	name = objPoolGet (TokenPool);
+	name = newToken ();
 	copyToken (name, token);
 
 	readToken (token);
@@ -894,7 +899,7 @@ static bool parseClassOrDef (tokenInfo *const token,
 			         parameterCount < ARRAY_SIZE (parameterTokens) &&
 			         PythonKinds[K_PARAMETER].enabled)
 			{
-				tokenInfo *parameterName = objPoolGet (TokenPool);
+				tokenInfo *parameterName = newToken ();
 
 				copyToken (parameterName, token);
 				parameterTokens[parameterCount++] = parameterName;
@@ -911,7 +916,7 @@ static bool parseClassOrDef (tokenInfo *const token,
 	lv = nestingLevelsPush (PythonNestingLevels, corkIndex);
 	PY_NL (lv)->indentation = token->indent;
 
-	objPoolPut (TokenPool, name);
+	deleteToken (name);
 	vStringDelete (arglist);
 
 	if (parameterCount > 0)
@@ -921,7 +926,7 @@ static bool parseClassOrDef (tokenInfo *const token,
 		for (i = 0; i < parameterCount; i++)
 		{
 			makeSimplePythonTag (parameterTokens[i], K_PARAMETER);
-			objPoolPut (TokenPool, parameterTokens[i]);
+			deleteToken (parameterTokens[i]);
 		}
 	}
 
@@ -937,7 +942,7 @@ static bool parseImport (tokenInfo *const token)
 		readQualifiedName (token);
 		if (token->type == TOKEN_IDENTIFIER)
 		{
-			fromModule = objPoolGet (TokenPool);
+			fromModule = newToken ();
 			copyToken (fromModule, token);
 			readToken (token);
 		}
@@ -970,7 +975,7 @@ static bool parseImport (tokenInfo *const token)
 
 			if (token->type == TOKEN_IDENTIFIER)
 			{
-				tokenInfo *name = objPoolGet (TokenPool);
+				tokenInfo *name = newToken ();
 
 				copyToken (name, token);
 				readToken (token);
@@ -1059,7 +1064,7 @@ static bool parseImport (tokenInfo *const token)
 					}
 				}
 
-				objPoolPut (TokenPool, name);
+				deleteToken (name);
 			}
 		}
 		while (token->type == ',');
@@ -1069,7 +1074,7 @@ static bool parseImport (tokenInfo *const token)
 	}
 
 	if (fromModule)
-		objPoolPut (TokenPool, fromModule);
+		deleteToken (fromModule);
 
 	return false;
 }
@@ -1086,7 +1091,7 @@ static bool parseVariable (tokenInfo *const token, const pythonKind kind)
 	while (token->type == TOKEN_IDENTIFIER &&
 	       nameCount < ARRAY_SIZE (nameTokens))
 	{
-		tokenInfo *name = objPoolGet (TokenPool);
+		tokenInfo *name = newToken ();
 		copyToken (name, token);
 
 		readToken (token);
@@ -1095,7 +1100,7 @@ static bool parseVariable (tokenInfo *const token, const pythonKind kind)
 			/* FIXME: what to do with dotted names?  We currently ignore them
 			 *        as we need to do something not to break the whole
 			 *        declaration, but the expected behavior is questionable */
-			objPoolPut (TokenPool, name);
+			deleteToken (name);
 			name = NULL;
 
 			do
@@ -1165,7 +1170,7 @@ static bool parseVariable (tokenInfo *const token, const pythonKind kind)
 	while (nameCount > 0)
 	{
 		if (nameTokens[--nameCount])
-			objPoolPut (TokenPool, nameTokens[nameCount]);
+			deleteToken (nameTokens[nameCount]);
 	}
 
 	return false;
@@ -1192,7 +1197,7 @@ static void setIndent (tokenInfo *const token)
 
 static void findPythonTags (void)
 {
-	tokenInfo *const token = objPoolGet (TokenPool);
+	tokenInfo *const token = newToken ();
 	vString *decorators = vStringNew ();
 	bool atStatementStart = true;
 
@@ -1275,7 +1280,7 @@ static void findPythonTags (void)
 
 	nestingLevelsFree (PythonNestingLevels);
 	vStringDelete (decorators);
-	objPoolPut (TokenPool, token);
+	deleteToken (token);
 	Assert (NextToken == NULL);
 }
 
@@ -1283,8 +1288,7 @@ static void initialize (const langType language)
 {
 	Lang_python = language;
 
-	TokenPool = objPoolNew (16, (objPoolCreateFunc)newToken, (objPoolDeleteFunc)deleteToken,
-		(objPoolClearFunc)clearToken);
+	TokenPool = objPoolNew (16, newPoolToken, deletePoolToken, clearPoolToken);
 }
 
 static void finalize (langType language CTAGS_ATTR_UNUSED, bool initialized)


### PR DESCRIPTION
I went through the more common languages, profiled them and checked if pool helps there - it seems to help for php and javascript. The numbers in the commit messages are after https://github.com/universal-ctags/ctags/pull/1091 is used.

On the way I noticed some more things that can be done - avoid common allocation of string in Fortran parser, apparently forgotten (or lost during rebase) use of isIdentifierChar() macro for the python parser.

Finally, the go patch doesn't bring any improvement - it just makes copyToken() work like in other parsers and makes it easier to adopt object pool if ever needed in the future.