### PR TITLE
main: support multiline regex parser

### DIFF
--- a/Units/regex-multiline-flag.d/args.ctags
+++ b/Units/regex-multiline-flag.d/args.ctags
@@ -1,0 +1,5 @@
+--langdef=javaspring
+--langmap=javaspring:.java
+--regex-javaspring=/@Subscribe([[:space:]])*([a-z ]+)[[:space:]]*([a-zA-Z]*)\(([a-zA-Z]*)/\3-\4/s,subscription/{_multiline=3}
+--excmd=mixed
+--fields=+ln

--- a/Units/regex-multiline-flag.d/expected.tags
+++ b/Units/regex-multiline-flag.d/expected.tags
@@ -1,0 +1,2 @@
+Event-SomeEvent	input.java	/^public void catchEvent(SomeEvent e)$/;"	s	line:2	language:javaspring
+recover-Exception	input.java	/^    recover(Exception e)$/;"	s	line:10	language:javaspring

--- a/Units/regex-multiline-flag.d/input.java
+++ b/Units/regex-multiline-flag.d/input.java
@@ -1,0 +1,13 @@
+@Subscribe
+public void catchEvent(SomeEvent e)
+{
+    return;
+}
+
+
+@Subscribe
+public void
+    recover(Exception e)
+{
+    return;
+}

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -330,6 +330,9 @@ is imperfect approach for ignoring text insides comments but it may
 be better than nothing. Ghost kind is assigned to the empty name
 pattern. (See "Ghost kind in regex parser".)
 
+NOTE: This flag doesn't work well with ``_multiline``.
+
+
 Ghost kind in regex parser
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -349,7 +352,6 @@ Conceptual example::
 	--regex-<LANG>=/regexp2/replacement/kind-spec/{transformer=lowercase}
 	--regex-<LANG>=/regexp2/replacement/kind-spec/{transformer=capitalize}
 
-Currently scope long flag taking such parameter.
 
 Scope tracking in a regex parser
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -438,6 +440,9 @@ Example 2::
 NOTE: Giving a scope long flag implies setting `useCork` of the parser
 to `TRUE`. See `cork API`.
 
+NOTE: This flag doesn't work well with ``multiline``.
+
+
 Override the letter for file kind
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (See also #317.)
@@ -489,6 +494,53 @@ To know the fileKind of languages, use ``--list-file-kind``::
 	...
 	Ruby !
 	...
+
+Multiline pattern match
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. NOT REVIEWED YET
+
+A pattern marked with `_multiline` is applied to whole file contents,
+not line by line.
+
+Next example is based on an issue #219 posted by @andreicristianpetcu::
+
+    $ cat input.java
+    @Subscribe
+    public void catchEvent(SomeEvent e)
+    {
+	return;
+    }
+
+
+    @Subscribe
+    public void
+	recover(Exception e)
+    {
+	return;
+    }
+
+    $ cat spring.ctags
+    --langdef=javaspring
+    --langmap=javaspring:.java
+    --regex-javaspring=/@Subscribe([[:space:]])*([a-z ]+)[[:space:]]*([a-zA-Z]*)\(([a-zA-Z]*)/\3-\4/s,subscription/{_multiline=3}
+    --excmd=mixed
+    --fields=+ln
+
+    $ ./ctags -o - --options=./spring.ctags input.java
+    Event-SomeEvent	input.java	/^public void catchEvent(SomeEvent e)$/;"	s	line:2	language:javaspring
+    recover-Exception	input.java	/^    recover(Exception e)$/;"	s	line:10	language:javaspring
+
+`{_multiline=N}`
+
+	This tells the patern should be applied to whole file
+	contents, not line by line.  `N` is the number of a group in the
+	pattern. The specified group is used to record the line number
+	and the pattern of tag. In the above example 3 is
+	specified. The start position of the group 3 within the whole
+	file contents is used.
+
+NOTE: This flag doesn't work well with scope related flags and ``exclusive`` flags.
 
 
 Submitting an optlib to universal-ctags project

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -410,7 +410,7 @@ static void pre_ptrn_flag_multiline_long (const char* const s CTAGS_ATTR_UNUSED,
 static flagDefinition multilinePtrnFlagDef[] = {
 #define EXPERIMENTAL "_"
 	{ '\0',  EXPERIMENTAL "multiline", NULL, pre_ptrn_flag_multiline_long ,
-	  NULL, "match in muletline mode"},
+	  NULL, "match in muletline mode. cannot combine with scope, placeholder, and exclusive"},
 };
 
 

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -84,6 +84,7 @@ typedef struct {
 	} u;
 	unsigned int scopeActions;
 	bool *disabled;
+	int   multiline;
 } regexPattern;
 
 
@@ -91,6 +92,7 @@ typedef struct {
 	regexPattern *patterns;
 	unsigned int count;
 	hashTable   *kinds;
+	unsigned int multilinePatternsCount;
 } patternSet;
 
 /*
@@ -130,6 +132,7 @@ static void clearPatternSet (const langType language)
 			eFree (set->patterns);
 		set->patterns = NULL;
 		set->count = 0;
+		set->multilinePatternsCount = 0;
 		hashTableDelete (set->kinds);
 		set->kinds = NULL;
 	}
@@ -140,7 +143,8 @@ static void clearPatternSet (const langType language)
 */
 
 static int makeRegexTag (
-		const vString* const name, const kindOption* const kind, int scopeIndex, int placeholder)
+		const vString* const name, const kindOption* const kind, int scopeIndex, int placeholder,
+		unsigned long line, MIOPos *pos)
 {
 	Assert (kind != NULL);
 	if (kind->enabled)
@@ -150,6 +154,12 @@ static int makeRegexTag (
 		initTagEntry (&e, vStringValue (name), kind);
 		e.extensionFields.scopeIndex = scopeIndex;
 		e.placeholder = !!placeholder;
+		if (line)
+		{
+			e.lineNumber = line;
+			e.filePosition = *pos;
+		}
+
 		return makeTagEntry (&e);
 	}
 	else
@@ -381,6 +391,29 @@ static regexPattern* addCompiledTagCommon (const langType language,
 	return ptrn;
 }
 
+static void pre_ptrn_flag_multiline_long (const char* const s CTAGS_ATTR_UNUSED, const char* const v, void* data)
+{
+
+	if (!strToInt (v, 10, data))
+	{
+		error (WARNING, "wrong multiline specificaiton: %s", v);
+		*((int *)data) = -1;
+	}
+	else if (*((int *)data) < 0 || *((int *)data) >= BACK_REFERENCE_COUNT)
+	{
+		error (WARNING, "out of range(0 ~ %d) multiline specificaiton: %s",
+		       (BACK_REFERENCE_COUNT - 1), v);
+		*((int *)data) = -1;
+	}
+}
+
+static flagDefinition multilinePtrnFlagDef[] = {
+#define EXPERIMENTAL "_"
+	{ '\0',  EXPERIMENTAL "multiline", NULL, pre_ptrn_flag_multiline_long ,
+	  NULL, "match in muletline mode"},
+};
+
+
 static regexPattern *addCompiledTagPattern (const langType language, regex_t* const pattern,
 					    const char* const name, char kind, const char* kindName,
 					    char *const description, const char* flags,
@@ -389,9 +422,12 @@ static regexPattern *addCompiledTagPattern (const langType language, regex_t* co
 	regexPattern * ptrn;
 	bool exclusive = false;
 	unsigned long scopeActions = 0UL;
+	int multiline = -1;
 
 	flagsEval (flags, prePtrnFlagDef, ARRAY_SIZE(prePtrnFlagDef), &exclusive);
 	flagsEval (flags, scopePtrnFlagDef, ARRAY_SIZE(scopePtrnFlagDef), &scopeActions);
+	flagsEval (flags, multilinePtrnFlagDef, ARRAY_SIZE(multilinePtrnFlagDef), &multiline);
+
 	if (*name == '\0' && exclusive && kind == KIND_REGEX_DEFAULT)
 	{
 		kind = KIND_GHOST;
@@ -403,6 +439,10 @@ static regexPattern *addCompiledTagPattern (const langType language, regex_t* co
 	ptrn->exclusive = exclusive;
 	ptrn->scopeActions = scopeActions;
 	ptrn->disabled = disabled;
+	ptrn->multiline = multiline;
+	if (multiline >= 0)
+		Sets [language].multilinePatternsCount++;
+
 	if (ptrn->u.tag.kind->letter == '\0')
 	{
 		/* This is a newly registered kind. */
@@ -437,6 +477,7 @@ static void addCompiledCallbackPattern (const langType language, regex_t* const 
 	ptrn->u.callback.userData = userData;
 	ptrn->exclusive = exclusive;
 	ptrn->disabled = disabled;
+	ptrn->multiline = -1;
 }
 
 
@@ -583,7 +624,8 @@ static void processLanguageRegex (const langType language,
 
 static vString* substitute (
 		const char* const in, const char* out,
-		const int nmatch, const regmatch_t* const pmatch)
+		const int nmatch, const regmatch_t* const pmatch,
+		bool allow_multiple)
 {
 	vString* result = vStringNew ();
 	const char* p;
@@ -598,18 +640,20 @@ static vString* substitute (
 				vStringNCatS (result, in + pmatch [dig].rm_so, diglen);
 			}
 		}
-		else if (*p != '\n'  &&  *p != '\r')
+		else if (allow_multiple || (*p != '\n'  &&  *p != '\r'))
 			vStringPut (result, *p);
 	}
 	return result;
 }
 
-static void matchTagPattern (const vString* const line,
+static void matchTagPattern (const char* line,
 		const regexPattern* const patbuf,
-		const regmatch_t* const pmatch)
+		const regmatch_t* const pmatch,
+			     off_t offset)
 {
-	vString *const name = substitute (vStringValue (line),
-			patbuf->u.tag.name_pattern, BACK_REFERENCE_COUNT, pmatch);
+	vString *const name = substitute (line,
+			patbuf->u.tag.name_pattern, BACK_REFERENCE_COUNT, pmatch,
+			!!(patbuf->multiline >= 0));
 	bool placeholder = !!((patbuf->scopeActions & SCOPE_PLACEHOLDER) == SCOPE_PLACEHOLDER);
 	unsigned long scope = CORK_NIL;
 	int n;
@@ -637,13 +681,28 @@ static void matchTagPattern (const vString* const line,
 	if (vStringLength (name) == 0 && (placeholder == false))
 	{
 		if (patbuf->accept_empty_name == false)
-			error (WARNING, "%s:%ld: null expansion of name pattern \"%s\"",
-			       getInputFileName (), getInputLineNumber (),
+			error (WARNING, "%s:%lu: null expansion of name pattern \"%s\"",
+			       getInputFileName (),
+			       (patbuf->multiline >= 0)
+			       ? getInputLineNumberForFileOffset (offset)
+			       : getInputLineNumber (),
 			       patbuf->u.tag.name_pattern);
 		n = CORK_NIL;
 	}
 	else
-		n = makeRegexTag (name, patbuf->u.tag.kind, scope, placeholder);
+	{
+		unsigned long ln = 0;
+		MIOPos pos;
+
+		if (patbuf->multiline >= 0)
+		{
+			ln = getInputLineNumberForFileOffset (offset);
+			pos = getInputFilePositionForLine (ln);
+		}
+
+		n = makeRegexTag (name, patbuf->u.tag.kind, scope, placeholder,
+				  ln, ln == 0? NULL: &pos);
+	}
 
 	if (patbuf->scopeActions & SCOPE_PUSH)
 		currentScope = n;
@@ -689,7 +748,7 @@ static bool matchRegexPattern (const vString* const line,
 	{
 		result = true;
 		if (patbuf->type == PTRN_TAG)
-			matchTagPattern (line, patbuf, pmatch);
+			matchTagPattern (vStringValue (line), patbuf, pmatch, 0);
 		else if (patbuf->type == PTRN_CALLBACK)
 			matchCallbackPattern (line, patbuf, pmatch);
 		else
@@ -701,6 +760,46 @@ static bool matchRegexPattern (const vString* const line,
 	return result;
 }
 
+static bool matchMultilineRegexPattern (const vString* const allLines,
+					const regexPattern* const patbuf)
+{
+	const char *start;
+	const char *current;
+
+	bool result = false;
+	regmatch_t pmatch [BACK_REFERENCE_COUNT];
+	int match = 0;
+
+	if (patbuf->disabled && *(patbuf->disabled))
+		return false;
+
+	start = vStringValue (allLines);
+	for (current = start;
+	     match == 0 && current < start + strlen(vStringValue (allLines));
+	     current += pmatch [0].rm_eo)
+	{
+		match = regexec (patbuf->pattern, current,
+				 BACK_REFERENCE_COUNT, pmatch, 0);
+		if (match == 0)
+		{
+			if (patbuf->type == PTRN_TAG)
+			{
+				matchTagPattern (current, patbuf, pmatch,
+						 (current + pmatch [patbuf->multiline].rm_eo) - start);
+				result = true;
+			}
+			else if (patbuf->type == PTRN_CALLBACK)
+				;	/* Not implemented yet */
+			else
+			{
+				Assert ("invalid pattern type" == NULL);
+				result = false;
+				break;
+			}
+		}
+	}
+	return result;
+}
 
 /* PUBLIC INTERFACE */
 
@@ -718,6 +817,8 @@ extern bool matchRegex (const vString* const line, const langType language)
 		for (i = 0  ;  i < set->count  ;  ++i)
 		{
 			regexPattern* ptrn = set->patterns + i;
+			if (ptrn->multiline >= 0)
+				continue;
 			if (matchRegexPattern (line, ptrn))
 			{
 				result = true;
@@ -1076,6 +1177,38 @@ extern void freeRegexResources (void)
 	Sets = NULL;
 	SetUpper = -1;
 }
+
+extern bool hasMultilineRegexPatterns (const langType language)
+{
+	if (language <= SetUpper  &&  Sets [language].count > 0)
+		return !! (Sets [language].multilinePatternsCount > 0);
+	else
+		return false;
+}
+
+extern bool matchMultilineRegex (const vString* const allLines, const langType language)
+{
+	bool result = false;
+	if (language != LANG_IGNORE  &&  language <= SetUpper  &&
+	    Sets [language].count > 0)
+	{
+		const patternSet* const set = Sets + language;
+		unsigned int i;
+		unsigned int multilinePatternsCount = set->multilinePatternsCount;
+
+		for (i = 0; i < set->count && 0 < multilinePatternsCount; ++i)
+		{
+			regexPattern* ptrn = set->patterns + i;
+			if (ptrn->multiline < 0)
+				continue;
+
+			multilinePatternsCount--;
+			result = matchMultilineRegexPattern (allLines, ptrn) || result;
+		}
+	}
+	return false;
+}
+
 
 /* Return true if available. */
 extern bool checkRegex (void)

--- a/main/parse.c
+++ b/main/parse.c
@@ -2219,6 +2219,11 @@ static bool createTagsWithFallback1 (const langType language)
 		}
 	}
 
+	/* Force filling allLines buffer and kick the multiline regex parser */
+	if (hasMultilineRegexPatterns (language))
+		while (readLineFromInputFile () != NULL)
+			; /* Do nothing */
+
 	if (LanguageTable [language]->useCork)
 		uncorkTagFile();
 

--- a/main/parse.h
+++ b/main/parse.h
@@ -287,6 +287,11 @@ extern void useRegexMethod (const langType language);
 extern void printRegexFlags (void);
 extern bool hasScopeActionInRegex (const langType language);
 
+/* Multiline Regex Interface */
+extern bool hasMultilineRegexPatterns (const langType language);
+extern bool matchMultilineRegex (const vString* const allLines, const langType language);
+
+
 #ifdef HAVE_COPROC
 extern bool invokeXcmd (const char* const fileName, const langType language);
 #endif

--- a/main/read.c
+++ b/main/read.c
@@ -987,7 +987,8 @@ extern void   pushNarrowedInputStream (const langType language,
 	mio_setpos (File.mio, &original);
 
 	subio = mio_new_mio (File.mio, p, q - p);
-
+	if (subio == NULL)
+		error (FATAL, "memory for mio may be exhausted");
 
 	BackupFile = File;
 

--- a/main/read.c
+++ b/main/read.c
@@ -760,10 +760,6 @@ static void readLine (vString *const vLine, MIO *const mio)
 	}
 }
 
-/* Stub */
-extern bool hasMultilineRegexPatterns (const langType language) { return false; }
-extern bool matchMultilineRegex (const vString* const allLines, const langType language) { return false; }
-
 static vString *iFileGetLine (void)
 {
 	if (File.line == NULL)

--- a/main/read.h
+++ b/main/read.h
@@ -116,4 +116,6 @@ extern void   popNarrowedInputStream  (void);
 extern void     pushLanguage(const langType language);
 extern langType popLanguage (void);
 
+extern unsigned long getInputLineNumberForFileOffset(long offset);
+
 #endif  /* CTAGS_MAIN_READ_H */


### PR DESCRIPTION
Close #219


A pattern marked with `_multiline` is applied to whole file contents, not line by line.

Next example is based on an issue #219 posted by @andreicristianpetcu::

    $ cat input.java
    @Subscribe
    public void catchEvent(SomeEvent e)
    {
	return;
    }


    @Subscribe
    public void
	recover(Exception e)
    {
	return;
    }

    $ cat spring.ctags
    --langdef=javaspring
    --langmap=javaspring:.java
    --regex-javaspring=/@Subscribe([[:space:]])*([a-z ]+)[[:space:]]*([a-zA-Z]*)\(([a-zA-Z]*)/\3-\4/s,subscription/{_multiline=3}
    --excmd=mixed
    --fields=+ln

    $ ./ctags -o - --options=./spring.ctags input.java
    Event-SomeEvent	input.java	/^public void catchEvent(SomeEvent e)$/;"	s	line:2	language:javaspring
    recover-Exception	input.java	/^    recover(Exception e)$/;"	s	line:10	language:javaspring

* `{_multiline=N}`

	This tells the patern should be applied to whole file
	contents, not line by line.  `N` is the number of a group in the
	pattern. The specified group is used to record the line number
	and the pattern of tag. In the above example 3 is
	specified. The start position of the group 3 within the whole
	file contents is used.

NOTE: This flag doesn't work well with scope related flags and ``exclusive`` flags.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>
