### PR TITLE
lregex: fix uninitialized memory access

### DIFF
--- a/main/lregex.c
+++ b/main/lregex.c
@@ -361,6 +361,7 @@ static regexPattern* addCompiledTagCommon (const langType language,
 						       hashPtreq,
 						       NULL,
 						       kindFree);
+			Sets [i].multilinePatternsCount = 0;
 		}
 		SetUpper = language;
 	}


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>