### PR TITLE
docs(man): fix style of block quotations

### DIFF
--- a/man/README
+++ b/man/README
@@ -3,4 +3,5 @@ Rules for writing man pages
 
 * put two single quotes around an option name like ``--help``.
 
-* .. code-block:: .. cannot be handled well in rst2man.
+* .. code-block:: LANGUAGE.. cannot be handled well in rst2man.
+  However, if LANGUAGE is not given, it works.

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -134,7 +134,9 @@ template file name testing
 
 		-*- mode: MODE -*-
 
-	or::
+	or
+
+	::
 
 		-*- MODE -*-
 
@@ -162,7 +164,9 @@ template file name testing
 
 		filetype=TYPE
 
-	or::
+	or
+
+	::
 
 		ft=TYPE
 
@@ -180,7 +184,10 @@ given.
 ``--print-language`` can be used just for printing the results of
 parser selections for given files instead of making tags file.
 
-Examples::
+Examples:
+
+.. code-block::
+
 	$ @CTAGS_NAME_EXECUTABLE@ --print-language config.h.in input.m input.unknown
 	config.h.in: C++
 	input.m: MatLab


### PR DESCRIPTION
Remove `:' after "or". A newline between "or" and a quoted
block is needed; without it rst processor recognizes or as
a title of section.

Use `.. code-block::' instead of `::'. However, LANGUAGE
after `.. code-block::' cannot be specified; this may be
a limitation of rst2man.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>