### PR TITLE
appveyor: Use MSYS2 for packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ If you want to try the latest universal-ctags without building it yourself...
 
 ### Windows
 - Go to https://ci.appveyor.com/project/masatake/ctags/branch/master
-  - Click the ```compiler=msvc_msys2, ARCH=x64, ...``` (or ```compiler=msvc_msys2, ARCH=x86, ...```) build.
+  - Click the ```compiler=msys2, ARCH=x64, ...``` (or ```compiler=msys2, ARCH=x86, ...```) build.
   - View the *Artifacts* tab and download ```ctags-XXXXXX-x64.zip``` (or ```ctags-XXXXXX-x86.zip```). (```XXXXXX``` is a version number or a commit ID.)
   - Add the binary folder to your PATH.
-  - If you need PDB files for debugging, download ```ctags-XXXXXX-x64.pdb.zip``` (or ```ctags-XXXXXX-x86.pdb.zip```).
 
 ### Mac
 See [Homebrew Tap for Universal Ctags](https://github.com/universal-ctags/homebrew-universal-ctags)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ If you want to try the latest universal-ctags without building it yourself...
   - Click the ```compiler=msys2, ARCH=x64, ...``` (or ```compiler=msys2, ARCH=x86, ...```) build.
   - View the *Artifacts* tab and download ```ctags-XXXXXX-x64.zip``` (or ```ctags-XXXXXX-x86.zip```). (```XXXXXX``` is a version number or a commit ID.)
   - Add the binary folder to your PATH.
+  - If you need unstripped binaries for debugging, download ```ctags-XXXXXX-x64.debug.zip``` (or ```ctags-XXXXXX-x86.debug.zip```).
 
 ### Mac
 See [Homebrew Tap for Universal Ctags](https://github.com/universal-ctags/homebrew-universal-ctags)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,20 @@ environment:
   matrix:
     - compiler: msbuild
       CONFIGURATION: Release
-    - compiler: msvc_msys2
+    - compiler: msys2
       ARCH: x64
       MSYS2_ARCH: x86_64
       MSYS2_DIR: msys64
       MSYSTEM: MINGW64
-    - compiler: msvc_msys2
+    - compiler: msys2
       ARCH: x86
       MSYS2_ARCH: i686
       MSYS2_DIR: msys64
       MSYSTEM: MINGW32
+    - compiler: msvc
+      ARCH: x64
+    #- compiler: msvc
+    #  ARCH: x86
     - compiler: mingw
     - compiler: cygwin
 

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -89,7 +89,26 @@ MSYS comes in two flavors. The original from MinGW and a MSYS2 http://sourceforg
 MSYS is old but still works. You can build ctags with it using ``make -f mk_mingw.mak``. The Autotools are too old on MSYS so you cannot use them.
 
 MSYS2 is a more maintained version of MSYS, but specially geared towards MinGW-w64. You can also use Autotools to build ctags.
-If you use Autotools you can enable parsers which require libxml2 or libyaml, and can also do the Units testing with `make units`.
+If you use Autotools you can enable parsers which require jansson, libxml2 or libyaml, and can also do the Units testing with ``make units``.
+
+The following packages are needed to build a full-featured version:
+
+- base-devel (make, autoconf)
+- mingw-w64-{i686,x86_64}-toolchain (mingw-w64-{i686,x86_64}-gcc, mingw-w64-{i686,x86_64}-pkg-config)
+- mingw-w64-{i686,x86_64}-jansson
+- mingw-w64-{i686,x86_64}-libxml2
+- mingw-w64-{i686,x86_64}-libyaml
+- mingw-w64-{i686,x86_64}-xz
+
+If you want to build a single static-linked binary, you can use the following command:
+
+.. code-block:: bash
+
+        ./autogen.sh
+        ./configure --disable-external-sort EXTRA_CFLAGS=-DLIBXML_STATIC LDFLAGS=-static LIBS='-lz -llzma -lws2_32'
+        make
+
+``--disable-external-sort`` is a recommended option for Windows builds.
 
 **Cygwin**
 
@@ -107,7 +126,7 @@ You can also build a native Windows version using Autotools.
 	./configure --host=i686-w64-mingw32 --disable-external-sort
 	make
 
-If you use Autotools you can also do the Units testing with `make units`. Some tests fail, that needs to be investigated.
+If you use Autotools you can also do the Units testing with ``make units``.
 
 Some anti-virus software slows down the build and test process significantly, especially when ``./configure`` is running and during the Units tests. In that case it could help to temporarily disable them. But be aware of the risks when you disable your anti-virus software.
 

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -12,7 +12,7 @@ if "%1"=="" (
   set target=%1
 )
 
-for %%i in (msbuild msvc_msys2 mingw cygwin) do if "%compiler%"=="%%i" goto %compiler%_%target%
+for %%i in (msbuild msvc msys2 mingw cygwin) do if "%compiler%"=="%%i" goto %compiler%_%target%
 
 echo Unknown build target.
 exit 1
@@ -43,16 +43,19 @@ goto :eof
 goto :eof
 
 
-:msvc_msys2_build
+:msvc_build
 :: ----------------------------------------------------------------------
 :: Using VC12 (VC2013) with nmake, iconv enabled
 :: Also build with msys2 and test the VC binary on msys2.
+set MSYS2_ARCH=x86_64
+set MSYS2_DIR=msys64
+set MSYSTEM=MINGW64
 call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" %ARCH%
 
 :: Build libiconv (MSVC port)
 set ICONV_BUILD_DIR=C:\projects\libiconv
 set "INCLUDE=%INCLUDE%;C:\Program Files (x86)\Microsoft SDKs\Windows\v7.1A\Include"
-git clone -q --branch=master https://github.com/koron/libiconv.git %ICONV_BUILD_DIR%
+git clone -q --branch=master --depth=1 https://github.com/koron/libiconv.git %ICONV_BUILD_DIR%
 cd %ICONV_BUILD_DIR%\msvc10
 nmake NODEBUG=1 NOMSVCRT=1
 
@@ -69,57 +72,84 @@ copy %ICONV_BUILD_DIR%\msvc10\iconv.dll %APPVEYOR_BUILD_FOLDER% > nul
 cd %APPVEYOR_BUILD_FOLDER%
 nmake -f mk_mvc.mak WITH_ICONV=yes ICONV_DIR=%ICONV_DIR% PDB=yes
 
+:: Backup VC binaries
+mkdir vc
+move *.exe vc > nul
+
+:: Build with msys2
+path C:\%MSYS2_DIR%\usr\bin;%PATH%
+set CHERE_INVOKING=yes
+:: Install and update necessary packages
+rem bash -lc "for i in {1..3}; do pacman --noconfirm -S mingw-w64-%MSYS2_ARCH%-{python3-sphinx,jansson,libxml2,libyaml} && break || sleep 15; done"
+
+bash -lc "./autogen.sh"
+:: Patching configure.
+:: Workaround for "./configure: line 557: 0: Bad file descriptor"
+perl -i".bak" -pe "s/^test -n \".DJDIR\"/#$&/" configure
+bash -lc "./configure && make"
+
+:: Restore VC binaries
+copy vc\*.exe . /y > nul
+touch *.exe
+
+@echo off
+goto :eof
+
+:msvc_test
+@echo on
 :: Check filetype (VC binaries)
 c:\cygwin\bin\file ctags.exe
 c:\cygwin\bin\file readtags.exe
 :: Check if it works
 .\ctags --version || exit 1
 
-:: Backup VC binaries
-mkdir vc
-move *.exe vc > nul
-
-:: Build with msys2
-PATH C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%
-set CHERE_INVOKING=yes
-:: Install and update necessary packages
-rem bash -lc "for i in {1..3}; do update-core && break || sleep 15; done"
-rem bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-{gcc,libiconv} automake autoconf make dos2unix && break || sleep 15; done"
-
-bash -lc "./autogen.sh"
-:: Patching configure.
-:: Workaround for "./configure: line 557: 0: Bad file descriptor"
-perl -i".bak" -pe "s/^test -n \".DJDIR\"/#$&/" configure
-bash -lc "./configure --enable-iconv && make"
-
-:: Check filetype (msys2 binaries)
-c:\cygwin\bin\file ctags.exe
-c:\cygwin\bin\file readtags.exe
-:: Check if it works
-.\ctags --version || exit 1
-
-:: Backup msys2 binaries (Currently not used.)
-mkdir msys2
-move *.exe msys2 > nul
-
-:: Restore VC binaries
-copy vc\*.exe . /y > nul
-
-@echo off
-goto :eof
-
-:msvc_msys2_test
-@echo on
 :: Run tests
 bash -lc "make check APPVEYOR=1"
 
 @echo off
 goto :eof
 
-:msvc_msys2_package
+:msvc_package
+:: Do nothing.
+goto :eof
+
+
+:msys2_build
+:: ----------------------------------------------------------------------
+:: Using msys2
+@echo on
+PATH C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%
+set CHERE_INVOKING=yes
+:: Install and update necessary packages
+bash -lc "for i in {1..3}; do pacman --noconfirm -S mingw-w64-%MSYS2_ARCH%-{python3-sphinx,jansson,libxml2,libyaml} && break || sleep 15; done"
+
+bash -lc "./autogen.sh"
+:: Patching configure.
+:: Workaround for "./configure: line 557: 0: Bad file descriptor"
+perl -i".bak" -pe "s/^test -n \".DJDIR\"/#$&/" configure
+:: Use static link.
+bash -lc "./configure --enable-iconv --disable-external-sort EXTRA_CFLAGS='-static -DLIBXML_STATIC' LIBS='-lz -llzma -lws2_32' && make"
+
+@echo off
+goto :eof
+
+:msys2_test
+@echo on
+:: Check filetype (msys2 binaries)
+c:\cygwin\bin\file ctags.exe
+c:\cygwin\bin\file readtags.exe
+:: Check if it works
+.\ctags --version || exit 1
+
+:: Run tests
+bash -lc "make check APPVEYOR=1"
+
+@echo off
+goto :eof
+
+:msys2_package
 md package
 :: Build html docs
-bash -lc "for i in {1..3}; do pacman --noconfirm -Su mingw-w64-%MSYS2_ARCH%-python3-sphinx && break || sleep 15; done"
 bash -lc "cd docs; make html"
 move docs\_build\html package\docs > nul
 rd /s/q package\docs\_sources
@@ -132,13 +162,11 @@ if "%APPVEYOR_REPO_TAG_NAME%"=="" (
 )
 
 :: Create zip package
-copy win32\mkstemp\COPYING.MinGW-w64-runtime.txt . > nul
-set filelist=ctags.exe readtags.exe iconv.dll COPYING COPYING.MinGW-w64-runtime.txt README.md
+set filelist=ctags.exe readtags.exe COPYING README.md
 robocopy . package %filelist% > nul
 cd package
 7z a ..\ctags-%ver%-%ARCH%.zip %filelist% docs
 cd ..
-7z a ctags-%ver%-%ARCH%.pdb.zip ctags.pdb readtags.pdb
 goto :eof
 
 

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -162,10 +162,13 @@ if "%APPVEYOR_REPO_TAG_NAME%"=="" (
 )
 
 :: Create zip package
-set filelist=ctags.exe readtags.exe COPYING README.md
+set filelist=ctags.exe readtags.exe README.md
 robocopy . package %filelist% > nul
+robocopy win32\license package\license > nul
+copy COPYING package\license > nul
+copy win32\mkstemp\COPYING.MinGW-w64-runtime.txt package\license > nul
 cd package
-7z a ..\ctags-%ver%-%ARCH%.zip %filelist% docs
+7z a ..\ctags-%ver%-%ARCH%.zip %filelist% docs license
 cd ..
 goto :eof
 

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -128,7 +128,7 @@ bash -lc "./autogen.sh"
 :: Workaround for "./configure: line 557: 0: Bad file descriptor"
 perl -i".bak" -pe "s/^test -n \".DJDIR\"/#$&/" configure
 :: Use static link.
-bash -lc "./configure --enable-iconv --disable-external-sort EXTRA_CFLAGS='-static -DLIBXML_STATIC' LIBS='-lz -llzma -lws2_32' && make"
+bash -lc "./configure --enable-iconv --disable-external-sort EXTRA_CFLAGS=-DLIBXML_STATIC LDFLAGS=-static LIBS='-lz -llzma -lws2_32' && make"
 
 @echo off
 goto :eof

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -168,6 +168,8 @@ robocopy win32\license package\license > nul
 copy COPYING package\license > nul
 copy win32\mkstemp\COPYING.MinGW-w64-runtime.txt package\license > nul
 cd package
+7z a ..\ctags-%ver%-%ARCH%.debug.zip %filelist% docs license
+strip *.exe
 7z a ..\ctags-%ver%-%ARCH%.zip %filelist% docs license
 cd ..
 goto :eof

--- a/win32/license/Copyright.libxml2
+++ b/win32/license/Copyright.libxml2
@@ -1,0 +1,23 @@
+Except where otherwise noted in the source code (e.g. the files hash.c,
+list.c and the trio files, which are covered by a similar licence but
+with different Copyright notices) all the files are:
+
+ Copyright (C) 1998-2012 Daniel Veillard.  All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is fur-
+nished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FIT-
+NESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/win32/license/LICENSE.janssen
+++ b/win32/license/LICENSE.janssen
@@ -1,0 +1,19 @@
+Copyright (c) 2009-2016 Petri Lehtinen <petri@digip.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/win32/license/LICENSE.libyaml
+++ b/win32/license/LICENSE.libyaml
@@ -1,0 +1,19 @@
+Copyright (c) 2006 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
* Use MSYS2 to create zip packages and stop using VC for it.
* Enable following libraries with MSYS2:
  jansson, libxml2, libyaml.
* Enable static link with MSYS2.