### PR TITLE
Fix 1498 (fix memory leaks in --interactive and ocaml's variable initialization bug) 

### DIFF
--- a/Units/parser-ocaml.r/ocaml_two_files.d/args.ctags
+++ b/Units/parser-ocaml.r/ocaml_two_files.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--fields=+n

--- a/Units/parser-ocaml.r/ocaml_two_files.d/expected.tags
+++ b/Units/parser-ocaml.r/ocaml_two_files.d/expected.tags
@@ -1,0 +1,4 @@
+Input	input.ml	/^let foo_function a b = (a, b)$/;"	M	line:1
+foo_function	input.ml	/^let foo_function a b = (a, b)$/;"	f	line:1
+Input-0	input-0.ml	/^let bar_function x y = (x, y)$/;"	M	line:1
+bar_function	input-0.ml	/^let bar_function x y = (x, y)$/;"	f	line:1

--- a/Units/parser-ocaml.r/ocaml_two_files.d/input-0.ml
+++ b/Units/parser-ocaml.r/ocaml_two_files.d/input-0.ml
@@ -1,0 +1,1 @@
+let bar_function x y = (x, y)

--- a/Units/parser-ocaml.r/ocaml_two_files.d/input.ml
+++ b/Units/parser-ocaml.r/ocaml_two_files.d/input.ml
@@ -1,0 +1,5 @@
+let foo_function a b = (a, b)
+(*
+ SOMETHING HERE
+ *)
+

--- a/main/entry.c
+++ b/main/entry.c
@@ -444,10 +444,14 @@ extern void openTagFile (void)
 		if (TagFile.mio == NULL)
 			error (FATAL | PERROR, "cannot open tag file");
 	}
-	if (TagsToStdout)
-		TagFile.directory = eStrdup (CurrentDirectory);
-	else
-		TagFile.directory = absoluteDirname (TagFile.name);
+
+	if (TagFile.directory == NULL)
+	{
+		if (TagsToStdout)
+			TagFile.directory = eStrdup (CurrentDirectory);
+		else
+			TagFile.directory = absoluteDirname (TagFile.name);
+	}
 }
 
 #ifdef USE_REPLACEMENT_TRUNCATE

--- a/main/entry.c
+++ b/main/entry.c
@@ -100,7 +100,7 @@ typedef struct eTagFile {
 *   DATA DEFINITIONS
 */
 
-tagFile TagFile = {
+static tagFile TagFile = {
     NULL,               /* tag file name */
     NULL,               /* tag file directory (absolute) */
     NULL,               /* file pointer */

--- a/main/writer-json.c
+++ b/main/writer-json.c
@@ -150,11 +150,13 @@ static void addExtensionFields (json_t *response, const tagEntryInfo *const tag)
 static int writeJsonEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 			       MIO * mio, const tagEntryInfo *const tag)
 {
-	json_t *response = json_pack ("{ss ss ss so}",
+	json_t *pat = escapeFieldValue(tag, FIELD_PATTERN, true);
+	json_t *response = json_pack ("{ss ss ss sO}",
 		"_type", "tag",
 		"name", tag->name,
 		"path", tag->sourceFileName,
-		"pattern", escapeFieldValue(tag, FIELD_PATTERN, true));
+		"pattern", pat);
+	json_decref (pat);
 
 	if (includeExtensionFlags ())
 	{

--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -2027,6 +2027,8 @@ static void findOcamlTags (void)
 
 	nextSt.name = vStringNew ();
 	nextSt.cp = readLineFromInputFile ();
+	ocaLineNumber = getInputLineNumber();
+	ocaFilePosition = getInputFilePosition();
 	toDoNext = &globalScope;
 	nextTok = lex (&nextSt);
 


### PR DESCRIPTION
Close #1498 in the last commit.
During inspecting the bug reported in #1498, valgrind some memory related bugs.
I fixed them, too.

As wrote in 5b447b1, this one has no test case because units harness has no ability to handle more than one source file.