### PR TITLE
Tmain: ignore ~/.ctags when running the test cases

### DIFF
--- a/Tmain/case-insensitive-pattern.d/run.sh
+++ b/Tmain/case-insensitive-pattern.d/run.sh
@@ -7,4 +7,4 @@ CTAGS=$1
 
 exit_if_no_case_insensitive_filenames "${CTAGS}"
 
-${CTAGS} --print-language MAKEFILE
+${CTAGS} --quiet --options=NONE --print-language MAKEFILE

--- a/Tmain/kinddef.d/run.sh
+++ b/Tmain/kinddef.d/run.sh
@@ -1,7 +1,7 @@
 # Copyright: 2016 Masatake YAMATO
 # License: GPL-2
 
-CTAGS=$1
+CTAGS="$1 --quiet --options=NONE"
 
 {
 

--- a/Tmain/lxcmd-reject-specifying-in-dot-ctags.d/README
+++ b/Tmain/lxcmd-reject-specifying-in-dot-ctags.d/README
@@ -1,0 +1,3 @@
+This case depends on ~/.ctags.
+--options=NONE cannot be used in this test case.
+

--- a/Tmain/tag-relative-option-in-etags.d/run.sh
+++ b/Tmain/tag-relative-option-in-etags.d/run.sh
@@ -2,7 +2,7 @@
 # License: GPL-2
 
 CTAGS=$1
-ARGS=--quiet --options=NONE
+ARGS="--quiet --options=NONE"
 O=TAGS.TMP
 
 for x in no yes default; do

--- a/Tmain/tag-relative-option.d/run.sh
+++ b/Tmain/tag-relative-option.d/run.sh
@@ -7,7 +7,7 @@ P=$(pwd)
 
 . ../utils.sh
 
-if ! ${CTAGS} --help | grep -e --tag-relative | grep --quiet -e always; then
+if ! ${CTAGS} $O --help | grep -e --tag-relative | grep --quiet -e always; then
 	echo "--tag-relative=always|never is not available on this platform"
 	exit ${__SKIP__}
 fi

--- a/Tmain/tmain-skip-example.d/run.sh
+++ b/Tmain/tmain-skip-example.d/run.sh
@@ -1,7 +1,7 @@
 # Copyright: 2015 Masatake YAMATO
 # License: GPL-2
 
-if ${CTAGS} --list-features | grep -q afasdfasfasfsa; then
+if ${CTAGS} --quiet --options=NONE --list-features | grep -q afasdfasfasfsa; then
     echo
 else
     echo "example: no such feature"

--- a/Tmain/utils.sh
+++ b/Tmain/utils.sh
@@ -21,6 +21,7 @@ is_feature_available()
 {
     local ctags=$1
 	local tmp=$2
+	local o="--quiet --options=NONE"
 	local neg
 	local feat
 
@@ -32,11 +33,11 @@ is_feature_available()
 	fi
 
 	if [ "${neg}" = 1 ]; then
-		if ${ctags} --list-features | grep -q "$feat"; then
+		if ${ctags} $o --list-features | grep -q "$feat"; then
 			skip "feature \"$feat\" is available in $ctags"
 		fi
 	else
-		if ! ${ctags} --list-features | grep -q "$feat"; then
+		if ! ${ctags} $o --list-features | grep -q "$feat"; then
 			skip "feature \"$feat\" is not available in $ctags"
 		fi
 	fi


### PR DESCRIPTION
~/.ctags affected the result of Tmain.
These commits make test cases not read ~/.ctags.
