### PR TITLE
Allows `./autogen.sh to` be called from another Makefile

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,7 +3,7 @@
 type autoreconf || exit 1
 type pkg-config || exit 1
 
-ctags_files=`make -f makefiles/list-translator-input.mak`
+ctags_files=`make -f makefiles/list-translator-input.mak --no-print-directory`
 misc/dist-test-cases > makefiles/test-cases.mak && \
     if autoreconf -vfi; then
 	if type perl > /dev/null; then


### PR DESCRIPTION
To reproduce the problem I was having create the following makefile:
```make
.PHONY: ctags
ctags:
	./autogen.sh
```

Then call it, you should see output as following:
```
./autogen.sh
autoreconf is /usr/bin/autoreconf
pkg-config is /usr/bin/pkg-config
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: running: /usr/bin/autoconf --force
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:262: installing './compile'
configure.ac:23: installing './config.guess'
configure.ac:23: installing './config.sub'
configure.ac:11: installing './install-sh'
configure.ac:11: installing './missing'
Makefile.am: installing './depcomp'
/usr/share/automake-1.15/am/tags.am: warning: redefinition of 'ctags' ...
/usr/share/automake-1.15/am/program.am: ... 'ctags$(EXEEXT)' previously defined here
Makefile.am:15:   while processing program 'ctags'
autoreconf: Leaving directory `.'
optlib2c: translating make[1]: to make[1]:.c
cannot open the optlib file: "make[1]:" at ./misc/optlib2c line 266.
optlib2c: translating Entering to Entering.c
cannot open the optlib file: "Entering" at ./misc/optlib2c line 266.
optlib2c: translating directory to directory.c
cannot open the optlib file: "directory" at ./misc/optlib2c line 266.
optlib2c: translating '/home/sdwolf/Projects/ctags' to '/home/sdwolf/Projects/ctags'.c
./autogen.sh: line 13: '/home/sdwolf/Projects/ctags'.c: No such file or directory
optlib2c: translating optlib/RSpec.ctags to optlib/RSpec.c
optlib2c: translating optlib/ctags-optlib.ctags to optlib/ctags-optlib.c
optlib2c: translating optlib/elm.ctags to optlib/elm.c
optlib2c: translating optlib/gdbinit.ctags to optlib/gdbinit.c
optlib2c: translating optlib/man.ctags to optlib/man.c
optlib2c: translating optlib/passwd.ctags to optlib/passwd.c
optlib2c: translating optlib/pod.ctags to optlib/pod.c
optlib2c: translating optlib/qemuhx.ctags to optlib/qemuhx.c
optlib2c: translating make[1]: to make[1]:.c
cannot open the optlib file: "make[1]:" at ./misc/optlib2c line 266.
optlib2c: translating Leaving to Leaving.c
cannot open the optlib file: "Leaving" at ./misc/optlib2c line 266.
optlib2c: translating directory to directory.c
cannot open the optlib file: "directory" at ./misc/optlib2c line 266.
optlib2c: translating '/home/sdwolf/Projects/ctags' to '/home/sdwolf/Projects/ctags'.c
./autogen.sh: line 13: '/home/sdwolf/Projects/ctags'.c: No such file or directory
make: *** [Mak:3: ctags] Error 1
```

This is because `make -f makefiles/list-translator-input.mak` produces the following output when being called from another Makefile:
```
make -f makefiles/list-translator-input.mak
make[1]: Entering directory '/home/sdwolf/Projects/ctags'
optlib/RSpec.ctags
optlib/ctags-optlib.ctags
optlib/elm.ctags
optlib/gdbinit.ctags
optlib/man.ctags
optlib/passwd.ctags
optlib/pod.ctags
optlib/qemuhx.ctags
make[1]: Leaving directory '/home/sdwolf/Projects/ctags'
```

When instead it should only output:
```
optlib/RSpec.ctags
optlib/ctags-optlib.ctags
optlib/elm.ctags
optlib/gdbinit.ctags
optlib/man.ctags
optlib/passwd.ctags
optlib/pod.ctags
optlib/qemuhx.ctags
```

I stumbled upon this while creating an ansible playbook for ctags. When running it with:
```bash
ansible-playbook playbooks/ctags/install.yml --ask-become-pass
```
everything went fine, but I wanted to run that command from a makefile because:
```bash
make ctags
```
is easyer to type.