### PR TITLE
Convert vStringPut macro to inline function (Was: Fix coding issues)

### DIFF
--- a/main/vstring.c
+++ b/main/vstring.c
@@ -79,18 +79,6 @@ extern vString *vStringNew (void)
 	return string;
 }
 
-#ifndef VSTRING_PUTC_MACRO
-extern void vStringPut (vString *const string, const int c)
-{
-	if (string->length + 1 == string->size)  /*  check for buffer overflow */
-		vStringResize (string, string->size * 2);
-
-	string->buffer [string->length] = c;
-	if (c != '\0')
-		string->buffer [++string->length] = '\0';
-}
-#endif
-
 extern vString *vStringNewCopy (const vString *const string)
 {
 	vString *vs = vStringNew ();

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -25,15 +25,6 @@
 /*
 *   MACROS
 */
-#ifndef DEBUG
-# define VSTRING_PUTC_MACRO 1
-#endif
-#ifdef VSTRING_PUTC_MACRO
-#define vStringPut(s,c) \
-	(void)(((s)->length + 1 == (s)->size ? vStringResize ((s), (s)->size * 2) : 0), \
-	((s)->buffer [(s)->length] = (c)), \
-	((c) == '\0' ? 0 : ((s)->buffer [++(s)->length] = '\0')))
-#endif
 
 #define vStringValue(vs)      ((vs)->buffer)
 #define vStringItem(vs,i)     ((vs)->buffer[i])
@@ -66,9 +57,6 @@ typedef struct sVString {
 extern void vStringResize (vString *const string, const size_t newSize);
 extern vString *vStringNew (void);
 extern void vStringDelete (vString *const string);
-#ifndef VSTRING_PUTC_MACRO
-extern void vStringPut (vString *const string, const int c);
-#endif
 extern void vStringStripNewline (vString *const string);
 extern void vStringStripLeading (vString *const string);
 extern void vStringChop (vString *const string);
@@ -94,5 +82,19 @@ extern char    *vStringDeleteUnwrap (vString *const string);
 
 extern void vStringCatSWithEscaping (vString* b, const char *s);
 extern void vStringCatSWithEscapingAsPattern (vString *output, const char* input);
+
+/*
+*   INLINE FUNCTIONS
+*/
+
+static __inline void vStringPut (vString *const string, const int c)
+{
+	if (string->length + 1 == string->size)  /*  check for buffer overflow */
+		vStringResize (string, string->size * 2);
+
+	string->buffer [string->length] = c;
+	if (c != '\0')
+		string->buffer [++string->length] = '\0';
+}
 
 #endif  /* CTAGS_MAIN_VSTRING_H */


### PR DESCRIPTION
Found with make CC=/rest/inst/gcc-6.1.0/usr/local/bin/gcc CFLAGS="-Wall -pedantic".