### PR TITLE
CPP/CXX: More preprocessor work

### DIFF
--- a/Units/parser-c.r/directives-2.c.d/args.ctags
+++ b/Units/parser-c.r/directives-2.c.d/args.ctags
@@ -1,0 +1,2 @@
+--extra=+r
+--fields=+r

--- a/Units/parser-c.r/directives-2.c.d/expected.tags
+++ b/Units/parser-c.r/directives-2.c.d/expected.tags
@@ -1,0 +1,2 @@
+func	input.c	/^int func()$/;"	f	typeref:typename:int
+main	input.c	/^int main()$/;"	f	typeref:typename:int

--- a/Units/parser-c.r/directives-2.c.d/input.c
+++ b/Units/parser-c.r/directives-2.c.d/input.c
@@ -1,0 +1,15 @@
+int main()
+{
+        if (something) {
+                printf("hello");
+#ifdef world
+        } else
+                printf(" world\n");
+#else
+        }
+#endif
+}
+
+int func()
+{
+}

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -51,6 +51,7 @@ typedef struct sConditionalInfo {
 	bool singleBranch;       /* choose only one branch */
 	bool branchChosen;       /* branch already selected */
 	bool ignoring;           /* current ignore state */
+	int enterExternalParserState;          /* the parser state when entering this conditional: used only by cxx */
 } conditionalInfo;
 
 enum eState {
@@ -131,10 +132,28 @@ static kindOption CPreProKinds [] = {
 
 static bool doesExaminCodeWithInIf0Branch;
 
+/*
+* CXX parser state. This is stored at the beginning of a conditional.
+* If at the exit of the conditional the state is changed then we assume
+* that no further branches should be followed.
+*/
+static int externalParserState;
+
 
 /*  Use brace formatting to detect end of block.
  */
 static bool BraceFormat = false;
+
+void cppSetExternalParserState(int iState)
+{
+	externalParserState = iState;
+}
+
+int cppGetExternalParserState()
+{
+	return externalParserState;
+}
+
 
 static cppState Cpp = {
 	LANG_IGNORE,
@@ -183,6 +202,10 @@ extern void cppInit (const bool state, const bool hasAtLiteralStrings,
 		     int headerSystemRoleIndex, int headerLocalRoleIndex)
 {
 	BraceFormat = state;
+
+	CXX_DEBUG_PRINT("cppInit: brace format is %d",BraceFormat);
+
+	externalParserState = 0;
 
 	if (Cpp.lang == LANG_IGNORE)
 	{
@@ -439,8 +462,39 @@ static bool isIgnoreBranch (void)
 	 *  en route. This may have allowed earlier branches containing complete
 	 *  statements to be followed, but we must follow no further branches.
 	 */
-	if (Cpp.resolveRequired  &&  ! BraceFormat)
+
+	/*
+	* CXX: Force a single branch if the external parser (cxx) state at the beginning
+	* of this conditional was not equal to the current state (at exit of the first branch).
+	* The meaning of the state is assigned by the parser: CXX, for now, uses the
+	* number of nested {} blocks. So
+	*
+	* Follow both branches example: (same state at enter and exit)
+	*
+	* #if something
+	*     xxxxx;
+	* #else
+	*     yyyy;
+	* #endif
+	*
+	* Follow single branch example: (different block level at enter and exit
+	*
+	*    if {
+	* #if something
+    *    } else x;
+	* #else
+	*    } 
+	* #endif
+	*/
+
+	if (
+			(Cpp.resolveRequired || (ifdef->enterExternalParserState != externalParserState)) &&
+			(!BraceFormat)
+		)
+	{
+		CXX_DEBUG_PRINT("Choosing single branch");
 		ifdef->singleBranch = true;
+	}
 
 	/*  We will ignore this branch in the following cases:
 	 *
@@ -491,6 +545,7 @@ static bool pushConditional (const bool firstBranchChosen)
 		ifdef->ignoring = (bool) (ignoreAllBranches || (
 				! firstBranchChosen  &&  ! BraceFormat  &&
 				(ifdef->singleBranch || !doesExaminCodeWithInIf0Branch)));
+		ifdef->enterExternalParserState = externalParserState;
 		ignoreBranch = ifdef->ignoring;
 	}
 	return ignoreBranch;
@@ -705,6 +760,7 @@ static bool directiveHash (const int c)
 			stringMatch (directive, "else"))
 	{
 		ignore = setIgnore (isIgnoreBranch ());
+		CXX_DEBUG_PRINT("Found #elif or #else: ignore is %d",ignore);
 		if (! ignore  &&  stringMatch (directive, "else"))
 			chooseBranch ();
 		Cpp.directive.state = DRCTV_NONE;

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -481,7 +481,7 @@ static bool isIgnoreBranch (void)
 	* #if something
     *    } else x;
 	* #else
-	*    } 
+	*    }
 	* #endif
 	*/
 

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -153,15 +153,8 @@ bool cxxParserParseBlockHandleOpeningBracket(void)
 	return true;
 }
 
-//
-// This is the toplevel scanning function. It's a forward-only scanner that keeps
-// accumulating tokens in the chain until either a characteristic token is found
-// or the statement ends. When a characteristic token is found it usually enters
-// a specialized scanning routine (e.g for classes, namespaces, structs...).
-// When the statement ends without finding any characteristic token the chain
-// is passed to an analysis routine which does a second scan pass.
-//
-bool cxxParserParseBlock(bool bExpectClosingBracket)
+
+static bool cxxParserParseBlockInternal(bool bExpectClosingBracket)
 {
 	CXX_DEBUG_ENTER();
 
@@ -533,6 +526,13 @@ process_token:
 			break;
 			case CXXTokenTypeClosingBracket:
 				// scope finished
+				if(!bExpectClosingBracket)
+				{
+					CXX_DEBUG_LEAVE_TEXT(
+						"Found unexpected closing bracket: probably preprocessing problem"
+					);
+					return false;
+				}
 				CXX_DEBUG_LEAVE_TEXT("Closing bracket!");
 				cxxParserNewStatement();
 				return true;
@@ -581,4 +581,20 @@ process_token:
 
 	CXX_DEBUG_LEAVE_TEXT("WARNING: Not reached");
 	return true;
+}
+
+//
+// This is the toplevel scanning function. It's a forward-only scanner that keeps
+// accumulating tokens in the chain until either a characteristic token is found
+// or the statement ends. When a characteristic token is found it usually enters
+// a specialized scanning routine (e.g for classes, namespaces, structs...).
+// When the statement ends without finding any characteristic token the chain
+// is passed to an analysis routine which does a second scan pass.
+//
+bool cxxParserParseBlock(bool bExpectClosingBracket)
+{
+	cppSetExternalParserState(cppGetExternalParserState() + 1);
+	bool bRet = cxxParserParseBlockInternal(bExpectClosingBracket);
+	cppSetExternalParserState(cppGetExternalParserState() - 1);
+	return bRet;
 }

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -593,8 +593,8 @@ process_token:
 //
 bool cxxParserParseBlock(bool bExpectClosingBracket)
 {
-	cppSetExternalParserState(cppGetExternalParserState() + 1);
+	cppPushExternalParserBlock();
 	bool bRet = cxxParserParseBlockInternal(bExpectClosingBracket);
-	cppSetExternalParserState(cppGetExternalParserState() - 1);
+	cppPopExternalParserBlock();
 	return bRet;
 }

--- a/parsers/meta-cpreprocessor.h
+++ b/parsers/meta-cpreprocessor.h
@@ -79,8 +79,8 @@ extern int cppSkipOverCComment (void);
 
 /* notify the external parser state for the purpose of conditional
    branche choice. The CXX parser stores the block level here. */
-extern void cppSetExternalParserState(int iState);
-extern int cppGetExternalParserState();
+extern void cppPushExternalParserBlock();
+extern void cppPopExternalParserBlock();
 
 #define CPP_MACRO_REPLACEMENT_FLAG_VARARGS 1
 #define CPP_MACRO_REPLACEMENT_FLAG_STRINGIFY 2

--- a/parsers/meta-cpreprocessor.h
+++ b/parsers/meta-cpreprocessor.h
@@ -77,6 +77,11 @@ extern void cppUngetString(const char * string,int len);
 extern int cppGetc (void);
 extern int cppSkipOverCComment (void);
 
+/* notify the external parser state for the purpose of conditional
+   branche choice. The CXX parser stores the block level here. */
+extern void cppSetExternalParserState(int iState);
+extern int cppGetExternalParserState();
+
 #define CPP_MACRO_REPLACEMENT_FLAG_VARARGS 1
 #define CPP_MACRO_REPLACEMENT_FLAG_STRINGIFY 2
 


### PR DESCRIPTION
Switch to single preprocessor conditional branch mode when nested {} block level at entry and exit of the first conditional is different. Fixes bug #1188 .