### PR TITLE
CXX: Better macro handling

### DIFF
--- a/Units/parser-cxx.r/complex-macros.d/args.ctags
+++ b/Units/parser-cxx.r/complex-macros.d/args.ctags
@@ -1,0 +1,7 @@
+--c++-kinds=*
+--fields-c++=+{properties}
+-I DECLARE_FUNCTION+=$0 $1()
+-I ARGS+=$*
+-I DECLARE_VARS+=int $0a; int $0b;
+-I IMPLEMENT_FUNCTIONS+=void $0a(){}; void $0b(){};
+-I DEPRECATED+=$* __attribute__((deprecated))

--- a/Units/parser-cxx.r/complex-macros.d/expected.tags
+++ b/Units/parser-cxx.r/complex-macros.d/expected.tags
@@ -1,0 +1,14 @@
+DECLARE_FUNCTION	input.cpp	/^#define DECLARE_FUNCTION(/;"	d	file:
+DECLARE_FUNCTION_2	input.cpp	/^#define DECLARE_FUNCTION_2(/;"	d	file:
+DECLARE_VARS	input.cpp	/^#define DECLARE_VARS(/;"	d	file:
+DEPRECATED	input.cpp	/^#define DEPRECATED(/;"	d	file:
+IMPLEMENT_FUNCTIONS	input.cpp	/^#define IMPLEMENT_FUNCTIONS(/;"	d	file:
+f1a	input.cpp	/^IMPLEMENT_FUNCTIONS(f1);$/;"	f	typeref:typename:void
+f1b	input.cpp	/^IMPLEMENT_FUNCTIONS(f1);$/;"	f	typeref:typename:void
+la	input.cpp	/^	DECLARE_VARS(l);$/;"	l	function:main	typeref:typename:int	file:
+lb	input.cpp	/^	DECLARE_VARS(l);$/;"	l	function:main	typeref:typename:int	file:
+main	input.cpp	/^int main(int,char **)$/;"	f	typeref:typename:int
+p1	input.cpp	/^DECLARE_FUNCTION(int,p1);$/;"	p	typeref:typename:int	file:
+p2	input.cpp	/^DECLARE_FUNCTION(std::string,p2);$/;"	p	typeref:typename:std::string	file:
+p3	input.cpp	/^DECLARE_FUNCTION(int,p3,int a,int b);$/;"	p	typeref:typename:int	file:
+p4	input.cpp	/^DEPRECATED(int p4());$/;"	p	typeref:typename:int	file:	properties:deprecated

--- a/Units/parser-cxx.r/complex-macros.d/input.cpp
+++ b/Units/parser-cxx.r/complex-macros.d/input.cpp
@@ -1,0 +1,31 @@
+#include <string>
+
+#define DECLARE_FUNCTION(_ret,_name) _ret _name();
+
+DECLARE_FUNCTION(int,p1);
+DECLARE_FUNCTION(std::string,p2);
+
+#define DECLARE_FUNCTION_2(_ret,_name,...) _ret _name(__VA_ARGS__);
+
+DECLARE_FUNCTION(int,p3,int a,int b);
+
+#define DEPRECATED(...) __VA_ARGS__ __attribute__((deprecated))
+
+DEPRECATED(int p4());
+
+#define IMPLEMENT_FUNCTIONS(_prefix) \
+	void _prefix ## a(){ }; \
+	void _prefix ## b(){ };
+
+IMPLEMENT_FUNCTIONS(f1);
+
+
+#define DECLARE_VARS(_prefix) int _prefix ## a; int _prefix ## b;
+
+
+int main(int,char **)
+{
+	DECLARE_VARS(l);
+
+	return 0;
+}

--- a/Units/parser-cxx.r/foreach.d/args.ctags
+++ b/Units/parser-cxx.r/foreach.d/args.ctags
@@ -1,0 +1,2 @@
+--c++-kinds=+pxl
+-I foreach+=for($0;;)

--- a/Units/parser-cxx.r/foreach.d/expected.tags
+++ b/Units/parser-cxx.r/foreach.d/expected.tags
@@ -1,0 +1,6 @@
+a	input.cpp	/^int a,b;$/;"	v	typeref:typename:int
+b	input.cpp	/^int a,b;$/;"	v	typeref:typename:int
+foreach	input.cpp	/^#define foreach(/;"	d	file:
+main	input.cpp	/^int main(int,char **)$/;"	f	typeref:typename:int
+p	input.cpp	/^	foreach(char * p,pointers)$/;"	l	function:main	typeref:typename:char *	file:
+pointers	input.cpp	/^char * pointers[10];$/;"	v	typeref:typename:char * [10]

--- a/Units/parser-cxx.r/foreach.d/input.cpp
+++ b/Units/parser-cxx.r/foreach.d/input.cpp
@@ -1,0 +1,27 @@
+
+// In real world this would have a (rather complex) implementation.
+// See Q_FOREACH() and foreach() macros in Qt as example.
+#define foreach(_a,_b)
+
+char * pointers[10];
+int a,b;
+
+int main(int,char **)
+{
+	
+	//...
+	
+	// p is declared inside foreach() parenthesis.
+	// pointers is NOT declared here
+	foreach(char * p,pointers)
+	{
+
+	}
+
+	// This is not a variable declaration.
+	if(a * b)
+	{
+	}
+
+	return 0;
+}

--- a/main/lcpp.c
+++ b/main/lcpp.c
@@ -63,7 +63,12 @@ enum eState {
 /*  Defines the current state of the pre-processor.
  */
 typedef struct sCppState {
-	int		ungetch, ungetch2;   /* ungotten characters, if any */
+
+	int * ungetBuffer;       /* memory buffer for unget characters */
+	int ungetBufferSize;      /* the current unget buffer size */
+	int * ungetPointer;      /* the current unget char: points in the middle of the buffer */
+	int ungetDataSize;        /* the number of valid unget characters in the buffer */
+
 	bool resolveRequired;     /* must resolve if/else/elif/endif branch */
 	bool hasAtLiteralStrings; /* supports @"c:\" strings */
 	bool hasCxxRawLiteralStrings; /* supports R"xxx(...)xxx" strings */
@@ -93,7 +98,10 @@ typedef struct sCppState {
 static bool BraceFormat = false;
 
 static cppState Cpp = {
-	'\0', '\0',  /* ungetch characters */
+	NULL,        /* ungetBuffer */
+	0,           /* ungetBufferSize */
+	NULL,        /* ungetPointer */
+	0,           /* ungetDataSize */
 	false,       /* resolveRequired */
 	false,       /* hasAtLiteralStrings */
 	false,       /* hasCxxRawLiteralStrings */
@@ -136,8 +144,7 @@ extern void cppInit (const bool state, const bool hasAtLiteralStrings,
 {
 	BraceFormat = state;
 
-	Cpp.ungetch         = '\0';
-	Cpp.ungetch2        = '\0';
+
 	Cpp.resolveRequired = false;
 	Cpp.hasAtLiteralStrings = hasAtLiteralStrings;
 	Cpp.hasCxxRawLiteralStrings = hasCxxRawLiteralStrings;
@@ -167,6 +174,12 @@ extern void cppTerminate (void)
 		vStringDelete (Cpp.directive.name);
 		Cpp.directive.name = NULL;
 	}
+	
+	if(Cpp.ungetBuffer)
+	{
+		eFree(Cpp.ungetBuffer);
+		Cpp.ungetBuffer = NULL;
+	}
 }
 
 extern void cppBeginStatement (void)
@@ -186,15 +199,120 @@ extern void cppEndStatement (void)
 *   directives and may emit a tag for #define directives.
 */
 
-/*  This puts a character back into the input queue for the input File.
- *  Up to two characters may be ungotten.
- */
+/*  This puts a character back into the input queue for the input File. */
 extern void cppUngetc (const int c)
 {
-	Assert (Cpp.ungetch2 == '\0');
-	Cpp.ungetch2 = Cpp.ungetch;
-	Cpp.ungetch = c;
+	if(!Cpp.ungetPointer)
+	{
+		// no unget data
+		if(!Cpp.ungetBuffer)
+		{
+			Cpp.ungetBuffer = (int *)eMalloc(8 * sizeof(int));
+			Cpp.ungetBufferSize = 8;
+		}
+		Assert(Cpp.ungetBufferSize > 0);
+		Cpp.ungetPointer = Cpp.ungetBuffer + Cpp.ungetBufferSize - 1;
+		*(Cpp.ungetPointer) = c;
+		Cpp.ungetDataSize = 1;
+		return;
+	}
+
+	// Already have some unget data in the buffer. Must prepend.
+	Assert(Cpp.ungetBuffer);
+	Assert(Cpp.ungetBufferSize > 0);
+	Assert(Cpp.ungetDataSize > 0);
+	Assert(Cpp.ungetPointer >= Cpp.ungetBuffer);
+	
+	if(Cpp.ungetPointer == Cpp.ungetBuffer)
+	{
+		Cpp.ungetBufferSize += 8;
+		int * tmp = (int *)eMalloc(Cpp.ungetBufferSize * sizeof(int));
+		memmove(tmp+8,Cpp.ungetPointer,Cpp.ungetDataSize);
+		eFree(Cpp.ungetBuffer);
+		Cpp.ungetBuffer = tmp;
+		Cpp.ungetPointer = tmp + 7;
+	} else {
+		Cpp.ungetPointer--;
+	}
+
+	*(Cpp.ungetPointer) = c;
+	Cpp.ungetDataSize++;
 }
+
+
+/*  This puts an entire string back into the input queue for the input File. */
+void cppUngetString(const char * string,int len)
+{
+	if(!string)
+		return;
+	if(len < 1)
+		return;
+
+	if(!Cpp.ungetPointer)
+	{
+		// no unget data
+		if(!Cpp.ungetBuffer)
+		{
+			Cpp.ungetBufferSize = 8 + len;
+			Cpp.ungetBuffer = (int *)eMalloc(Cpp.ungetBufferSize * sizeof(int));
+		} else if(Cpp.ungetBufferSize < len)
+		{
+			Cpp.ungetBufferSize = 8 + len;
+			Cpp.ungetBuffer = (int *)eRealloc(Cpp.ungetBuffer,Cpp.ungetBufferSize * sizeof(int));
+		}
+		Cpp.ungetPointer = Cpp.ungetBuffer + Cpp.ungetBufferSize - len;
+	} else {
+		// Already have some unget data in the buffer. Must prepend.
+		Assert(Cpp.ungetBuffer);
+		Assert(Cpp.ungetBufferSize > 0);
+		Assert(Cpp.ungetDataSize > 0);
+		Assert(Cpp.ungetPointer >= Cpp.ungetBuffer);
+
+		if(Cpp.ungetBufferSize < (Cpp.ungetDataSize + len))
+		{
+			Cpp.ungetBufferSize += 8 + len;
+			int * tmp = (int *)eMalloc(Cpp.ungetBufferSize * sizeof(int));
+			
+			memmove(tmp + 8 + len,Cpp.ungetPointer,Cpp.ungetDataSize);
+			eFree(Cpp.ungetBuffer);
+			Cpp.ungetBuffer = tmp;
+			Cpp.ungetPointer = tmp + 8;
+		} else {
+			Cpp.ungetPointer -= len;
+			Assert(Cpp.ungetPointer >= Cpp.ungetBuffer);
+		}
+	}
+
+	int * p = Cpp.ungetPointer;
+	const char * s = string;
+	const char * e = string + len;
+
+	while(s < e)
+		*p++ = *s++;
+
+	Cpp.ungetDataSize += len;
+}
+
+static int cppGetcFromUngetBufferOrFile(void)
+{
+	if(Cpp.ungetPointer)
+	{
+		Assert(Cpp.ungetBuffer);
+		Assert(Cpp.ungetBufferSize > 0);
+		Assert(Cpp.ungetDataSize > 0);
+		
+		int c = *(Cpp.ungetPointer);
+		Cpp.ungetDataSize--;
+		if(Cpp.ungetDataSize > 0)
+			Cpp.ungetPointer++;
+		else
+			Cpp.ungetPointer = NULL;
+		return c;
+	}
+
+	return getcFromInputFile();
+}
+
 
 /*  Reads a directive, whose first character is given by "c", into "name".
  */
@@ -206,10 +324,10 @@ static bool readDirective (int c, char *const name, unsigned int maxLength)
 	{
 		if (i > 0)
 		{
-			c = getcFromInputFile ();
+			c = cppGetcFromUngetBufferOrFile ();
 			if (c == EOF  ||  ! isalpha (c))
 			{
-				ungetcToInputFile (c);
+				cppUngetc (c);
 				break;
 			}
 		}
@@ -229,9 +347,9 @@ static void readIdentifier (int c, vString *const name)
 	do
 	{
 		vStringPut (name, c);
-		c = getcFromInputFile ();
+		c = cppGetcFromUngetBufferOrFile ();
 	} while (c != EOF  && cppIsident (c));
-	ungetcToInputFile (c);
+	cppUngetc (c);
 }
 
 static void readFilename (int c, vString *const name)
@@ -240,7 +358,7 @@ static void readFilename (int c, vString *const name)
 
 	vStringClear (name);
 
-	while (c = getcFromInputFile (), (c != EOF && c != c_end && c != '\n'))
+	while (c = cppGetcFromUngetBufferOrFile (), (c != EOF && c != c_end && c != '\n'))
 		vStringPut (name, c);
 }
 
@@ -405,7 +523,7 @@ static int directiveDefine (const int c, bool undef)
 		{
 			int p;
 
-			p = getcFromInputFile ();
+			p = cppGetcFromUngetBufferOrFile ();
 			if (p == '(')
 			{
 				signature = vStringNewOrClear (signature);
@@ -413,7 +531,7 @@ static int directiveDefine (const int c, bool undef)
 					if (!isspacetab(p))
 						vStringPut (signature, p);
 					/* TODO: Macro parameters can be captured here. */
-					p = getcFromInputFile ();
+					p = cppGetcFromUngetBufferOrFile ();
 				} while (p != ')' && p != EOF);
 
 				if (p == ')')
@@ -426,7 +544,7 @@ static int directiveDefine (const int c, bool undef)
 			}
 			else
 			{
-				ungetcToInputFile (p);
+				cppUngetc (p);
 				r = makeDefineTag (vStringValue (Cpp.directive.name), NULL, undef);
 			}
 		}
@@ -457,7 +575,7 @@ static void directivePragma (int c)
 			/* generate macro tag for weak name */
 			do
 			{
-				c = getcFromInputFile ();
+				c = cppGetcFromUngetBufferOrFile ();
 			} while (c == SPACE);
 			if (cppIsident1 (c))
 			{
@@ -560,7 +678,7 @@ static bool handleDirective (const int c, int *macroCorkIndex)
 static Comment isComment (void)
 {
 	Comment comment;
-	const int next = getcFromInputFile ();
+	const int next = cppGetcFromUngetBufferOrFile ();
 
 	if (next == '*')
 		comment = COMMENT_C;
@@ -570,7 +688,7 @@ static Comment isComment (void)
 		comment = COMMENT_D;
 	else
 	{
-		ungetcToInputFile (next);
+		cppUngetc (next);
 		comment = COMMENT_NONE;
 	}
 	return comment;
@@ -581,15 +699,15 @@ static Comment isComment (void)
  */
 int cppSkipOverCComment (void)
 {
-	int c = getcFromInputFile ();
+	int c = cppGetcFromUngetBufferOrFile ();
 
 	while (c != EOF)
 	{
 		if (c != '*')
-			c = getcFromInputFile ();
+			c = cppGetcFromUngetBufferOrFile ();
 		else
 		{
-			const int next = getcFromInputFile ();
+			const int next = cppGetcFromUngetBufferOrFile ();
 
 			if (next != '/')
 				c = next;
@@ -609,10 +727,10 @@ static int skipOverCplusComment (void)
 {
 	int c;
 
-	while ((c = getcFromInputFile ()) != EOF)
+	while ((c = cppGetcFromUngetBufferOrFile ()) != EOF)
 	{
 		if (c == BACKSLASH)
-			getcFromInputFile ();  /* throw away next character, too */
+			cppGetcFromUngetBufferOrFile ();  /* throw away next character, too */
 		else if (c == NEWLINE)
 			break;
 	}
@@ -624,15 +742,15 @@ static int skipOverCplusComment (void)
  */
 static int skipOverDComment (void)
 {
-	int c = getcFromInputFile ();
+	int c = cppGetcFromUngetBufferOrFile ();
 
 	while (c != EOF)
 	{
 		if (c != '+')
-			c = getcFromInputFile ();
+			c = cppGetcFromUngetBufferOrFile ();
 		else
 		{
-			const int next = getcFromInputFile ();
+			const int next = cppGetcFromUngetBufferOrFile ();
 
 			if (next != '/')
 				c = next;
@@ -653,10 +771,10 @@ static int skipToEndOfString (bool ignoreBackslash)
 {
 	int c;
 
-	while ((c = getcFromInputFile ()) != EOF)
+	while ((c = cppGetcFromUngetBufferOrFile ()) != EOF)
 	{
 		if (c == BACKSLASH && ! ignoreBackslash)
-			getcFromInputFile ();  /* throw away next character, too */
+			cppGetcFromUngetBufferOrFile ();  /* throw away next character, too */
 		else if (c == DOUBLE_QUOTE)
 			break;
 	}
@@ -672,11 +790,11 @@ static int isCxxRawLiteralDelimiterChar (int c)
 
 static int skipToEndOfCxxRawLiteralString (void)
 {
-	int c = getcFromInputFile ();
+	int c = cppGetcFromUngetBufferOrFile ();
 
 	if (c != '(' && ! isCxxRawLiteralDelimiterChar (c))
 	{
-		ungetcToInputFile (c);
+		cppUngetc (c);
 		c = skipToEndOfString (false);
 	}
 	else
@@ -699,15 +817,15 @@ static int skipToEndOfCxxRawLiteralString (void)
 			{
 				unsigned int i = 0;
 
-				while ((c = getcFromInputFile ()) != EOF && i < delimLen && delim[i] == c)
+				while ((c = cppGetcFromUngetBufferOrFile ()) != EOF && i < delimLen && delim[i] == c)
 					i++;
 				if (i == delimLen && c == DOUBLE_QUOTE)
 					break;
 				else
-					ungetcToInputFile (c);
+					cppUngetc (c);
 			}
 		}
-		while ((c = getcFromInputFile ()) != EOF);
+		while ((c = cppGetcFromUngetBufferOrFile ()) != EOF);
 		c = STRING_SYMBOL;
 	}
 	return c;
@@ -722,16 +840,16 @@ static int skipToEndOfChar (void)
 	int c;
 	int count = 0, veraBase = '\0';
 
-	while ((c = getcFromInputFile ()) != EOF)
+	while ((c = cppGetcFromUngetBufferOrFile ()) != EOF)
 	{
 	    ++count;
 		if (c == BACKSLASH)
-			getcFromInputFile ();  /* throw away next character, too */
+			cppGetcFromUngetBufferOrFile ();  /* throw away next character, too */
 		else if (c == SINGLE_QUOTE)
 			break;
 		else if (c == NEWLINE)
 		{
-			ungetcToInputFile (c);
+			cppUngetc (c);
 			break;
 		}
 		else if (Cpp.hasSingleQuoteLiteralNumbers)
@@ -740,7 +858,7 @@ static int skipToEndOfChar (void)
 				veraBase = c;
 			else if (veraBase != '\0'  &&  ! isalnum (c))
 			{
-				ungetcToInputFile (c);
+				cppUngetc (c);
 				break;
 			}
 		}
@@ -759,6 +877,7 @@ static void attachEndFieldMaybe (int macroCorkIndex)
 	}
 }
 
+
 /*  This function returns the next character, stripping out comments,
  *  C pre-processor directives, and the contents of single and double
  *  quoted strings. In short, strip anything which places a burden upon
@@ -771,17 +890,10 @@ extern int cppGetc (void)
 	int c;
 	int macroCorkIndex = CORK_NIL;
 
-	if (Cpp.ungetch != '\0')
-	{
-		c = Cpp.ungetch;
-		Cpp.ungetch = Cpp.ungetch2;
-		Cpp.ungetch2 = '\0';
-		return c;  /* return here to avoid re-calling debugPutc () */
-	}
-	else do
-	{
+
+	do {
 start_loop:
-		c = getcFromInputFile ();
+		c = cppGetcFromUngetBufferOrFile ();
 process:
 		switch (c)
 		{
@@ -841,7 +953,7 @@ process:
 				{
 					c = skipOverCplusComment ();
 					if (c == NEWLINE)
-						ungetcToInputFile (c);
+						cppUngetc (c);
 				}
 				else if (comment == COMMENT_D)
 					c = skipOverDComment ();
@@ -852,23 +964,23 @@ process:
 
 			case BACKSLASH:
 			{
-				int next = getcFromInputFile ();
+				int next = cppGetcFromUngetBufferOrFile ();
 
 				if (next == NEWLINE)
 					goto start_loop;
 				else
-					ungetcToInputFile (next);
+					cppUngetc (next);
 				break;
 			}
 
 			case '?':
 			{
-				int next = getcFromInputFile ();
+				int next = cppGetcFromUngetBufferOrFile ();
 				if (next != '?')
-					ungetcToInputFile (next);
+					cppUngetc (next);
 				else
 				{
-					next = getcFromInputFile ();
+					next = cppGetcFromUngetBufferOrFile ();
 					switch (next)
 					{
 						case '(':          c = '[';       break;
@@ -881,8 +993,8 @@ process:
 						case '-':          c = '~';       break;
 						case '=':          c = '#';       goto process;
 						default:
-							ungetcToInputFile ('?');
-							ungetcToInputFile (next);
+							cppUngetc ('?');
+							cppUngetc (next);
 							break;
 					}
 				}
@@ -894,32 +1006,32 @@ process:
 			 */
 			case '<':
 			{
-				int next = getcFromInputFile ();
+				int next = cppGetcFromUngetBufferOrFile ();
 				switch (next)
 				{
 					case ':':	c = '['; break;
 					case '%':	c = '{'; break;
-					default: ungetcToInputFile (next);
+					default: cppUngetc (next);
 				}
 				goto enter;
 			}
 			case ':':
 			{
-				int next = getcFromInputFile ();
+				int next = cppGetcFromUngetBufferOrFile ();
 				if (next == '>')
 					c = ']';
 				else
-					ungetcToInputFile (next);
+					cppUngetc (next);
 				goto enter;
 			}
 			case '%':
 			{
-				int next = getcFromInputFile ();
+				int next = cppGetcFromUngetBufferOrFile ();
 				switch (next)
 				{
 					case '>':	c = '}'; break;
 					case ':':	c = '#'; goto process;
-					default: ungetcToInputFile (next);
+					default: cppUngetc (next);
 				}
 				goto enter;
 			}
@@ -927,7 +1039,7 @@ process:
 			default:
 				if (c == '@' && Cpp.hasAtLiteralStrings)
 				{
-					int next = getcFromInputFile ();
+					int next = cppGetcFromUngetBufferOrFile ();
 					if (next == DOUBLE_QUOTE)
 					{
 						Cpp.directive.accept = false;
@@ -935,7 +1047,7 @@ process:
 						break;
 					}
 					else
-						ungetcToInputFile (next);
+						cppUngetc (next);
 				}
 				else if (c == 'R' && Cpp.hasCxxRawLiteralStrings)
 				{
@@ -964,9 +1076,9 @@ process:
 					    (! cppIsident (prev2) && (prev == 'L' || prev == 'u' || prev == 'U')) ||
 					    (! cppIsident (prev3) && (prev2 == 'u' && prev == '8')))
 					{
-						int next = getcFromInputFile ();
+						int next = cppGetcFromUngetBufferOrFile ();
 						if (next != DOUBLE_QUOTE)
-							ungetcToInputFile (next);
+							cppUngetc (next);
 						else
 						{
 							Cpp.directive.accept = false;

--- a/main/lcpp.c
+++ b/main/lcpp.c
@@ -144,6 +144,8 @@ extern void cppInit (const bool state, const bool hasAtLiteralStrings,
 {
 	BraceFormat = state;
 
+	Cpp.ungetBuffer = NULL;
+	Cpp.ungetPointer = NULL;
 
 	Cpp.resolveRequired = false;
 	Cpp.hasAtLiteralStrings = hasAtLiteralStrings;
@@ -227,7 +229,7 @@ extern void cppUngetc (const int c)
 	{
 		Cpp.ungetBufferSize += 8;
 		int * tmp = (int *)eMalloc(Cpp.ungetBufferSize * sizeof(int));
-		memmove(tmp+8,Cpp.ungetPointer,Cpp.ungetDataSize);
+		memcpy(tmp+8,Cpp.ungetPointer,Cpp.ungetDataSize * sizeof(int));
 		eFree(Cpp.ungetBuffer);
 		Cpp.ungetBuffer = tmp;
 		Cpp.ungetPointer = tmp + 7;
@@ -270,10 +272,9 @@ void cppUngetString(const char * string,int len)
 
 		if(Cpp.ungetBufferSize < (Cpp.ungetDataSize + len))
 		{
-			Cpp.ungetBufferSize += 8 + len;
+			Cpp.ungetBufferSize = 8 + len + Cpp.ungetDataSize;
 			int * tmp = (int *)eMalloc(Cpp.ungetBufferSize * sizeof(int));
-			
-			memmove(tmp + 8 + len,Cpp.ungetPointer,Cpp.ungetDataSize);
+			memcpy(tmp + 8 + len,Cpp.ungetPointer,Cpp.ungetDataSize * sizeof(int));
 			eFree(Cpp.ungetBuffer);
 			Cpp.ungetBuffer = tmp;
 			Cpp.ungetPointer = tmp + 8;

--- a/main/lcpp.h
+++ b/main/lcpp.h
@@ -72,6 +72,7 @@ extern void cppTerminate (void);
 extern void cppBeginStatement (void);
 extern void cppEndStatement (void);
 extern void cppUngetc (const int c);
+extern void cppUngetString(const char * string,int len);
 extern int cppGetc (void);
 extern int cppSkipOverCComment (void);
 

--- a/main/options.c
+++ b/main/options.c
@@ -57,7 +57,7 @@
 #define EXTENSION_SEPARATOR '.'
 #define PATTERN_START '('
 #define PATTERN_STOP  ')'
-#define IGNORE_SEPARATORS   ", \t\n"
+#define IGNORE_SEPARATORS   ",\n"
 
 #ifndef DEFAULT_FILE_FORMAT
 # define DEFAULT_FILE_FORMAT  2
@@ -2194,11 +2194,11 @@ static void saveIgnoreToken(const char * ignoreToken)
 	if(tokenEnd <= tokenBegin)
 		return;
 
-	
 	ignoredTokenInfo * info = (ignoredTokenInfo *)eMalloc(sizeof(ignoredTokenInfo));
 	
 	info->ignoreFollowingParenthesis = ignoreFollowingParenthesis;
 	info->replacement = replacement ? eStrdup(replacement) : NULL;
+	info->replacementLength = replacement ? strlen(replacement) : 0;
 
 	hashTablePutItem(Option.ignore,eStrndup(tokenBegin,tokenEnd - tokenBegin),info);
 

--- a/main/options.h
+++ b/main/options.h
@@ -63,6 +63,7 @@ typedef enum sortType {
 typedef struct sIgnoredTokenInfo {
 	bool ignoreFollowingParenthesis; /* -I SOMETHING+ */
 	char * replacement;              /* -I SOMETHING=REPLACEMENT */
+	int replacementLength;
 } ignoredTokenInfo;
 
 /*  This stores the command line options.

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1242,7 +1242,7 @@ bool cxxParserParseIfForWhileSwitch(void)
 			);
 
 		// Simple check for cases like if(a & b), if(a * b).
-		// If there is &, && or * then we expect there to be also a =.
+		// If there is &, && or * then we expect there to be also a = or a ;.
 		if(
 				// & && * not present
 				!cxxTokenChainFirstTokenOfType(
@@ -1250,10 +1250,10 @@ bool cxxParserParseIfForWhileSwitch(void)
 						CXXTokenTypeAnd | CXXTokenTypeMultipleAnds |
 						CXXTokenTypeStar
 					) ||
-				// or = present
+				// or [=;] present
 				cxxTokenChainFirstTokenOfType(
 						pChain,
-						CXXTokenTypeAssignment
+						CXXTokenTypeAssignment | CXXTokenTypeSemicolon
 					)
 			)
 		{

--- a/parsers/cxx/cxx_token_chain.c
+++ b/parsers/cxx/cxx_token_chain.c
@@ -437,6 +437,46 @@ void cxxTokenChainMoveEntryRange(
 	}
 }
 
+CXXTokenChain * cxxTokenChainSplitOnComma(CXXTokenChain * tc)
+{
+	if(!tc)
+		return NULL;
+	
+	CXXTokenChain * pRet = cxxTokenChainCreate();
+	
+	CXXToken * pToken = cxxTokenChainFirst(tc);
+	
+	if(!pToken)
+		return pRet;
+	
+	CXXToken * pStart = pToken;
+	
+	while(pStart && pToken->pNext)
+	{
+		while(pToken->pNext && (!cxxTokenTypeIs(pToken->pNext,CXXTokenTypeComma)))
+			pToken = pToken->pNext;
+	
+		CXXToken * pNew = cxxTokenChainExtractRange(pStart,pToken,0);
+		if(pNew)
+			cxxTokenChainAppend(pRet,pNew);
+		
+		pToken = pToken->pNext; // comma or nothing
+		if(pToken)
+			pToken = pToken->pNext; // after comma
+		pStart = pToken;
+	}
+
+	if(pStart)
+	{
+		// finished without comma
+		CXXToken * pNew = cxxTokenChainExtractRange(pStart,cxxTokenChainLast(tc),0);
+		if(pNew)
+			cxxTokenChainAppend(pRet,pNew);
+	}
+
+	return pRet;
+}
+
 
 void cxxTokenChainCondense(CXXTokenChain * tc,unsigned int uFlags)
 {

--- a/parsers/cxx/cxx_token_chain.h
+++ b/parsers/cxx/cxx_token_chain.h
@@ -189,6 +189,13 @@ vString * cxxTokenChainJoinRange(
 		unsigned int uFlags
 	);
 
+// Treat the tochek chain tc as a comma separated sequence
+// of items (something, blah foo, 1 2 3 4 5, ...)
+// Create a token chain that contains tokens corresponding
+// to each item (i.e, "something", "blah foo", "1 2 3 4 5").
+// Please note that the returned chain may be empty!
+CXXTokenChain * cxxTokenChainSplitOnComma(CXXTokenChain * tc);
+
 
 enum CXXTokenChainCondenseFlags
 {
@@ -197,6 +204,7 @@ enum CXXTokenChainCondenseFlags
 };
 
 void cxxTokenChainCondense(CXXTokenChain * tc,unsigned int uFlags);
+
 
 enum CXXTokenChainExtractRangeFlags
 {


### PR DESCRIPTION
- Replacement of macros defined with -I is now fully parsed, so it can contain whatever C/C++ code the user likes
- If a replacement of a + macro contains the $0,$1...$9 sequences, then they are replaced with the 0-th, 1-st...9-th parameter of the skipped parenthesis. This can be used to define almost real C/C++ macros.
- If a replacement of a + macro contains the $\* sequence then it's replaced by the whole parameter set extracted from the skipped parenthesis. This allows for handling of simple variadic macros.
