### PR TITLE
main: Replace last '\n' with '\0' before sorting (Fix #1411)

### DIFF
--- a/main/sort.c
+++ b/main/sort.c
@@ -193,7 +193,7 @@ static int compareTags (const void *const one, const void *const two)
 }
 
 static void writeSortedTags (
-		char **const table, const size_t numTags, const bool toStdout)
+		char **const table, const size_t numTags, const bool toStdout, bool newlineReplaced)
 {
 	MIO *mio;
 	size_t i;
@@ -214,8 +214,12 @@ static void writeSortedTags (
 		 *  pattern) if this is not an xref file.
 		 */
 		if (i == 0  ||  Option.xref  ||  strcmp (table [i], table [i-1]) != 0)
+		{
 			if (mio_puts (mio, table [i]) == EOF)
 				failedSort (mio, NULL);
+			else if (newlineReplaced)
+				mio_putc (mio, '\n');
+		}
 	}
 	if (toStdout)
 		mio_flush (mio);
@@ -228,11 +232,12 @@ extern void internalSortTags (const bool toStdout, MIO* mio, size_t numTags)
 	const char *line;
 	size_t i;
 	int (*cmpFunc)(const void *, const void *);
+	bool newlineReplaced = false;
 
 	/*  Allocate a table of line pointers to be sorted.
 	 */
 	const size_t tableSize = numTags * sizeof (char *);
-	char **const table = (char **) malloc (tableSize);  /* line pointers */
+	char **table = (char **) malloc (tableSize);  /* line pointers */
 	DebugStatement ( size_t mallocSize = tableSize; )  /* cumulative total */
 
 
@@ -260,6 +265,11 @@ extern void internalSortTags (const bool toStdout, MIO* mio, size_t numTags)
 				failedSort (mio, "out of memory");
 			DebugStatement ( mallocSize += stringSize; )
 			strcpy (table [i], line);
+			if (table[i][stringSize - 2] == '\n')
+			{
+				table[i][stringSize - 2] = '\0';
+				newlineReplaced = true;
+			}
 			++i;
 		}
 	}
@@ -270,7 +280,7 @@ extern void internalSortTags (const bool toStdout, MIO* mio, size_t numTags)
 	 */
 	qsort (table, numTags, sizeof (*table), cmpFunc);
 
-	writeSortedTags (table, numTags, toStdout);
+	writeSortedTags (table, numTags, toStdout, newlineReplaced);
 
 	PrintStatus (("sort memory: %ld bytes\n", (long) mallocSize));
 	for (i = 0 ; i < numTags ; ++i)


### PR DESCRIPTION
internalSortTags() sorted lines including the last '\n'. This caused
unexpected results.

This is based on a fix written by Masatake YAMATO.
https://github.com/universal-ctags/ctags/issues/1411#issuecomment-304450502