### PR TITLE
unit: handle ../ included in input file names

### DIFF
--- a/Units/xformat-option.r/format-NlKkFnP.d/filter
+++ b/Units/xformat-option.r/format-NlKkFnP.d/filter
@@ -1,2 +1,2 @@
 #!/bin/sh
-sed -e 's|\./.*/input.m|input.m|'
+sed -e 's|\.\{1,\}/.*/input.m|input.m|'


### PR DESCRIPTION
Partially close #1348.

Input file names can include ../ with following case:

    $ mkdir objdir
    $ cd objdir
    $ ../configure --prefix=$HOME/apps/ctags --program-prefix=u_
    $ make -j4
    $ make check

The ../ causes a trouble in input file name comparison. 

Signed-off-by: Masatake YAMATO <yamato@redhat.com>