### PR TITLE
build-sys: fix wrong usage of AC_CHECK_FUNCS used in checking mblen

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -707,7 +707,7 @@ fi
 # Output files
 # ------------
 
-AC_CHECK_FUNCS([mblen], [], [HAVE_MBLEN=1], [])
+AC_CHECK_FUNCS(mblen)
 
 AC_CONFIG_FILES([Makefile
 		 man/ctags.1.rst


### PR DESCRIPTION
The original code defines `HAVE_MBLEN=1` when mblen is not found.
It should be defined only when the function is found.

AC_CHECK_FUNCS defines the macro automatically when it is defiend
explicitly in the parameter list. So just specifying the name of
function is enough.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>