### PR TITLE
Cxx: fix a bug about handling EOF in debug-type decoder

### DIFF
--- a/misc/gencxxtypedumper.sh
+++ b/misc/gencxxtypedumper.sh
@@ -42,13 +42,10 @@ echo '	bool a = false;'
 echo '	static vString *buf;'
 echo '	buf = vStringNewOrClear (buf);'
 echo
-echo '	if (eType == CXXTokenTypeEOF) vStringCatS(buf, "EOF");'
 ${CTAGS} -o - --sort=no --language-force=C --kinds-C=e -x --_xformat="%N" "${INPUT}" \
 	| grep ^CXXTokenType \
 	| while read N; do
-	if [ $N != CXXTokenTypeEOF ]; then
 		echo "	if (eType & $N) a = append (buf, \"${N#CXXTokenType}\", a);"
-	fi
 done
 echo '	if (vStringLength(buf) == 0) vStringCatS(buf, "REALLY-UNKNOWN");'
 echo '	return vStringValue (buf);'

--- a/parsers/cxx/cxx_debug_type.c
+++ b/parsers/cxx/cxx_debug_type.c
@@ -17,7 +17,7 @@ const char * cxxDebugTypeDecode (enum CXXTokenType eType)
 	static vString *buf;
 	buf = vStringNewOrClear (buf);
 
-	if (eType == CXXTokenTypeEOF) vStringCatS(buf, "EOF");
+	if (eType & CXXTokenTypeEOF) a = append (buf, "EOF", a);
 	if (eType & CXXTokenTypeIdentifier) a = append (buf, "Identifier", a);
 	if (eType & CXXTokenTypeKeyword) a = append (buf, "Keyword", a);
 	if (eType & CXXTokenTypeNumber) a = append (buf, "Number", a);


### PR DESCRIPTION
I introduced a bug when allowing cxxDebugTypeDecode to handle
type bits. It deals with EOF in a wrong way.
This commit fixes it.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>