### PR TITLE
Standalone cpreprocessor parser

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -15,6 +15,9 @@ C	h	local	local header	on
 C++	d	undef	undefined	on
 C++	h	system	system header	on
 C++	h	local	local header	on
+CPreProcessor	d	undef	undefined	on
+CPreProcessor	h	system	system header	on
+CPreProcessor	h	local	local header	on
 DTS	d	undef	undefined	on
 DTS	h	system	system header	on
 DTS	h	local	local header	on
@@ -57,6 +60,9 @@ C	h	local	local header	on
 C++	d	undef	undefined	on
 C++	h	system	system header	on
 C++	h	local	local header	on
+CPreProcessor	d	undef	undefined	on
+CPreProcessor	h	system	system header	on
+CPreProcessor	h	local	local header	on
 DTS	d	undef	undefined	on
 DTS	h	system	system header	on
 DTS	h	local	local header	on
@@ -97,6 +103,8 @@ C	h	system	system header	on
 C	h	local	local header	on
 C++	h	system	system header	on
 C++	h	local	local header	on
+CPreProcessor	h	system	system header	on
+CPreProcessor	h	local	local header	on
 DTS	h	system	system header	on
 DTS	h	local	local header	on
 Vera	h	system	system header	on

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -18,9 +18,6 @@ C++	h	local	local header	on
 CPreProcessor	d	undef	undefined	on
 CPreProcessor	h	system	system header	on
 CPreProcessor	h	local	local header	on
-DTS	d	undef	undefined	on
-DTS	h	system	system header	on
-DTS	h	local	local header	on
 Java	p	imported	imported package	on
 M4	d	undef	undefined	on
 M4	I	included	included macro	on
@@ -63,9 +60,6 @@ C++	h	local	local header	on
 CPreProcessor	d	undef	undefined	on
 CPreProcessor	h	system	system header	on
 CPreProcessor	h	local	local header	on
-DTS	d	undef	undefined	on
-DTS	h	system	system header	on
-DTS	h	local	local header	on
 Java	p	imported	imported package	on
 M4	d	undef	undefined	on
 M4	I	included	included macro	on
@@ -105,8 +99,6 @@ C++	h	system	system header	on
 C++	h	local	local header	on
 CPreProcessor	h	system	system header	on
 CPreProcessor	h	local	local header	on
-DTS	h	system	system header	on
-DTS	h	local	local header	on
 Vera	h	system	system header	on
 Vera	h	local	local header	on
 

--- a/Units/parser-cpreprocessor.r/simple-cpreprocessor.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/simple-cpreprocessor.d/args.ctags
@@ -1,0 +1,3 @@
+--language-force=CPreProcessor
+--extra=+r
+--fields=+r

--- a/Units/parser-cpreprocessor.r/simple-cpreprocessor.d/expected.tags
+++ b/Units/parser-cpreprocessor.r/simple-cpreprocessor.d/expected.tags
@@ -1,0 +1,2 @@
+X	input.c	/^#define X /;"	d	file:
+stdio.h	input.c	/^#include <stdio.h>/;"	h	role:system

--- a/Units/parser-cpreprocessor.r/simple-cpreprocessor.d/input.c
+++ b/Units/parser-cpreprocessor.r/simple-cpreprocessor.d/input.c
@@ -1,0 +1,7 @@
+#define X 1
+#include <stdio.h>
+/*
+#define Y 2
+*/
+
+// #define Z 3

--- a/Units/parser-dts.r/dts-simple.d/args.ctags
+++ b/Units/parser-dts.r/dts-simple.d/args.ctags
@@ -1,2 +1,2 @@
---fields=+Zr
+--fields=+Zrl
 --extra=+rq

--- a/Units/parser-dts.r/dts-simple.d/expected.tags
+++ b/Units/parser-dts.r/dts-simple.d/expected.tags
@@ -1,8 +1,8 @@
-0x00	input.dts	/^	     phandle = <0x00>;$/;"	p	scope:label:label
-bar	input.dts	/^#define bar /;"	d	file:
-bar	input.dts	/^#undef bar$/;"	d	file:	role:undef
-foo.dtsi	input.dts	/^#include "foo.dtsi"/;"	h	role:local
-label	input.dts	/^label: test {$/;"	l
-label.0x00	input.dts	/^	     phandle = <0x00>;$/;"	p	scope:label:label
-label.label2	input.dts	/^	     label2: chosen { } ;$/;"	l	scope:label:label
-label2	input.dts	/^	     label2: chosen { } ;$/;"	l	scope:label:label
+0x00	input.dts	/^	     phandle = <0x00>;$/;"	p	language:DTS	scope:label:label
+bar	input.dts	/^#define bar /;"	d	language:CPreProcessor	file:
+bar	input.dts	/^#undef bar$/;"	d	language:CPreProcessor	file:	role:undef
+foo.dtsi	input.dts	/^#include "foo.dtsi"/;"	h	language:CPreProcessor	role:local
+label	input.dts	/^label: test {$/;"	l	language:DTS
+label.0x00	input.dts	/^	     phandle = <0x00>;$/;"	p	language:DTS	scope:label:label
+label.label2	input.dts	/^	     label2: chosen { } ;$/;"	l	language:DTS	scope:label:label
+label2	input.dts	/^	     label2: chosen { } ;$/;"	l	language:DTS	scope:label:label

--- a/main/lcpp.c
+++ b/main/lcpp.c
@@ -430,6 +430,11 @@ static int makeDefineTag (const char *const name, const char* const signature, b
 	return CORK_NIL;
 }
 
+static bool doesCPreProRunAsStandaloneParser (void)
+{
+	return (Cpp.headerKind == CPreProKinds + CPREPRO_HEADER);
+}
+
 static void makeIncludeTag (const  char *const name, bool systemHeader)
 {
 	tagEntryInfo e;
@@ -442,7 +447,7 @@ static void makeIncludeTag (const  char *const name, bool systemHeader)
 	    && isXtagEnabled (XTAG_REFERENCE_TAGS)
 	    && Cpp.headerKind->roles [ role_index ].enabled)
 	{
-		if (Cpp.headerKind == CPreProKinds + CPREPRO_HEADER)
+		if (doesCPreProRunAsStandaloneParser ())
 			pushLanguage (Cpp.lang);
 
 		initRefTagEntry (&e, name, Cpp.headerKind, role_index);
@@ -451,7 +456,7 @@ static void makeIncludeTag (const  char *const name, bool systemHeader)
 		e.truncateLine = true;
 		makeTagEntry (&e);
 
-		if (Cpp.headerKind == CPreProKinds + CPREPRO_HEADER)
+		if (doesCPreProRunAsStandaloneParser ())
 			popLanguage ();
 	}
 }

--- a/main/parsers.h
+++ b/main/parsers.h
@@ -49,6 +49,7 @@
 	CoffeeScriptParser, \
 	CParser, \
 	CppParser, \
+	CPreProParser, \
 	CssParser, \
 	CsharpParser, \
 	CtagsParser, \

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -16,37 +16,6 @@
 #include "parse.h"
 #include "routines.h"
 
-typedef enum {
-	DTS_MACRO_KIND_UNDEF_ROLE,
-} dtsMacroRole;
-
-static roleDesc DTSMacroRoles [] = {
-	RoleTemplateUndef,
-};
-
-
-typedef enum {
-	DTS_HEADER_KIND_SYSTEM_ROLE,
-	DTS_HEADER_KIND_LOCAL_ROLE,
-} dtsHeaderRole;
-
-static roleDesc DTSHeaderRoles [] = {
-	RoleTemplateSystem,
-	RoleTemplateLocal,
-};
-
-
-typedef enum {
-	DTS_MACRO, DTS_HEADER,
-} dtsKind;
-
-static kindOption DTSKinds [] = {
-	{ true,  'd', "macro",      "macro definitions",
-	  .referenceOnly = false, ATTACH_ROLES(DTSMacroRoles)},
-	{ true, 'h', "header",     "included header files",
-	  .referenceOnly = true, ATTACH_ROLES(DTSHeaderRoles)},
-};
-
 static tagRegexTable dtsTagRegexTable [] = {
 	/* phandle = <0x00> */
 	{"^[ \t]*phandle[ \t]+=[ \t]+<(0x[a-fA-F0-9]+)>", "\\1",
@@ -68,9 +37,8 @@ static tagRegexTable dtsTagRegexTable [] = {
 */
 static void runCppGetc (void)
 {
-	cppInit (0, false, false, false,
-		 DTSKinds + DTS_MACRO, DTS_MACRO_KIND_UNDEF_ROLE,
-		 DTSKinds + DTS_HEADER, DTS_HEADER_KIND_SYSTEM_ROLE, DTS_HEADER_KIND_LOCAL_ROLE);
+	cppInit (false, false, false, false,
+			 NULL, 0, NULL, 0, 0);
 
 	findRegexTagsMainloop (cppGetc);
 
@@ -81,8 +49,6 @@ extern parserDefinition* DTSParser (void)
 {
 	static const char *const extensions [] = { "dts", "dtsi", NULL };
 	parserDefinition* const def = parserNew ("DTS");
-	def->kinds      = DTSKinds;
-	def->kindCount  = ARRAY_SIZE (DTSKinds);
 	def->extensions = extensions;
 	def->parser     = runCppGetc;
 	def->tagRegexTable = dtsTagRegexTable;

--- a/parsers/protobuf.c
+++ b/parsers/protobuf.c
@@ -223,9 +223,8 @@ static void parseStatement (int kind)
 
 static void findProtobufTags (void)
 {
-	cppInit (false, false, false, false, NULL,
-		 ROLE_INDEX_DEFINITION, NULL,
-		 ROLE_INDEX_DEFINITION, ROLE_INDEX_DEFINITION);
+	cppInit (false, false, false, false,
+			 NULL, 0, NULL, 0, 0);
 	token.value = vStringNew ();
 
 	nextToken ();


### PR DESCRIPTION
@pragmaware, how do you think about this?

You wan to put more code to lcpp.c.
Before doing much, I think it is better to take efforts for making lcpp.c more extendable.

More of my work about main part if for parser. lcpp.c is not a parser. It is semi-meta-parser.
This commit converts lcpp.c to a parser and meta parser.
That means lcpp.c now gets its own parserDefinition. So we can add more things.

For exapmle per parser options name space `--opt-<LANG>=...` can be attached to lcpp.c.
