### PR TITLE
Cxx: handle struct var with initializer

### DIFF
--- a/Units/parser-c.r/c-struct-var-with-initializer.d/args.ctags
+++ b/Units/parser-c.r/c-struct-var-with-initializer.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--kinds-c=+lz
+--fields=+K

--- a/Units/parser-c.r/c-struct-var-with-initializer.d/expected.tags
+++ b/Units/parser-c.r/c-struct-var-with-initializer.d/expected.tags
@@ -1,0 +1,10 @@
+__anon61565e570108	input.c	/^struct {$/;"	struct	file:
+a	input.c	/^  int a;$/;"	member	struct:__anon61565e570108	typeref:typename:int	file:
+b	input.c	/^} b = { 1 };$/;"	variable	typeref:struct:__anon61565e570108
+c	input.c	/^int c;$/;"	variable	typeref:typename:int
+d	input.c	/^int d(int e) {$/;"	function	typeref:typename:int
+e	input.c	/^int d(int e) {$/;"	parameter	function:d	typeref:typename:int	file:
+__anon61565e570208	input.c	/^  struct {$/;"	struct	function:d	file:
+f	input.c	/^    int f;$/;"	member	struct:d::__anon61565e570208	typeref:typename:int	file:
+g	input.c	/^  } g = { 1 };$/;"	local	function:d	typeref:struct:d::__anon61565e570208	file:
+h	input.c	/^  int h;$/;"	local	function:d	typeref:typename:int	file:

--- a/Units/parser-c.r/c-struct-var-with-initializer.d/input.c
+++ b/Units/parser-c.r/c-struct-var-with-initializer.d/input.c
@@ -1,0 +1,15 @@
+/* Derived from an issue (#1311) opened by BodoStroesser */
+
+struct {
+  int a;
+} b = { 1 };
+
+int c;
+
+int d(int e) {
+  struct {
+    int f;
+  } g = { 1 };
+  int h;
+  g = (typeof(g)){ 2 };
+}


### PR DESCRIPTION
Close #1311.

Though s in

    struct {
      int h;
    } s ;

was tagged well,

s in

    struct {
      int h;
    } s = { 1 };

was not.

This commit makes ctags recognize `=' (CXXTokenTypeAssignment)
as the end marker of struct variable; an expression after the
marker is just skipped.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>