### PR TITLE
buildsys: add configure options to control xml, json, and yaml support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -586,46 +586,49 @@ AC_CHECK_FUNCS(fork waitpid execv pipe,[enable_xcmd=yes],[enable_xcmd=no])
 AM_CONDITIONAL([ENABLE_XCMD], [test "xyes" = "x$enable_xcmd"])
 
 AC_ARG_ENABLE([xml],
-	[AS_HELP_STRING([--enable-xml],
-		[enable xml support [no]])])
+	[AS_HELP_STRING([--disable-xml],
+		[disable xml support])])
 
 AH_TEMPLATE([HAVE_LIBXML],
 	[Define this value if libxml is available.])
 dnl About the condition of version
 dnl see https://mail.gnome.org/archives/xml/2010-February/msg00008.html
-AS_IF([test "${enable_xml}" = "yes"], [
+AS_IF([test "x$enable_xml" != "xno"], [
 	PKG_CHECK_MODULES(LIBXML, [libxml-2.0 >= 2.7.7],
 			       [have_libxml=yes
 			       AC_DEFINE(HAVE_LIBXML)],
-			       [AC_MSG_ERROR([libxml2 not found])])
+			       [AS_IF([test "x$enable_xml" = "xyes"], [
+			           AC_MSG_ERROR([libxml2 not found])])])
 ])
 AM_CONDITIONAL(HAVE_LIBXML, test "x$have_libxml" = xyes)
 
 AC_ARG_ENABLE([json],
-	[AS_HELP_STRING([--enable-json],
-		[enable json support [no]])])
+	[AS_HELP_STRING([--disable-json],
+		[disable json support])])
 
 AH_TEMPLATE([HAVE_JANSSON],
 	[Define this value if jansson is available.])
-AS_IF([test "${enable_json}" = "yes"], [
+AS_IF([test "x$enable_json" != "xno"], [
 	PKG_CHECK_MODULES(JANSSON, jansson,
 			       [have_jansson=yes
 			       AC_DEFINE(HAVE_JANSSON)],
-			       [AC_MSG_ERROR([jansson not found])])
+			       [AS_IF([test "x$enable_json" = "xyes"], [
+			           AC_MSG_ERROR([jansson not found])])])
 ])
 AM_CONDITIONAL(HAVE_JANSSON, test "x$have_jansson" = xyes)
 
 AC_ARG_ENABLE([yaml],
-	[AS_HELP_STRING([--enable-yaml],
-		[enable yaml support [no]])])
+	[AS_HELP_STRING([--disable-yaml],
+		[disable yaml support])])
 
 AH_TEMPLATE([HAVE_LIBYAML],
 	[Define this value if libyaml is available.])
-AS_IF([test "${enable_yaml}" = "yes"], [
+AS_IF([test "x$enable_yaml" != "xno"], [
 	PKG_CHECK_MODULES(LIBYAML, yaml-0.1,
 			       [have_libyaml=yes
 			       AC_DEFINE(HAVE_LIBYAML)],
-			       [AC_MSG_ERROR([libyaml not found])])
+			       [AS_IF([test "x$enable_yaml" = "xyes"], [
+			           AC_MSG_ERROR([libyaml not found])])])
 ])
 AM_CONDITIONAL(HAVE_LIBYAML, test "x$have_libyaml" = xyes)
 

--- a/configure.ac
+++ b/configure.ac
@@ -608,6 +608,10 @@ AC_ARG_ENABLE([json],
 
 AH_TEMPLATE([HAVE_JANSSON],
 	[Define this value if jansson is available.])
+dnl This enforces explicit feature usage regardless of the libraries
+dnl available on the build system. This avoids automagic dependencies which
+dnl can cause issues for source-based distros [1].
+dnl [1]: https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Automagic_dependencies
 AS_IF([test "x$enable_json" != "xno"], [
 	PKG_CHECK_MODULES(JANSSON, jansson,
 			       [have_jansson=yes

--- a/configure.ac
+++ b/configure.ac
@@ -585,30 +585,48 @@ AC_CHECK_FUNCS(scandir)
 AC_CHECK_FUNCS(fork waitpid execv pipe,[enable_xcmd=yes],[enable_xcmd=no])
 AM_CONDITIONAL([ENABLE_XCMD], [test "xyes" = "x$enable_xcmd"])
 
+AC_ARG_ENABLE([xml],
+	[AS_HELP_STRING([--enable-xml],
+		[enable xml support [no]])])
+
 AH_TEMPLATE([HAVE_LIBXML],
 	[Define this value if libxml is available.])
 dnl About the condition of version
 dnl see https://mail.gnome.org/archives/xml/2010-February/msg00008.html
-PKG_CHECK_MODULES(LIBXML, [libxml-2.0 >= 2.7.7],
-		       [have_libxml=yes
-		       AC_DEFINE(HAVE_LIBXML)],
-		       [have_libxml=no])
+AS_IF([test "${enable_xml}" = "yes"], [
+	PKG_CHECK_MODULES(LIBXML, [libxml-2.0 >= 2.7.7],
+			       [have_libxml=yes
+			       AC_DEFINE(HAVE_LIBXML)],
+			       [AC_MSG_ERROR([libxml2 not found])])
+])
 AM_CONDITIONAL(HAVE_LIBXML, test "x$have_libxml" = xyes)
+
+AC_ARG_ENABLE([json],
+	[AS_HELP_STRING([--enable-json],
+		[enable json support [no]])])
 
 AH_TEMPLATE([HAVE_JANSSON],
 	[Define this value if jansson is available.])
-PKG_CHECK_MODULES(JANSSON, jansson,
-		       [have_jansson=yes
-		       AC_DEFINE(HAVE_JANSSON)],
-		       [have_jansson=no])
+AS_IF([test "${enable_json}" = "yes"], [
+	PKG_CHECK_MODULES(JANSSON, jansson,
+			       [have_jansson=yes
+			       AC_DEFINE(HAVE_JANSSON)],
+			       [AC_MSG_ERROR([jansson not found])])
+])
 AM_CONDITIONAL(HAVE_JANSSON, test "x$have_jansson" = xyes)
+
+AC_ARG_ENABLE([yaml],
+	[AS_HELP_STRING([--enable-yaml],
+		[enable yaml support [no]])])
 
 AH_TEMPLATE([HAVE_LIBYAML],
 	[Define this value if libyaml is available.])
-PKG_CHECK_MODULES(LIBYAML, yaml-0.1,
-		       [have_libyaml=yes
-		       AC_DEFINE(HAVE_LIBYAML)],
-		       [have_libyaml=no])
+AS_IF([test "${enable_yaml}" = "yes"], [
+	PKG_CHECK_MODULES(LIBYAML, yaml-0.1,
+			       [have_libyaml=yes
+			       AC_DEFINE(HAVE_LIBYAML)],
+			       [AC_MSG_ERROR([libyaml not found])])
+])
 AM_CONDITIONAL(HAVE_LIBYAML, test "x$have_libyaml" = xyes)
 
 


### PR DESCRIPTION
This enforces explicit feature usage regardless of the libraries
available on the build system. This avoids automagic dependencies which
can cause issues for source-based distros [1].

[1]: https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Automagic_dependencies