### PR TITLE
Tokeninfo: add scope index as a filed to tokeninfo struct

### DIFF
--- a/main/tokeninfo.c
+++ b/main/tokeninfo.c
@@ -40,6 +40,7 @@ static void clearToken (void *data)
 	vStringClear (token->string);
 	token->lineNumber = getInputLineNumber ();
 	token->filePosition = getInputFilePosition ();
+	token->scopeIndex = CORK_NIL;
 }
 
 static void destroyToken (void *data)
@@ -122,6 +123,7 @@ void tokenCopyFull  (tokenInfo *dest, tokenInfo *src, void *data)
 	dest->filePosition = src->filePosition;
 	dest->type = src->type;
 	dest->keyword = src->keyword;
+	dest->scopeIndex = src->scopeIndex;
 	/* klass */
 	vStringCopy(dest->string, src->string);
 	if (src->klass->copy)

--- a/main/tokeninfo.c
+++ b/main/tokeninfo.c
@@ -161,7 +161,7 @@ bool tokenSkipToType (tokenInfo *token, tokenType t)
 	return tokenSkipToTypeFull (token, t, NULL);
 }
 
-void tokenUnreadFull (tokenInfo *token, void *data)
+void tokenUnreadFull (tokenInfo *token, bool keepScopeIndex, void *data)
 {
 	tokenInfo *backlog;
 
@@ -170,12 +170,14 @@ void tokenUnreadFull (tokenInfo *token, void *data)
 
 	backlog = newToken (token->klass);
 	tokenCopyFull (backlog, token, data);
+	if (!keepScopeIndex)
+		backlog->scopeIndex = CORK_NIL;
 	ptrArrayAdd (token->klass->backlog, backlog);
 }
 
 void tokenUnread      (tokenInfo *token)
 {
-	tokenUnreadFull (token, NULL);
+	tokenUnreadFull (token, false, NULL);
 }
 
 bool tokenSkipOverPair (tokenInfo *token)

--- a/main/tokeninfo.h
+++ b/main/tokeninfo.h
@@ -28,6 +28,7 @@ typedef struct sTokenInfo {
 	struct tokenInfoClass *klass;
 	unsigned long lineNumber;
 	MIOPos filePosition;
+	int scopeIndex;
 } tokenInfo;
 
 struct tokenTypePair {

--- a/main/tokeninfo.h
+++ b/main/tokeninfo.h
@@ -67,7 +67,17 @@ void  tokenDestroy    (tokenInfo *token);
 
 void tokenReadFull   (tokenInfo *token, void *data);
 void tokenRead       (tokenInfo *token);
-void tokenUnreadFull (tokenInfo *token, void *data); /* DATA passed to copy method internally. */
+
+/* tokenUnread* ()
+
+   Make a copy for TOKEN and put the copy to the tokenInfoClass internal queue.
+   For copying tokenCopy* function is used. DATA passed to copy method internally.
+
+   All fields are copyed. An exception is about `scopeIndex'.
+   The field is cleared to CORK_NIL if keepScopeIndex is false.
+
+   tokenUnread implies keepScopeIndex is false. */
+void tokenUnreadFull (tokenInfo *token, bool keepScopeIndex, void *data);
 void tokenUnread     (tokenInfo *token);
 
 

--- a/parsers/dtd.c
+++ b/parsers/dtd.c
@@ -123,12 +123,6 @@ enum eTokenType {
 };
 
 static void readToken (tokenInfo *const token, void *data CTAGS_ATTR_UNUSED);
-static void clearToken (tokenInfo *token);
-static void copyToken (tokenInfo *dest, tokenInfo *src, void *data CTAGS_ATTR_UNUSED);
-
-typedef struct sTokenExtra {
-	int scopeIndex;
-} tokenExtra;
 
 static struct tokenInfoClass dtdTokenInfoClass = {
 	.nPreAlloc = 16,
@@ -136,10 +130,10 @@ static struct tokenInfoClass dtdTokenInfoClass = {
 	.keywordNone      = KEYWORD_NONE,
 	.typeForKeyword   = TOKEN_KEYWORD,
 	.typeForEOF       = TOKEN_EOF,
-	.extraSpace       = sizeof (tokenExtra),
+	.extraSpace       = 0,
+	.clear			  = NULL,
 	.read             = readToken,
-	.clear            = clearToken,
-	.copy             = copyToken,
+	.copy             = NULL,
 };
 
 static langType Lang_dtd;
@@ -150,17 +144,6 @@ static langType Lang_dtd;
 static tokenInfo *newDtdToken (void)
 {
 	return newToken (&dtdTokenInfoClass);
-}
-
-static void clearToken (tokenInfo *token)
-{
-	TOKENX (token, tokenExtra)->scopeIndex = CORK_NIL;
-}
-
-static void copyToken (tokenInfo *dest, tokenInfo *src, void *data CTAGS_ATTR_UNUSED)
-{
-	TOKENX (dest, tokenExtra)->scopeIndex =
-		TOKENX (src, tokenExtra)->scopeIndex;
 }
 
 static void readToken (tokenInfo *const token, void *data CTAGS_ATTR_UNUSED)
@@ -290,7 +273,7 @@ static int makeDtdTagMaybe (tagEntryInfo *const e, tokenInfo *const token,
 					 role);
 	e->lineNumber = token->lineNumber;
 	e->filePosition = token->filePosition;
-	e->extensionFields.scopeIndex = TOKENX (token, tokenExtra)->scopeIndex;
+	e->extensionFields.scopeIndex = token->scopeIndex;
 
 	return makeTagEntry (e);
 }
@@ -446,7 +429,7 @@ static void parseAttDefs (tokenInfo *const token)
 		}
 		else if (tokenIsType(token, CLOSE))
 		{
-			TOKENX (token, tokenExtra)->scopeIndex = CORK_NIL;
+			token->scopeIndex = CORK_NIL;
 			tokenUnread (token);
 			break;
 		}
@@ -472,9 +455,9 @@ static void parseAttlist (tokenInfo *const token)
 										 DTD_PARAMETER_ENTITY_ELEMENT_NAME);
 				tokenDestroy (identifier);
 
-				TOKENX (token, tokenExtra)->scopeIndex = index;
+				token->scopeIndex = index;
 				parseAttDefs (token);
-				TOKENX (token, tokenExtra)->scopeIndex = CORK_NIL;
+				token->scopeIndex = CORK_NIL;
 			}
 		}
 	}
@@ -486,9 +469,9 @@ static void parseAttlist (tokenInfo *const token)
 								 K_ELEMENT, DTD_ELEMENT_ATT_OWNER);
 		tokenDestroy (element);
 
-		TOKENX (token, tokenExtra)->scopeIndex = index;
+		token->scopeIndex = index;
 		parseAttDefs (token);
-		TOKENX (token, tokenExtra)->scopeIndex = CORK_NIL;
+		token->scopeIndex = CORK_NIL;
 	}
 
 	tokenSkipToType (token, TOKEN_CLOSE);

--- a/parsers/dtd.c
+++ b/parsers/dtd.c
@@ -429,7 +429,6 @@ static void parseAttDefs (tokenInfo *const token)
 		}
 		else if (tokenIsType(token, CLOSE))
 		{
-			token->scopeIndex = CORK_NIL;
 			tokenUnread (token);
 			break;
 		}


### PR DESCRIPTION
tokenInfo is really useful. Now even I can write a simple parser!

These commits reflects my experience writing ldscript and dtd parsers.

* add scopeIndex to tokenInfo,
* reset scopeIndex to CORK_NIL in tokenUnread