### PR TITLE
CXX Better macros handling (take 2)

### DIFF
--- a/Tmain/list-params.d/stdout-expected.txt
+++ b/Tmain/list-params.d/stdout-expected.txt
@@ -2,27 +2,33 @@
 #PARSER         NAME     DESCRIPTION                   
 CPreProcessor   if0      examine code within "#if 0" branch (true or [false])
 CPreProcessor   ignore   a token to be specially handled
+CPreProcessor   define   define replacement for an identifier
 
 # ALL MACHINABLE
 #PARSER	NAME	DESCRIPTION
 CPreProcessor	if0	examine code within "#if 0" branch (true or [false])
 CPreProcessor	ignore	a token to be specially handled
+CPreProcessor	define	define replacement for an identifier
 
 # ALL MACHINABLE NOHEADER
 CPreProcessor	if0	examine code within "#if 0" branch (true or [false])
 CPreProcessor	ignore	a token to be specially handled
+CPreProcessor	define	define replacement for an identifier
 
 # CPP
 NAME     DESCRIPTION                   
 if0      examine code within "#if 0" branch (true or [false])
 ignore   a token to be specially handled
+define   define replacement for an identifier
 
 # CPP MACHINABLE
 NAME	DESCRIPTION
 if0	examine code within "#if 0" branch (true or [false])
 ignore	a token to be specially handled
+define	define replacement for an identifier
 
 # CPP MACHINABLE NOHEADER
 if0	examine code within "#if 0" branch (true or [false])
 ignore	a token to be specially handled
+define	define replacement for an identifier
 

--- a/Units/parser-cxx.r/complex-macros.d/args.ctags
+++ b/Units/parser-cxx.r/complex-macros.d/args.ctags
@@ -1,0 +1,7 @@
+--c++-kinds=*
+--fields-c++=+{properties}
+-D DECLARE_FUNCTION=$0 $1()
+-D ARGS=$*
+-D DECLARE_VARS=int $0a; int $0b;
+-D IMPLEMENT_FUNCTIONS=void $0a(){}; void $0b(){};
+-D DEPRECATED=$* __attribute__((deprecated))

--- a/Units/parser-cxx.r/complex-macros.d/expected.tags
+++ b/Units/parser-cxx.r/complex-macros.d/expected.tags
@@ -1,0 +1,14 @@
+DECLARE_FUNCTION	input.cpp	/^#define DECLARE_FUNCTION(/;"	d	file:
+DECLARE_FUNCTION_2	input.cpp	/^#define DECLARE_FUNCTION_2(/;"	d	file:
+DECLARE_VARS	input.cpp	/^#define DECLARE_VARS(/;"	d	file:
+DEPRECATED	input.cpp	/^#define DEPRECATED(/;"	d	file:
+IMPLEMENT_FUNCTIONS	input.cpp	/^#define IMPLEMENT_FUNCTIONS(/;"	d	file:
+f1a	input.cpp	/^IMPLEMENT_FUNCTIONS(f1);$/;"	f	typeref:typename:void
+f1b	input.cpp	/^IMPLEMENT_FUNCTIONS(f1);$/;"	f	typeref:typename:void
+la	input.cpp	/^	DECLARE_VARS(l);$/;"	l	function:main	typeref:typename:int	file:
+lb	input.cpp	/^	DECLARE_VARS(l);$/;"	l	function:main	typeref:typename:int	file:
+main	input.cpp	/^int main(int,char **)$/;"	f	typeref:typename:int
+p1	input.cpp	/^DECLARE_FUNCTION(int,p1);$/;"	p	typeref:typename:int	file:
+p2	input.cpp	/^DECLARE_FUNCTION(std::string,p2);$/;"	p	typeref:typename:std::string	file:
+p3	input.cpp	/^DECLARE_FUNCTION(int,p3,int a,int b);$/;"	p	typeref:typename:int	file:
+p4	input.cpp	/^DEPRECATED(int p4());$/;"	p	typeref:typename:int	file:	properties:deprecated

--- a/Units/parser-cxx.r/complex-macros.d/input.cpp
+++ b/Units/parser-cxx.r/complex-macros.d/input.cpp
@@ -1,0 +1,31 @@
+#include <string>
+
+#define DECLARE_FUNCTION(_ret,_name) _ret _name();
+
+DECLARE_FUNCTION(int,p1);
+DECLARE_FUNCTION(std::string,p2);
+
+#define DECLARE_FUNCTION_2(_ret,_name,...) _ret _name(__VA_ARGS__);
+
+DECLARE_FUNCTION(int,p3,int a,int b);
+
+#define DEPRECATED(...) __VA_ARGS__ __attribute__((deprecated))
+
+DEPRECATED(int p4());
+
+#define IMPLEMENT_FUNCTIONS(_prefix) \
+	void _prefix ## a(){ }; \
+	void _prefix ## b(){ };
+
+IMPLEMENT_FUNCTIONS(f1);
+
+
+#define DECLARE_VARS(_prefix) int _prefix ## a; int _prefix ## b;
+
+
+int main(int,char **)
+{
+	DECLARE_VARS(l);
+
+	return 0;
+}

--- a/Units/parser-cxx.r/foreach.d/args.ctags
+++ b/Units/parser-cxx.r/foreach.d/args.ctags
@@ -1,0 +1,2 @@
+--c++-kinds=+pxl
+-D foreach=for($0;;)

--- a/Units/parser-cxx.r/foreach.d/expected.tags
+++ b/Units/parser-cxx.r/foreach.d/expected.tags
@@ -1,0 +1,6 @@
+a	input.cpp	/^int a,b;$/;"	v	typeref:typename:int
+b	input.cpp	/^int a,b;$/;"	v	typeref:typename:int
+foreach	input.cpp	/^#define foreach(/;"	d	file:
+main	input.cpp	/^int main(int,char **)$/;"	f	typeref:typename:int
+p	input.cpp	/^	foreach(char * p,pointers)$/;"	l	function:main	typeref:typename:char *	file:
+pointers	input.cpp	/^char * pointers[10];$/;"	v	typeref:typename:char * [10]

--- a/Units/parser-cxx.r/foreach.d/input.cpp
+++ b/Units/parser-cxx.r/foreach.d/input.cpp
@@ -1,0 +1,27 @@
+
+// In real world this would have a (rather complex) implementation.
+// See Q_FOREACH() and foreach() macros in Qt as example.
+#define foreach(_a,_b)
+
+char * pointers[10];
+int a,b;
+
+int main(int,char **)
+{
+	
+	//...
+	
+	// p is declared inside foreach() parenthesis.
+	// pointers is NOT declared here
+	foreach(char * p,pointers)
+	{
+
+	}
+
+	// This is not a variable declaration.
+	if(a * b)
+	{
+	}
+
+	return 0;
+}

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1029,6 +1029,20 @@ the elements of the format.
 .. TODO: An example of using WILDCARD
 
 
+Incompatible changes in command line
+---------------------------------------------------------------------
+
+.. NOT REVIEWED YET
+
+``-D`` option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When debugging output is enabled in build config stage, ``-D`` was
+used for specifying the level of debugging output. It is changed to
+``-d``. This change is not critical because ``-D`` option was not
+described in ctags.1 man page.
+
+
 Readtags
 ---------------------------------------------------------------------
 

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -488,6 +488,49 @@ used to enable it.
 See :ref:`JSON output <output-json>` for more details.
 
 
+Defining a macro in CPreProcessor input
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. NOT REVIEWED YET
+
+Newly introduced ``-D`` option extends the function provided by
+``-I`` option.
+
+With ``-I`` option is used for ignoring specified identifiers in C and
+C++ source files.
+
+Instead of ignoring, with ``-D`` option, you can define a replacement for
+specified identifier. Here the identifier is considered as a macro in C/C++
+source code.
+
+.. code-block:: console
+
+   $ ctags ... -D foreach=for($0;;) ...
+
+This example defines `for($0;;)` as the replacement `foreach()`.
+
+With the example command line following C/C++ input:
+
+.. code-block:: C
+
+	foreach(char * p,pointers)
+	{
+
+	}
+
+is processed in new C/C++ parser as:
+
+.. code-block:: C
+
+	for(char * p;;)
+	{
+
+	}
+
+`$0` ... `$9` specifies the arguments passed to the identifier in
+source code. `$*` specifies the whole arguments.
+
+
 Changes to the tags file format
 ---------------------------------------------------------------------
 
@@ -1037,10 +1080,12 @@ Incompatible changes in command line
 ``-D`` option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When debugging output is enabled in build config stage, ``-D`` was
-used for specifying the level of debugging output. It is changed to
-``-d``. This change is not critical because ``-D`` option was not
-described in ctags.1 man page.
+For ctags buinary that debugging output is enabled in build config
+stage, ``-D`` was used for specifying the level of debugging
+output. It is changed to ``-d``. This change is not critical because
+``-D`` option was not described in ctags.1 man page.
+
+Instead ``-D`` is used for defining a macro in CPreProcessor parser.
 
 
 Readtags

--- a/main/options.c
+++ b/main/options.c
@@ -196,6 +196,8 @@ static optionDescription LongOptionDescription [] = {
  {1,"  -d <level>"},
  {1,"       Set debug level."},
 #endif
+ {1,"  -D <macro>=<definition>"},
+ {1,"       (CPreProcessor) Give definition for macro."},
  {0,"  -e   Output tag file for use with Emacs."},
  {1,"  -f <name>"},
  {1,"       Write tags to specified file. Value of \"-\" writes tags to stdout"},
@@ -2216,11 +2218,13 @@ static void addIgnoreListFromFile (const char *const fileName)
 	stringListDelete(tokens);
 }
 
-static void processIgnoreOption (const char *const list)
+static void processIgnoreOption (const char *const list, int IgnoreOrDefine)
 {
 	langType lang = getNamedLanguage ("CPreProcessor", 0);
 
-	if (strchr ("@./\\", list [0]) != NULL)
+	if (IgnoreOrDefine == 'D')
+		applyParameter (lang, "define", list);
+	else if (strchr ("@./\\", list [0]) != NULL)
 	{
 		const char* fileName = (*list == '@') ? list + 1 : list;
 		addIgnoreListFromFile (fileName);
@@ -2767,6 +2771,9 @@ static void processShortOption (
 		case 'B':
 			Option.backward = true;
 			break;
+		case 'D':
+			processIgnoreOption (parameter, *option);
+			break;
 		case 'e':
 			checkOptionOrder (option, false);
 			setEtagsMode ();
@@ -2795,7 +2802,7 @@ static void processShortOption (
 			processHeaderListOption (*option, parameter);
 			break;
 		case 'I':
-			processIgnoreOption (parameter);
+			processIgnoreOption (parameter, *option);
 			break;
 		case 'L':
 			if (Option.fileList != NULL)

--- a/main/options.c
+++ b/main/options.c
@@ -174,7 +174,7 @@ optionValues Option = {
 	.machinable = false,
 	.withListHeader = true,
 #ifdef DEBUG
-	0, 0        /* -D, -b */
+	0, 0        /* -d, -b */
 #endif
 };
 
@@ -193,7 +193,7 @@ static optionDescription LongOptionDescription [] = {
 #endif
  {0,"  -B   Use backward searching patterns (?...?)."},
 #ifdef DEBUG
- {1,"  -D <level>"},
+ {1,"  -d <level>"},
  {1,"       Set debug level."},
 #endif
  {0,"  -e   Output tag file for use with Emacs."},
@@ -2756,7 +2756,7 @@ static void processShortOption (
 				error (FATAL, "-%s: Invalid line number", option);
 			Option.breakLine = atol (parameter);
 			break;
-		case 'D':
+		case 'd':
 			if (!strToLong(parameter, 0, &Option.debugLevel))
 				error (FATAL, "-%s: Invalid debug level", option);
 

--- a/main/options.h
+++ b/main/options.h
@@ -99,7 +99,7 @@ typedef struct sOptionValues {
 	bool machinable;		/* --machinable */
 	bool withListHeader;		/* --with-list-header */
 #ifdef DEBUG
-	long debugLevel;        /* -D  debugging output */
+	long debugLevel;        /* -d  debugging output */
 	unsigned long breakLine;/* -b  input line at which to call lineBreak() */
 #endif
 } optionValues;

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -1779,7 +1779,7 @@ static void skipCppTemplateParameterList (void)
 		if (c == '<')
 		{
 			int x = cppGetc ();
-			if(x != '<') 
+			if(x != '<')
 			{
 				cppUngetc (x);
 				if (roundBracketsLevel == 0)
@@ -1794,7 +1794,7 @@ static void skipCppTemplateParameterList (void)
 		else if (c == '>')
 		{
 			int x = cppGetc ();
-			if( x != '>') 
+			if( x != '>')
 			{
 				cppUngetc (x);
 				if (roundBracketsLevel == 0)
@@ -1866,12 +1866,12 @@ static void analyzeIdentifier (tokenInfo *const token)
 			if(ignore->replacement)
 			{
 				// There is a replacement: analyze it
-				name = ignore->replacement;
+				name = vStringValue (ignore->replacement);
 			} else {
 				// There is no replacement: just ignore
 				name = NULL;
 			}
-			
+
 			if(ignore->ignoreFollowingParenthesis)
 			{
 				int c = skipToNonWhite ();

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1196,7 +1196,7 @@ extern const cppIgnoredTokenInfo * cppIsIgnoreToken(const char * name)
 	return (const cppIgnoredTokenInfo *)hashTableGetItem(ignoreTokenTable,(char *)name);
 }
 
-static void saveIgnoreToken(const char * ignoreToken)
+static void saveIgnoreToken(const char * ignoreToken, const char * param_name)
 {
 	if(!ignoreToken)
 		return;
@@ -1210,6 +1210,10 @@ static void saveIgnoreToken(const char * ignoreToken)
 	const char * tokenEnd = NULL;
 	const char * replacement = NULL;
 	bool ignoreFollowingParenthesis = false;
+
+
+	if (strcmp (param_name, "define") == 0)
+		ignoreFollowingParenthesis = true;
 
 	while(cc)
 	{
@@ -1287,7 +1291,7 @@ static void CpreProInstallIgnoreToken (const langType language, const char *name
 		verbose ("    clearing list\n");
 	}
 	else
-		saveIgnoreToken (arg);
+		saveIgnoreToken (arg, name);
 }
 
 static void CpreProSetIf0 (const langType language, const char *name, const char *arg)
@@ -1303,6 +1307,10 @@ static parameterHandlerTable CpreProParameterHandlerTable [] = {
 	},
 	{ .name = "ignore",
 	  .desc = "a token to be specially handled",
+	  .handleParameter = CpreProInstallIgnoreToken,
+	},
+	{ .name = "define",
+	  .desc = "define replacement for an identifier",
 	  .handleParameter = CpreProInstallIgnoreToken,
 	},
 };

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1244,7 +1244,7 @@ static void saveIgnoreToken(const char * ignoreToken)
 	cppIgnoredTokenInfo * info = (cppIgnoredTokenInfo *)eMalloc(sizeof(cppIgnoredTokenInfo));
 
 	info->ignoreFollowingParenthesis = ignoreFollowingParenthesis;
-	info->replacement = replacement ? eStrdup(replacement) : NULL;
+	info->replacement = replacement ? vStringNewInit(replacement) : NULL;
 
 	hashTablePutItem(ignoreTokenTable,eStrndup(tokenBegin,tokenEnd - tokenBegin),info);
 
@@ -1256,7 +1256,7 @@ static void freeIgnoredTokenInfo(cppIgnoredTokenInfo * info)
 	if(!info)
 		return;
 	if(info->replacement)
-		eFree(info->replacement);
+		vStringDelete (info->replacement);
 	eFree(info);
 }
 

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -65,7 +65,12 @@ enum eState {
  */
 typedef struct sCppState {
 	langType lang;
-	int		ungetch, ungetch2;   /* ungotten characters, if any */
+
+	int * ungetBuffer;       /* memory buffer for unget characters */
+	int ungetBufferSize;      /* the current unget buffer size */
+	int * ungetPointer;      /* the current unget char: points in the middle of the buffer */
+	int ungetDataSize;        /* the number of valid unget characters in the buffer */
+
 	bool resolveRequired;     /* must resolve if/else/elif/endif branch */
 	bool hasAtLiteralStrings; /* supports @"c:\" strings */
 	bool hasCxxRawLiteralStrings; /* supports R"xxx(...)xxx" strings */
@@ -131,7 +136,10 @@ static bool BraceFormat = false;
 
 static cppState Cpp = {
 	LANG_IGNORE,
-	'\0', '\0',  /* ungetch characters */
+	NULL,        /* ungetBuffer */
+	0,           /* ungetBufferSize */
+	NULL,        /* ungetPointer */
+	0,           /* ungetDataSize */
 	false,       /* resolveRequired */
 	false,       /* hasAtLiteralStrings */
 	false,       /* hasCxxRawLiteralStrings */
@@ -182,8 +190,9 @@ extern void cppInit (const bool state, const bool hasAtLiteralStrings,
 		initializeParser (t);
 	}
 
-	Cpp.ungetch         = '\0';
-	Cpp.ungetch2        = '\0';
+	Cpp.ungetBuffer = NULL;
+	Cpp.ungetPointer = NULL;
+
 	Cpp.resolveRequired = false;
 	Cpp.hasAtLiteralStrings = hasAtLiteralStrings;
 	Cpp.hasCxxRawLiteralStrings = hasCxxRawLiteralStrings;
@@ -218,6 +227,12 @@ extern void cppTerminate (void)
 		vStringDelete (Cpp.directive.name);
 		Cpp.directive.name = NULL;
 	}
+
+	if(Cpp.ungetBuffer)
+	{
+		eFree(Cpp.ungetBuffer);
+		Cpp.ungetBuffer = NULL;
+	}
 }
 
 extern void cppBeginStatement (void)
@@ -237,15 +252,119 @@ extern void cppEndStatement (void)
 *   directives and may emit a tag for #define directives.
 */
 
-/*  This puts a character back into the input queue for the input File.
- *  Up to two characters may be ungotten.
- */
+/*  This puts a character back into the input queue for the input File. */
 extern void cppUngetc (const int c)
 {
-	Assert (Cpp.ungetch2 == '\0');
-	Cpp.ungetch2 = Cpp.ungetch;
-	Cpp.ungetch = c;
+	if(!Cpp.ungetPointer)
+	{
+		// no unget data
+		if(!Cpp.ungetBuffer)
+		{
+			Cpp.ungetBuffer = (int *)eMalloc(8 * sizeof(int));
+			Cpp.ungetBufferSize = 8;
+		}
+		Assert(Cpp.ungetBufferSize > 0);
+		Cpp.ungetPointer = Cpp.ungetBuffer + Cpp.ungetBufferSize - 1;
+		*(Cpp.ungetPointer) = c;
+		Cpp.ungetDataSize = 1;
+		return;
+	}
+
+	// Already have some unget data in the buffer. Must prepend.
+	Assert(Cpp.ungetBuffer);
+	Assert(Cpp.ungetBufferSize > 0);
+	Assert(Cpp.ungetDataSize > 0);
+	Assert(Cpp.ungetPointer >= Cpp.ungetBuffer);
+
+	if(Cpp.ungetPointer == Cpp.ungetBuffer)
+	{
+		Cpp.ungetBufferSize += 8;
+		int * tmp = (int *)eMalloc(Cpp.ungetBufferSize * sizeof(int));
+		memcpy(tmp+8,Cpp.ungetPointer,Cpp.ungetDataSize * sizeof(int));
+		eFree(Cpp.ungetBuffer);
+		Cpp.ungetBuffer = tmp;
+		Cpp.ungetPointer = tmp + 7;
+	} else {
+		Cpp.ungetPointer--;
+	}
+
+	*(Cpp.ungetPointer) = c;
+	Cpp.ungetDataSize++;
 }
+
+
+/*  This puts an entire string back into the input queue for the input File. */
+void cppUngetString(const char * string,int len)
+{
+	if(!string)
+		return;
+	if(len < 1)
+		return;
+
+	if(!Cpp.ungetPointer)
+	{
+		// no unget data
+		if(!Cpp.ungetBuffer)
+		{
+			Cpp.ungetBufferSize = 8 + len;
+			Cpp.ungetBuffer = (int *)eMalloc(Cpp.ungetBufferSize * sizeof(int));
+		} else if(Cpp.ungetBufferSize < len)
+		{
+			Cpp.ungetBufferSize = 8 + len;
+			Cpp.ungetBuffer = (int *)eRealloc(Cpp.ungetBuffer,Cpp.ungetBufferSize * sizeof(int));
+		}
+		Cpp.ungetPointer = Cpp.ungetBuffer + Cpp.ungetBufferSize - len;
+	} else {
+		// Already have some unget data in the buffer. Must prepend.
+		Assert(Cpp.ungetBuffer);
+		Assert(Cpp.ungetBufferSize > 0);
+		Assert(Cpp.ungetDataSize > 0);
+		Assert(Cpp.ungetPointer >= Cpp.ungetBuffer);
+
+		if(Cpp.ungetBufferSize < (Cpp.ungetDataSize + len))
+		{
+			Cpp.ungetBufferSize = 8 + len + Cpp.ungetDataSize;
+			int * tmp = (int *)eMalloc(Cpp.ungetBufferSize * sizeof(int));
+			memcpy(tmp + 8 + len,Cpp.ungetPointer,Cpp.ungetDataSize * sizeof(int));
+			eFree(Cpp.ungetBuffer);
+			Cpp.ungetBuffer = tmp;
+			Cpp.ungetPointer = tmp + 8;
+		} else {
+			Cpp.ungetPointer -= len;
+			Assert(Cpp.ungetPointer >= Cpp.ungetBuffer);
+		}
+	}
+
+	int * p = Cpp.ungetPointer;
+	const char * s = string;
+	const char * e = string + len;
+
+	while(s < e)
+		*p++ = *s++;
+
+	Cpp.ungetDataSize += len;
+}
+
+static int cppGetcFromUngetBufferOrFile(void)
+{
+	if(Cpp.ungetPointer)
+	{
+		Assert(Cpp.ungetBuffer);
+		Assert(Cpp.ungetBufferSize > 0);
+		Assert(Cpp.ungetDataSize > 0);
+
+		int c = *(Cpp.ungetPointer);
+		Cpp.ungetDataSize--;
+		if(Cpp.ungetDataSize > 0)
+			Cpp.ungetPointer++;
+		else
+			Cpp.ungetPointer = NULL;
+		return c;
+	}
+
+	return getcFromInputFile();
+}
+
 
 /*  Reads a directive, whose first character is given by "c", into "name".
  */
@@ -257,10 +376,10 @@ static bool readDirective (int c, char *const name, unsigned int maxLength)
 	{
 		if (i > 0)
 		{
-			c = getcFromInputFile ();
+			c = cppGetcFromUngetBufferOrFile ();
 			if (c == EOF  ||  ! isalpha (c))
 			{
-				ungetcToInputFile (c);
+				cppUngetc (c);
 				break;
 			}
 		}
@@ -280,9 +399,9 @@ static void readIdentifier (int c, vString *const name)
 	do
 	{
 		vStringPut (name, c);
-		c = getcFromInputFile ();
-	} while (c != EOF && cppIsident (c));
-	ungetcToInputFile (c);
+		c = cppGetcFromUngetBufferOrFile ();
+	} while (c != EOF  && cppIsident (c));
+	cppUngetc (c);
 }
 
 static void readFilename (int c, vString *const name)
@@ -291,7 +410,7 @@ static void readFilename (int c, vString *const name)
 
 	vStringClear (name);
 
-	while (c = getcFromInputFile (), (c != EOF && c != c_end && c != '\n'))
+	while (c = cppGetcFromUngetBufferOrFile (), (c != EOF && c != c_end && c != '\n'))
 		vStringPut (name, c);
 }
 
@@ -472,7 +591,7 @@ static int directiveDefine (const int c, bool undef)
 		{
 			int p;
 
-			p = getcFromInputFile ();
+			p = cppGetcFromUngetBufferOrFile ();
 			if (p == '(')
 			{
 				signature = vStringNewOrClear (signature);
@@ -480,7 +599,7 @@ static int directiveDefine (const int c, bool undef)
 					if (!isspacetab(p))
 						vStringPut (signature, p);
 					/* TODO: Macro parameters can be captured here. */
-					p = getcFromInputFile ();
+					p = cppGetcFromUngetBufferOrFile ();
 				} while (p != ')' && p != EOF);
 
 				if (p == ')')
@@ -493,7 +612,7 @@ static int directiveDefine (const int c, bool undef)
 			}
 			else
 			{
-				ungetcToInputFile (p);
+				cppUngetc (p);
 				r = makeDefineTag (vStringValue (Cpp.directive.name), NULL, undef);
 			}
 		}
@@ -524,7 +643,7 @@ static void directivePragma (int c)
 			/* generate macro tag for weak name */
 			do
 			{
-				c = getcFromInputFile ();
+				c = cppGetcFromUngetBufferOrFile ();
 			} while (c == SPACE);
 			if (cppIsident1 (c))
 			{
@@ -627,7 +746,7 @@ static bool handleDirective (const int c, int *macroCorkIndex)
 static Comment isComment (void)
 {
 	Comment comment;
-	const int next = getcFromInputFile ();
+	const int next = cppGetcFromUngetBufferOrFile ();
 
 	if (next == '*')
 		comment = COMMENT_C;
@@ -637,7 +756,7 @@ static Comment isComment (void)
 		comment = COMMENT_D;
 	else
 	{
-		ungetcToInputFile (next);
+		cppUngetc (next);
 		comment = COMMENT_NONE;
 	}
 	return comment;
@@ -648,15 +767,15 @@ static Comment isComment (void)
  */
 int cppSkipOverCComment (void)
 {
-	int c = getcFromInputFile ();
+	int c = cppGetcFromUngetBufferOrFile ();
 
 	while (c != EOF)
 	{
 		if (c != '*')
-			c = getcFromInputFile ();
+			c = cppGetcFromUngetBufferOrFile ();
 		else
 		{
-			const int next = getcFromInputFile ();
+			const int next = cppGetcFromUngetBufferOrFile ();
 
 			if (next != '/')
 				c = next;
@@ -676,10 +795,10 @@ static int skipOverCplusComment (void)
 {
 	int c;
 
-	while ((c = getcFromInputFile ()) != EOF)
+	while ((c = cppGetcFromUngetBufferOrFile ()) != EOF)
 	{
 		if (c == BACKSLASH)
-			getcFromInputFile ();  /* throw away next character, too */
+			cppGetcFromUngetBufferOrFile ();  /* throw away next character, too */
 		else if (c == NEWLINE)
 			break;
 	}
@@ -691,15 +810,15 @@ static int skipOverCplusComment (void)
  */
 static int skipOverDComment (void)
 {
-	int c = getcFromInputFile ();
+	int c = cppGetcFromUngetBufferOrFile ();
 
 	while (c != EOF)
 	{
 		if (c != '+')
-			c = getcFromInputFile ();
+			c = cppGetcFromUngetBufferOrFile ();
 		else
 		{
-			const int next = getcFromInputFile ();
+			const int next = cppGetcFromUngetBufferOrFile ();
 
 			if (next != '/')
 				c = next;
@@ -720,10 +839,10 @@ static int skipToEndOfString (bool ignoreBackslash)
 {
 	int c;
 
-	while ((c = getcFromInputFile ()) != EOF)
+	while ((c = cppGetcFromUngetBufferOrFile ()) != EOF)
 	{
 		if (c == BACKSLASH && ! ignoreBackslash)
-			getcFromInputFile ();  /* throw away next character, too */
+			cppGetcFromUngetBufferOrFile ();  /* throw away next character, too */
 		else if (c == DOUBLE_QUOTE)
 			break;
 	}
@@ -738,11 +857,11 @@ static int isCxxRawLiteralDelimiterChar (int c)
 
 static int skipToEndOfCxxRawLiteralString (void)
 {
-	int c = getcFromInputFile ();
+	int c = cppGetcFromUngetBufferOrFile ();
 
 	if (c != '(' && ! isCxxRawLiteralDelimiterChar (c))
 	{
-		ungetcToInputFile (c);
+		cppUngetc (c);
 		c = skipToEndOfString (false);
 	}
 	else
@@ -765,15 +884,15 @@ static int skipToEndOfCxxRawLiteralString (void)
 			{
 				unsigned int i = 0;
 
-				while ((c = getcFromInputFile ()) != EOF && i < delimLen && delim[i] == c)
+				while ((c = cppGetcFromUngetBufferOrFile ()) != EOF && i < delimLen && delim[i] == c)
 					i++;
 				if (i == delimLen && c == DOUBLE_QUOTE)
 					break;
 				else
-					ungetcToInputFile (c);
+					cppUngetc (c);
 			}
 		}
-		while ((c = getcFromInputFile ()) != EOF);
+		while ((c = cppGetcFromUngetBufferOrFile ()) != EOF);
 		c = STRING_SYMBOL;
 	}
 	return c;
@@ -788,16 +907,16 @@ static int skipToEndOfChar (void)
 	int c;
 	int count = 0, veraBase = '\0';
 
-	while ((c = getcFromInputFile ()) != EOF)
+	while ((c = cppGetcFromUngetBufferOrFile ()) != EOF)
 	{
 	    ++count;
 		if (c == BACKSLASH)
-			getcFromInputFile ();  /* throw away next character, too */
+			cppGetcFromUngetBufferOrFile ();  /* throw away next character, too */
 		else if (c == SINGLE_QUOTE)
 			break;
 		else if (c == NEWLINE)
 		{
-			ungetcToInputFile (c);
+			cppUngetc (c);
 			break;
 		}
 		else if (Cpp.hasSingleQuoteLiteralNumbers)
@@ -806,7 +925,7 @@ static int skipToEndOfChar (void)
 				veraBase = c;
 			else if (veraBase != '\0'  &&  ! isalnum (c))
 			{
-				ungetcToInputFile (c);
+				cppUngetc (c);
 				break;
 			}
 		}
@@ -825,6 +944,7 @@ static void attachEndFieldMaybe (int macroCorkIndex)
 	}
 }
 
+
 /*  This function returns the next character, stripping out comments,
  *  C pre-processor directives, and the contents of single and double
  *  quoted strings. In short, strip anything which places a burden upon
@@ -837,17 +957,10 @@ extern int cppGetc (void)
 	int c;
 	int macroCorkIndex = CORK_NIL;
 
-	if (Cpp.ungetch != '\0')
-	{
-		c = Cpp.ungetch;
-		Cpp.ungetch = Cpp.ungetch2;
-		Cpp.ungetch2 = '\0';
-		return c;  /* return here to avoid re-calling debugPutc () */
-	}
-	else do
-	{
+
+	do {
 start_loop:
-		c = getcFromInputFile ();
+		c = cppGetcFromUngetBufferOrFile ();
 process:
 		switch (c)
 		{
@@ -907,7 +1020,7 @@ process:
 				{
 					c = skipOverCplusComment ();
 					if (c == NEWLINE)
-						ungetcToInputFile (c);
+						cppUngetc (c);
 				}
 				else if (comment == COMMENT_D)
 					c = skipOverDComment ();
@@ -918,23 +1031,23 @@ process:
 
 			case BACKSLASH:
 			{
-				int next = getcFromInputFile ();
+				int next = cppGetcFromUngetBufferOrFile ();
 
 				if (next == NEWLINE)
 					goto start_loop;
 				else
-					ungetcToInputFile (next);
+					cppUngetc (next);
 				break;
 			}
 
 			case '?':
 			{
-				int next = getcFromInputFile ();
+				int next = cppGetcFromUngetBufferOrFile ();
 				if (next != '?')
-					ungetcToInputFile (next);
+					cppUngetc (next);
 				else
 				{
-					next = getcFromInputFile ();
+					next = cppGetcFromUngetBufferOrFile ();
 					switch (next)
 					{
 						case '(':          c = '[';       break;
@@ -947,8 +1060,8 @@ process:
 						case '-':          c = '~';       break;
 						case '=':          c = '#';       goto process;
 						default:
-							ungetcToInputFile ('?');
-							ungetcToInputFile (next);
+							cppUngetc ('?');
+							cppUngetc (next);
 							break;
 					}
 				}
@@ -960,32 +1073,32 @@ process:
 			 */
 			case '<':
 			{
-				int next = getcFromInputFile ();
+				int next = cppGetcFromUngetBufferOrFile ();
 				switch (next)
 				{
 					case ':':	c = '['; break;
 					case '%':	c = '{'; break;
-					default: ungetcToInputFile (next);
+					default: cppUngetc (next);
 				}
 				goto enter;
 			}
 			case ':':
 			{
-				int next = getcFromInputFile ();
+				int next = cppGetcFromUngetBufferOrFile ();
 				if (next == '>')
 					c = ']';
 				else
-					ungetcToInputFile (next);
+					cppUngetc (next);
 				goto enter;
 			}
 			case '%':
 			{
-				int next = getcFromInputFile ();
+				int next = cppGetcFromUngetBufferOrFile ();
 				switch (next)
 				{
 					case '>':	c = '}'; break;
 					case ':':	c = '#'; goto process;
-					default: ungetcToInputFile (next);
+					default: cppUngetc (next);
 				}
 				goto enter;
 			}
@@ -993,7 +1106,7 @@ process:
 			default:
 				if (c == '@' && Cpp.hasAtLiteralStrings)
 				{
-					int next = getcFromInputFile ();
+					int next = cppGetcFromUngetBufferOrFile ();
 					if (next == DOUBLE_QUOTE)
 					{
 						Cpp.directive.accept = false;
@@ -1001,7 +1114,7 @@ process:
 						break;
 					}
 					else
-						ungetcToInputFile (next);
+						cppUngetc (next);
 				}
 				else if (c == 'R' && Cpp.hasCxxRawLiteralStrings)
 				{
@@ -1030,9 +1143,9 @@ process:
 					    (! cppIsident (prev2) && (prev == 'L' || prev == 'u' || prev == 'U')) ||
 					    (! cppIsident (prev3) && (prev2 == 'u' && prev == '8')))
 					{
-						int next = getcFromInputFile ();
+						int next = cppGetcFromUngetBufferOrFile ();
 						if (next != DOUBLE_QUOTE)
-							ungetcToInputFile (next);
+							cppUngetc (next);
 						else
 						{
 							Cpp.directive.accept = false;

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1351,7 +1351,7 @@ bool cxxParserParseIfForWhileSwitch(void)
 			);
 
 		// Simple check for cases like if(a & b), if(a * b).
-		// If there is &, && or * then we expect there to be also a =.
+		// If there is &, && or * then we expect there to be also a = or a ;.
 		if(
 				// & && * not present
 				!cxxTokenChainFirstTokenOfType(
@@ -1359,10 +1359,10 @@ bool cxxParserParseIfForWhileSwitch(void)
 						CXXTokenTypeAnd | CXXTokenTypeMultipleAnds |
 						CXXTokenTypeStar
 					) ||
-				// or = present
+				// or [=;] present
 				cxxTokenChainFirstTokenOfType(
 						pChain,
-						CXXTokenTypeAssignment
+						CXXTokenTypeAssignment | CXXTokenTypeSemicolon
 					)
 			)
 		{

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -968,14 +968,19 @@ static bool cxxParserParseNextTokenCondenseAttribute(void)
 // if it is not a parenthesis. This is because the ignored token
 // may have a replacement and is that one that has to be returned
 // back to the caller from cxxParserParseNextToken().
-static bool cxxParserParseNextTokenSkipIgnoredParenthesis(void)
+static bool cxxParserParseNextTokenSkipIgnoredParenthesis(CXXToken ** ppChain)
 {
 	CXX_DEBUG_ENTER();
+
+	CXX_DEBUG_ASSERT(ppChain,"ppChain should not be null here");
 
 	cxxParserSkipToNonWhiteSpace();
 
 	if(g_cxx.iChar != '(')
+	{
+		*ppChain = NULL;
 		return true; // no parenthesis
+	}
 
 	if(!cxxParserParseNextToken())
 	{
@@ -1007,10 +1012,134 @@ static bool cxxParserParseNextTokenSkipIgnoredParenthesis(void)
 		);
 
 	// Now just kill the chain.
-	cxxTokenDestroy(cxxTokenChainTakeLast(g_cxx.pTokenChain));
+	*ppChain = cxxTokenChainTakeLast(g_cxx.pTokenChain);
 
 	CXX_DEBUG_LEAVE();
 	return true;
+}
+
+static void cxxParserParseNextTokenApplyReplacement(
+		const cppIgnoredTokenInfo * pInfo,
+		CXXToken * pParameterChainToken
+	)
+{
+	CXX_DEBUG_ENTER();
+
+	CXX_DEBUG_ASSERT(pInfo,"Info must be not null");
+	CXX_DEBUG_ASSERT(pInfo->replacement,"There should be a replacement");
+	CXX_DEBUG_ASSERT(pInfo->replacementLength > 0,"The replacement is too short");
+
+	if(!pInfo->ignoreFollowingParenthesis)
+	{
+		CXX_DEBUG_ASSERT(!pParameterChainToken,"This shouldn't have been extracted");
+		cppUngetString(vStringValue (pInfo->replacement),vStringLength (pInfo->replacement));
+		CXX_DEBUG_LEAVE_TEXT("Applied simple replacement %s",vStringValue (pInfo->replacement));
+		return;
+	}
+
+	const char * c = vStringValue (pInfo->replacement);
+	const char * e = c + vStringLength (pInfo->replacement);
+
+	vString * pReplacement = vStringNew();
+
+	const char * b = c;
+
+	CXXTokenChain * pParameters = NULL;
+
+	while(c < e)
+	{
+		if(*c == '$')
+		{
+			if(c > b)
+				vStringNCatS(pReplacement,b,c-b);
+			c++;
+			if(c >= e)
+			{
+				// stray $
+				vStringPut(pReplacement,'$');
+				break;
+			}
+
+			int idx;
+
+			if(*c == '*')
+			{
+				idx = -1; // all parameters
+			} else {
+				if((*c < '0') && (*c > '9'))
+				{
+					vStringPut(pReplacement,'$');
+					b = c;
+					continue;
+				}
+				idx = *c - '0';
+			}
+
+
+			if(!pParameters)
+			{
+				if(pParameterChainToken && (pParameterChainToken->pChain->iCount >= 3))
+				{
+					// kill parenthesis
+					cxxTokenChainDestroyFirst(pParameterChainToken->pChain);
+					cxxTokenChainDestroyLast(pParameterChainToken->pChain);
+
+					pParameters = cxxTokenChainSplitOnComma(
+							pParameterChainToken->pChain
+						);
+
+					cxxTokenChainCondense(pParameterChainToken->pChain,0);
+
+					CXX_DEBUG_PRINT(
+							"Parameter chain is '%s'",
+							vStringValue(cxxTokenChainFirst(pParameterChainToken->pChain)->pszWord)
+						);
+				}
+			}
+
+			if(pParameters)
+			{
+				if(idx >= 0)
+				{
+					CXX_DEBUG_PRINT("Applying $%d",idx);
+
+					CXXToken * pParameter = cxxTokenChainAt(pParameters,idx);
+					if(pParameter)
+						vStringCat(pReplacement,pParameter->pszWord);
+				} else {
+					if(pParameterChainToken)
+					{
+						// Note that we have condensed the chain above!
+						CXXToken * pAll = cxxTokenChainFirst(
+								pParameterChainToken->pChain
+							);
+						if(pAll)
+							vStringCat(pReplacement,pAll->pszWord);
+					}
+				}
+
+			}
+
+			c++;
+			b = c;
+		} else {
+			c++;
+		}
+	}
+
+	if(c > b)
+		vStringNCatS(pReplacement,b,c-b);
+
+	if(pParameters)
+		cxxTokenChainDestroy(pParameters);
+
+	CXX_DEBUG_PRINT("Applying complex replacement '%s'",vStringValue(pReplacement));
+
+	cppUngetString(vStringValue(pReplacement),vStringLength(pReplacement));
+
+	vStringDelete(pReplacement);
+
+	CXX_DEBUG_LEAVE();
 }
 
 bool cxxParserParseNextToken(void)
@@ -1050,7 +1179,7 @@ bool cxxParserParseNextToken(void)
 
 	unsigned int uInfo = UINFO(g_cxx.iChar);
 
-	//printf("Char %c %02x info %u\n",g_cxx.iChar,g_cxx.iChar,uInfo);
+	//fprintf(stderr,"Char %c %02x info %u\n",g_cxx.iChar,g_cxx.iChar,uInfo);
 
 	if(uInfo & CXXCharTypeStartOfIdentifier)
 	{
@@ -1102,12 +1231,7 @@ bool cxxParserParseNextToken(void)
 			g_cxx.iChar = cppGetc();
 		}
 
-		int iCXXKeyword;
-		const cppIgnoredTokenInfo * pIgnore = NULL;
-
-check_keyword:
-
-		iCXXKeyword = lookupKeyword(t->pszWord->buffer,g_cxx.eLanguage);
+		int iCXXKeyword = lookupKeyword(t->pszWord->buffer,g_cxx.eLanguage);
 		if(iCXXKeyword >= 0)
 		{
 			if(
@@ -1136,48 +1260,59 @@ check_keyword:
 				}
 			}
 		} else {
-			// We can enter here also from a jump to check_keyword after finding
-			// and ignored token and a replacement.
 
-			if(!pIgnore)
+			const cppIgnoredTokenInfo * pIgnore = cppIsIgnoreToken(vStringValue(t->pszWord));
+
+			if(pIgnore)
 			{
-				pIgnore = cppIsIgnoreToken(vStringValue(t->pszWord));
+				CXX_DEBUG_PRINT("Ignore token %s",vStringValue(t->pszWord));
 
-				if(pIgnore)
+				cxxTokenChainDestroyLast(g_cxx.pTokenChain);
+
+				CXXToken * pParameterChain = NULL;
+
+				if(pIgnore->ignoreFollowingParenthesis)
 				{
-					CXX_DEBUG_PRINT("Ignore token %s",vStringValue(t->pszWord));
-
-					if(pIgnore->replacement)
-					{
-						CXX_DEBUG_PRINT(
-								"The token has replacement %s: applying",
-								pIgnore->replacement
-							);
-						vStringClear(t->pszWord);
-						vStringCatS(t->pszWord,pIgnore->replacement);
-					} else {
-						// kill it
-						CXX_DEBUG_PRINT("Ignore token has no replacement");
-						cxxTokenChainDestroyLast(g_cxx.pTokenChain);
-					}
-					
-					if(pIgnore->ignoreFollowingParenthesis)
-					{
-						CXX_DEBUG_PRINT("Ignored token specifies to ignore parens too");
-						if(!cxxParserParseNextTokenSkipIgnoredParenthesis())
-							return false;
-					}
-					
-					if(pIgnore->replacement)
-					{
-						// Already have a token to return
-						// Check again for keywords
-						goto check_keyword;
-					}
-					
-					// Have no token to return: parse it
-					return cxxParserParseNextToken();
+					CXX_DEBUG_PRINT("Ignored token specifies to ignore parens too");
+					if(!cxxParserParseNextTokenSkipIgnoredParenthesis(&pParameterChain))
+						return false;
 				}
+
+				// This is used to avoid infinite recursion in substitution
+				// (things like -I foo=foo or similar)
+				static int iReplacementRecursionCount = 0;
+
+				if(pIgnore->replacement)
+				{
+					CXX_DEBUG_PRINT(
+							"The token has replacement %s: applying",
+							pIgnore->replacement
+						);
+
+					if(iReplacementRecursionCount < 1024)
+					{
+						// unget last char
+						cppUngetc(g_cxx.iChar);
+						// unget the replacement
+						cxxParserParseNextTokenApplyReplacement(
+								pIgnore,
+								pParameterChain
+							);
+
+						g_cxx.iChar = cppGetc();
+					}
+				}
+
+				if(pParameterChain)
+					cxxTokenDestroy(pParameterChain);
+
+				iReplacementRecursionCount++;
+				// Have no token to return: parse it
+				CXX_DEBUG_PRINT("Parse inner token");
+				bool bRet = cxxParserParseNextToken();
+				CXX_DEBUG_PRINT("Parsed inner token: %s type %d",g_cxx.pToken->pszWord->buffer,g_cxx.pToken->eType);
+				iReplacementRecursionCount--;
+				return bRet;
 			}
 		}
 

--- a/parsers/cxx/cxx_token_chain.c
+++ b/parsers/cxx/cxx_token_chain.c
@@ -437,6 +437,46 @@ void cxxTokenChainMoveEntryRange(
 	}
 }
 
+CXXTokenChain * cxxTokenChainSplitOnComma(CXXTokenChain * tc)
+{
+	if(!tc)
+		return NULL;
+
+	CXXTokenChain * pRet = cxxTokenChainCreate();
+
+	CXXToken * pToken = cxxTokenChainFirst(tc);
+
+	if(!pToken)
+		return pRet;
+
+	CXXToken * pStart = pToken;
+
+	while(pStart && pToken->pNext)
+	{
+		while(pToken->pNext && (!cxxTokenTypeIs(pToken->pNext,CXXTokenTypeComma)))
+			pToken = pToken->pNext;
+
+		CXXToken * pNew = cxxTokenChainExtractRange(pStart,pToken,0);
+		if(pNew)
+			cxxTokenChainAppend(pRet,pNew);
+
+		pToken = pToken->pNext; // comma or nothing
+		if(pToken)
+			pToken = pToken->pNext; // after comma
+		pStart = pToken;
+	}
+
+	if(pStart)
+	{
+		// finished without comma
+		CXXToken * pNew = cxxTokenChainExtractRange(pStart,cxxTokenChainLast(tc),0);
+		if(pNew)
+			cxxTokenChainAppend(pRet,pNew);
+	}
+
+	return pRet;
+}
+
 
 void cxxTokenChainCondense(CXXTokenChain * tc,unsigned int uFlags)
 {

--- a/parsers/cxx/cxx_token_chain.c
+++ b/parsers/cxx/cxx_token_chain.c
@@ -217,13 +217,13 @@ void cxxTokenChainInsertAfter(CXXTokenChain * tc,CXXToken * before,CXXToken * t)
 		cxxTokenChainPrepend(tc,t);
 		return;
 	}
-	
+
 	if(!before->pNext)
 	{
 		cxxTokenChainAppend(tc,t);
 		return;
 	}
-	
+
 	t->pNext = before->pNext;
 	t->pPrev = before;
 	before->pNext = t;

--- a/parsers/cxx/cxx_token_chain.h
+++ b/parsers/cxx/cxx_token_chain.h
@@ -190,6 +190,7 @@ vString * cxxTokenChainJoinRange(
 	);
 
 
+
 enum CXXTokenChainCondenseFlags
 {
 	// Do not add trailing spaces for entries that are followed by space
@@ -197,6 +198,7 @@ enum CXXTokenChainCondenseFlags
 };
 
 void cxxTokenChainCondense(CXXTokenChain * tc,unsigned int uFlags);
+
 
 enum CXXTokenChainExtractRangeFlags
 {

--- a/parsers/cxx/cxx_token_chain.h
+++ b/parsers/cxx/cxx_token_chain.h
@@ -189,6 +189,12 @@ vString * cxxTokenChainJoinRange(
 		unsigned int uFlags
 	);
 
+// Treat the tochek chain tc as a comma separated sequence
+// of items (something, blah foo, 1 2 3 4 5, ...)
+// Create a token chain that contains tokens corresponding
+// to each item (i.e, "something", "blah foo", "1 2 3 4 5").
+// Please note that the returned chain may be empty!
+CXXTokenChain * cxxTokenChainSplitOnComma(CXXTokenChain * tc);
 
 
 enum CXXTokenChainCondenseFlags

--- a/parsers/meta-cpreprocessor.h
+++ b/parsers/meta-cpreprocessor.h
@@ -14,6 +14,7 @@
 */
 #include "general.h"  /* must always come first */
 #include "types.h"
+#include "vstring.h"
 
 /*
 *   MACROS
@@ -78,7 +79,7 @@ extern int cppSkipOverCComment (void);
 
 typedef struct sCppIgnoredTokenInfo {
 	bool ignoreFollowingParenthesis; /* -I SOMETHING+ */
-	char * replacement;              /* -I SOMETHING=REPLACEMENT */
+	vString *replacement;            /* -I SOMETHING=REPLACEMENT */
 } cppIgnoredTokenInfo;
 extern const cppIgnoredTokenInfo * cppIsIgnoreToken (const char *const name);
 

--- a/parsers/meta-cpreprocessor.h
+++ b/parsers/meta-cpreprocessor.h
@@ -72,6 +72,7 @@ extern void cppTerminate (void);
 extern void cppBeginStatement (void);
 extern void cppEndStatement (void);
 extern void cppUngetc (const int c);
+extern void cppUngetString(const char * string,int len);
 extern int cppGetc (void);
 extern int cppSkipOverCComment (void);
 


### PR DESCRIPTION
rebased version of #1161 

Instead of extending -I, we would like to introduce -D option.
However, the specification of arguments for -D is not well defined yet. See my comment in #1161 about `,`.

After defining the spec of -D, we have to do

* update args.ctags of test cases
* update news.rst at least (write about debugging level, too)
