### PR TITLE
appveyor: Include man page in zip package

### DIFF
--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -148,7 +148,7 @@ bash -lc "make check APPVEYOR=1"
 goto :eof
 
 :msys2_package
-md package
+md package\man
 :: Build html docs
 bash -lc "cd docs; make html"
 move docs\_build\html package\docs > nul
@@ -163,14 +163,16 @@ if "%APPVEYOR_REPO_TAG_NAME%"=="" (
 
 :: Create zip package
 set filelist=ctags.exe readtags.exe README.md
+set dirlist=docs license man
 robocopy . package %filelist% > nul
 robocopy win32\license package\license > nul
 copy COPYING package\license > nul
 copy win32\mkstemp\COPYING.MinGW-w64-runtime.txt package\license > nul
+copy man\ctags.1.rst package\man > nul
 cd package
-7z a ..\ctags-%ver%-%ARCH%.debug.zip %filelist% docs license
+7z a ..\ctags-%ver%-%ARCH%.debug.zip %filelist% %dirlist%
 strip *.exe
-7z a ..\ctags-%ver%-%ARCH%.zip %filelist% docs license
+7z a ..\ctags-%ver%-%ARCH%.zip %filelist% %dirlist%
 cd ..
 goto :eof
 


### PR DESCRIPTION
Include `man/ctags.1.rst` in zip package. See: https://github.com/universal-ctags/ctags/pull/1426#issuecomment-305165075