### PR TITLE
main: implement case insenstive glob matching

### DIFF
--- a/Tmain/case-insensitive-pattern.d/run.sh
+++ b/Tmain/case-insensitive-pattern.d/run.sh
@@ -1,0 +1,10 @@
+# Copyright: 2016 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+. ../utils.sh
+
+exit_if_no_case_insensitive_filenames "${CTAGS}"
+
+${CTAGS} --print-language MAKEFILE

--- a/Tmain/case-insensitive-pattern.d/stdout-expected.txt
+++ b/Tmain/case-insensitive-pattern.d/stdout-expected.txt
@@ -1,0 +1,1 @@
+MAKEFILE: Make

--- a/Tmain/utils.sh
+++ b/Tmain/utils.sh
@@ -52,6 +52,11 @@ exit_if_win32()
 	is_feature_available $1 '!' win32
 }
 
+exit_if_no_case_insensitive_filenames()
+{
+	is_feature_available $1 case-insensitive-filenames
+}
+
 run_with_format()
 {
     echo '#' $*

--- a/main/options.c
+++ b/main/options.c
@@ -492,6 +492,9 @@ static const char *const Features [] = {
 #ifdef HAVE_LIBYAML
 	"yaml",
 #endif
+#ifdef CASE_INSENSITIVE_FILENAMES
+	"case-insensitive-filenames",
+#endif
 	NULL
 };
 

--- a/main/strlist.c
+++ b/main/strlist.c
@@ -216,7 +216,21 @@ static bool fileNameMatched (
 		const vString* const vpattern, const char* const fileName)
 {
 	const char* const pattern = vStringValue (vpattern);
+
+#ifdef CASE_INSENSITIVE_FILENAMES
+	{
+		bool r;
+
+		char* const p = newUpperString (pattern);
+		char* const f = newUpperString (fileName);
+		r =  (bool) (fnmatch (p, f, 0) == 0);
+		eFree (f);
+		eFree (p);
+		return r;
+	}
+#else
 	return (bool) (fnmatch (pattern, fileName, 0) == 0);
+#endif
 }
 
 extern bool stringListFileMatched (


### PR DESCRIPTION
ctags uses file name (glob) patterns and extensions to choose a
proper parser for given input.

extensions work well in case insenstive environment.
However, patterns don't. This commit fixes this.

GNU implementation provides FNM_CASEFOLD.
I didn't use it to keep portability.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>