### PR TITLE
buildsys: use type instead of which to detect perl command

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,7 +3,7 @@
 ctags_files=`make -f makefiles/list-translator-input.mak`
 misc/dist-test-cases > makefiles/test-cases.mak && \
     if autoreconf -vfi; then
-	if which perl > /dev/null; then
+	if type perl > /dev/null; then
 	    for i in ${ctags_files}; do
 		o=${i%.ctags}.c
 		echo "optlib2c: translating $i to $o"


### PR DESCRIPTION
For recuding dependencies, use shell-builtin instead of
external command.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>