### PR TITLE
Fix sed usage in Tmain/sorted-help-message.d

### DIFF
--- a/Tmain/sorted-help-message.d/run.sh
+++ b/Tmain/sorted-help-message.d/run.sh
@@ -27,13 +27,13 @@ extract_short_options()
 extract_long_options()
 {
     sed -n '/Usage:/,$p'  | \
-    sed -n 's/\(^  --[[:alnum:]][<>[:alnum:]_-]*\).*/\1/p'
+    sed -n 's/\(^  --[[:alnum:]][<>[[:alnum:]]_-]*\).*/\1/p'
 }
 
 extract_debug_options()
 {
     sed -n '/Usage:/,$p'  | \
-    sed -n 's/\(^  --_[<>[:alnum:]_-]*\).*/\1/p'
+    sed -n 's/\(^  --_[<>[[:alnum:]]_-]*\).*/\1/p'
 }
 
 


### PR DESCRIPTION
I was seeing the following test failure when building the
universal-ctags-git AUR package:

```
Testing nolang-modeline-emacs-firstline1 as C               passed
stdout                                                      passed
stderr                                                      Testing nolang-modeline-vim0 as C                           failed (diff: /home/user/.cache/pacaur/universal-ctags-git/src/ctags/Tmain/sorted-help-message.d/stderr-diff.txt)
exit                                                        passed
```

The stderr-actual.txt file:

```
@@ -1,2 +0,0 @@
-sed: character class syntax is [[:space:]], not [:space:]
-sed: character class syntax is [[:space:]], not [:space:]
```

I've tried to reproduce it in my universal-ctags clone/checkout, but
there this test passed?!
It might be related to some special environment variable that is being
set during package builds, which makes `sed` more strict?!

I have `sed (GNU sed) 4.3` installed.