### PR TITLE
C improve c++ scope keywords handling in c

### DIFF
--- a/Units/parser-c.r/cxx-keywords-simple.d/args.ctags
+++ b/Units/parser-c.r/cxx-keywords-simple.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--kinds-C=+p
+--fields=+K

--- a/Units/parser-c.r/cxx-keywords-simple.d/expected.tags
+++ b/Units/parser-c.r/cxx-keywords-simple.d/expected.tags
@@ -1,0 +1,27 @@
+private	input.h	/^struct private {int x;} v24;$/;"	struct
+x	input.h	/^struct private {int x;} v24;$/;"	member	struct:private	typeref:typename:int
+v24	input.h	/^struct private {int x;} v24;$/;"	variable	typeref:struct:private
+protected	input.h	/^struct protected {int x;} v25;$/;"	struct
+x	input.h	/^struct protected {int x;} v25;$/;"	member	struct:protected	typeref:typename:int
+v25	input.h	/^struct protected {int x;} v25;$/;"	variable	typeref:struct:protected
+public	input.h	/^struct public {int x;} v26;$/;"	struct
+x	input.h	/^struct public {int x;} v26;$/;"	member	struct:public	typeref:typename:int
+v26	input.h	/^struct public {int x;} v26;$/;"	variable	typeref:struct:public
+s24	input.h	/^struct s24 {int private;} ;$/;"	struct
+private	input.h	/^struct s24 {int private;} ;$/;"	member	struct:s24	typeref:typename:int
+s25	input.h	/^struct s25 {int protected;} ;$/;"	struct
+protected	input.h	/^struct s25 {int protected;} ;$/;"	member	struct:s25	typeref:typename:int
+s26	input.h	/^struct s26 {int public;} ;$/;"	struct
+public	input.h	/^struct s26 {int public;} ;$/;"	member	struct:s26	typeref:typename:int
+private	input.h	/^typedef int private; \/* 24 *\/$/;"	typedef	typeref:typename:int
+protected	input.h	/^typedef int protected; \/* 25 *\/$/;"	typedef	typeref:typename:int
+public	input.h	/^typedef int public; \/* 26 *\/$/;"	typedef	typeref:typename:int
+v24	input.h	/^int v24, private;$/;"	variable	typeref:typename:int
+private	input.h	/^int v24, private;$/;"	variable	typeref:typename:int
+v25	input.h	/^int v25, protected;$/;"	variable	typeref:typename:int
+protected	input.h	/^int v25, protected;$/;"	variable	typeref:typename:int
+v26	input.h	/^int v26, public;$/;"	variable	typeref:typename:int
+public	input.h	/^int v26, public;$/;"	variable	typeref:typename:int
+private	input.h	/^int private (int a24);$/;"	prototype	typeref:typename:int
+protected	input.h	/^int protected (int a25);$/;"	prototype	typeref:typename:int
+public	input.h	/^int public (int a26);$/;"	prototype	typeref:typename:int

--- a/Units/parser-c.r/cxx-keywords-simple.d/input.h
+++ b/Units/parser-c.r/cxx-keywords-simple.d/input.h
@@ -1,0 +1,15 @@
+struct private {int x;} v24;
+struct protected {int x;} v25;
+struct public {int x;} v26;
+struct s24 {int private;} ;
+struct s25 {int protected;} ;
+struct s26 {int public;} ;
+typedef int private; /* 24 */
+typedef int protected; /* 25 */
+typedef int public; /* 26 */
+int v24, private;
+int v25, protected;
+int v26, public;
+int private (int a24);
+int protected (int a25);
+int public (int a26);

--- a/Units/parser-c.r/cxx-scope-keywords.d/args.ctags
+++ b/Units/parser-c.r/cxx-scope-keywords.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--kinds-C=+L
+--fields=+K

--- a/Units/parser-c.r/cxx-scope-keywords.d/expected.tags
+++ b/Units/parser-c.r/cxx-scope-keywords.d/expected.tags
@@ -1,0 +1,18 @@
+data0	input.h	/^struct data0 {$/;"	struct
+private	input.h	/^	void *private;$/;"	member	struct:data0	typeref:typename:void *
+public	input.h	/^	void *public;$/;"	member	struct:data0	typeref:typename:void *
+protected	input.h	/^	void *protected;$/;"	member	struct:data0	typeref:typename:void *
+data1	input.h	/^struct data1 {$/;"	struct
+private	input.h	/^	void *private\/* comment *\/;$/;"	member	struct:data1	typeref:typename:void *
+public	input.h	/^	void *public\/* comment$/;"	member	struct:data1	typeref:typename:void *
+protected	input.h	/^	void *protected \/* comment$/;"	member	struct:data1	typeref:typename:void *
+data2	input.h	/^struct data2 {$/;"	struct
+private	input.h	/^	void *private ;$/;"	member	struct:data2	typeref:typename:void *
+public	input.h	/^	int   public:1 ;$/;"	member	struct:data2	typeref:typename:int:1
+protected	input.h	/^	void *protected __attribute__ ((aligned (8)))  ;$/;"	member	struct:data2	typeref:typename:void *
+foo	input.h	/^void foo(void) {$/;"	function	typeref:typename:void
+private	input.h	/^private:$/;"	label	function:foo	file:
+bar	input.h	/^void bar(void) {$/;"	function	typeref:typename:void
+private	input.h	/^private :$/;"	label	function:bar	file:
+baz	input.h	/^void baz(void) {$/;"	function	typeref:typename:void
+private	input.h	/^ private\/* coment *\/:$/;"	label	function:baz	file:

--- a/Units/parser-c.r/cxx-scope-keywords.d/input.h
+++ b/Units/parser-c.r/cxx-scope-keywords.d/input.h
@@ -1,0 +1,37 @@
+struct data0 {
+	void *private;
+	void *public;
+	void *protected;
+};
+
+struct data1 {
+	void *private/* comment */;
+	void *public/* comment
+				 */ ;
+	void *protected /* comment
+					 */;
+};
+
+struct data2 {
+	void *private ;
+	int   public:1 ;
+	void *protected __attribute__ ((aligned (8)))  ;
+};
+
+void foo(void) {
+  goto private;
+private:
+  return;
+}
+
+void bar(void) {
+  goto private ;
+private :
+  return;
+}
+
+void baz(void) {
+	goto private/* comment */;
+ private/* coment */:
+  return;
+}

--- a/Units/parser-cxx.r/cxx-keywords-as-c-identifiers.b/args.ctags
+++ b/Units/parser-cxx.r/cxx-keywords-as-c-identifiers.b/args.ctags
@@ -1,3 +1,2 @@
 --sort=no
---kinds-Cxx=+px
-
+--kinds-C++=+px

--- a/misc/units
+++ b/misc/units
@@ -495,6 +495,7 @@ run_tcase ()
     local timeout_value
     local tmp
 
+    local broke_args_ctags
 
     #
     # Filtered by UNIT
@@ -510,10 +511,7 @@ run_tcase ()
     [ -f "${fargs}" ] && _CMDLINE="${_CMDLINE} --options=${fargs}"
 
     if [ -f "${fargs}" ] && ! ${_CMDLINE} --_force-quit=0 > /dev/null 2>&1; then
-	printf '%-60s' "Verifying args.ctags of ${name}"
-	run_result error '/dev/null' "broken args.ctags?"
-	L_BROKEN_ARGS_CTAGS="${L_BROKEN_ARGS_CTAGS} ${category}/${name}"
-	return 1
+	broke_args_ctags=1
     fi
 
     #
@@ -550,6 +548,10 @@ run_tcase ()
     elif [ "$WITH_TIMEOUT" = 0 ] && [ "${class}" = 'i' ]; then
 	L_SKIPPED_BY_ILOOP="$L_SKIPPED_BY_ILOOP ${category}/${name}"
 	run_result skip "${oresult}" "may cause an infinite loop"
+	return 1
+    elif [ "$broke_args_ctags" = 1 ]; then
+	run_result error '/dev/null' "broken args.ctags?"
+	L_BROKEN_ARGS_CTAGS="${L_BROKEN_ARGS_CTAGS} ${category}/${name}/"
 	return 1
     fi
 

--- a/misc/units
+++ b/misc/units
@@ -68,6 +68,7 @@ L_SKIPPED_BY_LANGUAGES=
 L_SKIPPED_BY_ILOOP=
 L_KNOWN_BUGS=
 L_FAILED_BY_TIMEED_OUT=
+L_BROKEN_ARGS_CTAGS=
 
 #
 # TODO
@@ -508,6 +509,13 @@ run_tcase ()
     _CMDLINE="${CTAGS} --verbose --options=NONE --libexec-dir=${LIBEXECDIR} --libexec-dir=+$t --data-dir=+$t -o -"
     [ -f "${fargs}" ] && _CMDLINE="${_CMDLINE} --options=${fargs}"
 
+    if [ -f "${fargs}" ] && ! ${_CMDLINE} --_force-quit=0 > /dev/null 2>&1; then
+	printf '%-60s' "Verifying args.ctags of ${name}"
+	run_result error '/dev/null' "broken args.ctags?"
+	L_BROKEN_ARGS_CTAGS="${L_BROKEN_ARGS_CTAGS} ${category}/${name}"
+	return 1
+    fi
+
     #
     # Filtered by LANGUAGES
     #
@@ -742,6 +750,12 @@ run_summary ()
 	echo "	${t#${_DEFAULT_CATEGORY}/}"
     done
 
+    printf '  %-40s' "#FAILED (broken args.ctags?):"
+    count_list $L_BROKEN_ARGS_CTAGS
+    for t in $L_BROKEN_ARGS_CTAGS; do
+	echo "	${t#${_DEFAULT_CATEGORY}/}"
+    done
+
     printf '  %-40s' "#FAILED (unexpected-exit-status):"
     count_list $L_FAILED_BY_STATUS
     for t in $L_FAILED_BY_STATUS; do
@@ -958,7 +972,10 @@ action_run ()
 
     run_summary "${build_dir}"
 
-    if [ -n "${L_FAILED_BY_STATUS}" ] || [ -n "${L_FAILED_BY_DIFF}" ] || [ -n "${L_FAILED_BY_TIMEED_OUT}" ]; then
+    if [ -n "${L_FAILED_BY_STATUS}" ] ||
+	   [ -n "${L_FAILED_BY_DIFF}" ] ||
+	   [ -n "${L_FAILED_BY_TIMEED_OUT}" ] ||
+	   [ -n "${L_BROKEN_ARGS_CTAGS}" ]; then
 	return 1
     else
 	return 0

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1231,7 +1231,7 @@ bool cxxParserParseClassStructOrUnion(
 	)
 {
 	// Trick for "smart" handling of public/protected/private keywords in .h files parsed as C++.
-	// See the declaration of bEnablePublicProtectedPrivateKeywords for more info.
+	// See the declaration of cxxKeywordEnablePublicProtectedPrivate for more info.
 
 	// Enable public/protected/private keywords and save the previous state
 	bool bEnablePublicProtectedPrivateKeywords = cxxKeywordEnablePublicProtectedPrivate(true);

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -1170,7 +1170,46 @@ bool cxxParserParseNextToken(void)
 			if(cxxKeywordIsDisabled((CXXKeyword)iCXXKeyword))
 			{
 				t->eType = CXXTokenTypeIdentifier;
+			} else if (isInputHeaderFile ()
+					   && (iCXXKeyword == CXXKeywordPUBLIC
+						   || iCXXKeyword == CXXKeywordPROTECTED
+						   || iCXXKeyword == CXXKeywordPRIVATE))
+			{
+				int c0 = g_cxx.iChar;
+
+				if (c0 == ':')
+				{
+					/* Specifying the scope of struct/union/class member */
+					goto assign_keyword;
+				}
+
+				if (isspace (c0))
+				{
+					int c1;
+
+					cxxParserSkipToNonWhiteSpace ();
+					c1 = g_cxx.iChar;
+					cppUngetc (c1);
+					g_cxx.iChar = c0;
+
+					if (c1 == ':')
+					{
+						/* Specifying the scope of struct/union/class member */
+						goto assign_keyword;
+					}
+					else if (isalpha (c1))
+					{
+
+						/* Specifying the scope of class inheritance */
+						goto assign_keyword;
+					}
+				}
+
+				t->eType = CXXTokenTypeIdentifier;
+				g_cxx.bConfirmedCPPLanguage = false;
+				cxxKeywordEnablePublicProtectedPrivate(false);
 			} else {
+			assign_keyword:
 				t->eType = CXXTokenTypeKeyword;
 				t->eKeyword = (CXXKeyword)iCXXKeyword;
 


### PR DESCRIPTION
 C: deal with C++ scope keywowrds as identifiers

In *.h file if [: \t] don't follows after protect|private|public,
deal with the token as an identifier, not a keywowrd.

TODO: The language for each tag entry is still C++. It should be C.
Signed-off-by: Masatake YAMATO <yamato@redhat.com>

