### PR TITLE
sh: use isBashFunctionChar as default check_char func

### DIFF
--- a/Units/parser-sh.r/function-identifiers-no-function-keyword-bash.d/expected.tags
+++ b/Units/parser-sh.r/function-identifiers-no-function-keyword-bash.d/expected.tags
@@ -1,0 +1,2 @@
+a::anotherTest	input.bash	/^function a::anotherTest() {$/;"	f
+a::test	input.bash	/^a::test() {$/;"	f

--- a/Units/parser-sh.r/function-identifiers-no-function-keyword-bash.d/input.bash
+++ b/Units/parser-sh.r/function-identifiers-no-function-keyword-bash.d/input.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+#
+# Taken from the original bug report (https://github.com/universal-ctags/ctags/issues/1261)
+#
+
+a::test() {
+    echo "test"
+}
+
+function a::anotherTest() {
+    echo "another test"
+}

--- a/parsers/sh.c
+++ b/parsers/sh.c
@@ -198,18 +198,18 @@ static void findShTags (void)
 				}
 			}
 
-			check_char = isIdentChar;
+			check_char = isBashFunctionChar;
 
 			if (strncmp ((const char*) cp, "function", (size_t) 8) == 0  &&
 				isspace ((int) cp [8]))
 			{
-				check_char = isBashFunctionChar;
 				found_kind = K_FUNCTION;
 				cp += 8;
 			}
 			else if (strncmp ((const char*) cp, "alias", (size_t) 5) == 0  &&
 				isspace ((int) cp [5]))
 			{
+				check_char = isIdentChar;
 				found_kind = K_ALIAS;
 				cp += 5;
 			}


### PR DESCRIPTION
Close #1261.

bash accepts many non isalnum characters as function identifiers even when
not using the `function` keyword.

If `function` keyword is used, ctags has a chance to switch check_char
var to a function specialized to bash. For the case `function` keyword
is not used, this commit change the default value of check_char var to
isBashFunctionChar.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>