### PR TITLE
Perl: fix a bug about making full qualified tags

### DIFF
--- a/Units/parser-perl.r/simple.pl.d/args.ctags
+++ b/Units/parser-perl.r/simple.pl.d/args.ctags
@@ -1,2 +1,2 @@
---extras=+g
+--extras=+gq
 --fields=+l

--- a/Units/parser-perl.r/simple.pl.d/expected.tags
+++ b/Units/parser-perl.r/simple.pl.d/expected.tags
@@ -1,5 +1,7 @@
 A	input.pl	/^use constant A => 3;$/;"	c	language:Perl
 A::B	input.pl	/^package A::B;$/;"	p	language:Perl
+A::B::A	input.pl	/^use constant A => 3;$/;"	c	language:Perl
+A::B::MySub	input.pl	/^sub MySub {}$/;"	s	language:Perl
 LABEL	input.pl	/^LABEL:$/;"	l	language:Perl
 MySub	input.pl	/^sub MySub {}$/;"	s	language:Perl
 NAME	input.pl	/^=head1 NAME$/;"	c	language:pod

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -528,6 +528,7 @@ static void findPerlTags (void)
 					initTagEntry (&fqe, vStringValue (qualifiedName),
 						      PerlKinds + kind);
 					markTagExtraBit (&fqe, XTAG_QUALIFIED_TAGS);
+					makeTagEntry (&fqe);
 					vStringDelete (qualifiedName);
 				}
 			}


### PR DESCRIPTION
In 5022e63a I mistakenly deleted the code making
full qualified tags.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>