### PR TITLE
docs, style: add dir-locals file for setting the style to linux in GNU emacs

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+;; Don't forget putting (add-hook 'hack-local-variables-hook (lambda () (editorconfig-apply))) to your .emacs.
+((c-mode . ((c-file-style . "linux"))))

--- a/docs/contributions.rst
+++ b/docs/contributions.rst
@@ -123,7 +123,46 @@ functional changes with style fixes makes reviewing harder.
 If possible, don't use file static variables. Find an alternative way
 that uses parameters.
 
-For indentation I'm using the linux style in cc-mode of GNU Emacs.
+
+.. NOT REVIEWED YET
+
+Notes for GNU emacs users
+.........................................................................
+
+If you use GNU emacs, utilize the `.editorconfig` configuration based
+on non-GNU C style. Here non-GNU C style means
+"align a keyword for control flow and `{` of the block start".
+
+GNU style:
+.. code-block:: C
+
+	if (...)
+	    {
+		...
+
+non-GNU style:
+.. code-block:: C
+
+	if (...)
+	{
+		...
+
+For combining the style and `.editorconfig` configuration, put
+following code snippet to your .emacs:
+
+.. code-block:: emacs
+
+	(add-hook 'hack-local-variables-hook
+		(lambda () (editorconfig-apply)))
+
+`.dir-locals.el` in ctags source tree applies "linux" style of `cc-mode`.
+Above code snippet applies the `.editorconfig` configuration AFTER
+installing the "linux" style to the current buffer.
+
+I like GNU style, but for keeping consistency in existing code of
+Exuberant-ctags, the origin of Universal-ctags, I introduced the style
+and configuration to my .emacs.  Please, do the same.
+
 
 Command line options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Though .editorconfig was introduced, it is not enough for GNU emacs users to make
the coding style consistent with existing code of ctags.

The default style of cc-mode of GNU emacs is "gnu". The "gnu" style adds
extra indentation in block opening:

________if (...)
__________{

The style is not consistent with the existing code.
This commit introduces .dir-locals.el file which forces the style
to "linux". With "linux" style the block opening is handled as follows:

________if (...)
________{

The difficulties is that the basic indent size of "linux" is 8.
It is different from .editorconfig.

So in the updated document, I wrote the way to apply .editorconfig
configuration after installing "linux" style.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>