### PR TITLE
Cxx: remove `pParamInfo' from CXX_DEBUG_ASSERT in cxxParserLookForFunctionSignatureCheckParenthesisAndIdentifier()

### DIFF
--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -568,8 +568,8 @@ static bool cxxParserLookForFunctionSignatureCheckParenthesisAndIdentifier(
 	CXX_DEBUG_ENTER();
 	
 	CXX_DEBUG_ASSERT(
-			pParenthesis && pIdentifierChain && pIdentifierStart && pIdentifierEnd && pInfo && pParamInfo,
-			"All parameters must be non null here"
+			pParenthesis && pIdentifierChain && pIdentifierStart && pIdentifierEnd && pInfo,
+			"All parameters other than `pParamInfo' must be non null here"
 		);
 
 	// Even if we have found a parenthesis and proper identifier we still


### PR DESCRIPTION
With enabling tracing feature, following input didn't
satisfy an assertion:

     void x (int i);

Signed-off-by: Masatake YAMATO <yamato@redhat.com>