### PR TITLE
main: add _multiline to the output of --list-regex-flags option

### DIFF
--- a/main/lregex.c
+++ b/main/lregex.c
@@ -411,7 +411,7 @@ static void pre_ptrn_flag_multiline_long (const char* const s CTAGS_ATTR_UNUSED,
 static flagDefinition multilinePtrnFlagDef[] = {
 #define EXPERIMENTAL "_"
 	{ '\0',  EXPERIMENTAL "multiline", NULL, pre_ptrn_flag_multiline_long ,
-	  NULL, "match in muletline mode. cannot combine with scope, placeholder, and exclusive"},
+	  NULL, "match in muletline mode. cannot be combined with scope, placeholder, and exclusive"},
 };
 
 
@@ -1166,6 +1166,7 @@ extern void printRegexFlags (void)
 	flagPrintHelp (regexFlagDefs,  ARRAY_SIZE (regexFlagDefs));
 	flagPrintHelp (prePtrnFlagDef, ARRAY_SIZE (prePtrnFlagDef));
 	flagPrintHelp (scopePtrnFlagDef, ARRAY_SIZE (scopePtrnFlagDef));
+	flagPrintHelp (multilinePtrnFlagDef, ARRAY_SIZE (multilinePtrnFlagDef));
 }
 
 extern void freeRegexResources (void)


### PR DESCRIPTION
This was missed when _multiline flag was introduced.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>