### PR TITLE
Rpmspec  n option in package directive

### DIFF
--- a/Units/simple-rpmspec.d/expected.tags
+++ b/Units/simple-rpmspec.d/expected.tags
@@ -15,3 +15,5 @@ perf_make	input.spec	/^%global perf_make make %{?_smp_mflags} -C tools\/perf -s 
 install_post	input.spec	/^%define install_post \\$/;"	kind:macro	line:28	end:35
 docs	input.spec	/^%package docs$/;"	kind:package	line:37	package:ctags
 ctags-docs	input.spec	/^%package docs$/;"	kind:package	line:37	package:ctags
+universal-ctags-devel	input.spec	/^%package -n universal-ctags-devel$/;"	kind:package	line:41	package:ctags
+ctags-universal-ctags-devel	input.spec	/^%package -n universal-ctags-devel$/;"	kind:package	line:41	package:ctags

--- a/Units/simple-rpmspec.d/input.spec
+++ b/Units/simple-rpmspec.d/input.spec
@@ -38,6 +38,10 @@ Install ctags if you are going to use your system for programming.
 %description docs
 Something must be written here.
 
+%package -n universal-ctags-devel
+%description universal-ctags-devel
+Something must be written here.
+
 %prep
 %setup -q
 

--- a/parsers/rpmspec.c
+++ b/parsers/rpmspec.c
@@ -154,7 +154,7 @@ static void found_package_cb (const char *line,
 		vString *name = vStringNew ();
 		tagEntryInfo tag;
 
-		vStringNCopyS (name, line + matches[1].start, matches[1].length);
+		vStringNCopyS (name, line + matches[2].start, matches[2].length);
 		initTagEntry (&tag, vStringValue (name), RpmSpecKinds + K_PACKAGE);
 		tag.extensionFields.scopeIndex = *(int *)userData;
 		makeTagEntry (&tag);
@@ -179,7 +179,7 @@ static void initializeRpmSpecParser (langType language)
 			  "{exclusive}", found_macro_cb, &rejecting, &undef);
 	addCallbackRegex (language, "^%global[ \t]+([A-Za-z_][A-Za-z_0-9]+)(\\([^)]+\\))?",
 			  "{exclusive}", found_macro_cb, &rejecting, &global);
-	addCallbackRegex (language, "^%package[ \t]+([A-Za-z_][A-Za-z_0-9-]+)",
+	addCallbackRegex (language, "^%package[ \t]+(-n[ \t]+)?([A-Za-z_][A-Za-z_0-9-]+)",
 			  "{exclusive}", found_package_cb, &rejecting, &package_index);
 }
 


### PR DESCRIPTION
This commit makes ctags capture `PACKAGE` in `%package -n PACKAGENAME`.
`-n` option in the line prevented ctags capturing PACKAGE.