### PR TITLE
main: use eFree instead of free

### DIFF
--- a/main/parse.c
+++ b/main/parse.c
@@ -2380,7 +2380,7 @@ extern void freeEncodingResources (void)
 			if (EncodingMap [i])
 				eFree (EncodingMap [i]);
 		}
-		free(EncodingMap);
+		eFree (EncodingMap);
 	}
 	if (Option.inputEncoding)
 		eFree (Option.inputEncoding);

--- a/main/read.c
+++ b/main/read.c
@@ -260,7 +260,7 @@ static void freeLineFposMap (inputLineFposMap *lineFposMap)
 {
 	if (lineFposMap->pos)
 	{
-		free (lineFposMap->pos);
+		eFree (lineFposMap->pos);
 		lineFposMap->pos = NULL;
 		lineFposMap->count = 0;
 		lineFposMap->size = 0;

--- a/main/routines.c
+++ b/main/routines.c
@@ -582,8 +582,8 @@ extern bool isSameFile (const char *const name1, const char *const name2)
 # else
 		result = (bool) (strcmp (n1, n2) == 0);
 # endif
-		free (n1);
-		free (n2);
+		eFree (n1);
+		eFree (n2);
 	}
 #endif
 	return result;
@@ -863,7 +863,7 @@ extern char* relativeFilename (const char *file, const char *dir)
 
 	/* Add the file name relative to the common root of file and dir. */
 	strcat (res, fp + 1);
-	free (absdir);
+	eFree (absdir);
 
 	return res;
 }


### PR DESCRIPTION
A memory object allocated with xMalloc, xRealloc, or xCalloc should be
free'ed with eFree.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>