### PR TITLE
appveyor: Additional fixes for #1445

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/universal-ctags/ctags.svg?branch=master)](https://travis-ci.org/universal-ctags/ctags)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/4355/badge.svg)](https://scan.coverity.com/projects/4355)
 [![Coverage Status](https://coveralls.io/repos/universal-ctags/ctags/badge.svg?branch=master&service=github)](https://coveralls.io/github/universal-ctags/ctags?branch=master)
-[![Build status](https://ci.appveyor.com/api/projects/status/1c4wwswe8yd99la2/branch/master?svg=true)](https://ci.appveyor.com/project/masatake/ctags/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/6hk2p5lv6jsrd9o7/branch/master?svg=true)](https://ci.appveyor.com/project/universalctags/ctags/branch/master)
 [![RTD build status](https://readthedocs.org/projects/ctags/badge)](http://docs.ctags.io)
 
 universal-ctags has the objective of continuing the development from
@@ -18,7 +18,7 @@ together.
 If you want to try the latest universal-ctags without building it yourself...
 
 ### Windows
-- Go to https://ci.appveyor.com/project/masatake/ctags/history
+- Go to https://ci.appveyor.com/project/universalctags/ctags/history
   - Select one of the builds named ```Daily build: YYYY-MM-DD```.
   - Click the ```compiler=msys2, ARCH=x64, ...``` (or ```compiler=msys2, ARCH=x86, ...```) job.
   - View the *Artifacts* tab and download ```ctags-XXXXXX-x64.zip``` (or ```ctags-XXXXXX-x86.zip```). (```XXXXXX``` is a version number or a commit ID.)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ together.
 If you want to try the latest universal-ctags without building it yourself...
 
 ### Windows
-- Go to https://ci.appveyor.com/project/masatake/ctags/branch/master
-  - Click the ```compiler=msys2, ARCH=x64, ...``` (or ```compiler=msys2, ARCH=x86, ...```) build.
+- Go to https://ci.appveyor.com/project/masatake/ctags/history
+  - Select one of the builds named ```Daily build: YYYY-MM-DD```.
+  - Click the ```compiler=msys2, ARCH=x64, ...``` (or ```compiler=msys2, ARCH=x86, ...```) job.
   - View the *Artifacts* tab and download ```ctags-XXXXXX-x64.zip``` (or ```ctags-XXXXXX-x86.zip```). (```XXXXXX``` is a version number or a commit ID.)
   - Add the binary folder to your PATH.
   - If you need unstripped binaries for debugging, download ```ctags-XXXXXX-x64.debug.zip``` (or ```ctags-XXXXXX-x86.debug.zip```).

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -76,7 +76,7 @@ nmake -f mk_mvc.mak WITH_ICONV=yes ICONV_DIR=%ICONV_DIR% PDB=yes || exit 1
 mkdir vc
 move *.exe vc > nul
 
-:: Build with msys2
+:: Create Makefile with msys2
 path C:\%MSYS2_DIR%\usr\bin;%PATH%
 set CHERE_INVOKING=yes
 :: Install and update necessary packages
@@ -86,7 +86,7 @@ bash -lc "./autogen.sh"
 :: Patching configure.
 :: Workaround for "./configure: line 557: 0: Bad file descriptor"
 perl -i".bak" -pe "s/^test -n \".DJDIR\"/#$&/" configure
-bash -lc "./configure && make"
+bash -lc "./configure && make -t"
 
 :: Restore VC binaries
 copy vc\*.exe . /y > nul
@@ -103,7 +103,7 @@ c:\cygwin\bin\file readtags.exe
 :: Check if it works
 .\ctags --version || exit 1
 
-:: Run tests
+:: Run tests on msys2
 bash -lc "make check APPVEYOR=1"
 
 @echo off

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -31,7 +31,7 @@ goto :eof
 cd win32
 @echo on
 :: Check filetype
-c:\cygwin\bin\file %CONFIGURATION%\ctags.exe
+c:\cygwin64\bin\file %CONFIGURATION%\ctags.exe
 :: Check if it works
 %CONFIGURATION%\ctags --version || exit 1
 
@@ -98,8 +98,8 @@ goto :eof
 :msvc_test
 @echo on
 :: Check filetype (VC binaries)
-c:\cygwin\bin\file ctags.exe
-c:\cygwin\bin\file readtags.exe
+c:\cygwin64\bin\file ctags.exe
+c:\cygwin64\bin\file readtags.exe
 :: Check if it works
 .\ctags --version || exit 1
 
@@ -150,8 +150,8 @@ goto :eof
 :msys2_test
 @echo on
 :: Check filetype (msys2 binaries)
-c:\cygwin\bin\file ctags.exe
-c:\cygwin\bin\file readtags.exe
+c:\cygwin64\bin\file ctags.exe
+c:\cygwin64\bin\file readtags.exe
 :: Check if it works
 .\ctags --version || exit 1
 
@@ -204,8 +204,8 @@ goto :eof
 :mingw_test
 @echo on
 :: Check filetype
-c:\cygwin\bin\file ctags.exe
-c:\cygwin\bin\file readtags.exe
+c:\cygwin64\bin\file ctags.exe
+c:\cygwin64\bin\file readtags.exe
 :: Check if it works
 .\ctags --version || exit 1
 
@@ -221,8 +221,8 @@ goto :eof
 :: ----------------------------------------------------------------------
 :: Using Cygwin, iconv enabled
 @echo on
-c:\cygwin\setup-x86.exe -qnNdO -P dos2unix,libiconv-devel
-PATH c:\cygwin\bin;%PATH%
+c:\cygwin64\setup-x86_64.exe -qnNdO -P dos2unix,libiconv-devel
+PATH c:\cygwin64\bin;%PATH%
 set CHERE_INVOKING=yes
 bash -lc "./autogen.sh"
 :: Patching configure.
@@ -236,8 +236,8 @@ goto :eof
 :cygwin_test
 @echo on
 :: Check filetype
-c:\cygwin\bin\file ctags.exe
-c:\cygwin\bin\file readtags.exe
+c:\cygwin64\bin\file ctags.exe
+c:\cygwin64\bin\file readtags.exe
 :: Check if it works
 .\ctags --version || exit 1
 :: Run tests

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -170,7 +170,7 @@ rd /s/q package\docs\_sources
 
 :: Get version
 if "%APPVEYOR_REPO_TAG_NAME%"=="" (
-  for /f %%i in ('git rev-parse --short HEAD') do set ver=%%i
+  for /f %%i in ('git describe --tags --always') do set ver=%%i
 ) else (
   set ver=%APPVEYOR_REPO_TAG_NAME%
 )

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -97,9 +97,6 @@ set CHERE_INVOKING=yes
 rem bash -lc "for i in {1..3}; do pacman --noconfirm -S mingw-w64-%MSYS2_ARCH%-{python3-sphinx,jansson,libxml2,libyaml} && break || sleep 15; done"
 
 bash -lc "./autogen.sh"
-:: Patching configure.
-:: Workaround for "./configure: line 557: 0: Bad file descriptor"
-perl -i".bak" -pe "s/^test -n \".DJDIR\"/#$&/" configure
 bash -lc "./configure && make -t"
 
 :: Restore VC binaries
@@ -155,9 +152,6 @@ if "%normalbuild%"=="no" (
 bash -lc "for i in {1..3}; do pacman --noconfirm --noprogressbar -S --needed mingw-w64-%MSYS2_ARCH%-{jansson,libxml2,libyaml} && break || sleep 15; done"
 
 bash -lc "./autogen.sh"
-:: Patching configure.
-:: Workaround for "./configure: line 557: 0: Bad file descriptor"
-perl -i".bak" -pe "s/^test -n \".DJDIR\"/#$&/" configure
 :: Use static link.
 bash -lc "./configure --enable-iconv --disable-external-sort EXTRA_CFLAGS=-DLIBXML_STATIC LDFLAGS=-static LIBS='-lz -llzma -lws2_32' && make"
 
@@ -250,9 +244,6 @@ c:\cygwin64\setup-x86_64.exe -qnNdO -P dos2unix,libiconv-devel
 PATH c:\cygwin64\bin;%PATH%
 set CHERE_INVOKING=yes
 bash -lc "./autogen.sh"
-:: Patching configure.
-:: Workaround for "./configure: line 557: 0: Bad file descriptor"
-perl -i".bak" -pe "s/^test -n \".DJDIR\"/#$&/" configure
 bash -lc "./configure --enable-iconv && make"
 
 @echo off


### PR DESCRIPTION
* It is not recommended to update only specified packages. (ArchWiki says so.)
  Use `pacman -Suy` as usual.
* Use `checkupdates` to check if there are any updates.
* Remove unused toolchain before updating so that reduce the time for updating.
  (Unfortunately, it takes about 3 ~ 5 minutes even with this workaround.)
* Use default setting when updating Cygwin packages.
* Stop building msys2 binary before testing MSVC binary. This reduces about 30 sec.
* Use 64-bit Cygwin instead of 32-bit version. 64-bit version is about 1 minute faster.