### PR TITLE
[FYI] getting raw string listeral from cpreprocessor

### DIFF
--- a/Tmain/generate-anon-ids.d/input0.c
+++ b/Tmain/generate-anon-ids.d/input0.c
@@ -1,0 +1,7 @@
+struct {
+	int x;
+} X;
+
+struct {
+	int y;
+} Y;

--- a/Tmain/generate-anon-ids.d/input1.c
+++ b/Tmain/generate-anon-ids.d/input1.c
@@ -1,0 +1,7 @@
+struct {
+	int a;
+} A;
+
+struct {
+	int b;
+} B;

--- a/Tmain/generate-anon-ids.d/run.sh
+++ b/Tmain/generate-anon-ids.d/run.sh
@@ -1,0 +1,6 @@
+# Copyright: 2017 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+${CTAGS} --quiet --options=NONE -o - input0.c input1.c

--- a/Tmain/generate-anon-ids.d/stdout-expected.txt
+++ b/Tmain/generate-anon-ids.d/stdout-expected.txt
@@ -1,0 +1,12 @@
+A	input1.c	/^} A;$/;"	v	typeref:struct:__anon840121570108
+B	input1.c	/^} B;$/;"	v	typeref:struct:__anon840121570208
+X	input0.c	/^} X;$/;"	v	typeref:struct:__anon84011d160108
+Y	input0.c	/^} Y;$/;"	v	typeref:struct:__anon84011d160208
+__anon84011d160108	input0.c	/^struct {$/;"	s	file:
+__anon84011d160208	input0.c	/^struct {$/;"	s	file:
+__anon840121570108	input1.c	/^struct {$/;"	s	file:
+__anon840121570208	input1.c	/^struct {$/;"	s	file:
+a	input1.c	/^	int a;$/;"	m	struct:__anon840121570108	typeref:typename:int	file:
+b	input1.c	/^	int b;$/;"	m	struct:__anon840121570208	typeref:typename:int	file:
+x	input0.c	/^	int x;$/;"	m	struct:__anon84011d160108	typeref:typename:int	file:
+y	input0.c	/^	int y;$/;"	m	struct:__anon84011d160208	typeref:typename:int	file:

--- a/Units/parser-yacc.r/c-anon-ids.d/README
+++ b/Units/parser-yacc.r/c-anon-ids.d/README
@@ -1,0 +1,6 @@
+This test case is for verifying that anonGenerate() works expectedly
+when a parser runs twice on different areas of the same input.
+
+input.y has two C areas.
+Anonymous structs are defined in each area.
+Four different anonIds must be generateda.

--- a/Units/parser-yacc.r/c-anon-ids.d/args.ctags
+++ b/Units/parser-yacc.r/c-anon-ids.d/args.ctags
@@ -1,0 +1,4 @@
+--sort=no
+--extra=+s
+--fields=-t
+

--- a/Units/parser-yacc.r/c-anon-ids.d/expected.tags
+++ b/Units/parser-yacc.r/c-anon-ids.d/expected.tags
@@ -1,0 +1,8 @@
+__anon04bc23ae0108	input.y	/^	struct {$/;"	s	file:
+x	input.y	/^		int x, y;$/;"	m	struct:__anon04bc23ae0108	file:
+y	input.y	/^		int x, y;$/;"	m	struct:__anon04bc23ae0108	file:
+point	input.y	/^	} point;$/;"	v
+__anon04bc23ae0208	input.y	/^	struct {$/;"	s	file:
+x	input.y	/^		int x, y;$/;"	m	struct:__anon04bc23ae0208	file:
+y	input.y	/^		int x, y;$/;"	m	struct:__anon04bc23ae0208	file:
+vector	input.y	/^	} vector;$/;"	v

--- a/Units/parser-yacc.r/c-anon-ids.d/input.y
+++ b/Units/parser-yacc.r/c-anon-ids.d/input.y
@@ -1,0 +1,13 @@
+%{
+	struct {
+		int x, y;
+	} point;
+%}
+
+%%
+
+%%
+	struct {
+		int x, y;
+	} vector;
+

--- a/Units/parser-yacc.r/not-union.d/expected.tags
+++ b/Units/parser-yacc.r/not-union.d/expected.tags
@@ -14,3 +14,4 @@ yyerror	input.y	/^static void yyerror(char *s)$/;"	f	language:C	typeref:typename
 get_token_from_line	input.y	/^static char *get_token_from_line(char **ptr)$/;"	f	language:C	typeref:typename:char *	file:
 yylex	input.y	/^int yylex(void)$/;"	f	language:C	typeref:typename:int
 ssfilter_parse	input.y	/^int ssfilter_parse(struct ssfilter **f, int argc, char **argv, FILE *fp)$/;"	f	language:C	typeref:typename:int
+END	input.y	/^#define END /;"	d	language:C	file:

--- a/Units/parser-yacc.r/not-union.d/input.y
+++ b/Units/parser-yacc.r/not-union.d/input.y
@@ -284,3 +284,5 @@ int ssfilter_parse(struct ssfilter **f, int argc, char **argv, FILE *fp)
 	}
 	return 0;
 }
+#define END 1
+

--- a/main/parse.c
+++ b/main/parse.c
@@ -2747,7 +2747,7 @@ extern bool makeKindDescriptionsPseudoTags (const langType language,
 extern void anonReset (void)
 {
 	parserDefinition* lang = LanguageTable [getInputLanguage ()];
-	lang -> anonumousIdentiferId = 0;
+	lang -> anonymousIdentiferId = 0;
 }
 
 static unsigned int anonHash(const unsigned char *str)
@@ -2764,14 +2764,14 @@ static unsigned int anonHash(const unsigned char *str)
 extern void anonGenerate (vString *buffer, const char *prefix, int kind)
 {
 	parserDefinition* lang = LanguageTable [getInputLanguage ()];
-	lang -> anonumousIdentiferId ++;
+	lang -> anonymousIdentiferId ++;
 
 	char szNum[32];
 
 	vStringCopyS(buffer, prefix);
 
 	unsigned int uHash = anonHash((const unsigned char *)getInputFileName());
-	sprintf(szNum,"%08x%02x%02x",uHash,lang -> anonumousIdentiferId, kind);
+	sprintf(szNum,"%08x%02x%02x",uHash,lang -> anonymousIdentiferId, kind);
 	vStringCatS(buffer,szNum);
 }
 

--- a/main/parse.h
+++ b/main/parse.h
@@ -272,7 +272,6 @@ extern bool makeKindSeparatorsPseudoTags (const langType language,
 extern bool makeKindDescriptionsPseudoTags (const langType language,
 					       const ptagDesc *pdesc);
 
-extern void anonReset (void);
 extern void anonGenerate (vString *buffer, const char *prefix, int kind);
 
 #endif  /* CTAGS_MAIN_PARSE_H */

--- a/main/parse.h
+++ b/main/parse.h
@@ -125,7 +125,7 @@ struct sParserDefinition {
 	stringList* currentPatterns;   /* current list of file name patterns */
 	stringList* currentExtensions; /* current list of extensions */
 	stringList* currentAliases;    /* current list of aliases */
-	unsigned int anonumousIdentiferId; /* managed by anon* functions */
+	unsigned int anonymousIdentiferId; /* managed by anon* functions */
 };
 
 typedef parserDefinition* (parserDefinitionFunc) (void);

--- a/main/ptrarray.c
+++ b/main/ptrarray.c
@@ -125,6 +125,16 @@ extern bool ptrArrayHasTest (const ptrArray *const current,
 	return result;
 }
 
+static bool ptrEq (const void *ptr, void *userData)
+{
+	return (ptr == userData);
+}
+
+extern bool ptrArrayHas (const ptrArray *const current, void *ptr)
+{
+	return ptrArrayHasTest (current, ptrEq, ptr);
+}
+
 extern void ptrArrayReverse (const ptrArray *const current)
 {
 	unsigned int i, j;

--- a/main/ptrarray.h
+++ b/main/ptrarray.h
@@ -36,7 +36,6 @@ extern unsigned int ptrArrayCount (const ptrArray *const current);
 extern void* ptrArrayItem (const ptrArray *const current, const unsigned int indx);
 extern void* ptrArrayLast (const ptrArray *const current);
 extern void ptrArrayDelete (ptrArray *const current);
-extern bool ptrArrayHasInsensitive (const ptrArray *const current, const void *const ptr);
 extern bool ptrArrayHasTest (const ptrArray *const current,
 				  bool (*test)(const void *ptr, void *userData),
 				  void *userData);

--- a/main/ptrarray.h
+++ b/main/ptrarray.h
@@ -39,6 +39,7 @@ extern void ptrArrayDelete (ptrArray *const current);
 extern bool ptrArrayHasTest (const ptrArray *const current,
 				  bool (*test)(const void *ptr, void *userData),
 				  void *userData);
+extern bool ptrArrayHas (const ptrArray *const current, void *ptr);
 extern void ptrArrayReverse (const ptrArray *const current);
 extern void ptrArrayDeleteItem (ptrArray* const current, unsigned int indx);
 

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -366,7 +366,12 @@ process_token:
 
 						if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeStringConstant))
 						{
+							boolean bSwitchToC = false;
 							// assume extern "language"
+
+							if (strcmp (g_cxx.pToken->pszWord, "\"C\"") == 0
+							    && cxxParserCurrentLanguageIsCPP())
+								bSwitchToC = C;
 
 							// Strictly speaking this is a C++ only syntax.
 							// However we allow it also in C as it doesn't really hurt.

--- a/parsers/cxx/cxx_token.c
+++ b/parsers/cxx/cxx_token.c
@@ -65,7 +65,7 @@ void cxxTokenAPIInit(void)
 
 void cxxTokenAPINewFile(void)
 {
-	anonReset ();
+	/* Stub */
 }
 
 void cxxTokenAPIDone(void)

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -2209,7 +2209,6 @@ static void findJsTags (void)
 {
 	tokenInfo *const token = newToken ();
 
-	anonReset ();
 	NextToken = NULL;
 	ClassNames = stringListNew ();
 	FunctionNames = stringListNew ();

--- a/parsers/meta-cpreprocessor.h
+++ b/parsers/meta-cpreprocessor.h
@@ -75,6 +75,7 @@ extern void cppEndStatement (void);
 extern void cppUngetc (const int c);
 extern void cppUngetString(const char * string,int len);
 extern int cppGetc (void);
+extern int cppGetcFull (vString *rawData, int maxlen);
 extern int cppSkipOverCComment (void);
 
 /* notify the external parser state for the purpose of conditional

--- a/parsers/yacc.c
+++ b/parsers/yacc.c
@@ -44,7 +44,7 @@ static  void change_section (const char *line CTAGS_ATTR_UNUSED,
 	if (not_in_grammar_rules)
 	{
 		const unsigned char *tmp, *last;
-		int endCharOffset;
+		long endCharOffset;
 		unsigned long c_start;
 		unsigned long c_source_start;
 		unsigned long c_end;

--- a/parsers/yacc.c
+++ b/parsers/yacc.c
@@ -43,6 +43,8 @@ static  void change_section (const char *line CTAGS_ATTR_UNUSED,
 
 	if (not_in_grammar_rules)
 	{
+		const unsigned char *tmp, *last;
+		int endCharOffset;
 		unsigned long c_start;
 		unsigned long c_source_start;
 		unsigned long c_end;
@@ -52,12 +54,20 @@ static  void change_section (const char *line CTAGS_ATTR_UNUSED,
 		c_source_start = getSourceLineNumber();
 
 		/* Skip the lines for finding the EOF. */
-		while (readLineFromInputFile ())
-			;
+		endCharOffset = 0;
+		last = NULL;
+		while ((tmp = readLineFromInputFile ()))
+			last = tmp;
+		if (last)
+			endCharOffset = strlen ((const char *)last);
+		/* If `last' is too long, strlen returns a too large value
+		   for the positive area of `endCharOffset'. */
+		if (endCharOffset < 0)
+			endCharOffset = 0;
 
 		c_end = getInputLineNumber ();
 
-		makePromise ("C", c_start, 0, c_end, 0, c_source_start);
+		makePromise ("C", c_start, 0, c_end, endCharOffset, c_source_start);
 	}
 }
 


### PR DESCRIPTION
Related to #1299.

Information about raw string literal is needed to recognize  "C" in 

```
extern "C"
```
because there can be `extern "C++"`.
This commit adds cppGetFull for the purpose.

This commit doesn't stand alone. This can be included in the future solution for #1299.