### PR TITLE
Remove redundant gcc-attr.h vcxproj entry

### DIFF
--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -273,7 +273,6 @@
     <ClInclude Include="..\parsers\cxx\cxx_token_chain.h" />
     <ClInclude Include="..\main\promise.h" />
     <ClInclude Include="..\main\dependency.h" />
-    <ClInclude Include="..\main\gcc-attr.h" />
     <ClInclude Include="..\parsers\make.h" />
     <ClInclude Include="..\parsers\iniconf.h" />
     <ClInclude Include="..\parsers\m4.h" />


### PR DESCRIPTION
Fixes loading the solution in VS 2015 for me.