### PR TITLE
win32: Generate repoinfo.h on VC2013

### DIFF
--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -10,7 +10,7 @@
 include source.mak
 
 OBJEXT = obj
-REGEX_DEFINES = -DHAVE_REGCOMP -D__USE_GNU -Dbool=int -Dfalse=0 -Dtrue=1 -Dstrcasecmp=stricmp
+REGEX_DEFINES = -DHAVE_REGCOMP -D__USE_GNU -Dbool=int -Dfalse=0 -Dtrue=1 -Dstrcasecmp=stricmp -DHAVE_REPOINFO_H
 DEFINES = -DWIN32 $(REGEX_DEFINES)
 INCLUDES = -I. -Imain -Ignu_regex -Ifnmatch -Iparsers
 OPT = /O2
@@ -37,6 +37,10 @@ PDBFLAG = /debug
 PDBFLAG =
 !endif
 
+# Generate repoinfo.h.
+!if [win32\gen-repoinfo.bat $(REPOINFO_HEADS)]
+!endif
+
 {main}.c{main}.obj::
 	$(CC) $(OPT) $(DEFINES) $(INCLUDES) /Fomain\ /c $<
 {optlib}.c{optlib}.obj::
@@ -52,7 +56,7 @@ all: ctags.exe readtags.exe
 
 ctags: ctags.exe
 
-ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS)
+ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS) $(REPOINFO_HEADS)
 	$(CC) $(OPT) /Fe$@ $(ALL_OBJS) /link setargv.obj $(LIBS) $(PDBFLAG)
 
 readtags.exe: $(READTAGS_OBJS) $(READTAGS_HEADS)
@@ -64,8 +68,10 @@ $(REGEX_OBJS): $(REGEX_SRCS)
 $(FNMATCH_OBJS): $(FNMATCH_SRCS)
 	$(CC) /c $(OPT) /Fo$@ $(INCLUDES) $(DEFINES) $(FNMATCH_SRCS)
 
+main\repoinfo.obj: main\repoinfo.c main\repoinfo.h
+
 
 clean:
-	- del *.obj main\*.obj optlib\*.obj parsers\*.obj parsers\cxx\*.obj gnu_regex\*.obj fnmatch\*.obj read\*.obj
+	- del *.obj main\*.obj optlib\*.obj parsers\*.obj parsers\cxx\*.obj gnu_regex\*.obj fnmatch\*.obj read\*.obj main\repoinfo.h
 	- del ctags.exe readtags.exe
 	- del tags

--- a/win32/gen-repoinfo.bat
+++ b/win32/gen-repoinfo.bat
@@ -1,4 +1,7 @@
 @echo off
+:: Copyright (C) 2017 Ken Takata
+:: License: GPL-2
+
 setlocal
 
 if "%1"=="" (

--- a/win32/gen-repoinfo.bat
+++ b/win32/gen-repoinfo.bat
@@ -1,0 +1,22 @@
+@echo off
+setlocal
+
+if "%1"=="" (
+  echo Usage: gen-repoinfo ^<headerfile^>
+  goto :eof
+)
+set repoinfo_header=%1
+
+set oldinfo=
+if exist %repoinfo_header% (
+  for /f "delims=" %%i in (%1) do set oldinfo=%%i
+) else (
+  type nul > %repoinfo_header%
+)
+
+set newinfo=%oldinfo%
+if exist .git\nul (
+  for /f %%i in ('cmd /c "git describe --tag --exact-match HEAD 2> nul || git rev-parse --short HEAD"') do set newinfo=#define CTAGS_REPOINFO "%%i"
+)
+
+if not "%newinfo%"=="%oldinfo%" echo %newinfo%> %repoinfo_header%


### PR DESCRIPTION
Do the same thing as `misc/gen-repoinfo`, when `mk_mvc.mak` is used.