### PR TITLE
ITcl: improve handling method 

### DIFF
--- a/Units/parser-itcl.r/fq-with-namespace.b/args.ctags
+++ b/Units/parser-itcl.r/fq-with-namespace.b/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--extras=+q

--- a/Units/parser-itcl.r/fq-with-namespace.b/expected.tags
+++ b/Units/parser-itcl.r/fq-with-namespace.b/expected.tags
@@ -1,0 +1,3 @@
+A	input.tcl	/^namespace eval A {$/;"	n
+B	input.tcl	/^    itcl::class B {$/;"	c	namespace:A
+A::B	input.tcl	/^    itcl::class B {$/;"	c	namespace:A

--- a/Units/parser-itcl.r/fq-with-namespace.b/input.tcl
+++ b/Units/parser-itcl.r/fq-with-namespace.b/input.tcl
@@ -1,0 +1,7 @@
+package require Itcl
+
+namespace eval A {
+    itcl::class B {
+    }
+}
+

--- a/Units/parser-itcl.r/simple-itcl.d/args.ctags
+++ b/Units/parser-itcl.r/simple-itcl.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+q
+--fields=*

--- a/Units/parser-itcl.r/simple-itcl.d/expected.tags
+++ b/Units/parser-itcl.r/simple-itcl.d/expected.tags
@@ -1,0 +1,32 @@
+Toaster	input.tcl	/^itcl::class Toaster {$/;"	kind:class	line:6	language:ITcl	extras:subparser
+crumbs	input.tcl	/^    variable crumbs 0$/;"	kind:variable	line:7	language:ITcl	scope:class:Toaster	extras:subparser	end:7
+Toaster::crumbs	input.tcl	/^    variable crumbs 0$/;"	kind:variable	line:7	language:ITcl	scope:class:Toaster	extras:qualified,subparser	end:7
+toast	input.tcl	/^    method toast {nslices} {$/;"	kind:method	line:8	language:ITcl	scope:class:Toaster	extras:subparser	end:13
+Toaster::toast	input.tcl	/^    method toast {nslices} {$/;"	kind:method	line:8	language:ITcl	scope:class:Toaster	extras:qualified,subparser	end:13
+clean	input.tcl	/^    method clean {} {$/;"	kind:method	line:14	language:ITcl	scope:class:Toaster	extras:subparser	end:16
+Toaster::clean	input.tcl	/^    method clean {} {$/;"	kind:method	line:14	language:ITcl	scope:class:Toaster	extras:qualified,subparser	end:16
+SmartToaster	input.tcl	/^itcl::class SmartToaster {$/;"	kind:class	line:19	language:ITcl	inherits:Toaster	extras:subparser
+toast	input.tcl	/^    method toast {nslices} {$/;"	kind:method	line:21	language:ITcl	scope:class:SmartToaster	extras:subparser	end:26
+SmartToaster::toast	input.tcl	/^    method toast {nslices} {$/;"	kind:method	line:21	language:ITcl	scope:class:SmartToaster	extras:qualified,subparser	end:26
+doSomethingPublic	input.tcl	/^    public method doSomethingPublic {} {$/;"	kind:method	line:28	language:ITcl	scope:class:SmartToaster	implementation:public	extras:subparser	end:29
+SmartToaster::doSomethingPublic	input.tcl	/^    public method doSomethingPublic {} {$/;"	kind:method	line:28	language:ITcl	scope:class:SmartToaster	implementation:public	extras:qualified,subparser	end:29
+doSomethingProtected	input.tcl	/^    protected method doSomethingProtected {} {$/;"	kind:method	line:30	language:ITcl	scope:class:SmartToaster	implementation:protected	extras:subparser	end:31
+SmartToaster::doSomethingProtected	input.tcl	/^    protected method doSomethingProtected {} {$/;"	kind:method	line:30	language:ITcl	scope:class:SmartToaster	implementation:protected	extras:qualified,subparser	end:31
+doSomethingPrivate	input.tcl	/^    private method doSomethingPrivate {} {$/;"	kind:method	line:32	language:ITcl	scope:class:SmartToaster	implementation:private	extras:subparser	end:33
+SmartToaster::doSomethingPrivate	input.tcl	/^    private method doSomethingPrivate {} {$/;"	kind:method	line:32	language:ITcl	scope:class:SmartToaster	implementation:private	extras:qualified,subparser	end:33
+procNoProtection	input.tcl	/^    proc procNoProtection {} {$/;"	kind:procedure	line:35	language:ITcl	scope:class:SmartToaster	extras:subparser	end:36
+SmartToaster::procNoProtection	input.tcl	/^    proc procNoProtection {} {$/;"	kind:procedure	line:35	language:ITcl	scope:class:SmartToaster	extras:qualified,subparser	end:36
+procPublic	input.tcl	/^    public proc procPublic {} {$/;"	kind:procedure	line:38	language:ITcl	scope:class:SmartToaster	implementation:public	extras:subparser	end:39
+SmartToaster::procPublic	input.tcl	/^    public proc procPublic {} {$/;"	kind:procedure	line:38	language:ITcl	scope:class:SmartToaster	implementation:public	extras:qualified,subparser	end:39
+procProtected	input.tcl	/^    protected proc procProtected {} {$/;"	kind:procedure	line:40	language:ITcl	scope:class:SmartToaster	implementation:protected	extras:subparser	end:41
+SmartToaster::procProtected	input.tcl	/^    protected proc procProtected {} {$/;"	kind:procedure	line:40	language:ITcl	scope:class:SmartToaster	implementation:protected	extras:qualified,subparser	end:41
+procPrivate	input.tcl	/^    private proc procPrivate {} {$/;"	kind:procedure	line:42	language:ITcl	scope:class:SmartToaster	implementation:private	extras:subparser	end:43
+SmartToaster::procPrivate	input.tcl	/^    private proc procPrivate {} {$/;"	kind:procedure	line:42	language:ITcl	scope:class:SmartToaster	implementation:private	extras:qualified,subparser	end:43
+commonNoProtection	input.tcl	/^    common commonNoProtection 0$/;"	kind:common	line:45	language:ITcl	scope:class:SmartToaster	extras:subparser	end:45
+SmartToaster::commonNoProtection	input.tcl	/^    common commonNoProtection 0$/;"	kind:common	line:45	language:ITcl	scope:class:SmartToaster	extras:qualified,subparser	end:45
+commonPublic	input.tcl	/^    public proc commonPublic "a"$/;"	kind:procedure	line:47	language:ITcl	scope:class:SmartToaster	implementation:public	extras:subparser	end:47
+SmartToaster::commonPublic	input.tcl	/^    public proc commonPublic "a"$/;"	kind:procedure	line:47	language:ITcl	scope:class:SmartToaster	implementation:public	extras:qualified,subparser	end:47
+commonProtected	input.tcl	/^    protected proc commonProtected "b"$/;"	kind:procedure	line:48	language:ITcl	scope:class:SmartToaster	implementation:protected	extras:subparser	end:48
+SmartToaster::commonProtected	input.tcl	/^    protected proc commonProtected "b"$/;"	kind:procedure	line:48	language:ITcl	scope:class:SmartToaster	implementation:protected	extras:qualified,subparser	end:48
+commonPrivate	input.tcl	/^    private proc commonPrivate "c"$/;"	kind:procedure	line:49	language:ITcl	scope:class:SmartToaster	implementation:private	extras:subparser	end:49
+SmartToaster::commonPrivate	input.tcl	/^    private proc commonPrivate "c"$/;"	kind:procedure	line:49	language:ITcl	scope:class:SmartToaster	implementation:private	extras:qualified,subparser	end:49

--- a/Units/parser-itcl.r/simple-itcl.d/input.tcl
+++ b/Units/parser-itcl.r/simple-itcl.d/input.tcl
@@ -1,0 +1,54 @@
+#
+# Derived from class.n man page of itcl
+#
+package require Itcl
+
+itcl::class Toaster {
+    variable crumbs 0
+    method toast {nslices} {
+        if {$crumbs > 50} {
+            error "== FIRE! FIRE! =="
+        }
+        set crumbs [expr $crumbs+4*$nslices]
+    }
+    method clean {} {
+        set crumbs 0
+    }
+}
+
+itcl::class SmartToaster {
+    inherit Toaster
+    method toast {nslices} {
+        if {$crumbs > 40} {
+            clean
+        }
+        return [chain $nslices]
+    }
+
+    public method doSomethingPublic {} {
+    }
+    protected method doSomethingProtected {} {
+    }
+    private method doSomethingPrivate {} {
+    }
+
+    proc procNoProtection {} {
+    }
+    
+    public proc procPublic {} {
+    }
+    protected proc procProtected {} {
+    }
+    private proc procPrivate {} {
+    }
+
+    common commonNoProtection 0
+    
+    public proc commonPublic "a"
+    protected proc commonProtected "b"
+    private proc commonPrivate "c"
+}
+
+set toaster [SmartToaster #auto]
+$toaster toast 2
+

--- a/Units/parser-tcl.r/simple.tcl.d/expected.tags
+++ b/Units/parser-tcl.r/simple.tcl.d/expected.tags
@@ -1,6 +1,1 @@
-itcl_class	input.tcl	/^itcl::class itcl_class$/;"	c
-method1	input.tcl	/^public method method1$/;"	m
-method2	input.tcl	/^protected method method2$/;"	m
-method3	input.tcl	/^private method method3$/;"	m
-simple1	input.tcl	/^proc simple1$/;"	p
-tcl_class	input.tcl	/^class tcl_class$/;"	c
+simple1	input.tcl	/^proc simple1 {} {$/;"	p

--- a/Units/parser-tcl.r/simple.tcl.d/input.tcl
+++ b/Units/parser-tcl.r/simple.tcl.d/input.tcl
@@ -1,10 +1,3 @@
 # proc comment
-proc simple1
-
-class tcl_class
-
-itcl::class itcl_class
-
-public method method1
-protected method method2
-private method method3
+proc simple1 {} {
+}

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -29,6 +29,8 @@ Fully rewritten parsers
 * C++ (see :ref:`The new C/C++ parser <cxx>`)
 * Python (see :ref:`The new Python parser <python>`)
 * HTML (see :ref:`The new HTML parser <html>`)
+* Tcl
+* ITcl
 
 New parsers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/main/entry.c
+++ b/main/entry.c
@@ -1253,7 +1253,20 @@ extern int makeQualifiedTagEntry (const tagEntryInfo *const e)
 		x.extensionFields.scopeName = NULL;
 		x.extensionFields.scopeIndex = CORK_NIL;
 #endif
+
+		bool in_subparser
+			= isTagExtraBitMarked (&x,
+								   XTAG_TAGS_GENERATED_BY_SUBPARSER);
+
+		/* TODO: very slow: entry should hold language-id,
+		   not langauge name. */
+		if (in_subparser)
+			pushLanguage(getNamedLanguage(x.language, 0));
+
 		r = makeTagEntry (&x);
+
+		if (in_subparser)
+			popLanguage();
 	}
 	return r;
 }

--- a/parsers/itcl.c
+++ b/parsers/itcl.c
@@ -11,16 +11,238 @@
 #include "entry.h"
 #include "parse.h"
 #include "string.h"
+#include "read.h"
+#include "keyword.h"
 
-enum {
+static scopeSeparator ITclGenericSeparators [] = {
+	{ KIND_WILDCARD, "::" },
+};
+
+enum ITclKind {
 	K_CLASS,
 	K_METHOD,
+	K_VARIABLE,
+	K_COMMON,
+	K_PROC,
 };
 
 static kindDefinition ITclKinds[] = {
 	{ true, 'c', "class", "classes" },
-	{ true, 'm', "method", "methods" },
+	{ true, 'm', "method", "methods",
+	  ATTACH_SEPARATORS(ITclGenericSeparators)},
+	{ true, 'v', "variable", "object-specific variables",
+	  ATTACH_SEPARATORS(ITclGenericSeparators)},
+	{ true, 'C', "common", "common variables",
+	  ATTACH_SEPARATORS(ITclGenericSeparators)},
+	{ true, 'p', "procedure", "procedures within the  class  namespace",
+	  ATTACH_SEPARATORS(ITclGenericSeparators)},
 };
+
+enum {
+	KEYWORD_INHERIT,
+	KEYWORD_METHOD,
+	KEYWORD_PRIVATE,
+	KEYWORD_PROTECTED,
+	KEYWORD_PUBLIC,
+	KEYWORD_VARIABLE,
+	KEYWORD_COMMON,
+	KEYWORD_PROC,
+};
+
+typedef int keywordId; /* to allow KEYWORD_NONE */
+
+static const keywordTable ITclKeywordTable[] = {
+	/* keyword			keyword ID */
+	{ "inherit",		KEYWORD_INHERIT		},
+	{ "method",			KEYWORD_METHOD		},
+	{ "private",		KEYWORD_PRIVATE		},
+	{ "protected",		KEYWORD_PROTECTED	},
+	{ "public",			KEYWORD_PUBLIC		},
+	{ "variable",		KEYWORD_VARIABLE	},
+	{ "common",			KEYWORD_COMMON		},
+	{ "proc",			KEYWORD_PROC		},
+};
+
+static keywordId resolveKeyword (vString *string)
+{
+	char *s = vStringValue (string);
+	static langType lang = LANG_AUTO;
+
+	if (lang == LANG_AUTO)
+		lang = getInputLanguage ();
+
+	return lookupKeyword (s, lang);
+}
+
+static void parseInherit (tokenInfo *token, int r)
+{
+	vString *inherits = vStringNew ();
+
+	do {
+		tokenRead (token);
+		if (tokenIsType (token, TCL_IDENTIFIER))
+		{
+			if (vStringLength(inherits) != 0)
+				vStringPut (inherits, ',');
+			vStringCat(inherits, token->string);
+		}
+		else if (tokenIsType(token, TCL_EOL))
+			break;
+		else
+		{
+			skipToEndOfTclCmdline (token);
+			break;
+		}
+	} while (1);
+
+	if (vStringLength(inherits) > 0)
+	{
+		tagEntryInfo *e = getEntryInCorkQueue (r);
+		if (e)
+		{
+			e->extensionFields.inheritance = vStringDeleteUnwrap (inherits);
+			return;
+		}
+	}
+
+	vStringDelete (inherits);
+}
+
+static void attachProtectionMaybe(tagEntryInfo *e, keywordId protection)
+{
+		switch (protection)
+		{
+		case KEYWORD_PROTECTED:
+			e->extensionFields.implementation = "protected";
+			break;
+		case KEYWORD_PRIVATE:
+			e->extensionFields.implementation = "private";
+			break;
+		case KEYWORD_PUBLIC:
+			e->extensionFields.implementation = "public";
+			break;
+		}
+}
+
+static void parseSubobject (tokenInfo *token, int parent, enum ITclKind kind, keywordId protection)
+{
+	int r = CORK_NIL;
+
+	tokenRead (token);
+	if (tokenIsType (token, TCL_IDENTIFIER))
+	{
+		tagEntryInfo e;
+
+		initTagEntry(&e, vStringValue (token->string), ITclKinds + kind);
+		e.extensionFields.scopeIndex = parent;
+		attachProtectionMaybe (&e, protection);
+		r = makeTagEntry (&e);
+	}
+
+	skipToEndOfTclCmdline (token);
+	if (r != CORK_NIL)
+	{
+		tagEntryInfo *e = getEntryInCorkQueue (r);
+		e->extensionFields.endLine = token->lineNumber;
+	}
+}
+
+
+static void parseVariable (tokenInfo *token, int r, keywordId protection)
+{
+	parseSubobject(token, r, K_VARIABLE, protection);
+}
+
+static void parseMethod (tokenInfo *token, int r, keywordId protection)
+{
+	parseSubobject(token, r, K_METHOD, protection);
+}
+
+static void parseProc (tokenInfo *token, int r, keywordId protection)
+{
+	parseSubobject(token, r, K_PROC, protection);
+}
+
+static void parseCommon (tokenInfo *token, int r, keywordId protection)
+{
+	parseSubobject(token, r, K_COMMON, protection);
+}
+
+static int parseClass (tclSubparser *s, int parentIndex)
+{
+	tokenInfo *token = newTclToken ();
+	int r = CORK_NIL;
+
+	tokenRead (token);
+	if (tokenIsType (token, TCL_IDENTIFIER))
+	{
+		tagEntryInfo e;
+
+		initTagEntry(&e, vStringValue (token->string), ITclKinds + K_CLASS);
+		e.extensionFields.scopeIndex = parentIndex;
+		r = makeTagEntry (&e);
+	}
+
+	if (tokenSkipToType (token, '{'))
+	{
+		keywordId protection = KEYWORD_NONE;
+
+		do {
+			tokenRead (token);
+			if (tokenIsType (token, TCL_IDENTIFIER))
+			{
+				keywordId k = resolveKeyword (token->string);
+				switch (k)
+				{
+				case KEYWORD_INHERIT:
+					parseInherit(token, r);
+					protection = KEYWORD_NONE;
+					break;
+				case KEYWORD_VARIABLE:
+					parseVariable(token, r, protection);
+					protection = KEYWORD_NONE;
+					break;
+				case KEYWORD_METHOD:
+					parseMethod(token, r, protection);
+					protection = KEYWORD_NONE;
+					break;
+				case KEYWORD_COMMON:
+					parseCommon(token, r, protection);
+					protection = KEYWORD_NONE;
+					break;
+				case KEYWORD_PUBLIC:
+				case KEYWORD_PROTECTED:
+				case KEYWORD_PRIVATE:
+					protection = k;
+					continue;
+				default:
+					protection = KEYWORD_NONE;
+					skipToEndOfTclCmdline (token);
+					break;
+				}
+			}
+			else if (tokenIsType (token, TCL_KEYWORD)
+					 && (resolveKeyword (token->string) == KEYWORD_PROC))
+			{
+				parseProc(token, r, protection);
+				protection = KEYWORD_NONE;
+			}
+			else if (token->type == '}')
+			{
+				protection = KEYWORD_NONE;
+				break;
+			}
+			else
+			{
+				protection = KEYWORD_NONE;
+				skipToEndOfTclCmdline (token);
+			}
+		} while (!tokenIsEOF(token));
+	}
+
+	tokenDestroy(token);
+	return r;
+}
 
 static int commandNotify (tclSubparser *s, char *command,
 						  int parentIndex)
@@ -29,44 +251,8 @@ static int commandNotify (tclSubparser *s, char *command,
 
 	if ((strcmp (command, "class") == 0)
 		|| (strcmp (command, "itcl::class") == 0))
-	{
-		tokenInfo *token = newTclToken ();
+		r = parseClass (s, parentIndex);
 
-		tokenRead (token);
-		if (tokenIsType (token, TCL_IDENTIFIER))
-		{
-			tagEntryInfo e;
-
-			initTagEntry(&e, vStringValue (token->string), ITclKinds + K_CLASS);
-			e.extensionFields.scopeIndex = parentIndex;
-			r = makeTagEntry (&e);
-		}
-		tokenDestroy(token);
-	}
-	else if ((strcmp (command, "public") == 0)
-			 || (strcmp (command, "protected") == 0)
-			 || (strcmp (command, "private") == 0))
-	{
-		tokenInfo *token = newTclToken ();
-		tokenRead (token);
-		if (tokenIsType (token, TCL_IDENTIFIER)
-			&& (strcmp(vStringValue(token->string), "method") == 0))
-		{
-			tokenRead (token);
-			if (tokenIsType (token, TCL_IDENTIFIER))
-			{
-				tagEntryInfo e;
-
-				initTagEntry(&e, vStringValue (token->string), ITclKinds + K_METHOD);
-				e.extensionFields.scopeIndex = parentIndex;
-				r = makeTagEntry (&e);
-				/* TODO: modifier should be attached. */
-			}
-		}
-		else
-			tokenUnread (token);
-		tokenDestroy(token);
-	}
 	return r;
 }
 
@@ -99,6 +285,10 @@ extern parserDefinition* ITclParser (void)
 	def->extensions = extensions;
 	def->parser = findITclTags;;
 	def->useCork = true;
+	def->requestAutomaticFQTag = true;
+
+	def->keywordTable = ITclKeywordTable;
+	def->keywordCount = ARRAY_SIZE (ITclKeywordTable);
 
 	return def;
 }

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -283,7 +283,7 @@ static void skipToEndOfCmdline (tokenInfo *const token)
 			break;
 		else if (tokenIsType (token, TCL_EOL))
 			break;
-		else if ((token->type == '[')
+		else if ((token->type == '{')
 				 || (token->type == '['))
 			tokenSkipOverPair(token);
 		tokenRead (token);

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -290,6 +290,11 @@ static void skipToEndOfCmdline (tokenInfo *const token)
 	} while (!tokenIsEOF (token));
 }
 
+extern void skipToEndOfTclCmdline (tokenInfo *const token)
+{
+	skipToEndOfCmdline (token);
+}
+
 static bool isAbsoluteIdentifier(tokenInfo *const token)
 {
 	return !strncmp (vStringValue (token->string), "::", 2);

--- a/parsers/tcl.h
+++ b/parsers/tcl.h
@@ -42,5 +42,6 @@ struct sTclSubparser {
 };
 
 extern tokenInfo *newTclToken (void);
+extern void skipToEndOfTclCmdline (tokenInfo *const token);
 
 #endif	/* CTAGS_PARSER_TCL_H */


### PR DESCRIPTION
ITcl assumed a method is defiend at the top level.
It seems that this is wrong. A method is defined in a class.

With this commit ITcl parser captures methods defined in a class;
"method" used in the top level is ignored.

In addition variables and commons defined in a class are captured.

TODO: A separator used between a ITcl class and Tcl namespace should
be :: but . is used. This is a bug.
