### PR TITLE
Javascript tags for ES6 exports

### DIFF
--- a/Units/parser-javascript.r/js-default-export.d/expected.tags
+++ b/Units/parser-javascript.r/js-default-export.d/expected.tags
@@ -1,0 +1,1 @@
+cube	input.js	/^export default function cube(x) {$/;"	f

--- a/Units/parser-javascript.r/js-default-export.d/input.js
+++ b/Units/parser-javascript.r/js-default-export.d/input.js
@@ -1,0 +1,5 @@
+/* https://developer.mozilla.org/en/docs/web/javascript/reference/statements/export#Using_the_default_export */
+
+export default function cube(x) {
+  return x * x * x;
+}

--- a/Units/parser-javascript.r/js-export.d/expected.tags
+++ b/Units/parser-javascript.r/js-export.d/expected.tags
@@ -1,0 +1,3 @@
+cube	input.js	/^export function cube(x) {$/;"	f
+foo	input.js	/^const foo = Math.PI + Math.SQRT2;$/;"	C
+pie	input.js	/^export const pie = Math.PI;$/;"	C

--- a/Units/parser-javascript.r/js-export.d/input.js
+++ b/Units/parser-javascript.r/js-export.d/input.js
@@ -1,0 +1,10 @@
+/* https://developer.mozilla.org/en/docs/web/javascript/reference/statements/export#Using_named_exports */
+
+export function cube(x) {
+  return x * x * x;
+}
+const foo = Math.PI + Math.SQRT2;
+export { cube, foo };
+
+/* augmented from the reference */
+export const pie = Math.PI;

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -128,6 +128,8 @@ enum eKeywordId {
 	KEYWORD_class,
 	KEYWORD_extends,
 	KEYWORD_static,
+	KEYWORD_default,
+	KEYWORD_export,
 };
 typedef int keywordId; /* to allow KEYWORD_NONE */
 
@@ -224,6 +226,8 @@ static const keywordTable JsKeywordTable [] = {
 	{ "class",		KEYWORD_class				},
 	{ "extends",	KEYWORD_extends				},
 	{ "static",		KEYWORD_static				},
+	{ "default",		KEYWORD_default				},
+	{ "export",		KEYWORD_export				},
 };
 
 /*
@@ -2182,6 +2186,9 @@ static void parseJsFile (tokenInfo *const token)
 
 		if (isType (token, TOKEN_KEYWORD) && token->keyword == KEYWORD_sap)
 			parseUI5 (token);
+		else if (isType (token, TOKEN_KEYWORD) && (token->keyword == KEYWORD_export ||
+		                                           token->keyword == KEYWORD_default))
+			/* skip those at top-level */;
 		else
 			parseLine (token, NULL, false);
 	} while (! isType (token, TOKEN_EOF));


### PR DESCRIPTION
This is just a cherry pick of the relevant changes from @b4n's [branch](https://github.com/b4n/fishman-ctags/commits/jscript/es7) which hasn't seen much action lately. It's based off @masatake's suggestion on the issue thread.

http://www.ecma-international.org/ecma-262/7.0/#sec-exports

Closes #1068.