### PR TITLE
main: mark -d as a compound option

### DIFF
--- a/main/options.c
+++ b/main/options.c
@@ -69,7 +69,7 @@
 # define RECURSE_SUPPORTED
 #endif
 
-#define isCompoundOption(c)  (bool) (strchr ("fohiILpDb", (c)) != NULL)
+#define isCompoundOption(c)  (bool) (strchr ("fohiILpdDb", (c)) != NULL)
 
 #define SUBDIR_OPTLIB "optlib"
 #define SUBDIR_PRELOAD "preload"


### PR DESCRIPTION
Close #1206.

-d option didn't work well because I didn't consider that the
option takes an argument.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>