### PR TITLE
Create *.pdb on AppVeyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you want to try the latest universal-ctags without building it yourself...
   - Click the ```compiler=msvc_msys2, ARCH=x64, ...``` (or ```compiler=msvc_msys2, ARCH=x86, ...```) build.
   - View the *Artifacts* tab and download ```ctags-XXXXXX-x64.zip``` (or ```ctags-XXXXXX-x86.zip```). (```XXXXXX``` is a version number or a commit ID.)
   - Add the binary folder to your PATH.
+  - If you need PDB files for debugging, download ```ctags-XXXXXX-x64.pdb.zip``` (or ```ctags-XXXXXX-x86.pdb.zip```).
 
 ### Mac
 See [Homebrew Tap for Universal Ctags](https://github.com/universal-ctags/homebrew-universal-ctags)

--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -27,10 +27,11 @@ INCLUDES = $(INCLUDES) -I$(ICONV_DIR)/include
 
 !ifdef DEBUG
 DEFINES = $(DEFINES) -DDEBUG
-OPT = $(OPT) /Zi
+PDB = yes
 !endif
 
 !ifdef PDB
+OPT = $(OPT) /Zi
 PDBFLAG = /debug
 !else
 PDBFLAG =

--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -30,6 +30,12 @@ DEFINES = $(DEFINES) -DDEBUG
 OPT = $(OPT) /Zi
 !endif
 
+!ifdef PDB
+PDBFLAG = /debug
+!else
+PDBFLAG =
+!endif
+
 {main}.c{main}.obj::
 	$(CC) $(OPT) $(DEFINES) $(INCLUDES) /Fomain\ /c $<
 {optlib}.c{optlib}.obj::
@@ -46,10 +52,10 @@ all: ctags.exe readtags.exe
 ctags: ctags.exe
 
 ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS)
-	$(CC) $(OPT) /Fe$@ $(ALL_OBJS) /link setargv.obj $(LIBS)
+	$(CC) $(OPT) /Fe$@ $(ALL_OBJS) /link setargv.obj $(LIBS) $(PDBFLAG)
 
 readtags.exe: $(READTAGS_OBJS) $(READTAGS_HEADS)
-	$(CC) $(OPT) /Fe$@ $(READTAGS_OBJS) /link setargv.obj
+	$(CC) $(OPT) /Fe$@ $(READTAGS_OBJS) /link setargv.obj $(PDBFLAG)
 
 $(REGEX_OBJS): $(REGEX_SRCS)
 	$(CC) /c $(OPT) /Fo$@ $(INCLUDES) $(DEFINES) $(REGEX_SRCS)

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -67,7 +67,7 @@ copy %ICONV_BUILD_DIR%\msvc10\iconv.dll %APPVEYOR_BUILD_FOLDER% > nul
 :: Build ctags with nmake
 @echo on
 cd %APPVEYOR_BUILD_FOLDER%
-nmake -f mk_mvc.mak WITH_ICONV=yes ICONV_DIR=%ICONV_DIR%
+nmake -f mk_mvc.mak WITH_ICONV=yes ICONV_DIR=%ICONV_DIR% PDB=yes
 
 :: Check filetype (VC binaries)
 c:\cygwin\bin\file ctags.exe
@@ -123,6 +123,7 @@ if "%APPVEYOR_REPO_TAG_NAME%"=="" (
   set ver=%APPVEYOR_REPO_TAG_NAME%
 )
 7z a ctags-%ver%-%ARCH%.zip ctags.exe readtags.exe iconv.dll COPYING docs README.md
+7z a ctags-%ver%-%ARCH%.pdb.zip ctags.pdb readtags.pdb
 goto :eof
 
 


### PR DESCRIPTION
Add `PDB=yes` flag to mk_mvc.mk.
If `PDB=yes` is specified, `ctags.pdb` and `readtags.pdb` will be created, and they will be packed into a zip file named `ctags-VER-ARCH.pdb.zip`.

See: #1361