### PR TITLE
Cxx: reduce blocks when parsing values for array/union initialization

### DIFF
--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -66,7 +66,8 @@ void cxxParserNewStatement(void)
 //
 bool cxxParserParseAndCondenseCurrentSubchain(
 		unsigned int uInitialSubchainMarkerTypes,
-		bool bAcceptEOF
+		bool bAcceptEOF,
+		bool bCanReduceInnerElements
 	)
 {
 	CXXTokenChain * pCurrentChain = g_cxx.pTokenChain;
@@ -93,7 +94,8 @@ bool cxxParserParseAndCondenseCurrentSubchain(
 		uTokenTypes |= CXXTokenTypeEOF;
 	bool bRet = cxxParserParseAndCondenseSubchainsUpToOneOf(
 			uTokenTypes,
-			uInitialSubchainMarkerTypes
+			uInitialSubchainMarkerTypes,
+			bCanReduceInnerElements
 		);
 	g_cxx.pTokenChain = pCurrentChain;
 	g_cxx.pToken = pCurrentChain->pTail;
@@ -115,10 +117,12 @@ bool cxxParserParseAndCondenseCurrentSubchain(
 //
 bool cxxParserParseAndCondenseSubchainsUpToOneOf(
 		unsigned int uTokenTypes,
-		unsigned int uInitialSubchainMarkerTypes
+		unsigned int uInitialSubchainMarkerTypes,
+		bool bCanReduceInnerElements
 	)
 {
-	CXX_DEBUG_ENTER_TEXT("Token types = 0x%x(%s)", uTokenTypes, cxxDebugTypeDecode(uTokenTypes));
+	CXX_DEBUG_ENTER_TEXT("Token types = 0x%x(%s), reduce = %d", uTokenTypes, cxxDebugTypeDecode(uTokenTypes),
+						 bCanReduceInnerElements);
 	if(!cxxParserParseNextToken())
 	{
 		CXX_DEBUG_LEAVE_TEXT("Found EOF");
@@ -139,6 +143,20 @@ bool cxxParserParseAndCondenseSubchainsUpToOneOf(
 
 		if(cxxTokenTypeIsOneOf(g_cxx.pToken,uTokenTypes))
 		{
+			if (bCanReduceInnerElements)
+			{
+				enum CXXTokenType eSentinelType = g_cxx.pToken->eType >> 4;
+				CXXToken *pTmp = g_cxx.pToken->pPrev, *pReducingCandidate;
+				while (pTmp && (!cxxTokenTypeIsOneOf (pTmp, eSentinelType)))
+				{
+					pReducingCandidate = pTmp;
+					pTmp = pTmp->pPrev;
+					pTmp->pNext = pReducingCandidate->pNext;
+					pReducingCandidate->pNext->pPrev = pTmp;
+					CXX_DEBUG_PRINT("reduce inner token: %p",pReducingCandidate);
+					cxxTokenDestroy (pReducingCandidate);
+				}
+			}
 			CXX_DEBUG_LEAVE_TEXT(
 					"Got terminator token '%s' 0x%x",
 					vStringValue(g_cxx.pToken->pszWord),
@@ -171,7 +189,8 @@ bool cxxParserParseAndCondenseSubchainsUpToOneOf(
 			} else {
 				if(!cxxParserParseAndCondenseCurrentSubchain(
 						uInitialSubchainMarkerTypes,
-						(uTokenTypes & CXXTokenTypeEOF)
+						(uTokenTypes & CXXTokenTypeEOF),
+						bCanReduceInnerElements
 					)
 				)
 				{
@@ -239,13 +258,15 @@ bool cxxParserParseAndCondenseSubchainsUpToOneOf(
 // This is usually what you want, unless you're really expecting a scope to begin
 // in the current statement.
 //
-bool cxxParserParseUpToOneOf(unsigned int uTokenTypes)
+bool cxxParserParseUpToOneOf(unsigned int uTokenTypes,
+							 bool bCanReduceInnerElements)
 {
 	return cxxParserParseAndCondenseSubchainsUpToOneOf(
 			uTokenTypes,
 			CXXTokenTypeOpeningBracket |
 				CXXTokenTypeOpeningParenthesis |
-				CXXTokenTypeOpeningSquareParenthesis
+				CXXTokenTypeOpeningSquareParenthesis,
+			bCanReduceInnerElements
 		);
 }
 
@@ -259,7 +280,8 @@ bool cxxParserSkipToSemicolonOrEOF(void)
 	if(cxxTokenTypeIsOneOf(g_cxx.pToken,CXXTokenTypeSemicolon | CXXTokenTypeEOF))
 		return true;
 
-	return cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF);
+	return cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF,
+								   false);
 }
 
 // This has to be called when pointing to a double-colon token
@@ -400,7 +422,7 @@ static bool cxxParserParseEnumStructClassOrUnionFullDeclarationTrailer(
 	int iFileLine = getInputLineNumber();
 
 	if(!cxxParserParseUpToOneOf(CXXTokenTypeEOF | CXXTokenTypeSemicolon | CXXTokenTypeOpeningBracket
-								| CXXTokenTypeAssignment))
+								| CXXTokenTypeAssignment, false))
 	{
 		CXX_DEBUG_LEAVE_TEXT("Failed to parse up to EOF/semicolon");
 		return false;
@@ -478,7 +500,7 @@ static bool cxxParserParseEnumStructClassOrUnionFullDeclarationTrailer(
 	  To be tolerant and handle unrecognized case, we
 	  put the code for skipping here. */
 	if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeAssignment) &&
-	   (!cxxParserParseUpToOneOf(CXXTokenTypeEOF | CXXTokenTypeSemicolon)))
+	   (!cxxParserParseUpToOneOf(CXXTokenTypeEOF | CXXTokenTypeSemicolon, true)))
 	{
 		CXX_DEBUG_LEAVE_TEXT("Failed to parse up to EOF/semicolon");
 		return false;
@@ -525,7 +547,8 @@ bool cxxParserParseEnum(void)
 	if(!cxxParserParseUpToOneOf(
 			CXXTokenTypeEOF | CXXTokenTypeSemicolon | CXXTokenTypeKeyword |
 				CXXTokenTypeSingleColon | CXXTokenTypeParenthesisChain |
-				CXXTokenTypeOpeningBracket
+				CXXTokenTypeOpeningBracket,
+			false
 		))
 	{
 		CXX_DEBUG_LEAVE_TEXT("Could not parse enum name");
@@ -547,7 +570,8 @@ bool cxxParserParseEnum(void)
 
 		if(!cxxParserParseUpToOneOf(
 				CXXTokenTypeEOF | CXXTokenTypeSemicolon | CXXTokenTypeSingleColon |
-					CXXTokenTypeParenthesisChain | CXXTokenTypeOpeningBracket
+				CXXTokenTypeParenthesisChain | CXXTokenTypeOpeningBracket,
+				false
 			))
 		{
 			CXX_DEBUG_LEAVE_TEXT("Could not parse enum name");
@@ -657,8 +681,8 @@ bool cxxParserParseEnum(void)
 		pTypeBegin = g_cxx.pToken;
 
 		if(!cxxParserParseUpToOneOf(
-				CXXTokenTypeEOF | CXXTokenTypeSemicolon | CXXTokenTypeOpeningBracket
-			))
+				CXXTokenTypeEOF | CXXTokenTypeSemicolon | CXXTokenTypeOpeningBracket,
+				false))
 		{
 			CXX_DEBUG_LEAVE_TEXT("Could not parse enum type");
 			return false;
@@ -768,7 +792,8 @@ bool cxxParserParseEnum(void)
 		cxxTokenChainClear(g_cxx.pTokenChain);
 
 		if(!cxxParserParseUpToOneOf(
-				CXXTokenTypeComma | CXXTokenTypeClosingBracket | CXXTokenTypeEOF
+				CXXTokenTypeComma | CXXTokenTypeClosingBracket | CXXTokenTypeEOF,
+				false
 			))
 		{
 			CXX_DEBUG_LEAVE_TEXT("Failed to parse enum contents");
@@ -869,7 +894,7 @@ static bool cxxParserParseClassStructOrUnionInternal(
 
 	for(;;)
 	{
-		bRet = cxxParserParseUpToOneOf(uTerminatorTypes);
+		bRet = cxxParserParseUpToOneOf(uTerminatorTypes, false);
 
 		if(!bRet)
 		{
@@ -894,6 +919,7 @@ static bool cxxParserParseClassStructOrUnionInternal(
 					CXXTokenTypeOpeningParenthesis | CXXTokenTypeOpeningBracket |
 						CXXTokenTypeOpeningSquareParenthesis |
 						CXXTokenTypeSmallerThanSign,
+					false,
 					false
 				);
 
@@ -987,7 +1013,7 @@ static bool cxxParserParseClassStructOrUnionInternal(
 		}
 
 		// Skip the initialization (which almost certainly contains a block)
-		if(!cxxParserParseUpToOneOf(CXXTokenTypeEOF | CXXTokenTypeSemicolon))
+		if(!cxxParserParseUpToOneOf(CXXTokenTypeEOF | CXXTokenTypeSemicolon, true))
 		{
 			CXX_DEBUG_LEAVE_TEXT("Failed to parse up to EOF/semicolon");
 			return false;
@@ -1088,7 +1114,8 @@ static bool cxxParserParseClassStructOrUnionInternal(
 		cxxTokenChainClear(g_cxx.pTokenChain);
 
 		if(!cxxParserParseUpToOneOf(
-				CXXTokenTypeEOF | CXXTokenTypeSemicolon | CXXTokenTypeOpeningBracket
+				CXXTokenTypeEOF | CXXTokenTypeSemicolon | CXXTokenTypeOpeningBracket,
+				false
 			))
 		{
 			cxxTokenDestroy(pClassName);
@@ -1452,7 +1479,8 @@ bool cxxParserParseAccessSpecifier(void)
 	// skip to the next :, without leaving scope.
 	if(!cxxParserParseUpToOneOf(
 			CXXTokenTypeSingleColon | CXXTokenTypeSemicolon |
-				CXXTokenTypeClosingBracket | CXXTokenTypeEOF
+				CXXTokenTypeClosingBracket | CXXTokenTypeEOF,
+			false
 		))
 	{
 		CXX_DEBUG_LEAVE_TEXT("Failed to parse up to the next ;");
@@ -1470,7 +1498,8 @@ bool cxxParserParseIfForWhileSwitch(void)
 
 	if(!cxxParserParseUpToOneOf(
 			CXXTokenTypeParenthesisChain | CXXTokenTypeSemicolon |
-				CXXTokenTypeOpeningBracket | CXXTokenTypeEOF
+				CXXTokenTypeOpeningBracket | CXXTokenTypeEOF,
+			false
 		))
 	{
 		CXX_DEBUG_LEAVE_TEXT("Failed to parse if/for/while/switch up to parenthesis");

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -93,7 +93,8 @@ bool cxxParserParseBlockHandleOpeningBracket(void)
 		bool bRet = cxxParserParseAndCondenseCurrentSubchain(
 				CXXTokenTypeOpeningBracket | CXXTokenTypeOpeningParenthesis |
 					CXXTokenTypeOpeningSquareParenthesis,
-				false
+				false,
+				true
 			);
 
 		CXX_DEBUG_LEAVE_TEXT("Handled array or list-like initialisation or return");
@@ -206,7 +207,7 @@ process_token:
 					case CXXKeywordNAMESPACE:
 					{
 						enum CXXScopeType eScopeType = cxxScopeGetType();
-						
+
 						if(
 								(
 									// toplevel or nested within a namespace
@@ -345,7 +346,8 @@ process_token:
 							g_cxx.uKeywordState |= CXXParserKeywordStateSeenReturn;
 						} else {
 							// ignore
-							if(!cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF))
+							if(!cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF,
+								   false))
 							{
 								CXX_DEBUG_LEAVE_TEXT("Failed to parse return");
 								return false;
@@ -357,7 +359,8 @@ process_token:
 					case CXXKeywordBREAK:
 					case CXXKeywordGOTO:
 						// ignore
-						if(!cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF))
+						if(!cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF,
+							   false))
 						{
 							CXX_DEBUG_LEAVE_TEXT("Failed to parse continue/break/goto");
 							return false;
@@ -368,7 +371,8 @@ process_token:
 						// ignore when inside a function
 						if(cxxScopeGetType() == CXXScopeTypeFunction)
 						{
-							if(!cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF))
+							if(!cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF,
+								   false))
 							{
 								CXX_DEBUG_LEAVE_TEXT("Failed to parse return/continue/break");
 								return false;
@@ -379,7 +383,8 @@ process_token:
 					case CXXKeywordCASE:
 						// ignore
 						if(!cxxParserParseUpToOneOf(
-								CXXTokenTypeSemicolon | CXXTokenTypeEOF | CXXTokenTypeSingleColon
+								CXXTokenTypeSemicolon | CXXTokenTypeEOF | CXXTokenTypeSingleColon,
+								false
 							))
 						{
 							CXX_DEBUG_LEAVE_TEXT("Failed to parse case keyword");
@@ -564,7 +569,8 @@ process_token:
 				if(!cxxParserParseAndCondenseCurrentSubchain(
 						CXXTokenTypeOpeningBracket | CXXTokenTypeOpeningParenthesis |
 							CXXTokenTypeOpeningSquareParenthesis,
-						true
+						true,
+						false
 					))
 				{
 					CXX_DEBUG_LEAVE_TEXT("Parsing the parenthesis failed");

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -233,7 +233,8 @@ int cxxParserMaybeParseKnRStyleFunctionDefinition()
 		CXXToken * pCurrentTail = g_cxx.pTokenChain->pTail;
 
 		if(!cxxParserParseUpToOneOf(
-				CXXTokenTypeSemicolon | CXXTokenTypeOpeningBracket | CXXTokenTypeEOF
+				CXXTokenTypeSemicolon | CXXTokenTypeOpeningBracket | CXXTokenTypeEOF,
+				false
 			))
 		{
 			cxxTokenDestroy(pIdentifier);

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -208,9 +208,11 @@ bool cxxParserParseClassStructOrUnion(
 	);
 bool cxxParserParseAndCondenseCurrentSubchain(
 		unsigned int uInitialSubchainMarkerTypes,
-		bool bAcceptEOF
+		bool bAcceptEOF,
+		bool bCanReduceInnerElements
 	);
-bool cxxParserParseUpToOneOf(unsigned int uTokenTypes);
+bool cxxParserParseUpToOneOf(unsigned int uTokenTypes,
+							 bool bCanReduceInnerElements);
 bool cxxParserParseIfForWhileSwitch(void);
 bool cxxParserParseTemplatePrefix(void);
 bool cxxParserParseUsingClause(void);
@@ -218,7 +220,8 @@ bool cxxParserParseAccessSpecifier(void);
 void cxxParserAnalyzeOtherStatement(void);
 bool cxxParserParseAndCondenseSubchainsUpToOneOf(
 		unsigned int uTokenTypes,
-		unsigned int uInitialSubchainMarkerTypes
+		unsigned int uInitialSubchainMarkerTypes,
+		bool bCanReduceInnerElements
 	);
 void cxxParserMarkEndLineForTagInCorkQueue(int iCorkQueueIndex);
 

--- a/parsers/cxx/cxx_parser_namespace.c
+++ b/parsers/cxx/cxx_parser_namespace.c
@@ -173,7 +173,8 @@ bool cxxParserParseNamespace(void)
 				if(!cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeOpeningBracket))
 				{
 					if(!cxxParserParseUpToOneOf(
-							CXXTokenTypeOpeningBracket | CXXTokenTypeSemicolon | CXXTokenTypeEOF
+							CXXTokenTypeOpeningBracket | CXXTokenTypeSemicolon | CXXTokenTypeEOF,
+							false
 						))
 					{
 						CXX_DEBUG_LEAVE_TEXT("Failed to parse up to an opening bracket");

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -63,7 +63,8 @@ static bool cxxParserParseTemplatePrefixAngleBrackets(void)
 					CXXTokenTypeOpeningBracket | CXXTokenTypeSemicolon |
 					CXXTokenTypeEOF | CXXTokenTypeAssignment,
 				CXXTokenTypeOpeningParenthesis |
-					CXXTokenTypeOpeningSquareParenthesis
+					CXXTokenTypeOpeningSquareParenthesis,
+				false
 			))
 		{
 			CXX_DEBUG_LEAVE_TEXT("Failed to parse up to '<>{EOF'");
@@ -113,7 +114,8 @@ evaluate_current_token:
 							if(!cxxParserParseAndCondenseCurrentSubchain(
 									CXXTokenTypeOpeningParenthesis |
 										CXXTokenTypeOpeningSquareParenthesis,
-									true
+									true,
+									false
 								))
 							{
 								CXX_DEBUG_LEAVE_TEXT("Failed to condense current subchain");
@@ -176,7 +178,8 @@ evaluate_current_token:
 						if(!cxxParserParseAndCondenseCurrentSubchain(
 								CXXTokenTypeOpeningParenthesis |
 									CXXTokenTypeOpeningSquareParenthesis,
-								true
+								true,
+								false
 							))
 						{
 							CXX_DEBUG_LEAVE_TEXT("Failed to condense current subchain");
@@ -200,7 +203,8 @@ evaluate_current_token:
 				if(!cxxParserParseUpToOneOf(
 						CXXTokenTypeGreaterThanSign | CXXTokenTypeComma |
 							CXXTokenTypeOpeningBracket | CXXTokenTypeSemicolon |
-							CXXTokenTypeEOF
+							CXXTokenTypeEOF,
+						false
 					))
 				{
 					CXX_DEBUG_LEAVE_TEXT("Failed to parse up to '}EOF'");
@@ -226,7 +230,7 @@ evaluate_current_token:
 							"but we try to recover..."
 					);
 				// skip the whole bracketed part.
-				if(!cxxParserParseUpToOneOf(CXXTokenTypeClosingBracket | CXXTokenTypeEOF))
+				if(!cxxParserParseUpToOneOf(CXXTokenTypeClosingBracket | CXXTokenTypeEOF, false))
 				{
 					CXX_DEBUG_LEAVE_TEXT("Failed to parse up to '}EOF'");
 					return false;
@@ -264,7 +268,8 @@ bool cxxParserParseTemplatePrefix(void)
 	cxxTokenChainDestroyLast(g_cxx.pTokenChain); // kill the template keyword
 
 	if(!cxxParserParseUpToOneOf(
-			CXXTokenTypeSmallerThanSign | CXXTokenTypeEOF | CXXTokenTypeSemicolon
+			CXXTokenTypeSmallerThanSign | CXXTokenTypeEOF | CXXTokenTypeSemicolon,
+			false
 		))
 	{
 		CXX_DEBUG_LEAVE_TEXT("Failed to parse up to the < sign");

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -900,6 +900,7 @@ static bool cxxParserParseNextTokenCondenseAttribute(void)
 			CXXTokenTypeOpeningParenthesis |
 				CXXTokenTypeOpeningSquareParenthesis |
 				CXXTokenTypeOpeningBracket,
+			false,
 			false
 		))
 	{
@@ -996,6 +997,7 @@ static bool cxxParserParseNextTokenSkipMacroParenthesis(CXXToken ** ppChain)
 
 	if(!cxxParserParseAndCondenseCurrentSubchain(
 			CXXTokenTypeOpeningParenthesis,
+			false,
 			false
 		))
 	{

--- a/parsers/cxx/cxx_parser_typedef.c
+++ b/parsers/cxx/cxx_parser_typedef.c
@@ -32,7 +32,8 @@ bool cxxParserParseGenericTypedef(void)
 	{
 		if(!cxxParserParseUpToOneOf(
 				CXXTokenTypeSemicolon | CXXTokenTypeEOF |
-				CXXTokenTypeClosingBracket | CXXTokenTypeKeyword
+				CXXTokenTypeClosingBracket | CXXTokenTypeKeyword,
+				false
 			))
 		{
 			CXX_DEBUG_LEAVE_TEXT("Failed to parse fast statement");

--- a/parsers/cxx/cxx_parser_using.c
+++ b/parsers/cxx/cxx_parser_using.c
@@ -37,7 +37,8 @@ bool cxxParserParseUsingClause(void)
 
 	// skip to the next ; without leaving scope.
 	if(!cxxParserParseUpToOneOf(
-			CXXTokenTypeSemicolon | CXXTokenTypeClosingBracket | CXXTokenTypeEOF
+			CXXTokenTypeSemicolon | CXXTokenTypeClosingBracket | CXXTokenTypeEOF,
+			false
 		))
 	{
 		CXX_DEBUG_LEAVE_TEXT("Failed to parse up to the next ;");


### PR DESCRIPTION
Close #1378.


Signed-off-by: Masatake YAMATO <yamato@redhat.com>