### PR TITLE
Extend foreach subparser macro

### DIFF
--- a/Tmain/list-subparsers-all.d/stdout-expected.txt
+++ b/Tmain/list-subparsers-all.d/stdout-expected.txt
@@ -1,7 +1,7 @@
 #NAME                          BASEPARSER           DIRECTION
-YumRepo                        Iniconf              sub => base
-SystemdUnit                    Iniconf              sub => base
-PythonLoggingConfig            Iniconf              sub <> base
-Autoconf                       M4                   sub <> base
-Automake                       Make                 sub => base
+YumRepo                        Iniconf              base <= sub
+SystemdUnit                    Iniconf              base <= sub
+PythonLoggingConfig            Iniconf              base <> sub
+Autoconf                       M4                   base <> sub
+Automake                       Make                 base <= sub
 RSpec                          Ruby                 base => sub

--- a/Units/parser-m4.r/m4-autoconf-and-optlib.d/README
+++ b/Units/parser-m4.r/m4-autoconf-and-optlib.d/README
@@ -1,0 +1,1 @@
+This case is inteded to be run under valgrind.

--- a/Units/parser-m4.r/m4-autoconf-and-optlib.d/args.ctags
+++ b/Units/parser-m4.r/m4-autoconf-and-optlib.d/args.ctags
@@ -1,0 +1,3 @@
+--langdef=NEWLANG{base=M4}
+--kinddef-NEWLANG=a,abc,abc def ghi
+--regex-NEWLANG=/SAMPLE (.*)/\1/a/

--- a/Units/parser-m4.r/m4-autoconf-and-optlib.d/expected.tags
+++ b/Units/parser-m4.r/m4-autoconf-and-optlib.d/expected.tags
@@ -1,0 +1,1 @@
+x	input.m4	/^define(x,1)$/;"	d

--- a/Units/parser-m4.r/m4-autoconf-and-optlib.d/input.m4
+++ b/Units/parser-m4.r/m4-autoconf-and-optlib.d/input.m4
@@ -1,0 +1,5 @@
+SAMPLE(INPUT)
+define(x,1)
+`abc'
+dnl x
+

--- a/docs/running-multi-parsers.rst
+++ b/docs/running-multi-parsers.rst
@@ -532,7 +532,7 @@ method. The macro and functions are declare in *main/subparser.h* .
 	    subparser *tmp;
 	    m4Subparser *m4found = NULL;
 
-	    foreachSubparser (tmp)
+	    foreachSubparser (tmp, false)
 	    {
 		    m4Subparser *m4tmp = (m4Subparser *)tmp;
 

--- a/main/dependency.c
+++ b/main/dependency.c
@@ -304,10 +304,10 @@ extern void printSubparsers (struct slaveControlBlock *scb, bool machinable)
 				direction = "base => sub";
 				break;
 			case SUBPARSER_SUB_RUNS_BASE:
-				direction = "sub => base";
+				direction = "base <= sub";
 				break;
 			case SUBPARSER_BI_DIRECTION:
-				direction = "sub <> base";
+				direction = "base <> sub";
 				break;
 			default:
 				direction  = "UNKNOWN(INTERNAL BUG)";

--- a/main/dependency.c
+++ b/main/dependency.c
@@ -141,7 +141,7 @@ extern void notifyInputStart (void)
 {
 	subparser *s;
 
-	foreachSubparser(s)
+	foreachSubparser(s, false)
 	{
 		if (s->inputStart)
 		{
@@ -156,7 +156,7 @@ extern void notifyInputEnd   (void)
 {
 	subparser *s;
 
-	foreachSubparser(s)
+	foreachSubparser(s, false)
 	{
 		if (s->inputEnd)
 		{

--- a/main/parse.c
+++ b/main/parse.c
@@ -2462,7 +2462,7 @@ static bool doesParserUseCork (parserDefinition *parser)
 		return true;
 
 	pushLanguage (parser->id);
-	foreachSubparser(tmp)
+	foreachSubparser(tmp, true)
 	{
 		langType t = getSubparserLanguage (tmp);
 		if (doesParserUseCork (LanguageTable[t].def))
@@ -2480,7 +2480,7 @@ static void setupLanguageSubparsersInUse (const langType language)
 	subparser *tmp;
 
 	setupSubparsersInUse ((LanguageTable + language)->slaveControlBlock);
-	foreachSubparser(tmp)
+	foreachSubparser(tmp, true)
 	{
 		langType t = getSubparserLanguage (tmp);
 		enterSubparser (tmp);
@@ -2493,7 +2493,7 @@ static subparser* teardownLanguageSubparsersInUse (const langType language)
 {
 	subparser *tmp;
 
-	foreachSubparser(tmp)
+	foreachSubparser(tmp, true)
 	{
 		langType t = getSubparserLanguage (tmp);
 		enterSubparser (tmp);
@@ -2851,7 +2851,7 @@ extern void matchLanguageMultilineRegex (const langType language, const vString*
 	subparser *tmp;
 
 	matchMultilineRegex ((LanguageTable + language)->lregexControlBlock, allLines);
-	foreachSubparser(tmp)
+	foreachSubparser(tmp, true)
 	{
 		langType t = getSubparserLanguage (tmp);
 		enterSubparser (tmp);
@@ -2868,7 +2868,7 @@ static bool lregexQueryParserAndSubparesrs (const langType language, bool (* pre
 	r = predicate ((LanguageTable + language)->lregexControlBlock);
 	if (!r)
 	{
-		foreachSubparser(tmp)
+		foreachSubparser(tmp, true)
 		{
 			langType t = getSubparserLanguage (tmp);
 			enterSubparser (tmp);
@@ -2911,7 +2911,7 @@ extern void matchLanguageRegex (const langType language, const vString* const li
 	subparser *tmp;
 
 	matchRegex ((LanguageTable + language)->lregexControlBlock, line);
-	foreachSubparser(tmp)
+	foreachSubparser(tmp, true)
 	{
 		langType t = getSubparserLanguage (tmp);
 		enterSubparser (tmp);
@@ -3263,7 +3263,8 @@ extern void applyParameter (const langType language, const char *name, const cha
 	error (FATAL, "no such parameter in %s: %s", parser->name, name);
 }
 
-extern subparser *getNextSubparser(subparser *last)
+extern subparser *getNextSubparser(subparser *last,
+								   bool includingNoneCraftedParser)
 {
 	langType lang = getInputLanguage ();
 	parserObject *parser = LanguageTable + lang;
@@ -3279,10 +3280,13 @@ extern subparser *getNextSubparser(subparser *last)
 		return r;
 
 	t = getSubparserLanguage(r);
-	if (isLanguageEnabled (t))
+	if (isLanguageEnabled (t) &&
+		(includingNoneCraftedParser
+		 || (!includingNoneCraftedParser &&
+			 ((((LanguageTable + t)->def->method) && METHOD_NOT_CRAFTED) == 0))))
 		return r;
 	else
-		return getNextSubparser (r);
+		return getNextSubparser (r, includingNoneCraftedParser);
 }
 
 extern slaveParser *getNextSlaveParser(slaveParser *last)
@@ -3342,7 +3346,7 @@ extern void scheduleRunningBaseparser (int dependencyIndex)
 
 		verbose ("scheduleRunningBaseparser %s with subparsers: ", base_name);
 		pushLanguage (base);
-		foreachSubparser(tmp)
+		foreachSubparser(tmp, true)
 		{
 			langType t = getSubparserLanguage (tmp);
 			verbose ("%s ", getLanguageName (t));

--- a/main/subparser.h
+++ b/main/subparser.h
@@ -46,10 +46,10 @@ extern void notifyInputEnd   (void);
 extern langType getSubparserLanguage (subparser *s);
 
 /* Interface for Baseparser */
-extern subparser *getNextSubparser(subparser *last);
-#define foreachSubparser(VAR)				\
+extern subparser *getNextSubparser(subparser *last, bool includingNoneCraftedParser);
+#define foreachSubparser(VAR, INCLUDING_NONE_CRAFTED_PARSER)\
 	VAR = NULL;								\
-	while ((VAR = getNextSubparser (VAR)) != NULL)
+	while ((VAR = getNextSubparser (VAR, INCLUDING_NONE_CRAFTED_PARSER)) != NULL)
 
 extern void enterSubparser(subparser *subparser);
 extern void leaveSubparser(void);

--- a/parsers/iniconf.c
+++ b/parsers/iniconf.c
@@ -48,7 +48,7 @@ static iniconfSubparser *maySwitchLanguage (const char *section, const char *key
 	iniconfSubparser *iniconf_subparser = NULL;
 	subparser *sub;
 
-	foreachSubparser (sub)
+	foreachSubparser (sub, false)
 	{
 		iniconfSubparser *s = (iniconfSubparser *)sub;
 		if ((sub->direction & SUBPARSER_BASE_RUNS_SUB)

--- a/parsers/m4.c
+++ b/parsers/m4.c
@@ -213,7 +213,7 @@ static m4Subparser * maySwitchLanguage (const char* token)
 	subparser *tmp;
 	m4Subparser *m4found = NULL;
 
-	foreachSubparser (tmp)
+	foreachSubparser (tmp, false)
 	{
 		m4Subparser *m4tmp = (m4Subparser *)tmp;
 

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -140,7 +140,7 @@ static void newMacro (vString *const name, bool with_define_directive, bool appe
 	if (!appending)
 		makeSimpleMakeTag (name, MakeKinds, K_MACRO);
 
-	foreachSubparser(s)
+	foreachSubparser(s, false)
 	{
 		makeSubparser *m = (makeSubparser *)s;
 		enterSubparser(s);
@@ -153,7 +153,7 @@ static void newMacro (vString *const name, bool with_define_directive, bool appe
 static void valueFound (vString *const name)
 {
 	subparser *s;
-	foreachSubparser(s)
+	foreachSubparser(s, false)
 	{
 		makeSubparser *m = (makeSubparser *)s;
 		enterSubparser(s);
@@ -166,7 +166,7 @@ static void valueFound (vString *const name)
 static void directiveFound (vString *const name)
 {
 	subparser *s;
-	foreachSubparser (s)
+	foreachSubparser (s, false)
 	{
 		makeSubparser *m = (makeSubparser *)s;
 		enterSubparser(s);

--- a/parsers/yaml.c
+++ b/parsers/yaml.c
@@ -138,7 +138,7 @@ static void findYamlTags (void)
 			break;
 
 		handlYamlToken (&token);
-		foreachSubparser(sub)
+		foreachSubparser(sub, false)
 		{
 			enterSubparser (sub);
 			((yamlSubparser *)sub)->newTokenNotfify ((yamlSubparser *)sub, &token);


### PR DESCRIPTION
A base parser expects subparers implement methods which the base parser
declared in *.h file. However, a subparer written in optlib isn't
satisfied the expectation. This causes a segment violation.

This commit provides the way to skip optlib based subparser in
foreachSubparser to avoid the segment violation.
