### PR TITLE
main: don't use a temporary file if possible

### DIFF
--- a/Tmain/interactive-resource-management.d/input.c
+++ b/Tmain/interactive-resource-management.d/input.c
@@ -1,0 +1,4 @@
+int
+main(void)
+{
+}

--- a/Tmain/interactive-resource-management.d/run.sh
+++ b/Tmain/interactive-resource-management.d/run.sh
@@ -1,0 +1,13 @@
+# Copyright: 2017 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+. ../utils.sh
+
+if is_feature_available ${CTAGS} json; then
+	exit_status_for_input_c $CTAGS NONE      --output-format=json -o -         --sort=no
+	exit_status_for_input_c $CTAGS tags.json --output-format=json -o tags.json --sort=no
+	exit_status_for_input_c $CTAGS tags.json --output-format=json -o tags.json
+	exit_status_for_input_c $CTAGS NONE      --output-format=json -o -
+fi

--- a/Tmain/interactive-resource-management.d/stdout-expected.txt
+++ b/Tmain/interactive-resource-management.d/stdout-expected.txt
@@ -1,0 +1,4 @@
+--output-format=json -o - --sort=no => ok
+--output-format=json -o tags.json --sort=no => ok
+--output-format=json -o tags.json => ok
+--output-format=json -o - => ok

--- a/Tmain/output-file-resource-management.d/input.c
+++ b/Tmain/output-file-resource-management.d/input.c
@@ -1,0 +1,4 @@
+int
+main(void)
+{
+}

--- a/Tmain/output-file-resource-management.d/run.sh
+++ b/Tmain/output-file-resource-management.d/run.sh
@@ -1,0 +1,21 @@
+# Copyright: 2017 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+. ../utils.sh
+
+exit_status_for_input_c $CTAGS NONE -o - --sort=no
+exit_status_for_input_c $CTAGS tags      --sort=no
+exit_status_for_input_c $CTAGS tags
+exit_status_for_input_c $CTAGS NONE -o -
+
+exit_status_for_input_c $CTAGS NONE -e -o - --sort=no
+exit_status_for_input_c $CTAGS TAGS -e      --sort=no
+exit_status_for_input_c $CTAGS TAGS -e
+exit_status_for_input_c $CTAGS NONE -e -o -
+
+exit_status_for_input_c $CTAGS NONE   -x -o -      --sort=no
+exit_status_for_input_c $CTAGS tags-x -x -o tags-x --sort=no
+exit_status_for_input_c $CTAGS tags-x -x -o tags-x
+exit_status_for_input_c $CTAGS NONE   -x -o -

--- a/Tmain/output-file-resource-management.d/stdout-expected.txt
+++ b/Tmain/output-file-resource-management.d/stdout-expected.txt
@@ -1,0 +1,12 @@
+-o - --sort=no => ok
+--sort=no => ok
+ => ok
+-o - => ok
+-e -o - --sort=no => ok
+-e --sort=no => ok
+-e => ok
+-e -o - => ok
+-x -o - --sort=no => ok
+-x -o tags-x --sort=no => ok
+-x -o tags-x => ok
+-x -o - => ok

--- a/Tmain/utils.sh
+++ b/Tmain/utils.sh
@@ -64,3 +64,26 @@ run_with_format()
     shift
     ${CTAGS} --quiet --options=NONE --output-format=$format "$@" -o - input.*
 }
+
+exit_status_for_input_c()
+{
+	local ctags=$1
+	shift
+
+	local remove_file=$1
+	shift
+
+	printf "%s => " "$*"
+	${ctags} --quiet --options=NONE "$@" input.c > /dev/null
+	local result_local=$?
+
+	if [ "$remove_file" != "none" ]; then
+		rm -f "$remove_file"
+	fi
+
+	if [ "$result_local" = 0 ]; then
+		echo "ok"
+	else
+		echo "failed"
+	fi
+}


### PR DESCRIPTION
Close #1350.

In both -o - and --sort=no is given, ctags should be able to
run without a temorary file.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>