### PR TITLE
Update docs

### DIFF
--- a/docs/format.rst
+++ b/docs/format.rst
@@ -480,9 +480,9 @@ Compatible output and weakness
 .. NOT REVIEWED YET
 
 Default behavior (``--output-format=u-ctags`` option) has the
-exceptions.  In ther hand, with ``--output-format=e-ctags`` option
+exceptions.  In other hand, with ``--output-format=e-ctags`` option
 ctags has no exception; Universal-ctags command may use the same file
 format as Exuberant-ctags. However, ``--output-format=e-ctags`` throws
 away a tag entry which name includes a space or a tab
-character. ``TAG_OUTPUT_MODE`` psuedo tag tells which format is
+character. ``TAG_OUTPUT_MODE`` pseudo tag tells which format is
 used when ctags generating tags file.

--- a/docs/interactive-mode.rst
+++ b/docs/interactive-mode.rst
@@ -4,7 +4,7 @@
 ``--_interactive`` Mode
 ======================================================================
 
-Universtal ctags can be run with ``--_interactive``, which enters a REPL that
+Universal ctags can be run with ``--_interactive``, which enters a REPL that
 can be used programatically to control ctags generation. In this mode, json
 commands are received over stdin, and corresponding responses are emitted over
 stdout.

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -641,7 +641,7 @@ the consistency of dynamically defined kinds in a language.
 A kind letter defined with ``--kinddef-<LANG>`` can be referred in
 ``--kinddef-<LANG>``.
 
-Previsouly you had to write in your optlib::
+Previously you had to write in your optlib::
 
     --regex-elm=/^([[:lower:]_][[:alnum:]_]*)[^=]*=$/\1/f,function,Functions/{scope=set}
     --regex-elm=/^[[:blank:]]+([[:lower:]_][[:alnum:]_]*)[^=]*=$/\1/f,function,Functions/{scope=ref}
@@ -718,7 +718,7 @@ The output is change as follows with `linux` parser:
 Using only `--regex-C=...` you can capture `setpriority`.
 However, there were concerns about kind confliction; when introducing
 a new kind with `--regex-C=...`, you cannot use a letter and name already
-used in C parser and `--regex-C=...` options sepcified in the other places.
+used in C parser and `--regex-C=...` options specified in the other places.
 
 You can use a newly defined subparser as a new namespace of kinds.
 In addition you can enable/disable with the subparser usable

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -533,7 +533,7 @@ Next example is based on an issue #219 posted by @andreicristianpetcu::
 
 ``{_multiline=N}``
 
-	This tells the patern should be applied to whole file
+	This tells the pattern should be applied to whole file
 	contents, not line by line.  ``N`` is the number of a group in the
 	pattern. The specified group is used to record the line number
 	and the pattern of tag. In the above example 3 is

--- a/docs/output-json.rst
+++ b/docs/output-json.rst
@@ -80,6 +80,6 @@ i
 b
 	boolean
 
-For exapmle, The value for "inherits" field is represented in the string or boolean type.
+For example, The value for "inherits" field is represented in the string or boolean type.
 
 	

--- a/docs/output-xref.rst
+++ b/docs/output-xref.rst
@@ -6,5 +6,5 @@
 Xref output
 ======================================================================
 
-* Priting `z`{kind} field in xref format doesn't include `kind:` prefix.
-* Priting `Z`{scope} field in xref format doesn't include `scope:` prefix.
+* Printing `z`{kind} field in xref format doesn't include `kind:` prefix.
+* Printing `Z`{scope} field in xref format doesn't include `scope:` prefix.

--- a/docs/parser-asm.rst
+++ b/docs/parser-asm.rst
@@ -8,7 +8,7 @@ Asm parser
 
 :Maintainer: Masatake YAMATO <yamato@redhat.com>
 
-The orignal(Exuberant-ctags) parser handles #define C preprocessor directive and C
+The original (Exuberant-ctags) parser handles #define C preprocessor directive and C
 style comments by itself. In Universal-ctags Asm parser utilizes CPreProcessor meta
 parser for handling them. So an language object defined with #define is tagged as
 "defines" of CPreProcessor language, not Asm language.

--- a/docs/parser-html.rst
+++ b/docs/parser-html.rst
@@ -24,7 +24,7 @@ It handles HTML comments correctly and in addition to existing tags it extracts
 also <h1>, <h2> and <h3> headings. It should be reasonably simple to add new
 tag types.
 
-Finally, the parser uses the new funtionality of universal-ctags to use another
+Finally, the parser uses the new functionality of universal-ctags to use another
 parser for parsing other languages within a host language. This is used for
 parsing JavaScript within <script> tags and CSS within <style> tags. This
 simplifies the parser and generates much better results than having a simplified

--- a/docs/running-multi-parsers.rst
+++ b/docs/running-multi-parsers.rst
@@ -735,7 +735,7 @@ In addition `bin` is tagged as directory, and `ctags` as program of Automake.
 
 `--extras=+r` is used in the example. `r` extra is needed to
 tag `bin`. `bin` is not defined in the line, `bin_PROGRAMS =`.
-`bin` is referenced as a name of directory where prgorams are
+`bin` is referenced as a name of directory where programs are
 stored. Therefore `r` is needed.
 
 For tagging `ctags`, the Automake parser must recognize

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -52,6 +52,10 @@ If you want to build a debug version using ``mk_mvc.mak``, you must specify ``DE
 
         nmake -f mk_mvc.mak DEBUG=1
 
+If you want to create PDB files for debugging even for a release version, you must specify ``PDB=1`` like below::
+
+        nmake -f mk_mvc.mak PDB=1
+
 GCC
 .............................................................................
 
@@ -76,7 +80,7 @@ If you want to build a debug version, you must specify ``DEBUG=1`` like below::
 
         make -f mk_mingw.mak DEBUG=1
 
-**MSYS**
+**MSYS / MSYS2**
 
 From their site: MSYS is a collection of GNU utilities such as bash, make, gawk and grep to allow building of applications and programs which depend on traditional UNIX tools to be present. It is intended to supplement MinGW and the deficiencies of the cmd shell.
 
@@ -85,6 +89,7 @@ MSYS comes in two flavors. The original from MinGW and a MSYS2 http://sourceforg
 MSYS is old but still works. You can build ctags with it using ``make -f mk_mingw.mak``. The Autotools are too old on MSYS so you cannot use them.
 
 MSYS2 is a more maintained version of MSYS, but specially geared towards MinGW-w64. You can also use Autotools to build ctags.
+If you use Autotools you can enable parsers which require libxml2 or libyaml, and can also do the Units testing with `make units`.
 
 **Cygwin**
 
@@ -121,7 +126,7 @@ Microsoft Visual Studio
 
 As already mentioned Microsoft Visual Studio 2013 has the free Express and Community editions. For ctags the Windows Desktop Express Edition is enough to get the job done. The IDE has a proper debugger. Project files for VS2013 can be found in the win32 directory.
 
-Please know that when files are added to the sources.mak, these files need to be added to the .vcproj and .vcproj.filters files as well. The XML of these files should not be a problem.
+Please know that when files are added to the sources.mak, these files need to be added to the .vcxproj and .vcxproj.filters files as well. The XML of these files should not be a problem.
 
 Code::Blocks
 .............................................................................


### PR DESCRIPTION
Update Windows document and fix typos.

* Add description about PDB=1 option.
* Change a section name from "MSYS" to "MSYS / MSYS2" to make clear that the section also mentions MSYS2.
* Add merits using Autotools on MSYS2.
* Recent Visual Studio uses `*.vcxproj*` for its project filename instead of `*.vcproj*`.
* Fix typos.