### PR TITLE
read: Fix theoretical access to freed memory

### DIFF
--- a/main/read.c
+++ b/main/read.c
@@ -1022,8 +1022,6 @@ char* readLineRawWithNoSeek (vString* const vline, FILE *const pp)
 				break;
 		}
 
-		result = vStringValue (vline);
-		
 		if (c == '\n' || c == '\r')
 			nlcr = true;
 		else if (nlcr)
@@ -1033,6 +1031,8 @@ char* readLineRawWithNoSeek (vString* const vline, FILE *const pp)
 		}
 		else
 			vStringPut (vline, c);
+
+		result = vStringValue (vline);
 	}
 
 	return result;


### PR DESCRIPTION
`readLineRawWithNoSeek()` could get the pointer to the internal string
buffer before last modifying it, if reading the last line of the input
and that line has no terminating `\r` or `\n`.  Thus, if the last
modification to the string resulted in an allocation move (e.g. if
`realloc()` returned a different pointer), `readLineRawWithNoSeek()`
would return the pointer to the previous, now invalid, string buffer.
