### PR TITLE
buildsys: Fix `make distclean`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,13 @@
 include $(top_srcdir)/source.mak
 
 # Test cases are added to EXTRA_DIST in makefiles/test-cases.mak
-EXTRA_DIST   = gnu_regex/regcomp.c gnu_regex/regexec.c \
+EXTRA_DIST   = README.md \
+	       gnu_regex/regcomp.c gnu_regex/regexec.c \
 	       gnu_regex/regex_internal.c gnu_regex/regex_internal.h \
-	       $(WIN32_HEADS) $(WIN32_SRCS)
+	       $(WIN32_HEADS) $(WIN32_SRCS) mk_mingw.mak mk_mvc.mak \
+	       win32/appveyor.bat win32/ctags_vs2013.sln \
+	       win32/ctags_vs2013.vcxproj win32/ctags_vs2013.vcxproj.filters \
+	       win32/gen-repoinfo.bat
 
 bin_PROGRAMS = ctags
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,11 +1,14 @@
 include $(top_srcdir)/source.mak
 
 # Test cases are added to EXTRA_DIST in makefiles/test-cases.mak
-EXTRA_DIST   = README.md \
-	       gnu_regex/regcomp.c gnu_regex/regexec.c \
+EXTRA_DIST   = README.md autogen.sh \
+	       .ctags .dir-locals.el .editorconfig .gdbinit .gitignore \
+	       .indent.pro .uncrustify.cfg \
+	       gnu_regex/README.txt gnu_regex/regcomp.c gnu_regex/regexec.c \
 	       gnu_regex/regex_internal.c gnu_regex/regex_internal.h \
 	       $(WIN32_HEADS) $(WIN32_SRCS) mk_mingw.mak mk_mvc.mak \
-	       win32/appveyor.bat win32/ctags_vs2013.sln \
+	       win32/mkstemp/COPYING.MinGW-w64-runtime.txt \
+	       win32/ctags_vs2013.sln \
 	       win32/ctags_vs2013.vcxproj win32/ctags_vs2013.vcxproj.filters \
 	       win32/gen-repoinfo.bat
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,8 @@ include $(top_srcdir)/source.mak
 
 # Test cases are added to EXTRA_DIST in makefiles/test-cases.mak
 EXTRA_DIST   = gnu_regex/regcomp.c gnu_regex/regexec.c \
-	       gnu_regex/regex_internal.c gnu_regex/regex_internal.h
+	       gnu_regex/regex_internal.c gnu_regex/regex_internal.h \
+	       $(WIN32_HEADS) $(WIN32_SRCS)
 
 bin_PROGRAMS = ctags
 
@@ -82,7 +83,7 @@ OPTLIB2C = $(srcdir)/misc/optlib2c
 %.c: %.ctags $(OPTLIB2C) Makefile
 	$(optlib2c_verbose)$(OPTLIB2C) --transform-xcmd="$(program_transform_name)" $< > $@
 endif
-dist_ctags_SOURCES = $(ALL_HEADS) $(ALL_SRCS) $(WIN32_HEADS) $(WIN32_SRCS)
+dist_ctags_SOURCES = $(ALL_HEADS) $(ALL_SRCS)
 
 if ENABLE_XCMD
 driversdir = $(pkglibexecdir)/drivers

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,8 @@
 include $(top_srcdir)/source.mak
 
 # Test cases are added to EXTRA_DIST in makefiles/test-cases.mak
-EXTRA_DIST   = $(NULL)
+EXTRA_DIST   = gnu_regex/regcomp.c gnu_regex/regexec.c \
+	       gnu_regex/regex_internal.c gnu_regex/regex_internal.h
 
 bin_PROGRAMS = ctags
 
@@ -81,7 +82,7 @@ OPTLIB2C = $(srcdir)/misc/optlib2c
 %.c: %.ctags $(OPTLIB2C) Makefile
 	$(optlib2c_verbose)$(OPTLIB2C) --transform-xcmd="$(program_transform_name)" $< > $@
 endif
-dist_ctags_SOURCES = $(ALL_HEADS) $(ALL_SRCS)
+dist_ctags_SOURCES = $(ALL_HEADS) $(ALL_SRCS) $(WIN32_HEADS) $(WIN32_SRCS)
 
 if ENABLE_XCMD
 driversdir = $(pkglibexecdir)/drivers

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@
 
 AC_PREREQ([2.59])
 AC_INIT([universal-ctags],[0.0.0])
-AM_INIT_AUTOMAKE([foreign subdir-objects])
+AM_INIT_AUTOMAKE([foreign subdir-objects tar-ustar])
 AM_SILENT_RULES([yes])
 AC_CONFIG_HEADERS([config.h])
 if ! test -e "${srcdir}/config.h.in"; then

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -2,6 +2,8 @@
 
 check: tmain units
 
+clean-local: clean-units clean-tmain
+
 CTAGS_TEST = ./ctags$(EXEEXT)
 READ_TEST = ./readtags$(EXEEXT)
 TIMEOUT=

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -60,7 +60,7 @@ all: ctags.exe readtags.exe
 
 ctags: ctags.exe
 
-ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS)
+ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS) $(WIN32_HEADS)
 	$(V_CC) $(CC) $(OPT) $(CFLAGS) $(LDFLAGS) $(DEFINES) $(INCLUDES) -o $@ $(ALL_OBJS) $(LIBS)
 
 read/%.o: read/%.c

--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -59,7 +59,7 @@ all: ctags.exe readtags.exe
 
 ctags: ctags.exe
 
-ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS) $(REPOINFO_HEADS)
+ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS) $(WIN32_HEADS) $(REPOINFO_HEADS)
 	$(CC) $(OPT) /Fe$@ $(ALL_OBJS) /link setargv.obj $(LIBS) $(PDBFLAG)
 
 readtags.exe: $(READTAGS_OBJS) $(READTAGS_HEADS)

--- a/source.mak
+++ b/source.mak
@@ -115,10 +115,11 @@ PARSER_HEADS = \
 	parsers/cxx/cxx_token.h \
 	parsers/cxx/cxx_token_chain.h \
 	\
+	parsers/cpreprocessor.h \
 	parsers/iniconf.h \
 	parsers/m4.h \
 	parsers/make.h \
-	parsers/cpreprocessor.h \
+	parsers/tcl.h \
 	\
 	$(NULL)
 
@@ -227,7 +228,7 @@ XML_SRCS = \
 	 \
 	 $(NULL)
 
-YAML_HEAD = parsers/meta-yaml.h
+YAML_HEADS = parsers/yaml.h
 YAML_SRCS = \
 	  parsers/yaml.c		\
 	  \
@@ -241,7 +242,7 @@ DEBUG_SRCS = main/debug.c
 ALL_HEADS = $(MAIN_HEADS) $(PARSER_HEADS) $(DEBUG_HEADS)
 ALL_SRCS = $(MAIN_SRCS) $(PARSER_SRCS) $(DEBUG_SRCS)
 
-ENVIRONMENT_HEADS = e_msoft.h
+ENVIRONMENT_HEADS =
 ENVIRONMENT_SRCS =
 
 REGEX_HEADS = gnu_regex/regex.h
@@ -252,6 +253,7 @@ FNMATCH_HEADS = fnmatch/fnmatch.h
 FNMATCH_SRCS = fnmatch/fnmatch.c
 FNMATCH_OBJS = $(FNMATCH_SRCS:.c=.$(OBJEXT))
 
+WIN32_HEADS = main/e_msoft.h
 WIN32_SRCS = win32/mkstemp/mkstemp.c
 WIN32_OBJS = $(WIN32_SRCS:.c=.$(OBJEXT))
 


### PR DESCRIPTION
We use Automake, so we can use `make dist` to create a tarball and `make distcheck` to create and check it.
However, `make distcheck` fails because of some reasons.

* Source files are not properly listed. We also need to care about Windows specific source files.
* Creating a tarball fails because of very long filenames.
  See: https://www.gnu.org/software/automake/manual/html_node/List-of-Automake-options.html
  `tar-v7` supports file names with up to only 99 characters.
  However we have some files which names are longer than that.
  So we should use `tar-ustar` or `tar-pax`.
* `make distclean` leaves some files in build directory. So the following error will be shown:
  ```
  ERROR: files left in build directory after distclean:
  ./Units/conflib-recursive.d/BUNDLES
  ./Units/conflib-recursive.d/optlib/lang.d/def.d/a.ctags
  ...
  ```
  The outputs of unit tests should be cleaned by `make clean` or `make distclean`. 