### PR TITLE
main: revise the code for rendering pattern field

### DIFF
--- a/Tmain/json-output-format.d/input.go
+++ b/Tmain/json-output-format.d/input.go
@@ -1,0 +1,4 @@
+package main
+
+func main() {
+}

--- a/Tmain/json-output-format.d/stdout-expected.txt
+++ b/Tmain/json-output-format.d/stdout-expected.txt
@@ -2,10 +2,14 @@
 {"_type": "tag", "name": "Foo", "path": "input.py", "pattern": "/^class Foo:$/", "kind": "class"}
 {"_type": "tag", "name": "doIt", "path": "input.py", "pattern": "/^    def doIt():$/", "kind": "member", "scope": "Foo", "scopeKind": "class"}
 {"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "typeref": "int", "kind": "function"}
+{"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^func main() {$/", "kind": "func"}
+{"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^package main$/", "kind": "package"}
 # json --fields=*
 {"_type": "tag", "name": "Foo", "path": "input.py", "pattern": "/^class Foo:$/", "access": "public", "inherits": "", "language": "Python", "line": 1, "kind": "class", "end": "3"}
 {"_type": "tag", "name": "doIt", "path": "input.py", "pattern": "/^    def doIt():$/", "access": "public", "language": "Python", "line": 2, "signature": "()", "kind": "member", "scope": "Foo", "scopeKind": "class", "end": "3"}
 {"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "language": "C", "line": 4, "signature": "(void)", "typeref": "int", "kind": "function", "end": "7"}
+{"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^func main() {$/", "language": "Go", "line": 3, "signature": "()", "kind": "func"}
+{"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^package main$/", "language": "Go", "line": 1, "kind": "package"}
 # json --fields=* --extra=*
 {"_type": "ptag", "name": "JSON_OUTPUT_VERSION", "path": "0.0", "pattern": "in development"}
 {"_type": "ptag", "name": "TAG_FILE_FORMAT", "path": "2", "pattern": "extended format; --format=1 will not append ;\" to lines"}
@@ -17,6 +21,10 @@
 {"_type": "tag", "name": "Foo.doIt", "path": "input.py", "pattern": "/^    def doIt():$/", "access": "public", "language": "Python", "line": 2, "signature": "()", "kind": "member", "scope": "Foo", "extra": "qualified", "scopeKind": "class", "end": "3"}
 {"_type": "tag", "name": "doIt", "path": "input.py", "pattern": "/^    def doIt():$/", "access": "public", "language": "Python", "line": 2, "signature": "()", "kind": "member", "scope": "Foo", "scopeKind": "class", "end": "3"}
 {"_type": "tag", "name": "input.c", "path": "input.c", "pattern": "", "language": "C", "line": 1, "kind": "file", "extra": "inputFile", "end": "7"}
+{"_type": "tag", "name": "input.go", "path": "input.go", "pattern": "", "language": "Go", "line": 1, "kind": "file", "extra": "inputFile", "end": "4"}
 {"_type": "tag", "name": "input.py", "path": "input.py", "pattern": "", "language": "Python", "line": 1, "kind": "file", "extra": "inputFile", "end": "3"}
 {"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "language": "C", "line": 4, "signature": "(void)", "typeref": "int", "kind": "function", "end": "7"}
+{"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^func main() {$/", "language": "Go", "line": 3, "signature": "()", "kind": "func"}
+{"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^package main$/", "language": "Go", "line": 1, "kind": "package"}
+{"_type": "tag", "name": "main.main", "path": "input.go", "pattern": "/^func main() {$/", "language": "Go", "line": 3, "signature": "()", "kind": "func", "extra": "qualified"}
 {"_type": "tag", "name": "stdio.h", "path": "input.c", "pattern": "/^#include <stdio.h>/", "language": "C", "line": 1, "kind": "header", "role": "system", "extra": "reference"}

--- a/main/entry.c
+++ b/main/entry.c
@@ -804,7 +804,7 @@ extern void getTagScopeInformation (tagEntryInfo *const tag,
 }
 
 
-extern int   makePatternStringCommon (const tagEntryInfo *const tag,
+static int   makePatternStringCommon (const tagEntryInfo *const tag,
 				      int putc_func (char , void *),
 				      int puts_func (const char* , void *),
 				      void *output)
@@ -923,8 +923,6 @@ static void recordTagEntryInQueue (const tagEntryInfo *const tag, tagEntryInfo* 
 
 	if (slot->pattern)
 		slot->pattern = eStrdup (slot->pattern);
-	else if (!slot->lineNumberEntry)
-		slot->pattern = makePatternString (slot);
 
 	slot->inputFileName = eStrdup (slot->inputFileName);
 	slot->name = eStrdup (slot->name);

--- a/main/field.c
+++ b/main/field.c
@@ -716,9 +716,19 @@ static const char *renderFieldPattern (const tagEntryInfo *const tag,
 				       vString* b,
 					   bool *rejected)
 {
-	char* tmp = makePatternString (tag);
-	vStringCatS (b, tmp);
-	eFree (tmp);
+	if (tag->lineNumberEntry)
+		return NULL;
+
+	if (tag->pattern)
+		vStringCatS (b, tag->pattern);
+	else
+	{
+		char* tmp;
+
+		tmp = makePatternString (tag);
+		vStringCatS (b, tmp);
+		eFree (tmp);
+	}
 	return vStringValue (b);
 }
 

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -126,19 +126,6 @@ static int writeLineNumberEntry (tagWriter *writer, MIO * mio, const tagEntryInf
 		return mio_printf (mio, "%lu", tag->lineNumber);
 }
 
-static int file_putc (char c, void *data)
-{
-	MIO *fp = data;
-	mio_putc (fp, c);
-	return 1;
-}
-
-static int file_puts (const char* s, void *data)
-{
-	MIO *fp = data;
-	return mio_puts (fp, s);
-}
-
 static int addExtensionFields (tagWriter *writer, MIO *mio, const tagEntryInfo *const tag)
 {
 	bool isKindKeyEnabled = isFieldEnabled (FIELD_KIND_KEY);
@@ -225,11 +212,6 @@ static int addExtensionFields (tagWriter *writer, MIO *mio, const tagEntryInfo *
 	return length;
 }
 
-static int writePatternEntry (MIO *mio, const tagEntryInfo *const tag)
-{
-	return makePatternStringCommon (tag, file_putc, file_puts, mio);
-}
-
 static int writeCtagsEntry (tagWriter *writer,
 							MIO * mio, const tagEntryInfo *const tag)
 {
@@ -250,10 +232,8 @@ static int writeCtagsEntry (tagWriter *writer,
 
 	if (tag->lineNumberEntry)
 		length += writeLineNumberEntry (writer, mio, tag);
-	else if (tag->pattern)
-		length += mio_printf(mio, "%s", tag->pattern);
 	else
-		length += writePatternEntry (mio, tag);
+		length += mio_puts(mio, escapeFieldValue(writer, tag, FIELD_PATTERN));
 
 	if (includeExtensionFlags ())
 	{

--- a/main/writer.h
+++ b/main/writer.h
@@ -66,10 +66,6 @@ extern void writerBuildFqTagCache (tagEntryInfo *const tag);
 
 extern bool outputFormatUsedStdoutByDefault (void);
 
-extern int makePatternStringCommon (const tagEntryInfo *const tag,
-				    int putc_func (char , void *),
-				    int puts_func (const char* , void *),
-				    void *output);
 extern void truncateTagLine (char *const line, const char *const token,
 			     const bool discardNewline);
 extern void abort_if_ferror(MIO *const fp);


### PR DESCRIPTION
The responsibility for rendering pattern field was not clear.
json and ctags writers did their own way.

This commit moves the rendering code to field.c and make the
writers use functions exported from field.c.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>