### PR TITLE
Change EditorConfig setting for win32 files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ insert_final_newline = true
 indent_size = 4
 indent_style = tab
 trim_trailing_whitespace = true
+
+[win32/*]
+end_of_line = crlf


### PR DESCRIPTION
Files under the win32 directory should have CRLF EOL.