### PR TITLE
main, refactor: rename truncateLine field of tagEntryInfo

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -710,7 +710,7 @@ extern char *readLineFromBypassAnyway (vString *const vLine, const tagEntryInfo 
 /*  Truncates the text line containing the tag at the character following the
  *  tag, providing a character which designates the end of the tag.
  */
-extern void truncateTagLine (
+extern void truncateTagLineAfterTag (
 		char *const line, const char *const token, const bool discardNewline)
 {
 	char *p = strstr (line, token);
@@ -822,21 +822,21 @@ static int   makePatternStringCommon (const tagEntryInfo *const tag,
 	static vString *cached_pattern;
 	static MIOPos   cached_location;
 	if (TagFile.patternCacheValid
-	    && (! tag->truncateLine)
+	    && (! tag->truncateLineAfterTag)
 	    && (memcmp (&tag->filePosition, &cached_location, sizeof(MIOPos)) == 0))
 		return puts_func (vStringValue (cached_pattern), output);
 
 	line = readLineFromBypass (TagFile.vLine, tag->filePosition, NULL);
 	if (line == NULL)
 		error (FATAL, "could not read tag line from %s at line %lu", getInputFileName (),tag->lineNumber);
-	if (tag->truncateLine)
-		truncateTagLine (line, tag->name, false);
+	if (tag->truncateLineAfterTag)
+		truncateTagLineAfterTag (line, tag->name, false);
 
 	line_len = strlen (line);
 	searchChar = Option.backward ? '?' : '/';
 	terminator = (bool) (line [line_len - 1] == '\n') ? "$": "";
 
-	if (!tag->truncateLine)
+	if (!tag->truncateLineAfterTag)
 	{
 		making_cache = true;
 		cached_pattern = vStringNewOrClear (cached_pattern);

--- a/main/entry.h
+++ b/main/entry.h
@@ -44,7 +44,7 @@ struct sTagEntryInfo {
 	unsigned int lineNumberEntry:1;  /* pattern or line number entry */
 	unsigned int isFileScope    :1;  /* is tag visible only within input file? */
 	unsigned int isFileEntry    :1;  /* is this just an entry for a file name? */
-	unsigned int truncateLine   :1;  /* truncate tag line at end of tag name? */
+	unsigned int truncateLineAfterTag :1;  /* truncate tag line at end of tag name? */
 	unsigned int placeholder    :1;	 /* This is just a part of scope context.
 					    Put this entry to cork queue but
 					    don't print it to tags file. */

--- a/main/writer-etags.c
+++ b/main/writer-etags.c
@@ -99,8 +99,8 @@ static int writeEtagsEntry (tagWriter *writer,
 
 		len = strlen (line);
 
-		if (tag->truncateLine)
-			truncateTagLine (line, tag->name, true);
+		if (tag->truncateLineAfterTag)
+			truncateTagLineAfterTag (line, tag->name, true);
 		else
 			line [len - 1] = '\0';
 

--- a/main/writer.h
+++ b/main/writer.h
@@ -66,7 +66,7 @@ extern void writerBuildFqTagCache (tagEntryInfo *const tag);
 
 extern bool outputFormatUsedStdoutByDefault (void);
 
-extern void truncateTagLine (char *const line, const char *const token,
+extern void truncateTagLineAfterTag (char *const line, const char *const token,
 			     const bool discardNewline);
 extern void abort_if_ferror(MIO *const fp);
 

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -594,7 +594,7 @@ static int makeDefineTag (const char *const name, const char* const signature, b
 		e.isFileScope  = isFileScope;
 		if (isFileScope)
 			markTagExtraBit (&e, XTAG_FILE_SCOPE);
-		e.truncateLine = true;
+		e.truncateLineAfterTag = true;
 		e.extensionFields.signature = signature;
 
 		r = makeTagEntry (&e);
@@ -633,7 +633,7 @@ static void makeIncludeTag (const  char *const name, bool systemHeader)
 
 		initRefTagEntry (&e, name, Cpp.headerKind, role_index);
 		e.isFileScope  = false;
-		e.truncateLine = true;
+		e.truncateLineAfterTag = true;
 		makeTagEntry (&e);
 
 		if (doesCPreProRunAsStandaloneParser ())

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -528,7 +528,7 @@ static void makeFortranTag (tokenInfo *const token, tagType tag)
 		e.isFileScope	= isFileScope (token->tag);
 		if (e.isFileScope)
 			markTagExtraBit (&e, XTAG_FILE_SCOPE);
-		e.truncateLine	= (bool) (token->tag != TAG_LABEL);
+		e.truncateLineAfterTag = (bool) (token->tag != TAG_LABEL);
 
 		if (ancestorCount () > 0)
 		{


### PR DESCRIPTION
For handing too long source input lines, Universal ctags
has been extend the way to trancate them. As the result
the field name, truncateLine in tagEntryInfo struct is
too ambiguous to know what happens if it is true.

This commit rename it to truncateLineAfterTag to represnet
the intent of the field.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>