### PR TITLE
Fix VC warnings

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -817,8 +817,8 @@ extern void getTagScopeInformation (tagEntryInfo *const tag,
 
 
 static int   makePatternStringCommon (const tagEntryInfo *const tag,
-				      int putc_func (char , void *),
-				      int puts_func (const char* , void *),
+				      int (* putc_func) (char , void *),
+				      int (* puts_func) (const char* , void *),
 				      void *output)
 {
 	int length = 0;

--- a/main/options.c
+++ b/main/options.c
@@ -2519,7 +2519,7 @@ static void processPatternLengthLimit(const char *const option, const char *cons
 		error (FATAL, "-%s: Invalid pattern length limit", option);
 }
 
-static bool* redirectToXtag(const booleanOption *const option)
+static bool* redirectToXtag(booleanOption *const option)
 {
 	/* WARNING/TODO: This function breaks capsulization. */
 	xtagType t = (xtagType)option->pValue;

--- a/main/parse.c
+++ b/main/parse.c
@@ -915,7 +915,7 @@ pickLanguageBySelection (selectLanguage selector, MIO *input,
 
 static int compareParsersByName (const void *a, const void* b)
 {
-	parserDefinition *const *la = a, *const *lb = b;
+	const parserDefinition *const *la = a, *const *lb = b;
 	return strcasecmp ((*la)->name, (*lb)->name);
 }
 

--- a/main/routines.c
+++ b/main/routines.c
@@ -556,7 +556,7 @@ static char *strRSeparator (const char *s)
 		last = s;
 		s++;
 	}
-	return last;
+	return (char*) last;
 #else
 	return strrchr (s, PATH_SEPARATOR);
 #endif

--- a/main/routines.h
+++ b/main/routines.h
@@ -121,9 +121,9 @@ extern void toUpperString (char* str);
 extern char* newLowerString (const char* str);
 extern char* newUpperString (const char* str);
 extern bool strToUInt(const char *const str, int base, unsigned int *value);
-extern bool strToULong(const char *string, int base, unsigned long *value);
+extern bool strToULong(const char *const string, int base, unsigned long *value);
 extern bool strToInt(const char *const str, int base, int *value);
-extern bool strToLong(const char *string, int base, long *value);
+extern bool strToLong(const char *const string, int base, long *value);
 
 /* File system functions */
 extern void setCurrentDirectory (void);

--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -13,7 +13,7 @@ OBJEXT = obj
 REGEX_DEFINES = -DHAVE_REGCOMP -D__USE_GNU -Dbool=int -Dfalse=0 -Dtrue=1 -Dstrcasecmp=stricmp -DHAVE_REPOINFO_H
 DEFINES = -DWIN32 $(REGEX_DEFINES)
 INCLUDES = -I. -Imain -Ignu_regex -Ifnmatch -Iparsers
-OPT = /O2
+OPT = /O2 /WX
 REGEX_OBJS = $(REGEX_SRCS:.c=.obj)
 FNMATCH_OBJS = $(FNMATCH_SRCS:.c=.obj)
 WIN32_OBJS = $(WIN32_SRCS:.c=.obj)

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1256,7 +1256,7 @@ static hashTable * defineMacroTable;
 
 /*  Determines whether or not "name" should be ignored, per the ignore list.
  */
-extern const cppMacroInfo * cppFindMacro(const char * name)
+extern const cppMacroInfo * cppFindMacro(const char *const name)
 {
 	if(!defineMacroTable)
 		return NULL;

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -1061,7 +1061,7 @@ static void cxxParserParseNextTokenApplyReplacement(
 	if(pParameters)
 	{
 		cxxTokenChainDestroy(pParameters);
-		eFree(aParameters);
+		eFree((char**)aParameters);
 	}
 
 	CXX_DEBUG_PRINT("Applying complex replacement '%s'",vStringValue(pReplacement));


### PR DESCRIPTION
VC shows the following warnings:

```
main\entry.c(860) : warning C4550: expression evaluates to a function which is missing an argument list
main\entry.c(861) : warning C4550: expression evaluates to a function which is missing an argument list
main\options.c(2522) : warning C4114: same type qualifier used more than once
main\parse.c(918) : warning C4090: 'initializing' : different 'const' qualifiers
main\routines.c(383) : warning C4028: formal parameter 1 different from declaration
main\routines.c(397) : warning C4028: formal parameter 1 different from declaration
main\routines.c(559) : warning C4090: 'return' : different 'const' qualifiers
parsers\cpreprocessor.c(1260) : warning C4028: formal parameter 1 different from declaration
parsers\cxx\cxx_parser_tokenizer.c(1064) : warning C4090: 'function' : different 'const' qualifiers
```

See https://ci.appveyor.com/project/masatake/ctags/build/1.0.2058/job/ceca1toq5bfs857s for full log.
This PR fixes them.