### PR TITLE
Autoconf:  do nothing special about shell-oriented string literals

### DIFF
--- a/Units/parser-autoconf.r/no-string-literal.d/expected.tags
+++ b/Units/parser-autoconf.r/no-string-literal.d/expected.tags
@@ -1,0 +1,2 @@
+HAVE_CONFDB	input.ac	/^AC_DEFINE_UNQUOTED(HAVE_CONFDB, $HAVE_confdb, Have the old herarchial Corosync config API)$/;"	d
+UUID_FILE	input.ac	/^AC_DEFINE_UNQUOTED(UUID_FILE,"$localstatedir\/lib\/heartbeat\/hb_uuid", I'm a bad boy.)$/;"	d

--- a/Units/parser-autoconf.r/no-string-literal.d/input.ac
+++ b/Units/parser-autoconf.r/no-string-literal.d/input.ac
@@ -1,0 +1,3 @@
+dnl Taken from configure.ac of pacemaker
+AC_DEFINE_UNQUOTED(UUID_FILE,"$localstatedir/lib/heartbeat/hb_uuid", I'm a bad boy.)
+AC_DEFINE_UNQUOTED(HAVE_CONFDB, $HAVE_confdb, Have the old herarchial Corosync config API)

--- a/parsers/autoconf.c
+++ b/parsers/autoconf.c
@@ -73,7 +73,8 @@ static bool doesLineCommentStart (m4Subparser *m4, int c, const char* token)
 
 static bool doesStringLiteralStart (m4Subparser *m4, int c)
 {
-	return (c == '"') || (c == '\'') || (c == '`');
+	// return (c == '"') || (c == '\'') || (c == '`');
+	return false;
 }
 
 static bool probeLanguage (m4Subparser *m4, const char* token)

--- a/parsers/m4.c
+++ b/parsers/m4.c
@@ -94,18 +94,10 @@ extern void setM4Quotes(char openQuote, char closeQuote)
 static int getCloseQuote(int openQuote)
 {
 	if (openQuote == m4QuoteOpen)
-		return m4QuoteClose;
-	return 0;
-
-	switch (openQuote)
 	{
-		case '[': return ']';
-		case '`': return '\'';
-		case '\'':
-		case '"': return openQuote;
-
-		default: return 0;
+		return m4QuoteClose;
 	}
+	return 0;
 }
 
 static void skipQuotes(int c)


### PR DESCRIPTION
The original code makes m4 base parser skip shell-oriented string
literals like `...`, '...', and "...".

However, it casues failure of capturing HAVE_CONFDB in following configure.ac:

AC_DEFINE_UNQUOTED(UUID_FILE,"$localstatedir/lib/heartbeat/hb_uuid", I'm a bad boy.)
AC_DEFINE_UNQUOTED(HAVE_CONFDB, $HAVE_confdb, Have the old herarchial Corosync config API)

Lines after the single quote in "I'm a bod boy" are ignored.
It seems that handling such characters something speciall is not a good idea.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>

1 parent 823ed35 commit aba1da58c0ed65b54ba51b8ee69c1f975a9d130c 