### PR TITLE
CXX: Properly handle the 'const override {' sequence

### DIFF
--- a/Units/parser-cxx.r/cxx11-override.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-override.d/expected.tags
@@ -1,6 +1,7 @@
 Base	input.cpp	/^class Base$/;"	c	file:
 Derived	input.cpp	/^class Derived : public Base$/;"	c	file:
 foo	input.cpp	/^	virtual void foo() = 0;$/;"	p	class:Base	typeref:typename:void	file:	signature:()
+foo	input.cpp	/^	virtual void foo() const override;$/;"	p	class:Derived	typeref:typename:void	file:	signature:() const
 foo	input.cpp	/^	virtual void foo() override;$/;"	p	class:Derived	typeref:typename:void	file:	signature:()
 foo	input.cpp	/^void Base::foo()$/;"	f	class:Base	typeref:typename:void	signature:()
 foo	input.cpp	/^void Derived::foo()$/;"	f	class:Derived	typeref:typename:void	signature:()

--- a/Units/parser-cxx.r/cxx11-override.d/input.cpp
+++ b/Units/parser-cxx.r/cxx11-override.d/input.cpp
@@ -7,6 +7,7 @@ public:
 class Derived : public Base
 {
 	virtual void foo() override;
+	virtual void foo() const override;
 	virtual void override();
 };
 

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -66,7 +66,9 @@ static bool cxxParserParseBlockHandleOpeningBracket(void)
 									// FIXME: This check could be made stricter?
 									CXXTokenTypeSingleColon | CXXTokenTypeComma
 							))
-						)
+						) &&
+						// "override" is handled as identifier since it's a keyword only after function signatures
+						(strcmp(vStringValue(g_cxx.pToken->pPrev->pszWord),"override") != 0)
 					) || (
 						// type var[][][]..[] { ... }
 						// (but not '[] { ... }' which is a parameterelss lambda)


### PR DESCRIPTION
Implement @masatake 's fix for the 'const override {' and similar sequences.