### PR TITLE
CXX: Improve handling of C++ keywords when C++ language isn't confirmed

### DIFF
--- a/parsers/cxx/cxx_keyword.h
+++ b/parsers/cxx/cxx_keyword.h
@@ -129,12 +129,56 @@ bool cxxKeywordIsConstant(CXXKeyword eKeywordId);
 bool cxxKeywordMayBePartOfTypeName(CXXKeyword eKeywordId);
 bool cxxKeywordIsTypeRefMarker(CXXKeyword eKeywordId);
 bool cxxKeywordExcludeFromTypeNames(CXXKeyword eKeywordId);
+bool cxxKeywordIsCPPSpecific(CXXKeyword eKeywordId);
+
 
 const char * cxxKeywordName(CXXKeyword eKeywordId);
 
 // uLanguage is really CXXLanguage, but we keep it as unsigned int to avoid
 // problems with header inclusions. It works anyway.
 void cxxBuildKeywordHash(const langType eLangType,unsigned int uLanguage);
+
+// Keyword enabled/disabled state management.
+//
+// public, protected, private, class, namespace... keywords are C++ only.
+// However when parsing .h files we don't know if they belong to a C program or C++
+// one and thus for safety we parse them as C++. If our guess is wrong then the parser
+// may become confused and in some cases even bail out.
+//
+// For this reason we enable/disable the processing of certain keyword sets
+// in certain contexts.
+
+
+//
+// "public,protected,private" keywords
+//
+// In header files we disable processing of such keywords until we either figure
+// out that the file really contains C++ or we start parsing a struct/union.
+//
+// This flag is meaningful only when parsing a .h file as C++ since in C
+// public/protected/private are never keywords and we assume that .cpp files
+// have C++ content (so public/protected/private are always keywords).
+//
+// This function returns the previous state of the public/protected/private keywords
+// enabled flag so it can be easily restored.
+bool cxxKeywordEnablePublicProtectedPrivate(bool bEnableIt);
+
+//
+// "namespace"
+//
+// This is not valid inside a class/struct/union
+//
+bool cxxKeywordEnableNamespace(bool bEnableIt);
+
+//
+// "final" keyword
+//
+// This is actually special at C++ level: it's a keyword only within a specific part
+// of a class declaration. In other contexts it's not a keyword.
+void cxxKeywordEnableFinal(bool bEnableIt);
+
+// Is the specific keyword currently disabled?
+bool cxxKeywordIsDisabled(CXXKeyword eKeywordId);
 
 
 #endif //!ctags_cxx_keyword_h_

--- a/parsers/cxx/cxx_keyword.h
+++ b/parsers/cxx/cxx_keyword.h
@@ -164,13 +164,6 @@ void cxxBuildKeywordHash(const langType eLangType,unsigned int uLanguage);
 bool cxxKeywordEnablePublicProtectedPrivate(bool bEnableIt);
 
 //
-// "namespace"
-//
-// This is not valid inside a class/struct/union
-//
-bool cxxKeywordEnableNamespace(bool bEnableIt);
-
-//
 // "final" keyword
 //
 // This is actually special at C++ level: it's a keyword only within a specific part

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -297,25 +297,10 @@ typedef struct _CXXParserState
 	// Please note that the keywords appearing inside a () subchain are NOT marked.
 	unsigned int uKeywordState;
 
-	// This is used to handle the special case of "final" which is a keyword
-	// in class/struct/union declarations but not anywhere else
-	bool bParsingClassStructOrUnionDeclaration;
-
-	// public, protected and private keywords are C++ only.
-	// However when parsing .h files we don't know if they belong to
-	// a C program or C++ one and thus for safety we parse them as C++.
-	// If our guess is wrong then we might discard certain variable
-	// declarations thinking that they're composed of keywords.
-	//
-	// For public, protected, and private keywords we can try the following trick.
-	//
-	// In header files we disable processing of such keywords until we either figure
-	// out that the file really contains C++ or we start parsing a struct/union.
-	//
-	// This flag is meaningful only when parsing a .h file as C++ since in C
-	// public/protected/private are never keywords and we assume that .cpp files
-	// have C++ content (so public/protected/private are always keywords).
-	bool bEnablePublicProtectedPrivateKeywords;
+	// This is set to true when we're parsing a *.cpp file (cpp extension!)
+	// or we're parsing a header but we have encountered valid C++ constructs that
+	// definitely confirm we're parsing C++.
+	bool bConfirmedCPPLanguage;
 
 } CXXParserState;
 

--- a/parsers/cxx/cxx_parser_namespace.c
+++ b/parsers/cxx/cxx_parser_namespace.c
@@ -284,6 +284,14 @@ bool cxxParserParseNamespace(void)
 			"Should have an opening bracket here!"
 		);
 
+	if(!g_cxx.bConfirmedCPPLanguage)
+	{
+		CXX_DEBUG_PRINT(
+				"Succeeded in parsing a C++ namespace: this really seems to be C++"
+			);
+		g_cxx.bConfirmedCPPLanguage = true;
+	}
+
 	// Here we certainly got an opening bracket: namespace block
 
 	if(!cxxParserParseBlock(true))

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -1167,19 +1167,7 @@ bool cxxParserParseNextToken(void)
 		int iCXXKeyword = lookupKeyword(t->pszWord->buffer,g_cxx.eLangType);
 		if(iCXXKeyword >= 0)
 		{
-			if(
-					(
-						(iCXXKeyword == CXXKeywordFINAL) &&
-						(!g_cxx.bParsingClassStructOrUnionDeclaration)
-					) || (
-						(
-							(iCXXKeyword == CXXKeywordPUBLIC) ||
-							(iCXXKeyword == CXXKeywordPROTECTED) ||
-							(iCXXKeyword == CXXKeywordPRIVATE)
-						) &&
-						(!g_cxx.bEnablePublicProtectedPrivateKeywords)
-					)
-				)
+			if(cxxKeywordIsDisabled((CXXKeyword)iCXXKeyword))
 			{
 				t->eType = CXXTokenTypeIdentifier;
 			} else {

--- a/parsers/cxx/cxx_parser_typedef.c
+++ b/parsers/cxx/cxx_parser_typedef.c
@@ -287,6 +287,7 @@ skip_to_comma_or_end:
 			// then we might try to look for a C++ identifier here.
 			if(
 				cxxParserCurrentLanguageIsCPP() &&
+				(!g_cxx.bConfirmedCPPLanguage) &&
 				cxxTokenTypeIs(pLookupStart,CXXTokenTypeKeyword) &&
 				cxxKeywordIsCPPSpecific(pLookupStart->eKeyword)
 			)

--- a/parsers/cxx/cxx_parser_typedef.c
+++ b/parsers/cxx/cxx_parser_typedef.c
@@ -257,6 +257,7 @@ skip_to_comma_or_end:
 		// Now look for the identifier
 		//
 		CXXTokenChain * pTParentChain;
+		CXXToken * pLookupStart = t;
 
 		if(cxxTokenTypeIs(t,CXXTokenTypeIdentifier))
 		{
@@ -281,8 +282,25 @@ skip_to_comma_or_end:
 
 		if(!t)
 		{
-			CXX_DEBUG_LEAVE_TEXT("Didn't find an identifier: something nasty is going on");
-			return;
+			// Not found yet.
+			// If we're in C++ mode but we haven't confirmed that the language is really C++
+			// then we might try to look for a C++ identifier here.
+			if(
+				cxxParserCurrentLanguageIsCPP() &&
+				cxxTokenTypeIs(pLookupStart,CXXTokenTypeKeyword) &&
+				cxxKeywordIsCPPSpecific(pLookupStart->eKeyword)
+			)
+			{
+				// treat as identifier
+				pLookupStart->eType = CXXTokenTypeIdentifier;
+				t = pLookupStart;
+			}
+
+			if(!t)
+			{
+				CXX_DEBUG_LEAVE_TEXT("Didn't find an identifier: something nasty is going on");
+				return;
+			}
 		}
 
 		tagEntryInfo * tag = cxxTagBegin(CXXTagKindTYPEDEF,t);

--- a/parsers/cxx/cxx_parser_using.c
+++ b/parsers/cxx/cxx_parser_using.c
@@ -153,6 +153,14 @@ bool cxxParserParseUsingClause(void)
 		}
 	}
 
+	if(!g_cxx.bConfirmedCPPLanguage)
+	{
+		CXX_DEBUG_PRINT(
+				"Succeeded in parsing C++ using: this really seems to be C++"
+			);
+		g_cxx.bConfirmedCPPLanguage = true;
+	}
+
 	CXX_DEBUG_LEAVE();
 	return true;
 }


### PR DESCRIPTION
Try to handle C++ keywords as identifiers when they are found in unexpected places and C++ language isn't confirmed yet (as happens in headers).

Fixes #1299 .