### PR TITLE
whitelist munmap for seccomp.

### DIFF
--- a/main/seccomp.c
+++ b/main/seccomp.c
@@ -27,6 +27,7 @@ int installSyscallFilter (void)
 
 	// Memory allocation.
 	seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (mmap), 0);
+	seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (munmap), 0);
 	seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (brk), 0);
 
 	// I/O


### PR DESCRIPTION
free() may call munmap under the hood.