### PR TITLE
Multi pass parsing over multi source files

### DIFF
--- a/main/entry.h
+++ b/main/entry.h
@@ -51,6 +51,7 @@ struct sTagEntryInfo {
 	unsigned int placeholder    :1;	 /* This is just a part of scope context.
 					    Put this entry to cork queue but
 					    don't print it to tags file. */
+	unsigned int barrel: 1;		/* store to barrel */
 
 	unsigned long lineNumber;     /* line number of tag */
 	const char* pattern;	      /* pattern for locating input line
@@ -172,6 +173,9 @@ void          uncorkTagFile(void);
 tagEntryInfo *getEntryInCorkQueue   (unsigned int n);
 tagEntryInfo *getEntryOfNestingLevel (const NestingLevel *nl);
 size_t        countEntryInCorkQueue (void);
+void          handOverEntryToNextMMPass (unsigned int n);
+
+extern void clearTagEntry (tagEntryInfo* slot);
 
 extern void makeFileTag (const char *const fileName);
 

--- a/main/main.c
+++ b/main/main.c
@@ -70,6 +70,7 @@
 #include "error.h"
 #include "field.h"
 #include "keyword.h"
+#include "mm.h"
 #include "main.h"
 #include "options.h"
 #include "read.h"
@@ -480,6 +481,8 @@ static void batchMakeTags (cookedArgs *args, void *user CTAGS_ATTR_UNUSED)
 	}
 	if (! files  &&  Option.recurse)
 		resize = recurseIntoDirectory (".");
+
+	resize = mmRun ()? true: resize;
 
 	timeStamp (1);
 

--- a/main/mm.c
+++ b/main/mm.c
@@ -1,0 +1,110 @@
+/*
+*   Copyright (c) 2017, Masatake YAMATO
+*
+*   Author: Masatake YAMATO <yamato@redhat.com>
+*           https://ctags.io
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*   It is provided on an as-is basis and no responsibility is accepted for its
+*   failure to perform as expected.
+*
+*   This module contains infrastructure to realize Multi pass parsing over
+*   Multi source files (MM).
+*/
+
+#include "general.h"  /* must always come first */
+
+#define OPTION_WRITE
+#include "options.h"
+
+#include "mm.h"
+#include "ptrarray.h"
+#include "routines.h"
+#include "types.h"
+
+
+static ptrArray *mmSourceFiles;
+
+struct mmEntry {
+	char *fileName;
+	langType lang;
+};
+
+static void mmEntryDelete (void *p)
+{
+	struct mmEntry *m = p;
+
+	eFree (m->fileName);
+	m->fileName = NULL;
+	eFree (m);
+}
+
+extern void mmSchedule (const char*fname, langType lang)
+{
+	struct mmEntry * mm_entry = xMalloc (1, struct mmEntry);
+	mm_entry->fileName = eStrdup (fname);
+	mm_entry->lang = lang;
+
+	if (!mmSourceFiles)
+		mmSourceFiles = ptrArrayNew (mmEntryDelete);
+
+	ptrArrayAdd (mmSourceFiles, mm_entry);
+}
+
+static stringList *mmTakeOverSourceFiles (void)
+{
+	ptrArray *tmp = mmSourceFiles;
+
+	mmSourceFiles = NULL;
+	return tmp;
+}
+
+static int currentPass = 0;
+
+static int mmEnterPass (void)
+{
+	return --currentPass;
+}
+
+extern int mmCurrentPass (void)
+{
+	return currentPass;
+}
+
+extern bool inMMPass (void)
+{
+	return !(currentPass >= 0);
+}
+
+static bool mmRun0 (void)
+{
+	bool resize = false;
+	ptrArray *mm_sources;
+
+	while ((mm_sources = mmTakeOverSourceFiles ()) != NULL)
+	{
+		mmEnterPass ();
+		for (unsigned int i = 0; i < ptrArrayCount (mm_sources); i++)
+		{
+			struct mmEntry *mm_entry = ptrArrayItem (mm_sources, i);
+			Option.language = mm_entry->lang;
+			resize = parseFile (mm_entry->fileName)? true: resize;
+		}
+		ptrArrayDelete (mm_sources);
+	}
+
+	return resize;
+}
+
+
+extern bool mmRun (void)
+{
+	bool r;
+	langType tmp = Option.language;
+
+	r = mmRun0 ();
+
+	Option.language = tmp;
+	return r;
+}

--- a/main/mm.h
+++ b/main/mm.h
@@ -1,0 +1,29 @@
+/*
+*
+*   Copyright (c) 2017, Red Hat, Inc.
+*   Copyright (c) 2017, Masatake YAMATO
+*
+*   Author: Masatake YAMATO <yamato@redhat.com>
+*           https://ctags.io
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   This module contains infrastructure to realize Multi pass parsing over
+*   Multi source files (MM).
+*/
+
+#ifndef CTAGS_MM_H
+#define CTAGS_MM_H
+
+#include "general.h"  /* must always come first */
+#include "types.h"
+
+void mmSchedule (const char*fname, langType lang);
+
+bool mmRun (void);
+
+int mmCurrentPass (void);
+bool inMMPass (void);
+
+#endif

--- a/main/mm.h
+++ b/main/mm.h
@@ -26,4 +26,13 @@ bool mmRun (void);
 int mmCurrentPass (void);
 bool inMMPass (void);
 
+void pourEntryToBarrel (tagEntryInfo *e);
+
+struct sBarrel;
+typedef struct sBarrel Barrel;
+
+unsigned int countEntryInBarrel (Barrel *b);
+tagEntryInfo* getEntryInBarrel (Barrel *b, unsigned int index);
+
+
 #endif

--- a/main/options.h
+++ b/main/options.h
@@ -88,7 +88,7 @@ typedef struct sOptionValues {
 	char *inputEncoding;	/* --input-encoding	convert text into --output-encoding */
 	char *outputEncoding;	/* --output-encoding	write tags file as this encoding */
 #endif
-	langType language;      /* --lang specified language override */
+	langType language;      /* --language-force specified language override */
 	bool followLinks;    /* --link  follow symbolic links? */
 	bool filter;         /* --filter  behave as filter: files in, tags out */
 	char* filterTerminator; /* --filter-terminator  string to output */

--- a/main/parse.c
+++ b/main/parse.c
@@ -2702,7 +2702,7 @@ extern bool processFielddefOption (const char *const option, const char *const p
 */
 
 static rescanReason createTagsForFile (const langType language,
-				       const unsigned int passCount)
+				       const int passCount)
 {
 	parserDefinition *const lang = LanguageTable [language].def;
 	rescanReason rescan = RESCAN_NONE;
@@ -2780,7 +2780,7 @@ static bool createTagsWithFallback1 (const langType language,
 	unsigned long numTags	= numTagsAdded ();
 	MIOPos tagfpos;
 	int lastPromise = getLastPromise ();
-	unsigned int passCount = 0;
+	int passCount = 0;
 	rescanReason whyRescan;
 	parserObject *parser;
 	bool useCork;

--- a/main/parse.c
+++ b/main/parse.c
@@ -79,6 +79,7 @@ typedef struct sParserObject {
 	struct slaveControlBlock *slaveControlBlock;
 	struct kindControlBlock  *kindControlBlock;
 	struct lregexControlBlock *lregexControlBlock;
+	int mmPassCount;
 } parserObject;
 
 /*
@@ -3665,6 +3666,19 @@ extern void printLangdefFlags (bool withListHeader, bool machinable, FILE *fp)
 
 	flagsColprintTablePrint (table, withListHeader, machinable, fp);
 	colprintTableDelete(table);
+}
+
+extern bool setupParserMM (langType lang, int mmPassCount, Barrel *barrel)
+{
+	parserObject *parser = (LanguageTable + lang);
+
+	if (parser->mmPassCount != mmPassCount)
+	{
+		parser->def->setupMM (lang, barrel);
+		parser->mmPassCount = mmPassCount;
+		return true;
+	}
+	return false;
 }
 
 /*

--- a/main/parse.h
+++ b/main/parse.h
@@ -20,6 +20,7 @@
 #include "kind.h"
 #include "lregex.h"
 #include "lxpath.h"
+#include "mm.h"
 #include "param.h"
 #include "parsers.h"  /* contains list of parsers */
 #include "strlist.h"
@@ -48,6 +49,7 @@ typedef void (*simpleParser) (void);
    passCount <  0 in multiple source files multi pass processing. */
 typedef rescanReason (*rescanParser) (const int passCount);
 
+typedef void (* parserSetupMM) (langType language, Barrel *barrel);
 typedef void (*parserInitialize) (langType language);
 
 /* Per language finalizer is called anytime when ctags exits.
@@ -84,6 +86,7 @@ struct sParserDefinition {
 	parserFinalize finalize;       /* finalize routine, if needed */
 	simpleParser parser;           /* simple parser (common case) */
 	rescanParser parser2;          /* rescanning parser (unusual case) */
+	parserSetupMM setupMM;
 	selectLanguage* selectLanguage; /* may be used to resolve conflicts */
 	unsigned int method;           /* See METHOD_ definitions above */
 	bool useCork;
@@ -237,5 +240,7 @@ extern bool makeKindDescriptionsPseudoTags (const langType language,
 
 extern void anonGenerate (vString *buffer, const char *prefix, int kind);
 extern void anonHashString (const char *filename, char buf[9]);
+
+extern bool setupParserMM (langType lang, int mmPassCount, Barrel *barrel);
 
 #endif  /* CTAGS_MAIN_PARSE_H */

--- a/main/parse.h
+++ b/main/parse.h
@@ -37,12 +37,16 @@
 typedef enum {
 	RESCAN_NONE,   /* No rescan needed */
 	RESCAN_FAILED, /* Scan failed, clear out tags added, rescan */
-	RESCAN_APPEND  /* Scan succeeded, rescan */
+	RESCAN_APPEND, /* Scan succeeded, rescan */
 } rescanReason;
 
 typedef void (*createRegexTag) (const vString* const name);
 typedef void (*simpleParser) (void);
-typedef rescanReason (*rescanParser) (const unsigned int passCount);
+
+/* passCount >= 0 in single source file multi pass processing.
+   passCount <  0 in multiple source files multi pass processing. */
+typedef rescanReason (*rescanParser) (const int passCount);
+
 typedef void (*parserInitialize) (langType language);
 
 /* Per language finalizer is called anytime when ctags exits.

--- a/main/parse.h
+++ b/main/parse.h
@@ -38,6 +38,7 @@ typedef enum {
 	RESCAN_NONE,   /* No rescan needed */
 	RESCAN_FAILED, /* Scan failed, clear out tags added, rescan */
 	RESCAN_APPEND, /* Scan succeeded, rescan */
+	RESCAN_MM,     /* Rescan is needed after parsing all specified source files. */
 } rescanReason;
 
 typedef void (*createRegexTag) (const vString* const name);

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3482,7 +3482,7 @@ static void createTags (const unsigned int nestLevel,
 	DebugStatement ( if (nestLevel > 0) debugParseNest (false, nestLevel - 1); )
 }
 
-static rescanReason findCTags (const unsigned int passCount)
+static rescanReason findCTags (const int passCount)
 {
 	exception_t exception;
 	rescanReason rescan;

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1572,7 +1572,7 @@ bool cxxParserParseIfForWhileSwitch(void)
 	return bRet;
 }
 
-static rescanReason cxxParserMain(const unsigned int passCount)
+static rescanReason cxxParserMain(const int passCount)
 {
 	cxxScopeClear();
 	cxxTokenAPINewFile();
@@ -1617,7 +1617,7 @@ static rescanReason cxxParserMain(const unsigned int passCount)
 	return RESCAN_NONE;
 }
 
-rescanReason cxxCParserMain(const unsigned int passCount)
+rescanReason cxxCParserMain(const int passCount)
 {
 	CXX_DEBUG_ENTER();
 	cxxTagInitForLanguage(g_cxx.eCLangType);
@@ -1630,7 +1630,7 @@ rescanReason cxxCParserMain(const unsigned int passCount)
 	return r;
 }
 
-rescanReason cxxCUDAParserMain(const unsigned int passCount)
+rescanReason cxxCUDAParserMain(const int passCount)
 {
 	CXX_DEBUG_ENTER();
 	cxxTagInitForLanguage(g_cxx.eCUDALangType);
@@ -1644,7 +1644,7 @@ rescanReason cxxCUDAParserMain(const unsigned int passCount)
 	return r;
 }
 
-rescanReason cxxCppParserMain(const unsigned int passCount)
+rescanReason cxxCppParserMain(const int passCount)
 {
 	CXX_DEBUG_ENTER();
 	cxxTagInitForLanguage(g_cxx.eCPPLangType);

--- a/parsers/cxx/cxx_parser.h
+++ b/parsers/cxx/cxx_parser.h
@@ -14,9 +14,9 @@
 #include "parse.h"
 
 // public parser api
-rescanReason cxxCParserMain(const unsigned int passCount);
-rescanReason cxxCppParserMain(const unsigned int passCount);
-rescanReason cxxCUDAParserMain(const unsigned int passCount);
+rescanReason cxxCParserMain(const int passCount);
+rescanReason cxxCppParserMain(const int passCount);
+rescanReason cxxCUDAParserMain(const int passCount);
 
 void cxxCParserInitialize(const langType language);
 void cxxCppParserInitialize(const langType language);

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -2522,7 +2522,7 @@ static void parseProgramUnit (tokenInfo *const token)
 	} while (! isType (token, TOKEN_EOF));
 }
 
-static rescanReason findFortranTags (const unsigned int passCount)
+static rescanReason findFortranTags (const int passCount)
 {
 	tokenInfo *token;
 	rescanReason rescan;

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -62,7 +62,8 @@ typedef enum {
 	K_PROGRAM,
 	K_PROTOTYPE,
 	K_PROPERTY,
-	K_TYPEDEF
+	K_TYPEDEF,
+	K_MEMBER,
 } verilogKind;
 
 typedef struct {
@@ -123,7 +124,8 @@ static kindDefinition SystemVerilogKinds [] = {
  { true, 'P', "program",   "programs" },
  { false,'Q', "prototype", "prototypes" },
  { true, 'R', "property",  "properties" },
- { true, 'T', "typedef",   "type declarations" }
+ { true, 'T', "typedef",   "type declarations" },
+ { true, 'v', "member",    "member elements" },
 };
 
 static const keywordAssoc KeywordTable [] = {
@@ -1097,7 +1099,20 @@ static void findTag (tokenInfo *const token)
 	}
 	else if (token->kind == K_TYPEDEF)
 	{
-		processTypedef (token);
+		if (strcmp (vStringValue (token->name), "typedef") == 0)
+			processTypedef (token);
+		else if (currentContext->kind == K_CLASS)
+		{
+			int c;
+			c = skipWhite (vGetc ());
+			if (isIdentifierCharacter (c))
+			{
+				readIdentifier (token, c);
+				token->kind = K_MEMBER;
+				createTagCommon (token, true);
+				/* TODO: typeref field can be filled. */
+			}
+		}
 	}
 	else if (token->kind == K_CLASS)
 	{

--- a/source.mak
+++ b/source.mak
@@ -31,6 +31,7 @@ MAIN_HEADS =			\
 	main/lxpath.h		\
 	main/main.h		\
 	main/mbcs.h		\
+	main/mm.h		\
 	main/nestlevel.h	\
 	main/objpool.h		\
 	main/options.h		\
@@ -72,6 +73,7 @@ MAIN_SRCS =				\
 	main/lxpath.c			\
 	main/main.c			\
 	main/mbcs.c			\
+	main/mm.c			\
 	main/nestlevel.c		\
 	main/objpool.c			\
 	main/options.c			\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -113,6 +113,7 @@
     <ClCompile Include="..\main\lxpath.c" />
     <ClCompile Include="..\main\main.c" />
     <ClCompile Include="..\main\mio.c" />
+    <ClCompile Include="..\main\mm.c" />
     <ClCompile Include="..\main\nestlevel.c" />
     <ClCompile Include="..\main\objpool.c" />
     <ClCompile Include="..\main\options.c" />
@@ -257,6 +258,7 @@
     <ClInclude Include="..\main\lxpath.h" />
     <ClInclude Include="..\main\main.h" />
     <ClInclude Include="..\main\mio.h" />
+    <ClInclude Include="..\main\mm.h" />
     <ClInclude Include="..\main\nestlevel.h" />
     <ClInclude Include="..\main\objpool.h" />
     <ClInclude Include="..\main\options.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -93,6 +93,9 @@
     <ClCompile Include="..\main\mio.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
+    <ClCompile Include="..\main\mm.c">
+      <Filter>Source Files\Main</Filter>
+    </ClCompile>
     <ClCompile Include="..\main\nestlevel.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
@@ -519,6 +522,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\mio.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\main\mm.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\nestlevel.h">


### PR DESCRIPTION
Close #80.

@vhda, how do you think about these changes? See the commits whose logs are started with ` 	[TEMPORARY] `.
I will update docs/internal.rst after getting your approval.

In my version, SystemVerilog emits the most of all tags in the first (-1) pass. However, you can pass some of them two the next mm pass via "barrel". In the seond (-2) pass, tags in the barrel are stored to the keyword table.

For testing I choose typedef kind tags. In the -2 pass, SystemVerilog parser can recognize the next token of typedef'ed type. If such token is recognized in class context, the token can be tagged as "member" kind.
I didn't choose the kind name "variable" though 'v' was chosen. Because a member of class is not a variable. 

This will not work well in interactive mode. I have to research the area more.

```
   $ cat a.sv
    class test;
       t_user t_user_memb;
    endclass
    $ cat b.sv
    typedef int t_user;
    $ ./ctags -o -  a.sv b.sv
    t_user	b.sv	/^typedef int t_user;$/;"	T
    t_user_memb	a.sv	/^   t_user t_user_memb;$/;"	v	class:test
    test	a.sv	/^class test;$/;"	C
```