### PR TITLE
CXX: Handle 'typedef struct X (Y)()' and similar forms

### DIFF
--- a/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
@@ -9,6 +9,12 @@ T201	input.cpp	/^typedef int* T201;$/;"	t	typeref:typename:int *	file:
 T202	input.cpp	/^typedef const AClass* *  T202;$/;"	t	typeref:typename:const AClass **	file:
 T301	input.cpp	/^typedef int (*T301) (int &,int , AUnion *);$/;"	t	typeref:typename:int (*)(int &,int,AUnion *)	file:
 T302	input.cpp	/^typedef AClass &(* T302)(AClass &);$/;"	t	typeref:typename:AClass & (*)(AClass &)	file:
+T303	input.cpp	/^typedef struct AStruct (*T303)(struct AStruct &);$/;"	t	typeref:struct:AStruct (*)(struct AStruct &)	file:
+T304	input.cpp	/^typedef int (T304)(int);$/;"	t	typeref:typename:int ()(int)	file:
+T305	input.cpp	/^typedef struct AStruct (T305)(int);$/;"	t	typeref:struct:AStruct ()(int)	file:
+T306	input.cpp	/^typedef union AUnion & (T306)(int);$/;"	t	typeref:union:AUnion & ()(int)	file:
+T307	input.cpp	/^typedef AClass (T307)(int);$/;"	t	typeref:typename:AClass ()(int)	file:
+T308	input.cpp	/^typedef enum AEnum (T308)(int);$/;"	t	typeref:enum:AEnum ()(int)	file:
 T401	input.cpp	/^typedef int T401 [ 10];$/;"	t	typeref:typename:int[10]	file:
 T501	input.cpp	/^typedef ATemplate1<int > T501;$/;"	t	typeref:typename:ATemplate1<int>	file:
 T502	input.cpp	/^typedef ATemplate1< unsigned short int> T502;$/;"	t	typeref:typename:ATemplate1<unsigned short int>	file:

--- a/Units/parser-cxx.r/typedefs.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/typedefs.cpp.d/input.cpp
@@ -23,9 +23,15 @@ typedef enum { E2 } T103;
 typedef int* T201;
 typedef const AClass* *  T202;
 
-// function pointers
+// function pointers and functions
 typedef int (*T301) (int &,int , AUnion *);
 typedef AClass &(* T302)(AClass &);
+typedef struct AStruct (*T303)(struct AStruct &);
+typedef int (T304)(int);
+typedef struct AStruct (T305)(int);
+typedef union AUnion & (T306)(int);
+typedef AClass (T307)(int);
+typedef enum AEnum (T308)(int);
 
 // arrays
 typedef int T401 [ 10];

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -565,6 +565,11 @@ bool cxxParserParseEnum(void)
 
 	if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeParenthesisChain))
 	{
+		if(uInitialKeywordState & CXXParserKeywordStateSeenTypedef)
+		{
+			CXX_DEBUG_LEAVE_TEXT("Found parenthesis after typedef: parsing as generic typedef");
+			return cxxParserParseGenericTypedef();
+		}
 		// probably a function declaration/prototype
 		// something like enum x func()....
 		// do not clear statement
@@ -905,6 +910,11 @@ static bool cxxParserParseClassStructOrUnionInternal(
 
 	if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeParenthesisChain))
 	{
+		if(uInitialKeywordState & CXXParserKeywordStateSeenTypedef)
+		{
+			CXX_DEBUG_LEAVE_TEXT("Found parenthesis after typedef: parsing as generic typedef");
+			return cxxParserParseGenericTypedef();
+		}
 		// probably a function declaration/prototype
 		// something like struct x * func()....
 		// do not clear statement


### PR DESCRIPTION
Fixes bug #1329 