### PR TITLE
Detect .git on git-submodule

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -311,7 +311,7 @@ AM_CONDITIONAL([HAVE_RST2MAN], [test "x$RST2MAN" != "xno"])
 # --------------------------------
 in_git_repo=no
 AC_MSG_CHECKING(building in a git repository)
-if test -f "${srcdir}/.git/HEAD"; then
+if test -f "${srcdir}/.git/HEAD" || test -f "${srcdir}/.git"; then
 	in_git_repo=yes
 fi
 AC_MSG_RESULT(${in_git_repo})

--- a/win32/gen-repoinfo.bat
+++ b/win32/gen-repoinfo.bat
@@ -18,7 +18,7 @@ if exist %repoinfo_header% (
 )
 
 set newinfo=%oldinfo%
-if exist .git\nul (
+if exist .git (
   for /f %%i in ('cmd /c "git describe --tag --exact-match HEAD 2> nul || git rev-parse --short HEAD"') do set newinfo=#define CTAGS_REPOINFO "%%i"
 )
 


### PR DESCRIPTION
If this repository is added as a git-submodule of another repository,
`.git` becomes a normal file. Detect it properly.