### PR TITLE
C,CUDA: remove unnecessary CASE_INSENSITIVE_FILENAMES block

### DIFF
--- a/parsers/cxx/cxx.c
+++ b/parsers/cxx/cxx.c
@@ -77,9 +77,6 @@ parserDefinition * CParser (void)
 	static const char * const extensions [] =
 	{
 		"c",
-#ifndef CASE_INSENSITIVE_FILENAMES
-		"C",
-#endif
 		NULL
 	};
 
@@ -141,9 +138,6 @@ parserDefinition * CUDAParser (void)
 	static const char * const extensions [] =
 	{
 		"cu", "cuh",
-#ifndef CASE_INSENSITIVE_FILENAMES
-		"CU", "CUH",
-#endif
 		NULL
 	};
 	static parserDependency dependencies [] = {
@@ -167,4 +161,3 @@ parserDefinition * CUDAParser (void)
 
 	return def;
 }
-


### PR DESCRIPTION
In case-sensitive platform/environment (in other word #ifndef CASE_INSENSITIVE_FILENAMES),
using C (upper case) as extension for C source code is not popular.
Like C, using CUDA (upper case) as extension for CUDA source code is not popular.

What is popular is using C as extension for C++ source code.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>