### PR TITLE
vString: Implement vStringStripLeading() in a more efficient way

### DIFF
--- a/main/vstring.c
+++ b/main/vstring.c
@@ -156,13 +156,14 @@ extern void vStringStripNewline (vString *const string)
  */
 extern void vStringStripLeading (vString *const string)
 {
-	while (isspace ((int) string->buffer [0]) && string->length > 0)
+	size_t n = 0;
+
+	while (n < string->length && isspace ((int) string->buffer [n]))
+		n++;
+	if (n > 0)
 	{
-		size_t i;
-		for (i = 1  ;  i < string->length  ;  ++i)
-			string->buffer [i - 1] = string->buffer [i];
-		--string->length;
-		string->buffer [string->length] = '\0';
+		memmove (string->buffer, string->buffer + n, string->length - n);
+		vStringTruncate (string, string->length - n);
 	}
 }
 


### PR DESCRIPTION
Don't move the whole string several times if there are more than one
byte to strip; instead count the bytes to strip and move accordingly in
one go.

Also, use memmove() that is highly likely to be more efficient but on
very tiny buffers.

---
**DISCLAIMER**: I did **not** do performance tests on this.  I changed it because I saw the implementation and it hurt my eyes.  I'm pretty confident it'll be a lot faster when stripping more than one byte (because the move will happen only once), or when the string is longer than *[insert some small number here]* (because `memmove()` is a *lot* faster at actually moving the bytes in any current architecture, so the question is only whether calling cost outweights the benefits).