### PR TITLE
parser: Use inttypes.h to fix printf warning

### DIFF
--- a/parsers/yaml.c
+++ b/parsers/yaml.c
@@ -10,6 +10,8 @@
 
 #include "general.h"  /* must always come first */
 
+#include <inttypes.h>
+
 #include "debug.h"
 #include "htable.h"
 #include "options.h"
@@ -145,7 +147,7 @@ static void findYamlTags (void)
 			leaveSubparser ();
 		}
 
-		verbose("yaml token:%s<%d>@Line:%lu\n", tokenTypeName[token.type], token.type,
+		verbose("yaml token:%s<%d>@Line:%"PRIuPTR"\n", tokenTypeName[token.type], token.type,
 				token.start_mark.line + 1);
 		if (token.type == YAML_STREAM_END_TOKEN)
 			done = true;


### PR DESCRIPTION
On Windows, the following warning is shown:
https://ci.appveyor.com/project/k-takata/ctags/build/1.0.176/job/i3gcx6qr2wieq3tl#L500
> ```
> parsers/yaml.c:148:37: warning: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'size_t {aka long long unsigned int}' [-Wformat=]
>   verbose("yaml token:%s<%d>@Line:%lu\n", tokenTypeName[token.type], token.type,
>                                     ^
> ```

Include `inttypes.h` and use `PRIuPTR` to fix the warning.
Note that `long` is 32-bit and `size_t` is 64-bit on 64-bit Windows.