### PR TITLE
main: use long type to represent byte offsets of area in promise API

### DIFF
--- a/main/parse.c
+++ b/main/parse.c
@@ -2252,17 +2252,17 @@ static bool createTagsWithFallback1 (const langType language)
 }
 
 extern bool runParserInNarrowedInputStream (const langType language,
-					       unsigned long startLine, int startCharOffset,
-					       unsigned long endLine, int endCharOffset,
+					       unsigned long startLine, long startCharOffset,
+					       unsigned long endLine, long endCharOffset,
 					       unsigned long sourceLineOffset)
 {
 	bool tagFileResized;
 
 	verbose ("runParserInNarrowedInputStream: %s; "
 			 "file: %s, "
-			 "start(line: %lu, offset: %u, srcline: %lu)"
+			 "start(line: %lu, offset: %lu, srcline: %lu)"
 			 " - "
-			 "end(line: %lu, offset: %u)\n",
+			 "end(line: %lu, offset: %lu)\n",
 			 getLanguageName (language),
 			 getInputFileName (),
 			 startLine, startCharOffset, sourceLineOffset,

--- a/main/parse.h
+++ b/main/parse.h
@@ -210,8 +210,8 @@ extern bool doesParserRequireMemoryStream (const langType language);
 extern bool parseFile (const char *const fileName);
 extern bool parseFileWithMio (const char *const fileName, MIO *mio);
 extern bool runParserInNarrowedInputStream (const langType language,
-					       unsigned long startLine, int startCharOffset,
-					       unsigned long endLine, int endCharOffset,
+					       unsigned long startLine, long startCharOffset,
+					       unsigned long endLine, long endCharOffset,
 					       unsigned long sourceLineOffset);
 
 #ifdef HAVE_ICONV

--- a/main/promise.c
+++ b/main/promise.c
@@ -19,9 +19,9 @@
 struct promise {
 	langType lang;
 	unsigned long startLine;
-	int startCharOffset;
+	long startCharOffset;
 	unsigned long endLine;
-	int endCharOffset;
+	long endCharOffset;
 	unsigned long sourceLineOffset;
 };
 
@@ -30,8 +30,8 @@ static int promise_count;
 static int promise_allocated;
 
 int  makePromise   (const char *parser,
-		    unsigned long startLine, int startCharOffset,
-		    unsigned long endLine, int endCharOffset,
+		    unsigned long startLine, long startCharOffset,
+		    unsigned long endLine, long endCharOffset,
 		    unsigned long sourceLineOffset)
 {
 	struct promise *p;

--- a/main/promise.h
+++ b/main/promise.h
@@ -17,8 +17,8 @@
 #include "parse.h"
 
 int  makePromise   (const char *parser,
-		    unsigned long startLine, int startCharOffset,
-		    unsigned long endLine, int endCharOffset,
+		    unsigned long startLine, long startCharOffset,
+		    unsigned long endLine, long endCharOffset,
 		    unsigned long sourceLineOffset);
 bool forcePromises (void);
 void breakPromisesAfter (int promise);

--- a/main/read.c
+++ b/main/read.c
@@ -80,9 +80,9 @@ typedef struct sInputLineFposMap {
 
 typedef struct sNestedInputStreamInfo {
 	unsigned long startLine;
-	int startCharOffset;
+	long startCharOffset;
 	unsigned long endLine;
-	int endCharOffset;
+	long endCharOffset;
 } nestedInputStreamInfo;
 
 typedef struct sInputFile {
@@ -1028,8 +1028,8 @@ out:
 }
 
 extern void   pushNarrowedInputStream (const langType language,
-				       unsigned long startLine, int startCharOffset,
-				       unsigned long endLine, int endCharOffset,
+				       unsigned long startLine, long startCharOffset,
+				       unsigned long endLine, long endCharOffset,
 				       unsigned long sourceLineOffset)
 {
 	long p, q;

--- a/main/read.h
+++ b/main/read.h
@@ -108,8 +108,8 @@ extern char *readLineFromBypassSlow (vString *const vLine, unsigned long lineNum
 				     const char *pattern, long *const pSeekValue);
 
 extern void   pushNarrowedInputStream (const langType language,
-				       unsigned long startLine, int startCharOffset,
-				       unsigned long endLine, int endCharOffset,
+				       unsigned long startLine, long startCharOffset,
+				       unsigned long endLine, long endCharOffset,
 				       unsigned long sourceLineOffset);
 extern void   popNarrowedInputStream  (void);
 

--- a/parsers/html.c
+++ b/parsers/html.c
@@ -248,7 +248,7 @@ static void appendText (vString *text, vString *appendedText)
 	}
 }
 
-static bool readTagContent (tokenInfo *token, vString *text, long *line, int *lineOffset)
+static bool readTagContent (tokenInfo *token, vString *text, long *line, long *lineOffset)
 {
 	tokenType type;
 
@@ -318,9 +318,9 @@ static void readTag (tokenInfo *token, vString *text)
 		{
 			long startSourceLineNumber = getSourceLineNumber ();
 			long startLineNumber = getInputLineNumber ();
-			int startLineOffset = getInputLineOffset ();
+			long startLineOffset = getInputLineOffset ();
 			long endLineNumber;
-			int endLineOffset;
+			long endLineOffset;
 			bool tag_start2;
 
 			tag_start2 = readTagContent (token, text, &endLineNumber, &endLineOffset);


### PR DESCRIPTION
mio_seed used behind promise API expects long values.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>