### PR TITLE
Use langid in tagentryinfo

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -1258,10 +1258,8 @@ extern int makeQualifiedTagEntry (const tagEntryInfo *const e)
 			= isTagExtraBitMarked (&x,
 								   XTAG_TAGS_GENERATED_BY_SUBPARSER);
 
-		/* TODO: very slow: entry should hold language-id,
-		   not langauge name. */
 		if (in_subparser)
-			pushLanguage(getNamedLanguage(x.language, 0));
+			pushLanguage(x.langType);
 
 		r = makeTagEntry (&x);
 
@@ -1276,7 +1274,7 @@ extern void initTagEntry (tagEntryInfo *const e, const char *const name,
 {
 	initTagEntryFull(e, name,
 			 getInputLineNumber (),
-			 getInputLanguageName (),
+			 getInputLanguage (),
 			 getInputFilePosition (),
 			 getInputFileTagPath (),
 			 kind,
@@ -1291,7 +1289,7 @@ extern void initRefTagEntry (tagEntryInfo *const e, const char *const name,
 {
 	initTagEntryFull(e, name,
 			 getInputLineNumber (),
-			 getInputLanguageName (),
+			 getInputLanguage (),
 			 getInputFilePosition (),
 			 getInputFileTagPath (),
 			 kind,
@@ -1303,7 +1301,7 @@ extern void initRefTagEntry (tagEntryInfo *const e, const char *const name,
 
 extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 			      unsigned long lineNumber,
-			      const char* language,
+			      langType langType,
 			      MIOPos      filePosition,
 			      const char *inputFileName,
 			      const kindDefinition *kind,
@@ -1319,7 +1317,7 @@ extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 	e->lineNumberEntry = (bool) (Option.locate == EX_LINENUM);
 	e->lineNumber      = lineNumber;
 	e->boundaryInfo    = getNestedInputBoundaryInfo (lineNumber);
-	e->language        = language;
+	e->langType        = langType;
 	e->filePosition    = filePosition;
 	e->inputFileName   = inputFileName;
 	e->name            = name;

--- a/main/entry.c
+++ b/main/entry.c
@@ -959,8 +959,6 @@ static void recordTagEntryInQueue (const tagEntryInfo *const tag, tagEntryInfo* 
 		slot->extensionFields.xpath = eStrdup (slot->extensionFields.xpath);
 #endif
 
-	if (slot->sourceLanguage)
-		slot->sourceLanguage = eStrdup (slot->sourceLanguage);
 	if (slot->sourceFileName)
 		slot->sourceFileName = eStrdup (slot->sourceFileName);
 
@@ -1013,8 +1011,6 @@ static void clearTagEntryInQueue (tagEntryInfo* slot)
 		eFree ((char *)slot->extensionFields.xpath);
 #endif
 
-	if (slot->sourceLanguage)
-		eFree ((char *)slot->sourceLanguage);
 	if (slot->sourceFileName)
 		eFree ((char *)slot->sourceFileName);
 
@@ -1280,7 +1276,7 @@ extern void initTagEntry (tagEntryInfo *const e, const char *const name,
 			 kind,
 			 ROLE_INDEX_DEFINITION,
 			 getSourceFileTagPath(),
-			 getSourceLanguageName(),
+			 getSourceLanguage(),
 			 getSourceLineNumber() - getInputLineNumber ());
 }
 
@@ -1295,19 +1291,19 @@ extern void initRefTagEntry (tagEntryInfo *const e, const char *const name,
 			 kind,
 			 roleIndex,
 			 getSourceFileTagPath(),
-			 getSourceLanguageName(),
+			 getSourceLanguage(),
 			 getSourceLineNumber() - getInputLineNumber ());
 }
 
 extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 			      unsigned long lineNumber,
-			      langType langType,
+			      langType langType_,
 			      MIOPos      filePosition,
 			      const char *inputFileName,
 			      const kindDefinition *kind,
 			      int roleIndex,
 			      const char *sourceFileName,
-			      const char* sourceLanguage,
+			      langType sourceLangType,
 			      long sourceLineNumberDifference)
 {
 	int i;
@@ -1317,7 +1313,7 @@ extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 	e->lineNumberEntry = (bool) (Option.locate == EX_LINENUM);
 	e->lineNumber      = lineNumber;
 	e->boundaryInfo    = getNestedInputBoundaryInfo (lineNumber);
-	e->langType        = langType;
+	e->langType        = langType_;
 	e->filePosition    = filePosition;
 	e->inputFileName   = inputFileName;
 	e->name            = name;
@@ -1334,7 +1330,7 @@ extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 	if (doesSubparserRun ())
 		markTagExtraBit (e, XTAG_TAGS_GENERATED_BY_SUBPARSER);
 
-	e->sourceLanguage = sourceLanguage;
+	e->sourceLangType = sourceLangType;
 	e->sourceFileName = sourceFileName;
 	e->sourceLineNumberDifference = sourceLineNumberDifference;
 

--- a/main/entry.h
+++ b/main/entry.h
@@ -54,7 +54,7 @@ struct sTagEntryInfo {
 				       * (may be NULL if not present) *//*  */
 	unsigned int boundaryInfo;    /* info about nested input stream */
 	MIOPos      filePosition;     /* file position of line containing tag */
-	const char* language;         /* language of input file */
+	langType langType;         /* language of input file */
 	const char *inputFileName;   /* name of input file */
 	const char *name;             /* name of the tag */
 	const kindDefinition *kind;	      /* kind descriptor */
@@ -121,7 +121,7 @@ extern void initRefTagEntry (tagEntryInfo *const e, const char *const name,
 			     const kindDefinition *kind, int roleIndex);
 extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 			      unsigned long lineNumber,
-			      const char* language,
+			      langType langType,
 			      MIOPos      filePosition,
 			      const char *inputFileName,
 			      const kindDefinition *kind,

--- a/main/entry.h
+++ b/main/entry.h
@@ -94,7 +94,7 @@ struct sTagEntryInfo {
 
 	/* Following source* fields are used only when #line is found
 	   in input and --line-directive is given in ctags command line. */
-	const char* sourceLanguage;
+	langType sourceLangType;
 	const char *sourceFileName;
 	unsigned long sourceLineNumberDifference;
 };
@@ -121,13 +121,13 @@ extern void initRefTagEntry (tagEntryInfo *const e, const char *const name,
 			     const kindDefinition *kind, int roleIndex);
 extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 			      unsigned long lineNumber,
-			      langType langType,
+			      langType langType_,
 			      MIOPos      filePosition,
 			      const char *inputFileName,
 			      const kindDefinition *kind,
 			      int roleIndex,
 			      const char *sourceFileName,
-			      const char* sourceLanguage,
+			      langType sourceLangType,
 			      long sourceLineNumberDifference);
 extern int makeQualifiedTagEntry (const tagEntryInfo *const e);
 

--- a/main/field.c
+++ b/main/field.c
@@ -469,7 +469,7 @@ static const char *renderEscapedName (const char* s,
 		{
 			verbose ("Unexpected character (0 < *c && *c < 0x20) included in a tagEntryInfo: %s\n", base);
 			verbose ("File: %s, Line: %lu, Lang: %s, Kind: %c\n",
-				 tag->inputFileName, tag->lineNumber, tag->language, tag->kind->letter);
+				 tag->inputFileName, tag->lineNumber, getLanguageName(tag->langType), tag->kind->letter);
 			verbose ("Escape the character\n");
 			break;
 		}
@@ -712,7 +712,7 @@ static const char *renderFieldLanguage (const tagEntryInfo *const tag,
 					vString* b,
 					bool *rejected)
 {
-	const char *l = tag->language;
+	const char *l = getLanguageName(tag->langType);
 
 	if (Option.lineDirectives && tag->sourceLanguage)
 		l = tag->sourceLanguage;
@@ -862,7 +862,7 @@ static const char *renderFieldEnd (const tagEntryInfo *const tag,
 
 static bool     isLanguageFieldAvailable (const tagEntryInfo *const tag)
 {
-	return (tag->language != NULL)? true: false;
+	return (tag->langType == LANG_IGNORE)? false: true;
 }
 
 static bool     isTyperefFieldAvailable  (const tagEntryInfo *const tag)

--- a/main/field.c
+++ b/main/field.c
@@ -712,10 +712,12 @@ static const char *renderFieldLanguage (const tagEntryInfo *const tag,
 					vString* b,
 					bool *rejected)
 {
-	const char *l = getLanguageName(tag->langType);
+	const char *l;
 
-	if (Option.lineDirectives && tag->sourceLanguage)
-		l = tag->sourceLanguage;
+	if (Option.lineDirectives && (tag->sourceLangType != LANG_IGNORE))
+		l = getLanguageName(tag->sourceLangType);
+	else
+		l = getLanguageName(tag->langType);
 
 	return renderAsIs (b, WITH_DEFUALT_VALUE(l));
 }

--- a/main/htable.c
+++ b/main/htable.c
@@ -85,7 +85,7 @@ static void  entry_reclaim (hentry* entry,
 		entry = entry_destroy (entry, keyfreefn, valfreefn);
 }
 
-static void *entry_find (hentry* entry, void* key, hashTableEqualFunc equalfn)
+static void *entry_find (hentry* entry, const void* const key, hashTableEqualFunc equalfn)
 {
 	while (entry)
 	{
@@ -175,7 +175,7 @@ extern void       hashTablePutItem    (hashTable *htable, void *key, void *value
 	htable->table[i] = entry_new(key, value, htable->table[i]);
 }
 
-extern void*      hashTableGetItem   (hashTable *htable, void *key)
+extern void*      hashTableGetItem   (hashTable *htable, const void * key)
 {
 	unsigned int i;
 
@@ -192,7 +192,7 @@ extern bool     hashTableDeleteItem (hashTable *htable, void *key)
 			    htable->equalfn, htable->keyfreefn, htable->valfreefn);
 }
 
-extern bool    hashTableHasItem    (hashTable *htable, void *key)
+extern bool    hashTableHasItem    (hashTable *htable, const void *key)
 {
 	return hashTableGetItem (htable, key)? true: false;
 }
@@ -217,19 +217,18 @@ extern int        hashTableCountItem   (hashTable *htable)
 	hashTableForeachItem (htable, count, &c);
 	return c;
 }
-unsigned int hashPtrhash (void * x)
+
+unsigned int hashPtrhash (const void * const x)
 {
 	union {
-		void *ptr;
+		const void *const ptr;
 		unsigned int ui;
-	} v;
+	} v = {.ui = 0, .ptr = x};
 
-	v.ui = 0;
-	v.ptr = x;
 	return v.ui;
 }
 
-bool hashPtreq (void *a, void *b)
+bool hashPtreq (const void *const a, const void *const b)
 {
 	return (a == b)? true: false;
 }
@@ -237,7 +236,7 @@ bool hashPtreq (void *a, void *b)
 
 /* http://www.cse.yorku.ca/~oz/hash.html */
 static unsigned long
-djb2(unsigned char *str)
+djb2(const unsigned char *str)
 {
 	unsigned long hash = 5381;
 	int c;
@@ -248,18 +247,18 @@ djb2(unsigned char *str)
 	return hash;
 }
 
-unsigned int hashCstrhash (void * x)
+unsigned int hashCstrhash (const void *const x)
 {
-	char *s = x;
-	return (unsigned int)djb2((unsigned char *)s);
+	const char *const s = x;
+	return (unsigned int)djb2((const unsigned char *)s);
 }
 
-bool hashCstreq (void *a, void *b)
+bool hashCstreq (const void * const a, const void *const b)
 {
 	return !!(strcmp (a, b) == 0);
 }
 
-unsigned int hashInthash (void *x)
+unsigned int hashInthash (const void *const x)
 {
        union tmp {
                unsigned int u;
@@ -271,7 +270,7 @@ unsigned int hashInthash (void *x)
        return x0.u;
 }
 
-bool hashInteq (void *a, void *b)
+bool hashInteq (const void *const a, const void *const b)
 {
        int ai = *(int *)a;
        int bi = *(int *)b;

--- a/main/htable.c
+++ b/main/htable.c
@@ -247,6 +247,23 @@ djb2(const unsigned char *str)
 	return hash;
 }
 
+static unsigned long
+casedjb2(const unsigned char *str)
+{
+	unsigned long hash = 5381;
+	int c;
+
+	while ((c = *str++))
+	{
+		if (('a' <= c) && (c <= 'z'))
+			c += ('A' - 'a');
+		hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
+	}
+
+	return hash;
+}
+
+
 unsigned int hashCstrhash (const void *const x)
 {
 	const char *const s = x;
@@ -276,4 +293,16 @@ bool hashInteq (const void *const a, const void *const b)
        int bi = *(int *)b;
 
        return !!(ai == bi);
+}
+
+
+unsigned int hashCstrcasehash (const void *const x)
+{
+	const char *const s = x;
+	return (unsigned int)casedjb2((const unsigned char *)s);
+}
+
+bool hashCstrcaseeq (const void *const a, const void *const b)
+{
+	return !!(strcasecmp (a, b) == 0);
 }

--- a/main/htable.h
+++ b/main/htable.h
@@ -25,6 +25,9 @@ bool hashPtreq (const void * a, const void * constb);
 unsigned int hashCstrhash (const void * x);
 bool hashCstreq (const void * a, const void * b);
 
+unsigned int hashCstrcasehash (const void * x);
+bool hashCstrcaseeq (const void * a, const void * b);
+
 unsigned int hashInthash (const void * x);
 bool hashInteq (const void * a, const void * b);
 

--- a/main/htable.h
+++ b/main/htable.h
@@ -14,19 +14,19 @@
 #include "general.h"
 
 typedef struct sHashTable hashTable;
-typedef unsigned int (* hashTableHashFunc)  (void * key);
-typedef bool      (* hashTableEqualFunc) (void* a, void* b);
+typedef unsigned int (* hashTableHashFunc)  (const void * const key);
+typedef bool      (* hashTableEqualFunc) (const void* a, const void* b);
 typedef void         (* hashTableFreeFunc)  (void * ptr);
 typedef void         (* hashTableForeachFunc) (void *key, void *value, void* user_data);
 
-unsigned int hashPtrhash (void * x);
-bool hashPtreq (void *a, void *b);
+unsigned int hashPtrhash (const void * x);
+bool hashPtreq (const void * a, const void * constb);
 
-unsigned int hashCstrhash (void * x);
-bool hashCstreq (void *a, void *b);
+unsigned int hashCstrhash (const void * x);
+bool hashCstreq (const void * a, const void * b);
 
-unsigned int hashInthash (void *x);
-bool hashInteq (void *a, void *b);
+unsigned int hashInthash (const void * x);
+bool hashInteq (const void * a, const void * b);
 
 extern hashTable* hashTableNew         (unsigned int size,
 					hashTableHashFunc hashfn,
@@ -36,8 +36,8 @@ extern hashTable* hashTableNew         (unsigned int size,
 extern void       hashTableDelete      (hashTable *htable);
 extern void       hashTableClear       (hashTable *htable);
 extern void       hashTablePutItem     (hashTable *htable, void *key, void *value);
-extern void*      hashTableGetItem     (hashTable *htable, void *key);
-extern bool    hashTableHasItem     (hashTable *htable, void *key);
+extern void*      hashTableGetItem     (hashTable *htable, const void * key);
+extern bool    hashTableHasItem     (hashTable * htable, const void * key);
 extern bool    hashTableDeleteItem  (hashTable *htable, void *key);
 extern void       hashTableForeachItem (hashTable *htable, hashTableForeachFunc proc, void *user_data);
 extern int        hashTableCountItem   (hashTable *htable);

--- a/main/lxcmd.c
+++ b/main/lxcmd.c
@@ -1085,7 +1085,7 @@ static bool makeTagEntryFromTagEntry (xcmdPath* path, tagEntry* entry)
 			  entry->kind,
 			  ROLE_INDEX_DEFINITION,
 			  NULL,
-			  NULL,
+			  LANG_IGNORE,
 			  0);
 
 	tag.pattern = entry->address.pattern;

--- a/main/lxcmd.c
+++ b/main/lxcmd.c
@@ -1074,7 +1074,6 @@ static bool makeTagEntryFromTagEntry (xcmdPath* path, tagEntry* entry)
 
 	memset(&filePosition, 0, sizeof(filePosition));
 
-	// TODO: getNamedLanguage is slow.
 	const char* lang = entryLookupField(entry, "language", true);
 	langType langType = getNamedLanguage (lang, 0);
 	initTagEntryFull (&tag, entry->name,

--- a/main/lxcmd.c
+++ b/main/lxcmd.c
@@ -1074,10 +1074,12 @@ static bool makeTagEntryFromTagEntry (xcmdPath* path, tagEntry* entry)
 
 	memset(&filePosition, 0, sizeof(filePosition));
 
-	// pseudo if (entry->name...);
+	// TODO: getNamedLanguage is slow.
+	const char* lang = entryLookupField(entry, "language", true);
+	langType langType = getNamedLanguage (lang, 0);
 	initTagEntryFull (&tag, entry->name,
 			  entry->address.lineNumber,
-			  entryLookupField(entry, "language", true),
+			  langType,
 			  filePosition,
 			  entry->file,
 			  entry->kind,

--- a/main/read.c
+++ b/main/read.c
@@ -215,9 +215,9 @@ extern const char *getSourceFileTagPath (void)
 	return vStringValue (File.source.tagPath);
 }
 
-extern const char *getSourceLanguageName (void)
+extern langType getSourceLanguage (void)
 {
-	return getLanguageName (File.source.langInfo.type);
+	return File.source.langInfo.type;
 }
 
 extern unsigned long getSourceLineNumber (void)

--- a/main/read.h
+++ b/main/read.h
@@ -99,7 +99,7 @@ enum nestedInputBoundaryFlag {
 extern unsigned int getNestedInputBoundaryInfo (unsigned long lineNumber);
 
 extern const char *getSourceFileTagPath (void);
-extern const char *getSourceLanguageName (void);
+extern langType getSourceLanguage (void);
 extern unsigned long getSourceLineNumber (void);
 
 /* Raw: reading from given a parameter, mio */


### PR DESCRIPTION
In the last commit I introduced following code
```
pushLanguage(getNamedLanguage(x.language, 0));
```
for flushing the cork queue in which tags generated by a subparser are stored.
pushLanguage expects a language id. However, the tag holds only the name of language.
Therefore getNamedLanguage is needed for converting. getNamedLanguage is rather slow because it uses liner search internally.

With this commit a tag entry holds language id instead of language name.
So ctags doesn't have to call getNamedLanguage when flushing the queue.
However, xcmd interface has to the function instead.
To avoid the liner search in xcmd, introduce a hashtable as a backend for getNamedLanguage.
