### PR TITLE
Revise lxpath

### DIFF
--- a/main/lxpath.h
+++ b/main/lxpath.h
@@ -60,6 +60,10 @@ typedef struct sTagXpathTableTable {
 } tagXpathTableTable;
 
 typedef struct sXpathFileSpec {
+	/*
+	   NULL represents the associated field in DTD is not examined.
+	   "" (an empty string) represents the associated field in DTD
+	   (and root element) must not exist. */
 	const char *rootElementName;
 	const char *nameInDTD;
 	const char *externalID;

--- a/main/lxpath.h
+++ b/main/lxpath.h
@@ -1,0 +1,68 @@
+/*
+*   Copyright (c) 2016, Masatake YAMATO
+*   Copyright (c) 2016, Red Hat, Inc.
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   Xpath based parer API
+*/
+#ifndef CTAGS_LXPATH_PARSE_H
+#define CTAGS_LXPATH_PARSE_H
+
+#include "general.h"  /* must always come first */
+#include "types.h"
+
+#ifdef HAVE_LIBXML
+#include <libxml/xpath.h>
+#include <libxml/tree.h>
+#else
+#define xmlNode void
+#define xmlXPathCompExpr void
+#define xmlXPathContext void
+#endif
+
+typedef struct sTagXpathMakeTagSpec {
+	int   kind;
+	int   role;
+	/* If make is NULL, just makeTagEntry is used instead. */
+	void (*make) (xmlNode *node,
+		      const struct sTagXpathMakeTagSpec *spec,
+		      tagEntryInfo *tag,
+		      void *userData);
+} tagXpathMakeTagSpec;
+
+typedef struct sTagXpathRecurSpec {
+	void (*enter) (xmlNode *node,
+		       const struct sTagXpathRecurSpec *spec,
+		       xmlXPathContext *ctx,
+		       void *userData);
+
+	int  nextTable;		/* A parser can use this field any purpose.
+				   main/lxpath part doesn't touch this. */
+
+} tagXpathRecurSpec;
+
+typedef struct sTagXpathTable
+{
+	const char *const xpath;
+	enum  { LXPATH_TABLE_DO_MAKE, LXPATH_TABLE_DO_RECUR } specType;
+	union {
+		tagXpathMakeTagSpec makeTagSpec;
+		tagXpathRecurSpec   recurSpec;
+	} spec;
+	xmlXPathCompExpr* xpathCompiled;
+} tagXpathTable;
+
+typedef struct sTagXpathTableTable {
+	tagXpathTable *table;
+	unsigned int   count;
+} tagXpathTableTable;
+
+/* Xpath interface */
+extern void findXMLTags (xmlXPathContext *ctx, xmlNode *root,
+			 const tagXpathTableTable *xpathTableTable,
+			 const kindOption* const kinds, void *userData);
+extern void addTagXpath (const langType language, tagXpathTable *xpathTable);
+
+#endif  /* CTAGS_LXPATH_PARSE_H */

--- a/main/lxpath.h
+++ b/main/lxpath.h
@@ -59,6 +59,15 @@ typedef struct sTagXpathTableTable {
 	unsigned int   count;
 } tagXpathTableTable;
 
+typedef struct sXpathFileSpec {
+	const char *rootElementName;
+	const char *nameInDTD;
+	const char *externalID;
+	const char *systemID;
+	const char *rootNSPrefix;
+	const char *rootNSHref;
+} xpathFileSpec;
+
 /* Xpath interface */
 extern void findXMLTags (xmlXPathContext *ctx, xmlNode *root,
 			 const tagXpathTableTable *xpathTableTable,

--- a/main/parse.c
+++ b/main/parse.c
@@ -809,9 +809,19 @@ commonSelector (const parserCandidate *candidates, int n_candidates)
  * language associated with the string returned by the selector.
  */
 static int
-pickLanguageBySelection (selectLanguage selector, MIO *input)
+pickLanguageBySelection (selectLanguage selector, MIO *input,
+						 parserCandidate *candidates,
+						 unsigned int nCandidates)
 {
-    const char *lang = selector(input);
+	const char *lang;
+	langType *cs = xMalloc(nCandidates, langType);
+	int i;
+
+	for (i = 0; i < nCandidates; i++)
+		cs[i] = candidates[i].lang;
+    lang = selector(input, cs, nCandidates);
+	eFree (cs);
+
     if (lang)
     {
         verbose ("		selection: %s\n", lang);
@@ -930,7 +940,7 @@ static langType getSpecLanguageCommon (const char *const spec, struct getLangCtx
 		GLC_FOPEN_IF_NECESSARY(glc, fopen_error, memStreamRequired);
 		if (selector) {
 			verbose ("	selector: %p\n", selector);
-			language = pickLanguageBySelection(selector, glc->input);
+			language = pickLanguageBySelection(selector, glc->input, candidates, n_candidates);
 		} else {
 			verbose ("	selector: NONE\n");
 		fopen_error:

--- a/main/parse.c
+++ b/main/parse.c
@@ -2579,6 +2579,27 @@ static void installTagXpathTable (const langType language)
 	}
 }
 
+extern unsigned int getXpathFileSpecCount (const langType language)
+{
+	parserDefinition* lang;
+
+	Assert (0 <= language  &&  language < (int) LanguageCount);
+	lang = LanguageTable [language];
+
+	return lang->xpathFileSpecCount;
+}
+
+extern xpathFileSpec* getXpathFileSpec (const langType language, unsigned int nth)
+{
+	parserDefinition* lang;
+
+	Assert (0 <= language  &&  language < (int) LanguageCount);
+	lang = LanguageTable [language];
+
+	Assert (nth < lang->xpathFileSpecCount);
+	return lang->xpathFileSpecs + nth;
+}
+
 extern bool makeKindSeparatorsPseudoTags (const langType language,
 					     const ptagDesc *pdesc)
 {

--- a/main/parse.h
+++ b/main/parse.h
@@ -54,8 +54,6 @@ typedef void (*parserInitialize) (langType language);
    is called. */
 typedef void (*parserFinalize) (langType language, bool initialized);
 
-typedef const char * (*selectLanguage) (MIO *);
-
 typedef enum {
 	METHOD_NOT_CRAFTED    = 1 << 0,
 	METHOD_REGEX          = 1 << 1,

--- a/main/parse.h
+++ b/main/parse.h
@@ -18,18 +18,10 @@
 #include "dependency.h"
 #include "field.h"
 #include "kind.h"
+#include "lxpath.h"
 #include "param.h"
 #include "parsers.h"  /* contains list of parsers */
 #include "strlist.h"
-
-#ifdef HAVE_LIBXML
-#include <libxml/xpath.h>
-#include <libxml/tree.h>
-#else
-#define xmlNode void
-#define xmlXPathCompExpr void
-#define xmlXPathContext void
-#endif
 
 /*
 *   MACROS
@@ -80,44 +72,6 @@ typedef struct {
 	const char *const flags;
 	bool    *disabled;
 } tagRegexTable;
-
-typedef struct sTagXpathMakeTagSpec {
-	int   kind;
-	int   role;
-	/* If make is NULL, just makeTagEntry is used instead. */
-	void (*make) (xmlNode *node,
-		      const struct sTagXpathMakeTagSpec *spec,
-		      tagEntryInfo *tag,
-		      void *userData);
-} tagXpathMakeTagSpec;
-
-typedef struct sTagXpathRecurSpec {
-	void (*enter) (xmlNode *node,
-		       const struct sTagXpathRecurSpec *spec,
-		       xmlXPathContext *ctx,
-		       void *userData);
-
-	int  nextTable;		/* A parser can use this field any purpose.
-				   main/lxpath part doesn't touch this. */
-
-} tagXpathRecurSpec;
-
-typedef struct sTagXpathTable
-{
-	const char *const xpath;
-	enum  { LXPATH_TABLE_DO_MAKE, LXPATH_TABLE_DO_RECUR } specType;
-	union {
-		tagXpathMakeTagSpec makeTagSpec;
-		tagXpathRecurSpec   recurSpec;
-	} spec;
-	xmlXPathCompExpr* xpathCompiled;
-} tagXpathTable;
-
-typedef struct sTagXpathTableTable {
-	tagXpathTable *table;
-	unsigned int   count;
-} tagXpathTableTable;
-
 
 typedef struct {
 	const char *name;
@@ -309,13 +263,6 @@ extern void foreachXcmdKinds (const langType language, bool (* func) (kindOption
 extern void freeXcmdResources (void);
 extern void useXcmdMethod (const langType language);
 extern void notifyAvailabilityXcmdMethod (const langType language);
-
-/* Xpath interface */
-extern void findXMLTags (xmlXPathContext *ctx, xmlNode *root,
-			 const tagXpathTableTable *xpathTableTable,
-			 const kindOption* const kinds, void *userData);
-extern void addTagXpath (const langType language, tagXpathTable *xpathTable);
-
 
 extern bool makeKindSeparatorsPseudoTags (const langType language,
 					     const ptagDesc *pdesc);

--- a/main/parse.h
+++ b/main/parse.h
@@ -110,6 +110,9 @@ struct sParserDefinition {
 	parameterHandlerTable  *parameterHandlerTable;
 	unsigned int parameterHandlerCount;
 
+	xpathFileSpec *xpathFileSpecs;
+	unsigned int xpathFileSpecCount;
+
 	/* used internally */
 	langType id;		    /* id assigned to language */
 	unsigned int enabled:1;	       /* currently enabled? */
@@ -244,6 +247,8 @@ extern bool hasScopeActionInRegex (const langType language);
 extern bool hasMultilineRegexPatterns (const langType language);
 extern bool matchMultilineRegex (const vString* const allLines, const langType language);
 
+extern unsigned int   getXpathFileSpecCount (const langType language);
+extern xpathFileSpec* getXpathFileSpec (const langType language, unsigned int nth);
 
 #ifdef HAVE_COPROC
 extern bool invokeXcmd (const char* const fileName, const langType language);

--- a/main/selectors.c
+++ b/main/selectors.c
@@ -317,14 +317,24 @@ xmlParseMIO (MIO *input)
 static const char *
 selectParserForXmlDoc (xmlDocPtr doc)
 {
-	if (doc && doc->children && doc->children->name)
-		verbose ("		Xml[root name]: %s\n", doc->children->name);
-	if (doc && doc->intSubset && doc->intSubset->ExternalID)
-		verbose ("		Xml[ExternalID]: %s\n", doc->intSubset->ExternalID);
-	if (doc && doc->intSubset && doc->intSubset->SystemID)
-		verbose ("		Xml[SystemID]: %s\n", doc->intSubset->SystemID);
-	if (doc && doc->children && doc->children->ns && doc->children->ns->href)
-		verbose ("		Xml[NS]: %s\n", doc->children->ns->href);
+	verbose ("		Xml[rootElementName]: %s\n",
+			 (doc->children && doc->children->name)
+			 ? ((char *)doc->children->name): "-");
+	verbose ("		Xml[nameInDTD]: %s\n",
+			 (doc->intSubset && doc->intSubset->name)
+			 ? ((char *)doc->intSubset->name): "-");
+	verbose ("		Xml[externalID]: %s\n",
+			 (doc->intSubset && doc->intSubset->ExternalID)
+			 ? ((char *)doc->intSubset->ExternalID): "-");
+	verbose ("		Xml[systemID]: %s\n",
+			 (doc->intSubset && doc->intSubset->SystemID)
+			 ? ((char *)doc->intSubset->SystemID): "-");
+	verbose ("		Xml[rootNSPrefix]: %s\n",
+			 (doc->children && doc->children->ns && doc->children->ns->prefix)
+			 ? ((char *)doc->children->ns->prefix): "-");
+	verbose ("		Xml[rootNSHref]: %s\n",
+			 (doc->children && doc->children->ns && doc->children->ns->href)
+			 ? ((char *)doc->children->ns->href): "-");
 
 	/* These conditions should be part of parsers. */
 	if (doc->children

--- a/main/selectors.c
+++ b/main/selectors.c
@@ -119,7 +119,9 @@ tastePerlLine (const char *line, void *data CTAGS_ATTR_UNUSED)
 }
 
 const char *
-selectByPickingPerlVersion (MIO *input)
+selectByPickingPerlVersion (MIO *input,
+							langType *candidates CTAGS_ATTR_UNUSED,
+							unsigned int nCandidates CTAGS_ATTR_UNUSED)
 {
     /* Default to Perl 5 */
     return selectByLines (input, tastePerlLine, TR_PERL5, NULL);
@@ -160,7 +162,9 @@ tasteObjectiveCOrMatLabLines (const char *line, void *data CTAGS_ATTR_UNUSED)
 }
 
 const char *
-selectByObjectiveCAndMatLabKeywords (MIO * input)
+selectByObjectiveCAndMatLabKeywords (MIO * input,
+									 langType *candidates CTAGS_ATTR_UNUSED,
+									 unsigned int nCandidates CTAGS_ATTR_UNUSED)
 {
     return selectByLines (input, tasteObjectiveCOrMatLabLines,
 			  NULL, NULL);
@@ -178,7 +182,9 @@ tasteObjectiveC (const char *line, void *data CTAGS_ATTR_UNUSED)
 }
 
 const char *
-selectByObjectiveCKeywords (MIO * input)
+selectByObjectiveCKeywords (MIO * input,
+							langType *candidates CTAGS_ATTR_UNUSED,
+							unsigned int nCandidates CTAGS_ATTR_UNUSED)
 {
     /* TODO: Ideally opening input should be delayed til
        enable/disable based selection is done. */
@@ -218,7 +224,9 @@ tasteR (const char *line, void *data CTAGS_ATTR_UNUSED)
 }
 
 const char *
-selectByArrowOfR (MIO *input)
+selectByArrowOfR (MIO *input,
+				  langType *candidates CTAGS_ATTR_UNUSED,
+				  unsigned int nCandidates CTAGS_ATTR_UNUSED)
 {
     /* TODO: Ideally opening input should be delayed till
        enable/disable based selection is done. */
@@ -264,7 +272,9 @@ tasteREXXOrDosBatch (const char *line, void *data)
 }
 
 const char *
-selectByRexxCommentAndDosbatchLabelPrefix (MIO *input)
+selectByRexxCommentAndDosbatchLabelPrefix (MIO *input,
+										   langType *candidates CTAGS_ATTR_UNUSED,
+										   unsigned int nCandidates CTAGS_ATTR_UNUSED)
 {
     /* TODO: Ideally opening input should be delayed till
        enable/disable based selection is done. */
@@ -370,7 +380,9 @@ selectParserForXmlDoc (xmlDocPtr doc)
 }
 
 const char *
-selectByDTD (MIO *input)
+selectByDTD (MIO *input,
+			 langType *candidates,
+			 unsigned int nCandidates)
 {
 	xmlDocPtr doc;
 	const char *r = NULL;

--- a/main/selectors.c
+++ b/main/selectors.c
@@ -324,9 +324,102 @@ xmlParseMIO (MIO *input)
 	return xmlParseMemory((const char *)buf, len);
 }
 
-static const char *
-selectParserForXmlDoc (xmlDocPtr doc)
+static bool
+matchXpathFileSpec (xmlDocPtr doc, xpathFileSpec *spec)
 {
+	if (spec->rootElementName)
+	{
+		if (*spec->rootElementName == '\0')
+		{
+			/* The statement is just for keeping code symmetric.
+			   Meaningless examination: a root element is
+			   always there.*/
+			if (doc->children && doc->children->name)
+				return false;
+		}
+		else if (! (doc->children
+					&& doc->children->name
+					&& (strcmp (spec->rootElementName, (char *)doc->children->name) == 0)))
+			return false;
+	}
+
+	if (spec->nameInDTD)
+	{
+		if (*spec->rootElementName == '\0')
+		{
+			if (doc->intSubset && doc->intSubset->name)
+				return false;
+		}
+		else if (! (doc->intSubset
+					&& doc->intSubset->name
+					&& (strcmp (spec->nameInDTD, (char *)doc->intSubset->name) == 0)))
+			return false;
+	}
+
+	if (spec->externalID)
+	{
+		if (*spec->externalID == '\0')
+		{
+			if (doc->intSubset && doc->intSubset->ExternalID)
+				return false;
+		}
+		else if (! (doc->intSubset
+					&& doc->intSubset->ExternalID
+					&& (strcmp (spec->externalID, (char *)doc->intSubset->ExternalID) == 0)))
+			return false;
+	}
+
+	if (spec->systemID)
+	{
+		if (*spec->systemID == '\0')
+		{
+			if (doc->intSubset && doc->intSubset->SystemID)
+				return false;
+		}
+		else if (! (doc->intSubset
+					&& doc->intSubset->SystemID
+					&& (strcmp (spec->systemID, (char *)doc->intSubset->SystemID) == 0)))
+			return false;
+	}
+
+	if (spec->rootNSPrefix)
+	{
+		if (*spec->rootNSPrefix == '\0')
+		{
+			if (doc->children && doc->children->ns && doc->children->ns->prefix)
+				return false;
+		}
+		else if (! (doc->children
+					&& doc->children->ns
+					&& doc->children->ns->prefix
+					&& (strcmp (spec->rootNSPrefix, (char *)doc->children->ns->prefix))))
+			return false;
+	}
+
+	if (spec->rootNSHref)
+	{
+		if (*spec->rootNSHref == '\0')
+		{
+			if (doc->children && doc->children->ns && doc->children->ns->href)
+				return false;
+		}
+		else if (! (doc->children
+					&& doc->children->ns
+					&& doc->children->ns->href
+					&& (strcmp (spec->rootNSHref, (char *)doc->children->ns->href) == 0)))
+			return false;
+	}
+	return true;
+}
+
+static const char *
+selectParserForXmlDoc (xmlDocPtr doc,
+					   langType *candidates,
+					   unsigned int nCandidates)
+{
+
+	unsigned int lang_index;
+
 	verbose ("		Xml[rootElementName]: %s\n",
 			 (doc->children && doc->children->name)
 			 ? ((char *)doc->children->name): "-");
@@ -346,34 +439,21 @@ selectParserForXmlDoc (xmlDocPtr doc)
 			 (doc->children && doc->children->ns && doc->children->ns->href)
 			 ? ((char *)doc->children->ns->href): "-");
 
-	/* These conditions should be part of parsers. */
-	if (doc->children
-	    && doc->intSubset
-	    && doc->children->name && doc->intSubset->name
-	    && (strcmp ((const char *)doc->children->name, (const char *)doc->intSubset->name) == 0)
-	    && doc->intSubset->ExternalID
-	    && (strcmp ((const char *)doc->intSubset->ExternalID,
-			"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN") == 0)
-	    && doc->intSubset->SystemID
-	    && (strcmp ((const char *)doc->intSubset->SystemID,
-			"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd") == 0))
+	for (lang_index = 0; lang_index < nCandidates; lang_index++)
 	{
-		/* <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
-		   "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
-		   <node ... */
-		return "DBusIntrospect";
-	}
-	else if (doc->children
-		 && doc->children->name
-		 && (strcmp ((const char*)doc->children->name, "project") == 0))
-	{
-		if ((doc->children->ns != NULL)
-		    && doc->children->ns->href != NULL
-		    && (strcmp ((const char *)doc->children->ns->href,
-				"http://maven.apache.org/POM/4.0.0") == 0))
-			return "Maven2";
-		else
-			return "Ant";
+		unsigned int spec_index;
+		xpathFileSpec* spec;
+		unsigned int spec_count;
+
+		verbose ("		lxpath examines %s\n", getLanguageName (candidates[lang_index]));
+
+		spec_count = getXpathFileSpecCount (candidates[lang_index]);
+		for (spec_index = 0; spec_index < spec_count; spec_index++)
+		{
+			spec = getXpathFileSpec (candidates[lang_index], spec_index);
+			if (matchXpathFileSpec (doc, spec))
+				return getLanguageName (candidates[lang_index]);
+		}
 	}
 
 	return NULL;
@@ -391,7 +471,7 @@ selectByDTD (MIO *input,
 	if (doc == NULL)
 		return NULL;
 
-	r = selectParserForXmlDoc (doc);
+	r = selectParserForXmlDoc (doc, candidates, nCandidates);
 
 	if (r == NULL)
 		xmlFreeDoc (doc);

--- a/main/selectors.c
+++ b/main/selectors.c
@@ -460,9 +460,9 @@ selectParserForXmlDoc (xmlDocPtr doc,
 }
 
 const char *
-selectByDTD (MIO *input,
-			 langType *candidates,
-			 unsigned int nCandidates)
+selectByXpathFileSpec (MIO *input,
+					   langType *candidates,
+					   unsigned int nCandidates)
 {
 	xmlDocPtr doc;
 	const char *r = NULL;

--- a/main/selectors.h
+++ b/main/selectors.h
@@ -29,7 +29,7 @@ selectByRexxCommentAndDosbatchLabelPrefix (MIO *, langType *, unsigned int);
 
 #ifdef HAVE_LIBXML
 const char *
-selectByDTD (MIO *input, langType *candidates, unsigned int nCandidates);
+selectByXpathFileSpec (MIO *input, langType *candidates, unsigned int nCandidates);
 #endif
 
 #endif

--- a/main/selectors.h
+++ b/main/selectors.h
@@ -10,26 +10,26 @@
 #ifndef CTAGS_MAIN_SELECTORS_H
 #define CTAGS_MAIN_SELECTORS_H
 
-#include <stdio.h>
+#include "types.h"
 
 const char *
-selectByPickingPerlVersion (MIO *);
+selectByPickingPerlVersion (MIO *, langType *, unsigned int);
 
 const char *
-selectByObjectiveCAndMatLabKeywords (MIO *);
+selectByObjectiveCAndMatLabKeywords (MIO *, langType *, unsigned int);
 
 const char *
-selectByObjectiveCKeywords(MIO *);
+selectByObjectiveCKeywords(MIO *, langType *, unsigned int);
 
 const char *
-selectByArrowOfR (MIO *);
+selectByArrowOfR (MIO *, langType *, unsigned int);
 
 const char *
-selectByRexxCommentAndDosbatchLabelPrefix (MIO *);
+selectByRexxCommentAndDosbatchLabelPrefix (MIO *, langType *, unsigned int);
 
 #ifdef HAVE_LIBXML
 const char *
-selectByDTD (MIO *input);
+selectByDTD (MIO *input, langType *candidates, unsigned int nCandidates);
 #endif
 
 #endif

--- a/main/types.h
+++ b/main/types.h
@@ -26,4 +26,8 @@ typedef struct sKindOption kindOption;
 
 struct sParserDefinition;
 typedef struct sParserDefinition parserDefinition;
+
+struct _MIO;
+typedef const char * (*selectLanguage) (struct _MIO *);
+
 #endif	/* CTAGS_MAIN_TYPES_H */

--- a/main/types.h
+++ b/main/types.h
@@ -28,6 +28,6 @@ struct sParserDefinition;
 typedef struct sParserDefinition parserDefinition;
 
 struct _MIO;
-typedef const char * (*selectLanguage) (struct _MIO *);
+typedef const char * (*selectLanguage) (struct _MIO *, langType *, unsigned int);
 
 #endif	/* CTAGS_MAIN_TYPES_H */

--- a/parsers/ant.c
+++ b/parsers/ant.c
@@ -224,7 +224,7 @@ extern parserDefinition* AntParser (void)
 	static const char *const patterns [] = { "build.xml", NULL };
 	parserDefinition* const def = parserNew ("Ant");
 #ifdef HAVE_LIBXML
-	static selectLanguage selectors[] = { selectByDTD, NULL };
+	static selectLanguage selectors[] = { selectByXpathFileSpec, NULL };
 	static xpathFileSpec xpathFileSpecs[] = {
 		/* See http://ant.apache.org/faq.html#dtd */
 		{

--- a/parsers/ant.c
+++ b/parsers/ant.c
@@ -225,6 +225,25 @@ extern parserDefinition* AntParser (void)
 	parserDefinition* const def = parserNew ("Ant");
 #ifdef HAVE_LIBXML
 	static selectLanguage selectors[] = { selectByDTD, NULL };
+	static xpathFileSpec xpathFileSpecs[] = {
+		/* See http://ant.apache.org/faq.html#dtd */
+		{
+			.rootElementName = "project",
+			.nameInDTD       = "",
+			.externalID      = "",
+			.systemID        = "",
+			.rootNSPrefix    = "",
+			.rootNSHref      = "",
+		},
+		{
+			.rootElementName = "project",
+			.nameInDTD       = "project",
+			.externalID      = "",
+			.systemID        = "",
+			.rootNSPrefix    = "",
+			.rootNSHref      = "",
+		}
+	};
 #endif
 	def->extensions = extensions;
 	def->patterns = patterns;
@@ -236,6 +255,8 @@ extern parserDefinition* AntParser (void)
 	def->tagXpathTableCount = ARRAY_SIZE (antXpathTableTable);
 	def->useCork = true;
 	def->selectLanguage = selectors;
+	def->xpathFileSpecs = xpathFileSpecs;
+	def->xpathFileSpecCount = ARRAY_SIZE (xpathFileSpecs);
 #else
 	def->tagRegexTable = antTagRegexTable;
 	def->tagRegexCount = ARRAY_SIZE (antTagRegexTable);

--- a/parsers/dbusintrospect.c
+++ b/parsers/dbusintrospect.c
@@ -145,6 +145,15 @@ DbusIntrospectParser (void)
 	parserDefinition* const def = parserNew ("DBusIntrospect");
 	static selectLanguage selectors[] = { selectByDTD, NULL };
 
+	static xpathFileSpec xpathFileSpecs[] = {
+		{
+			/* <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+			   "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+			   <node ... */
+			.externalID = "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN",
+			.systemID   = "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd",
+		},
+	};
 	def->kinds         = DbusIntrospectKinds;
 	def->kindCount     = ARRAY_SIZE (DbusIntrospectKinds);
 	def->extensions    = extensions;
@@ -153,5 +162,8 @@ DbusIntrospectParser (void)
 	def->tagXpathTableCount = ARRAY_SIZE (dbusIntrospectXpathTableTable);
 	def->useCork = true;
 	def->selectLanguage = selectors;
+	def->xpathFileSpecs = xpathFileSpecs;
+	def->xpathFileSpecCount = ARRAY_SIZE (xpathFileSpecs);
+
 	return def;
 }

--- a/parsers/dbusintrospect.c
+++ b/parsers/dbusintrospect.c
@@ -143,7 +143,7 @@ DbusIntrospectParser (void)
 {
 	static const char *const extensions [] = { "xml", NULL };
 	parserDefinition* const def = parserNew ("DBusIntrospect");
-	static selectLanguage selectors[] = { selectByDTD, NULL };
+	static selectLanguage selectors[] = { selectByXpathFileSpec, NULL };
 
 	static xpathFileSpec xpathFileSpecs[] = {
 		{

--- a/parsers/maven2.c
+++ b/parsers/maven2.c
@@ -250,7 +250,7 @@ Maven2Parser (void)
 	static const char *const extensions [] = { "pom", "xml", NULL };
 	static const char *const patterns [] =   { "pom.xml", NULL };
 	parserDefinition* const def = parserNew ("Maven2");
-	static selectLanguage selectors[] = { selectByDTD, NULL };
+	static selectLanguage selectors[] = { selectByXpathFileSpec, NULL };
 
 	static xpathFileSpec xpathFileSpecs[] = {
 		{

--- a/parsers/maven2.c
+++ b/parsers/maven2.c
@@ -247,10 +247,17 @@ findMaven2Tags (void)
 extern parserDefinition*
 Maven2Parser (void)
 {
-	static const char *const extensions [] = { "pom", NULL };
+	static const char *const extensions [] = { "pom", "xml", NULL };
 	static const char *const patterns [] =   { "pom.xml", NULL };
 	parserDefinition* const def = parserNew ("Maven2");
 	static selectLanguage selectors[] = { selectByDTD, NULL };
+
+	static xpathFileSpec xpathFileSpecs[] = {
+		{
+			.rootElementName = "project",
+			.rootNSHref      = "http://maven.apache.org/POM/4.0.0",
+		},
+	};
 
 	def->kinds         = Maven2Kinds;
 	def->kindCount     = ARRAY_SIZE (Maven2Kinds);
@@ -263,5 +270,7 @@ Maven2Parser (void)
 	def->selectLanguage = selectors;
 	def->fieldSpecs = Maven2Fields;
 	def->fieldSpecCount = ARRAY_SIZE (Maven2Fields);
+	def->xpathFileSpecs = xpathFileSpecs;
+	def->xpathFileSpecCount = ARRAY_SIZE (xpathFileSpecs);
 	return def;
 }

--- a/source.mak
+++ b/source.mak
@@ -26,6 +26,7 @@ MAIN_HEADS =			\
 	main/interactive.h	\
 	main/keyword.h		\
 	main/kind.h		\
+	main/lxpath.h		\
 	main/main.h		\
 	main/mbcs.h		\
 	main/nestlevel.h	\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -247,6 +247,7 @@
     <ClInclude Include="..\main\options.h" />
     <ClInclude Include="..\main\param.h" />
     <ClInclude Include="..\main\parse.h" />
+    <ClInclude Include="..\main\lxpath.h" />
     <ClInclude Include="..\main\parsers.h" />
     <ClInclude Include="..\main\ptag.h" />
     <ClInclude Include="..\main\read.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -455,6 +455,9 @@
     <ClInclude Include="..\main\parse.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\main\lxpath.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\main\parsers.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
The logic for selecting a xpath based parser was hard-coded in selectByDTD.
This commit set tries converting the logic to more declarative data structures defined in each xpath based parser. 