### PR TITLE
CXX: Fix a bad pointer access

### DIFF
--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -1143,8 +1143,11 @@ int cxxParserEmitFunctionTags(
 
 	// We'll be removing the scope and identifier, fix type
 	if(
-		(pInfo->pTypeStart == pInfo->pScopeStart) ||
-		(pInfo->pTypeStart == pInfo->pIdentifierStart)
+		pInfo->pTypeStart &&
+		(
+			(pInfo->pTypeStart == pInfo->pScopeStart) ||
+			(pInfo->pTypeStart == pInfo->pIdentifierStart)
+		)
 	)
 		pInfo->pTypeStart = pInfo->pIdentifierEnd->pNext;
 	


### PR DESCRIPTION
Added trivial check for null pointer to avoid later corrupted memory access.