### PR TITLE
tests: use --options=NONE with more tests

### DIFF
--- a/Tmain/interactive-mode.d/run.sh
+++ b/Tmain/interactive-mode.d/run.sh
@@ -12,6 +12,8 @@ s()
 	sed -e s/':"'/': "'/g
 }
 
+CTAGS="$CTAGS --options=NONE"
+
 echo identification message on startup
 echo =======================================
 ${CTAGS} --_interactive < /dev/null |s

--- a/Tmain/output-input-field-with-no-escape.d/run.sh
+++ b/Tmain/output-input-field-with-no-escape.d/run.sh
@@ -12,9 +12,9 @@ if ! ( echo '#define foo' > 'a\b.c' ) 2> /dev/null; then
 fi
 
 echo '# u-ctags'
-${CTAGS} --pseudo-tags=TAG_OUTPUT_MODE --extra=+p --output-format=u-ctags -o - 'a\b.c'
+${CTAGS} --options=NONE --pseudo-tags=TAG_OUTPUT_MODE --extra=+p --output-format=u-ctags -o - 'a\b.c'
 
 echo '# e-ctags'
-${CTAGS} --pseudo-tags=TAG_OUTPUT_MODE --extra=+p --output-format=e-ctags -o - 'a\b.c'
+${CTAGS} --options=NONE --pseudo-tags=TAG_OUTPUT_MODE --extra=+p --output-format=e-ctags -o - 'a\b.c'
 
 rm 'a\b.c'


### PR DESCRIPTION
Using `--fields=+ln` in `~/.ctags` caused these tests to fail for me.