### PR TITLE
CXX: Handle yet one more special case of function pointers

### DIFF
--- a/Units/parser-cxx.r/functions.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/functions.cpp.d/expected.tags
@@ -16,6 +16,8 @@ f07	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	f	typer
 f07a01	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	z	function:f07	typeref:typename:int (*)(int * x1,int x2)	file:
 f08	input.cpp	/^void (*f08(void (*)(int *f08a01)))(int *)$/;"	f	typeref:typename:void (*)(int *)	signature:(void (*)(int * f08a01))	end:69
 f08a01	input.cpp	/^void (*f08(void (*)(int *f08a01)))(int *)$/;"	z	function:f08	typeref:typename:void (*)(int *)	file:
+f09	input.cpp	/^int f09(char *((*f09a01)()))$/;"	f	typeref:typename:int	signature:(char * ((* f09a01)()))	end:74
+f09a01	input.cpp	/^int f09(char *((*f09a01)()))$/;"	z	function:f09	typeref:typename:char * ((*)())	file:
 p01	input.cpp	/^int p01(int p01a01,int p01a02);$/;"	p	typeref:typename:int	file:	signature:(int p01a01,int p01a02)
 p02	input.cpp	/^unsigned short int * p02(unsigned int & p02a01,...);$/;"	p	typeref:typename:unsigned short int *	file:	signature:(unsigned int & p02a01,...)
 p03	input.cpp	/^auto p03(const int & p03a01,void * p03a02) -> const int &;$/;"	p	typeref:typename:const int &	file:	signature:(const int & p03a01,void * p03a02)
@@ -25,7 +27,7 @@ p06	input.cpp	/^		auto p06(n01::c01 && p06a01) -> type01 *;$/;"	p	namespace:n01:
 p06	input.cpp	/^auto n01::n02::p06(n01::c01 && p06a01) -> n01::n02::type01 *;$/;"	p	class:n01::n02	typeref:typename:n01::n02::type01 *	file:	signature:(n01::c01 && p06a01)
 p07	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	p	typeref:typename:unsigned int	file:	signature:(int (* p07a01)(int * x1,int x2),...)
 p08	input.cpp	/^void (*p08(void (*)(int *p08a01)))(int *);$/;"	p	typeref:typename:void (*)(int *)	file:	signature:(void (*)(int * p08a01))
-t01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t01a01)	end:75
+t01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t01a01)	end:80
 t01a01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	z	function:t01	typeref:typename:T &&	file:
-t02	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t02a01)	end:80
+t02	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t02a01)	end:85
 t02a01	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	z	function:t02	typeref:typename:T &&	file:

--- a/Units/parser-cxx.r/functions.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/functions.cpp.d/input.cpp
@@ -68,6 +68,11 @@ void (*f08(void (*)(int *f08a01)))(int *)
 	return 0;
 }
 
+int f09(char *((*f09a01)()))
+{
+	return 0;
+}
+
 // Valid function templates
 template <typename T> std::unique_ptr<T> t01(T && t01a01)
 {

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -1730,6 +1730,7 @@ bool cxxParserTokenChainLooksLikeFunctionParameterList(
 		//    type variable[..]
 		//    type variable:bits
 		//    type (*variable)(args)
+		//    type ((*variable)(args))
 		//    <anything of the above> = default <-- C++ only
 		//    ... <-- vararg
 		//
@@ -1778,6 +1779,7 @@ try_again:
 			// Either part of function pointer declaration or a very ugly variable decl
 			// Examples are:
 			//    type (*name)(args)
+			//    type ((*name)(args))
 			//    type (*name)
 			//    type (&name)
 			//    type (&name)[something]
@@ -1798,7 +1800,13 @@ try_again:
 					cxxParserTokenChainLooksLikeFunctionParameterList(
 							t->pChain,
 							NULL
-						) // args
+						) || // (args)
+					!cxxTokenChainFirstTokenNotOfType(
+							t->pChain,
+							CXXTokenTypeOpeningParenthesis |
+								CXXTokenTypeParenthesisChain |
+								CXXTokenTypeClosingParenthesis
+						) // ((whatever)(whatever))
 				)
 			)
 				goto try_again;


### PR DESCRIPTION
Handle function signatures with pointers declared as `type ((something)(something))`
Fixes #1309