### PR TITLE
etags-writer: truncate too long hints (step 1)

### DIFF
--- a/Tmain/omit-long-patterns-etags.d/input.sh
+++ b/Tmain/omit-long-patterns-etags.d/input.sh
@@ -1,0 +1,16 @@
+                                                                                                func96()
+{
+
+}
+                                                                                               func95()
+{
+
+}
+                                                                                                 func97()
+{
+
+}
+
+func96
+func95
+func97

--- a/Tmain/omit-long-patterns-etags.d/run.sh
+++ b/Tmain/omit-long-patterns-etags.d/run.sh
@@ -1,0 +1,7 @@
+# Copyright: 2015 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+# strlen ("func95()") => 8
+${CTAGS} --quiet --options=NONE --pattern-length-limit=`expr 96 + 8` -e -o - ./input.sh

--- a/Tmain/omit-long-patterns-etags.d/stdout-expected.txt
+++ b/Tmain/omit-long-patterns-etags.d/stdout-expected.txt
@@ -1,0 +1,5 @@
+
+input.sh,349
+                                                                                                func96(func961,0
+                                                                                               func95()func955,110
+                                                                                                 func97func979,219

--- a/main/writer-etags.c
+++ b/main/writer-etags.c
@@ -90,16 +90,22 @@ static int writeEtagsEntry (tagWriter *writer,
 				tag->name, tag->lineNumber);
 	else
 	{
+		size_t len;
 		long seekValue;
 		char *const line =
 				readLineFromBypassAnyway (etags->vLine, tag, &seekValue);
 		if (line == NULL)
 			return 0;
 
+		len = strlen (line);
+
 		if (tag->truncateLine)
 			truncateTagLine (line, tag->name, true);
 		else
-			line [strlen (line) - 1] = '\0';
+			line [len - 1] = '\0';
+
+		if (Option.patternLengthLimit < len)
+			line [Option.patternLengthLimit - 1] = '\0';
 
 		length = mio_printf (mio, "%s\177%s\001%lu,%ld\n", line,
 				tag->name, tag->lineNumber, seekValue);


### PR DESCRIPTION
Close #1247.

Like javascript and css optimized by tools, there are source files that are made
up of one very long line. Such input files can make TAGS file much larger.

As we did in tags output, this commit truncates hints in TAGS output if they are
longer than the value specified with --pattern-length-limit option.

TODO: json output, xref output.
Signed-off-by: Masatake YAMATO <yamato@redhat.com>