### PR TITLE
Cxx: free the value returned from cxxTagSetProperties

### DIFF
--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -675,6 +675,7 @@ bool cxxParserParseEnum(void)
 		tag->isFileScope = !isInputHeaderFile();
 
 		CXXToken * pTypeName = NULL;
+		vString * pszProperties = NULL;
 
 		if(pTypeEnd)
 		{
@@ -683,10 +684,13 @@ bool cxxParserParseEnum(void)
 		}
 
 		if(bIsScopedEnum)
-			cxxTagSetProperties(CXXTagPropertyScopedEnum);
+			pszProperties = cxxTagSetProperties(CXXTagPropertyScopedEnum);
 
 		iCorkQueueIndex = cxxTagCommit();
-		
+
+		if (pszProperties)
+			vStringDelete (pszProperties);
+
 		if(pTypeName)
 			cxxTokenDestroy(pTypeName);
 	}


### PR DESCRIPTION
A test case, cxx11enum.cpp.d, reports memory leaks.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>