### PR TITLE
cspell: add a missing misc/spelling.ctags

### DIFF
--- a/dictfiles/english.list
+++ b/dictfiles/english.list
@@ -1,12 +1,15 @@
+boston
 # doesn't
 doesn
 # don't
 don
+franklin
 merchantability
 namespace
 namespaces
 readonly
 splitter
+usa
 whitespace
 whitespaces
 wildcards

--- a/misc/spelling.ctags
+++ b/misc/spelling.ctags
@@ -1,0 +1,27 @@
+#
+#  Copyright (c) 2017, Red Hat, Inc.
+#  Copyright (c) 2017, Masatake YAMATO
+#
+#  Author: Masatake YAMATO <yamato@redhat.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+# USA.
+#
+-x
+--languages=+UCtagsAspell
+--param-UCtagsAspell:subwords=true
+--language-force=UCtagsAspell
+--extras=+r
+--fields=+r


### PR DESCRIPTION
This helper script should be add when merging
self-spell-checking branch.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>