### PR TITLE
CXX: Improve macro handling

### DIFF
--- a/Units/parser-cxx.r/complex-macros.d/args.ctags
+++ b/Units/parser-cxx.r/complex-macros.d/args.ctags
@@ -11,3 +11,6 @@
 -D STRINGIFY(token)=#token
 -D IMPLEMENT_FUNCTIONS(_prefix)=void _prefix ## a(){ }; void _prefix ## b(){ };
 -D DECLARE_VARS(_prefix)=int _prefix ## a; int _prefix ## b;
+-D DECLARE_FUNCTION_4(Ret,Class,Method,...)=Ret Class##__##Method(Class *this, ##__VA_ARGS__)
+-D DECLARE_FUNCTION_4_BEGIN(...)={
+-D DECLARE_FUNCTION_4_END(...)=}

--- a/Units/parser-cxx.r/complex-macros.d/expected.tags
+++ b/Units/parser-cxx.r/complex-macros.d/expected.tags
@@ -14,6 +14,11 @@ p5a	input.cpp	/^DECLARE_TWO_VERSIONS_OF_FUNCTIONS(p5,p6)$/;"	p	typeref:typename:
 p6a	input.cpp	/^DECLARE_TWO_VERSIONS_OF_FUNCTIONS(p5,p6)$/;"	p	typeref:typename:int	file:	signature:()
 STRINGIFY	input.cpp	/^#define STRINGIFY(/;"	d	file:	signature:(token)
 test	input.cpp	/^const char * test = "" STRINGIFY(; int notVisible;);$/;"	v	typeref:typename:const char *
+DECLARE_FUNCTION_4	input.cpp	/^#define DECLARE_FUNCTION_4(/;"	d	file:	signature:(Ret,Class,Method,...)
+DECLARE_FUNCTION_4_BEGIN	input.cpp	/^#define DECLARE_FUNCTION_4_BEGIN(/;"	d	file:	signature:(...)
+DECLARE_FUNCTION_4_END	input.cpp	/^#define DECLARE_FUNCTION_4_END(/;"	d	file:	signature:(...)
+foo__bar	input.cpp	/^DECLARE_FUNCTION_4(int,foo,bar,int x)$/;"	f	typeref:typename:int	signature:(foo * this,int x)
+x	input.cpp	/^DECLARE_FUNCTION_4(int,foo,bar,int x)$/;"	z	function:foo__bar	typeref:typename:int	file:
 IMPLEMENT_FUNCTIONS	input.cpp	/^#define IMPLEMENT_FUNCTIONS(/;"	d	file:	signature:(_prefix)
 f1a	input.cpp	/^IMPLEMENT_FUNCTIONS(f1);$/;"	f	typeref:typename:void	signature:()
 f1b	input.cpp	/^IMPLEMENT_FUNCTIONS(f1);$/;"	f	typeref:typename:void	signature:()

--- a/Units/parser-cxx.r/complex-macros.d/input.cpp
+++ b/Units/parser-cxx.r/complex-macros.d/input.cpp
@@ -40,6 +40,16 @@ DECLARE_TWO_VERSIONS_OF_FUNCTIONS(p5,p6)
 
 const char * test = "" STRINGIFY(; int notVisible;);
 
+// Unbalanced brackets (this comes from a nasty example in a github issue)
+#define DECLARE_FUNCTION_4(Ret,Class,Method,...) Ret Class##__##Method(Class *this, ##__VA_ARGS__)
+#define DECLARE_FUNCTION_4_BEGIN(...) { /*not really this, but this is what ctags should see*/
+#define DECLARE_FUNCTION_4_END(...) } /*not really this, but this is what ctags should see*/
+
+// Unbalanced brackets
+DECLARE_FUNCTION_4(int,foo,bar,int x)
+DECLARE_FUNCTION_4_BEGIN({)
+DECLARE_FUNCTION_4_END(},{ /*dtors*/ })
+
 // Token pasting
 
 #define IMPLEMENT_FUNCTIONS(_prefix) \

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1555,7 +1555,7 @@ static void saveMacro(const char * macro)
 
 				CXX_DEBUG_PRINT("Check token '%.*s'",tokenLen,tokenBegin);
 
-				bool bIsVarArg = strncmp(tokenBegin,"__VA_ARGS__",tokenLen) == 0;
+				bool bIsVarArg = (tokenLen == 11) && (strncmp(tokenBegin,"__VA_ARGS__",11) == 0);
 
 				int i = 0;
 				for(;i<iParamCount;i++)

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -995,9 +995,7 @@ static bool cxxParserParseNextTokenSkipMacroParenthesis(CXXToken ** ppChain)
 	}
 
 	if(!cxxParserParseAndCondenseCurrentSubchain(
-			CXXTokenTypeOpeningParenthesis |
-				CXXTokenTypeOpeningSquareParenthesis |
-				CXXTokenTypeOpeningBracket,
+			CXXTokenTypeOpeningParenthesis,
 			false
 		))
 	{


### PR DESCRIPTION
Fix a bug in macro handling.
Support unbalanced brackets as macro parameters.
Add related unit test.
Fixes #1357