### PR TITLE
appveyor: Create html docs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
       MSYSTEM: MINGW64
     - compiler: msvc_msys2
       ARCH: x86
-      MSYS2_ARCH: x86
+      MSYS2_ARCH: i686
       MSYS2_DIR: msys64
       MSYSTEM: MINGW32
     - compiler: mingw

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -117,11 +117,20 @@ bash -lc "make check APPVEYOR=1"
 goto :eof
 
 :msvc_msys2_package
+:: Build html docs
+bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-python3-sphinx && break || sleep 15; done"
+bash -lc "cd docs; make html"
+move docs\_build\html docs > nul
+rd /s/q docs\_build
+
+:: Get version
 if "%APPVEYOR_REPO_TAG_NAME%"=="" (
   for /f %%i in ('git rev-parse --short HEAD') do set ver=%%i
 ) else (
   set ver=%APPVEYOR_REPO_TAG_NAME%
 )
+
+:: Create zip package
 copy win32\mkstemp\COPYING.MinGW-w64-runtime.txt . > nul
 7z a ctags-%ver%-%ARCH%.zip ctags.exe readtags.exe iconv.dll COPYING COPYING.MinGW-w64-runtime.txt docs README.md
 7z a ctags-%ver%-%ARCH%.pdb.zip ctags.pdb readtags.pdb

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -117,11 +117,12 @@ bash -lc "make check APPVEYOR=1"
 goto :eof
 
 :msvc_msys2_package
+md package
 :: Build html docs
 bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-python3-sphinx && break || sleep 15; done"
 bash -lc "cd docs; make html"
-move docs\_build\html docs > nul
-rd /s/q docs\_build
+move docs\_build\html package\docs > nul
+rd /s/q package\docs\_sources
 
 :: Get version
 if "%APPVEYOR_REPO_TAG_NAME%"=="" (
@@ -132,7 +133,11 @@ if "%APPVEYOR_REPO_TAG_NAME%"=="" (
 
 :: Create zip package
 copy win32\mkstemp\COPYING.MinGW-w64-runtime.txt . > nul
-7z a ctags-%ver%-%ARCH%.zip ctags.exe readtags.exe iconv.dll COPYING COPYING.MinGW-w64-runtime.txt docs README.md
+set filelist=ctags.exe readtags.exe iconv.dll COPYING COPYING.MinGW-w64-runtime.txt README.md
+robocopy . package %filelist% > nul
+cd package
+7z a ..\ctags-%ver%-%ARCH%.zip %filelist% docs
+cd ..
 7z a ctags-%ver%-%ARCH%.pdb.zip ctags.pdb readtags.pdb
 goto :eof
 


### PR DESCRIPTION
Create html docs on AppVeyor.
I put the html docs in `docs/html/`, but I'm not sure this is the right directory structure.

```
 .
├── COPYING
├── COPYING.MinGW-w64-runtime.txt
├── ctags.exe
├── docs
│   ├── *.rst
│   └── html
│       └── *.html
├── iconv.dll
├── README.md
└── readtags.exe
```