### PR TITLE
CXX: K&R-style functions with enum/struct/union variables in the signature

### DIFF
--- a/Units/parser-cxx.r/k-and-r.d/args.ctags
+++ b/Units/parser-cxx.r/k-and-r.d/args.ctags
@@ -1,0 +1,2 @@
+--kinds-c=*
+--sort=no

--- a/Units/parser-cxx.r/k-and-r.d/expected.tags
+++ b/Units/parser-cxx.r/k-and-r.d/expected.tags
@@ -1,0 +1,48 @@
+f00	input.c	/^void f00(a00) int  a00; {}$/;"	f
+a00	input.c	/^void f00(a00) int  a00; {}$/;"	z	function:f00	typeref:typename:int	file:
+f01	input.c	/^void f01(a01) int *a01; {}$/;"	f
+a01	input.c	/^void f01(a01) int *a01; {}$/;"	z	function:f01	typeref:typename:int *	file:
+f10	input.c	/^void f10(a10) struct file *a10; {}$/;"	f
+a10	input.c	/^void f10(a10) struct file *a10; {}$/;"	z	function:f10	typeref:struct:file *	file:
+f11	input.c	/^void f11(a11, a12) struct file *a11; int a12; {}$/;"	f
+a11	input.c	/^void f11(a11, a12) struct file *a11; int a12; {}$/;"	z	function:f11	typeref:struct:file *	file:
+a12	input.c	/^void f11(a11, a12) struct file *a11; int a12; {}$/;"	z	function:f11	typeref:typename:int	file:
+f12	input.c	/^void f12(a13, a14) int a13; struct file *a14; {}$/;"	f
+a13	input.c	/^void f12(a13, a14) int a13; struct file *a14; {}$/;"	z	function:f12	typeref:typename:int	file:
+a14	input.c	/^void f12(a13, a14) int a13; struct file *a14; {}$/;"	z	function:f12	typeref:struct:file *	file:
+f13	input.c	/^void f13(a15) register struct file *a15; {}$/;"	f
+a15	input.c	/^void f13(a15) register struct file *a15; {}$/;"	z	function:f13	typeref:typename:register struct file *	file:
+f14	input.c	/^void f14(a16, a17) register struct file *a16; int a17; {}$/;"	f
+a16	input.c	/^void f14(a16, a17) register struct file *a16; int a17; {}$/;"	z	function:f14	typeref:typename:register struct file *	file:
+a17	input.c	/^void f14(a16, a17) register struct file *a16; int a17; {}$/;"	z	function:f14	typeref:typename:int	file:
+f15	input.c	/^void f15(a18, a19) register int a18; struct file *a19; {}$/;"	f
+a18	input.c	/^void f15(a18, a19) register int a18; struct file *a19; {}$/;"	z	function:f15	typeref:typename:register int	file:
+a19	input.c	/^void f15(a18, a19) register int a18; struct file *a19; {}$/;"	z	function:f15	typeref:struct:file *	file:
+f16	input.c	/^void f16(a19_1) const struct file *a19_1; {}$/;"	f
+a19_1	input.c	/^void f16(a19_1) const struct file *a19_1; {}$/;"	z	function:f16	typeref:typename:const struct file *	file:
+f17	input.c	/^void f17(a19_2, a19_3) const struct file *a19_2; int a19_3; {}$/;"	f
+a19_2	input.c	/^void f17(a19_2, a19_3) const struct file *a19_2; int a19_3; {}$/;"	z	function:f17	typeref:typename:const struct file *	file:
+a19_3	input.c	/^void f17(a19_2, a19_3) const struct file *a19_2; int a19_3; {}$/;"	z	function:f17	typeref:typename:int	file:
+f18	input.c	/^void f18(a19_4, a19_5) const int a19_4; struct file *a19_5; {}$/;"	f
+a19_4	input.c	/^void f18(a19_4, a19_5) const int a19_4; struct file *a19_5; {}$/;"	z	function:f18	typeref:typename:const int	file:
+a19_5	input.c	/^void f18(a19_4, a19_5) const int a19_4; struct file *a19_5; {}$/;"	z	function:f18	typeref:struct:file *	file:
+f20	input.c	/^void f20(a20) union file *a20; {}$/;"	f
+a20	input.c	/^void f20(a20) union file *a20; {}$/;"	z	function:f20	typeref:union:file *	file:
+f21	input.c	/^void f21(a21, a22) union file *a21; int a22; {}$/;"	f
+a21	input.c	/^void f21(a21, a22) union file *a21; int a22; {}$/;"	z	function:f21	typeref:union:file *	file:
+a22	input.c	/^void f21(a21, a22) union file *a21; int a22; {}$/;"	z	function:f21	typeref:typename:int	file:
+f22	input.c	/^void f22(a23, a24) int a23; union file *a24; {}$/;"	f
+a23	input.c	/^void f22(a23, a24) int a23; union file *a24; {}$/;"	z	function:f22	typeref:typename:int	file:
+a24	input.c	/^void f22(a23, a24) int a23; union file *a24; {}$/;"	z	function:f22	typeref:union:file *	file:
+f30	input.c	/^void f30(a30) enum file *a30; {}$/;"	f
+a30	input.c	/^void f30(a30) enum file *a30; {}$/;"	z	function:f30	typeref:enum:file *	file:
+f31	input.c	/^void f31(a31, a32) enum file *a31; int a32; {}$/;"	f
+a31	input.c	/^void f31(a31, a32) enum file *a31; int a32; {}$/;"	z	function:f31	typeref:enum:file *	file:
+a32	input.c	/^void f31(a31, a32) enum file *a31; int a32; {}$/;"	z	function:f31	typeref:typename:int	file:
+f32	input.c	/^void f32(a33, a34) int a33; enum file *a34; {}$/;"	f
+a33	input.c	/^void f32(a33, a34) int a33; enum file *a34; {}$/;"	z	function:f32	typeref:typename:int	file:
+a34	input.c	/^void f32(a33, a34) int a33; enum file *a34; {}$/;"	z	function:f32	typeref:enum:file *	file:
+f40	input.c	/^void f40 (a41, a42, a43) struct file a41;  union file a42; enum file a43; {}$/;"	f
+a41	input.c	/^void f40 (a41, a42, a43) struct file a41;  union file a42; enum file a43; {}$/;"	z	function:f40	typeref:struct:file	file:
+a42	input.c	/^void f40 (a41, a42, a43) struct file a41;  union file a42; enum file a43; {}$/;"	z	function:f40	typeref:union:file	file:
+a43	input.c	/^void f40 (a41, a42, a43) struct file a41;  union file a42; enum file a43; {}$/;"	z	function:f40	typeref:enum:file	file:

--- a/Units/parser-cxx.r/k-and-r.d/input.c
+++ b/Units/parser-cxx.r/k-and-r.d/input.c
@@ -1,0 +1,28 @@
+void f00(a00) int  a00; {}
+void f01(a01) int *a01; {}
+
+/* struct */
+void f10(a10) struct file *a10; {}
+void f11(a11, a12) struct file *a11; int a12; {}
+void f12(a13, a14) int a13; struct file *a14; {}
+
+void f13(a15) register struct file *a15; {}
+void f14(a16, a17) register struct file *a16; int a17; {}
+void f15(a18, a19) register int a18; struct file *a19; {}
+
+void f16(a19_1) const struct file *a19_1; {}
+void f17(a19_2, a19_3) const struct file *a19_2; int a19_3; {}
+void f18(a19_4, a19_5) const int a19_4; struct file *a19_5; {}
+
+/* union */
+void f20(a20) union file *a20; {}
+void f21(a21, a22) union file *a21; int a22; {}
+void f22(a23, a24) int a23; union file *a24; {}
+
+/* enum */
+void f30(a30) enum file *a30; {}
+void f31(a31, a32) enum file *a31; int a32; {}
+void f32(a33, a34) int a33; enum file *a34; {}
+
+/* struct union enum */
+void f40 (a41, a42, a43) struct file a41;  union file a42; enum file a43; {}

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -346,10 +346,10 @@ void cxxParserMarkEndLineForTagInCorkQueue(int iCorkQueueIndex)
 
 // Make sure that the token chain contains only the specified keyword and eventually
 // the "const" or "volatile" type modifiers.
-static void cxxParserCleanupEnumStructClassOrUnionPrefixChain(CXXKeyword eKeyword)
+static void cxxParserCleanupEnumStructClassOrUnionPrefixChain(CXXKeyword eKeyword,CXXToken * pLastToken)
 {
 	CXXToken * pToken = cxxTokenChainFirst(g_cxx.pTokenChain);
-	while(pToken)
+	while(pToken && (pToken != pLastToken))
 	{
 		if(
 				cxxTokenTypeIs(pToken,CXXTokenTypeKeyword) &&
@@ -474,9 +474,8 @@ bool cxxParserParseEnum(void)
 	CXX_DEBUG_ENTER();
 
 	unsigned int uInitialKeywordState = g_cxx.uKeywordState;
-
-	if(g_cxx.pTokenChain->iCount > 1)
-		cxxParserCleanupEnumStructClassOrUnionPrefixChain(CXXKeywordENUM);
+	int iInitialTokenCount = g_cxx.pTokenChain->iCount;
+	CXXToken * pLastToken = cxxTokenChainLast(g_cxx.pTokenChain);
 
 	/*
 		Spec is:
@@ -552,6 +551,44 @@ bool cxxParserParseEnum(void)
 		CXX_DEBUG_LEAVE_TEXT("Probably a function declaration!");
 		return true;
 	}
+
+	// If we have found a semicolon then we might be in the special case of KnR function
+	// declaration. This requires at least 5 tokens and has some additional constraints.
+	// See cxxParserMaybeParseKnRStyleFunctionDefinition() for more informations.
+	if(
+			// found semicolon
+			cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeSemicolon) &&
+			// many tokens before the enum keyword
+			(iInitialTokenCount > 3) &&
+			// C language
+			cxxParserCurrentLanguageIsC() &&
+			// global scope
+			cxxScopeIsGlobal() &&
+			// no typedef
+			(!(uInitialKeywordState & CXXParserKeywordStateSeenTypedef))
+		)
+	{
+		CXX_DEBUG_PRINT("Maybe KnR funciton definition");
+
+		switch(cxxParserMaybeParseKnRStyleFunctionDefinition())
+		{
+			case 1:
+				// parser moved forward and started a new statement
+				CXX_DEBUG_LEAVE_TEXT("K&R parser did the job");
+				return true;
+			break;
+			case 0:
+				// something else, go ahead
+			break;
+			default:
+				CXX_DEBUG_LEAVE_TEXT("Failed to check for K&R style function definition");
+				return false;
+			break;
+		}
+	}
+
+	if(iInitialTokenCount > 1)
+		cxxParserCleanupEnumStructClassOrUnionPrefixChain(CXXKeywordENUM,pLastToken);
 
 	if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeSemicolon))
 	{
@@ -770,9 +807,8 @@ static bool cxxParserParseClassStructOrUnionInternal(
 	CXX_DEBUG_ENTER();
 
 	unsigned int uInitialKeywordState = g_cxx.uKeywordState;
-
-	if(g_cxx.pTokenChain->iCount > 1)
-		cxxParserCleanupEnumStructClassOrUnionPrefixChain(eKeyword);
+	int iInitialTokenCount = g_cxx.pTokenChain->iCount;
+	CXXToken * pLastToken = cxxTokenChainLast(g_cxx.pTokenChain);
 
 	/*
 		Spec is:
@@ -855,6 +891,45 @@ static bool cxxParserParseClassStructOrUnionInternal(
 		CXX_DEBUG_LEAVE_TEXT("Probably a function declaration!");
 		return true;
 	}
+
+	// If we have found a semicolon then we might be in the special case of KnR function
+	// declaration. This requires at least 5 tokens and has some additional constraints.
+	// See cxxParserMaybeParseKnRStyleFunctionDefinition() for more informations.
+	// FIXME: This block is duplicated in enum
+	if(
+			// found semicolon
+			cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeSemicolon) &&
+			// many tokens before the enum keyword
+			(iInitialTokenCount > 3) &&
+			// C language
+			cxxParserCurrentLanguageIsC() &&
+			// global scope
+			cxxScopeIsGlobal() &&
+			// no typedef
+			(!(uInitialKeywordState & CXXParserKeywordStateSeenTypedef))
+		)
+	{
+		CXX_DEBUG_PRINT("Maybe KnR funciton definition?");
+
+		switch(cxxParserMaybeParseKnRStyleFunctionDefinition())
+		{
+			case 1:
+				// parser moved forward and started a new statement
+				CXX_DEBUG_LEAVE_TEXT("K&R function definition parser did the job");
+				return true;
+			break;
+			case 0:
+				// something else, go ahead
+			break;
+			default:
+				CXX_DEBUG_LEAVE_TEXT("Failed to check for K&R style function definition");
+				return false;
+			break;
+		}
+	}
+
+	if(iInitialTokenCount > 1)
+		cxxParserCleanupEnumStructClassOrUnionPrefixChain(eKeyword,pLastToken);
 
 	// FIXME: This block is duplicated in enum
 	if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeSemicolon))

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -481,7 +481,7 @@ process_token:
 			case CXXTokenTypeSemicolon:
 			{
 				if(
-						(g_cxx.eLangType == g_cxx.eCLangType) &&
+						(cxxParserCurrentLanguageIsC()) &&
 						cxxScopeIsGlobal() &&
 						(!(g_cxx.uKeywordState & CXXParserKeywordStateSeenExtern)) &&
 						(!(g_cxx.uKeywordState & CXXParserKeywordStateSeenTypedef))
@@ -493,20 +493,10 @@ process_token:
 					//  type whatever fname(par1,par2) int par1; int par2; {
 					//                                        ^
 					//
-					int iCorkQueueIndex = CORK_NIL;
-					switch(cxxParserMaybeExtractKnRStyleFunctionDefinition(&iCorkQueueIndex))
+					switch(cxxParserMaybeParseKnRStyleFunctionDefinition())
 					{
 						case 1:
-							// got K&R style function definition, one scope was pushed.
-							cxxParserNewStatement();
-							if(!cxxParserParseBlock(true))
-							{
-								CXX_DEBUG_LEAVE_TEXT("Failed to parse nested block");
-								return false;
-							}
-							if(iCorkQueueIndex > CORK_NIL)
-								cxxParserMarkEndLineForTagInCorkQueue(iCorkQueueIndex);
-							cxxScopePop();
+							// K&R parser did the job and started a new statement
 						break;
 						case 0:
 							// something else

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -29,10 +29,16 @@
 // C and we are in global scope.
 //
 // Try to handle the special case of C K&R style function declarations.
-// Returns -1 in case of error, 1 if a K&R style function declaration has been
-// found and parsed, 0 if no K&R style function declaration has been found.
 //
-int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
+// The possible return values are:
+//   1: The parser has moved forward, the statement has been parsed and cleared.
+//      A K&R function declaration has possibly been extracted (but not necessairly).
+//      Anyway, a new statement has been started.
+//   0: The parser has NOT moved forward and the current statement hasn't been cleared:
+//      other options may be evaluated.
+//  -1: unrecoverable error
+//
+int cxxParserMaybeParseKnRStyleFunctionDefinition()
 {
 #ifdef CXX_DO_DEBUGGING
 	vString * pChain = cxxTokenChainJoin(g_cxx.pTokenChain,NULL,0);
@@ -42,9 +48,6 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 		);
 	vStringDelete(pChain);
 #endif
-
-	if(piCorkQueueIndex)
-		*piCorkQueueIndex = CORK_NIL;
 
 	// Check if we are in the following situation:
 	//
@@ -218,6 +221,8 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 	CXXToken * aExtraParameterStarts[MAX_EXTRA_KNR_PARAMETERS];
 	int iExtraStatementsInChain = 0;
 
+	// From here we should never return 0 as the parser is going to move forward.
+
 	// Now we should have no more than iParameterCount-1 parameters before
 	// an opening bracket. There may be less declarations as each one may
 	// declare multiple variables and C89 supports the implicit "int" type rule.
@@ -240,7 +245,8 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 		{
 			cxxTokenDestroy(pIdentifier);
 			cxxTokenDestroy(pParenthesis);
-			return 0; // tolerate syntax error
+			cxxParserNewStatement();
+			return 1; // tolerate syntax error
 		}
 
 		if(iExtraStatementsInChain < MAX_EXTRA_KNR_PARAMETERS)
@@ -265,10 +271,13 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 		cxxTokenDestroy(pParenthesis);
 		// Didn't find an opening bracket.
 		// This probably wasn't a K&R style function declaration after all.
-		return 0;
+		cxxParserNewStatement();
+		return 1;
 	}
 
 	tagEntryInfo * tag = cxxTagBegin(CXXTagKindFUNCTION,pIdentifier);
+
+	int iCorkQueueIndex = CORK_NIL;
 
 	if(tag)
 	{
@@ -291,10 +300,7 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 		if(pszSignature)
 			tag->extensionFields.signature = vStringValue(pszSignature);
 
-		int iCorkQueueIndex = cxxTagCommit();
-
-		if(piCorkQueueIndex)
-			*piCorkQueueIndex = iCorkQueueIndex;
+		iCorkQueueIndex = cxxTagCommit();
 
 		if(pszSignature)
 			vStringDelete(pszSignature);
@@ -331,6 +337,18 @@ int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex)
 		}
 	}
 
+	cxxParserNewStatement();
+
+	if(!cxxParserParseBlock(true))
+	{
+		CXX_DEBUG_PRINT("Failed to parse K&R function block");
+		return -1;
+	}
+
+	if(iCorkQueueIndex > CORK_NIL)
+		cxxParserMarkEndLineForTagInCorkQueue(iCorkQueueIndex);
+
+	cxxScopePop();
 	return 1;
 }
 

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -141,7 +141,7 @@ typedef struct _CXXFunctionSignatureInfo
 
 } CXXFunctionSignatureInfo;
 
-int cxxParserMaybeExtractKnRStyleFunctionDefinition(int * piCorkQueueIndex);
+int cxxParserMaybeParseKnRStyleFunctionDefinition();
 int cxxParserExtractFunctionSignatureBeforeOpeningBracket(int * piCorkQueueIndex);
 
 #define CXX_MAX_EXTRACTED_PARAMETERS 24


### PR DESCRIPTION
Handle K&R-style functions when they have enum/struct/union variables in the signature.
Also refactor a little bit to simplify handling of K&R functions in general.
Based on masatake's patch "fix handling struct keyword in k&r parameter decls".