### PR TITLE
Incorrect handling of types causes a segfault on arm

### DIFF
--- a/main/parse.c
+++ b/main/parse.c
@@ -244,7 +244,7 @@ extern int defineLanguageKind (const langType language, kindDefinition *def,
 	return defineKind (LanguageTable [language].kindControlBlock, def, freeKindDef);
 }
 
-extern kindDefinition* getLanguageKind (const langType language, char kindIndex)
+extern kindDefinition* getLanguageKind (const langType language, signed char kindIndex)
 {
 	kindDefinition* kdef;
 

--- a/main/parse.h
+++ b/main/parse.h
@@ -147,8 +147,9 @@ extern parserDefinition* parserNew (const char* name);
 extern bool doesLanguageAllowNullTag (const langType language);
 extern bool doesLanguageRequestAutomaticFQTag (const langType language);
 extern const char *getLanguageName (const langType language);
+/* kindIndex has to be explicitly signed because char is not signed in all platforms. */
 extern kindDefinition* getLanguageKindForLetter (const langType language, char kindLetter);
-extern kindDefinition* getLanguageKind(const langType language, char kindIndex);
+extern kindDefinition* getLanguageKind(const langType language, signed char kindIndex);
 extern int defineLanguageKind (const langType language, kindDefinition *def,
 							   freeKindDefFunc freeKindDef);
 extern langType getNamedLanguage (const char *const name, size_t len);


### PR DESCRIPTION
On armv7l, char type is actually unsigned. So doing a switch on an unsigned value kindIndex with a negative case value actually does not work. My suggestion is to fix the type of kindIndex specifically to signed char. All unit tests pass if I make that change as well.

make units is passed.

Created an issue: https://github.com/universal-ctags/ctags/issues/1423

I am contributing the code under the terms of the General Public License version 2 or any later version.