### PR TITLE
Cxx,refactor: introduce generic function for reducing tokens

### DIFF
--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -144,19 +144,7 @@ bool cxxParserParseAndCondenseSubchainsUpToOneOf(
 		if(cxxTokenTypeIsOneOf(g_cxx.pToken,uTokenTypes))
 		{
 			if (bCanReduceInnerElements)
-			{
-				enum CXXTokenType eSentinelType = g_cxx.pToken->eType >> 4;
-				CXXToken *pTmp = g_cxx.pToken->pPrev, *pReducingCandidate;
-				while (pTmp && (!cxxTokenTypeIsOneOf (pTmp, eSentinelType)))
-				{
-					pReducingCandidate = pTmp;
-					pTmp = pTmp->pPrev;
-					pTmp->pNext = pReducingCandidate->pNext;
-					pReducingCandidate->pNext->pPrev = pTmp;
-					CXX_DEBUG_PRINT("reduce inner token: %p",pReducingCandidate);
-					cxxTokenDestroy (pReducingCandidate);
-				}
-			}
+				cxxTokenReduceBackward (g_cxx.pToken);
 			CXX_DEBUG_LEAVE_TEXT(
 					"Got terminator token '%s' 0x%x",
 					vStringValue(g_cxx.pToken->pszWord),

--- a/parsers/cxx/cxx_token.c
+++ b/parsers/cxx/cxx_token.c
@@ -153,3 +153,20 @@ void cxxTokenAppendToString(vString * s,CXXToken * t)
 		break;
 	}
 }
+
+void cxxTokenReduceBackward (CXXToken *pStart)
+{
+	enum CXXTokenType eSentinelType = pStart->eType >> 4;
+	CXXToken *pTmp = pStart->pPrev;
+	CXXToken *pReducingCandidate;
+
+	while (pTmp && (!cxxTokenTypeIsOneOf (pTmp, eSentinelType)))
+	{
+		pReducingCandidate = pTmp;
+		pTmp = pTmp->pPrev;
+		pTmp->pNext = pReducingCandidate->pNext;
+		pReducingCandidate->pNext->pPrev = pTmp;
+		CXX_DEBUG_PRINT("reduce inner token: %p",pReducingCandidate);
+		cxxTokenDestroy (pReducingCandidate);
+	}
+}

--- a/parsers/cxx/cxx_token.h
+++ b/parsers/cxx/cxx_token.h
@@ -111,5 +111,6 @@ void cxxTokenAPIInit(void);
 void cxxTokenAPINewFile(void);
 void cxxTokenAPIDone(void);
 
+void cxxTokenReduceBackward (CXXToken *pStart);
 
 #endif //!ctags_cxx_token_h_


### PR DESCRIPTION
In commit:

        Cxx: reduce blocks when parsing values for array/union initialization

I introduced a loop to delete tokens to make memory usage during parsing
a large array smaller.

Newly introduced function cxxTokenReduceBackward is generalized version
of the loop. So you can apply to another place in the parser.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>