### PR TITLE
main, buildsys: Specify -std=gnu99 in building on mingw

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -162,9 +162,7 @@ static void rememberMaxLengths (const size_t nameLength, const size_t lineLength
 
 static void addCommonPseudoTags (void)
 {
-	int i;
-
-	for (i = 0; i < PTAG_COUNT; i++)
+	for (int i = 0; i < PTAG_COUNT; i++)
 	{
 		if (isPtagCommonInParsers (i))
 			makePtagIfEnabled (i, NULL);

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -4,7 +4,7 @@ include source.mak
 
 REGEX_DEFINES = -DHAVE_REGCOMP -D__USE_GNU -Dbool=int -Dfalse=0 -Dtrue=1 -Dstrcasecmp=stricmp
 
-CFLAGS = -Wall
+CFLAGS = -Wall -std=gnu99
 DEFINES = -DWIN32 $(REGEX_DEFINES)
 INCLUDES = -I. -Imain -Ignu_regex -Ifnmatch -Iparsers
 CC = gcc


### PR DESCRIPTION
(Ideally this should be c99.)

Inspired by https://github.com/universal-ctags/ctags/pull/1281#discussion_r97571242

See what happens.