### PR TITLE
docs: fix typos

### DIFF
--- a/docs/interactive-mode.rst
+++ b/docs/interactive-mode.rst
@@ -5,7 +5,7 @@
 ======================================================================
 
 Universal ctags can be run with ``--_interactive``, which enters a REPL that
-can be used programatically to control ctags generation. In this mode, json
+can be used programmatically to control ctags generation. In this mode, json
 commands are received over stdin, and corresponding responses are emitted over
 stdout.
 

--- a/docs/internal.rst
+++ b/docs/internal.rst
@@ -48,7 +48,7 @@ in the current input text stream.
 A case when a tool generates the input file from another file, a tool
 can record the original source file to the generated file with using
 the `#line` directive. `source` is used for tracking/recording the
-informations appeared on #line directives.
+information appeared on #line directives.
 
 Regex pattern matching are also done behind calling the functions of
 this group.
@@ -284,7 +284,7 @@ Output tag stream
 	    :scale: 80%
 
 Ctags provides `makeTagEntry` to parsers as an entry point for writing
-tag informations to MIO. `makeTagEntry` calls `writeTagEntry` if the
+tag information to MIO. `makeTagEntry` calls `writeTagEntry` if the
 parser does not set `useCork` field. `writeTagEntry` calls `writerWriteTag`.
 `writerWriteTag` just calls `writeEntry` of writer backends.
 `writerTable` variable holds the four backends: ctagsWriter, etagsWriter,

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -656,7 +656,7 @@ will be processed as
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A new ``--_interactive`` option launches a JSON based command REPL which
-can be used to control ctags generation programatically.
+can be used to control ctags generation programmatically.
 
 See :ref:`--_interactive Mode <interactive-mode>` for more details.
 

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -250,7 +250,7 @@ with two restrictions:
 
   To customize one of file under
   */usr/share/ctags/preload/something.d*, copy
-  */usr/share/ctags/preload/something.d* to *~/.ctags.d/somethind.d* recursively.
+  */usr/share/ctags/preload/something.d* to *~/.ctags.d/something.d* recursively.
   Symbolic links can also be used. After copying or symbolic linking, edit
   one of the copied file.
 
@@ -539,11 +539,11 @@ Exuberant-ctags allows one of the specified group in a regex pattern can be
 used as a part of the name of a tagEntry. Universal-ctags offers using
 the other groups in the regex pattern.
 
-A optlib parser can have its own fields. The groups can be used as a
+An optlib parser can have its own fields. The groups can be used as a
 value of the fields of a tagEntry.
 
 Let's think about *Unknown*, an imaginary language.
-Here is an source file(``input.unknown``) written in *Unknown*:
+Here is a source file(``input.unknown``) written in *Unknown*:
 
     public func foo(n, m);
     protected func bar(n);

--- a/docs/parser-asm.rst
+++ b/docs/parser-asm.rst
@@ -10,7 +10,7 @@ Asm parser
 
 The original (Exuberant-ctags) parser handles #define C preprocessor directive and C
 style comments by itself. In Universal-ctags Asm parser utilizes CPreProcessor meta
-parser for handling them. So an language object defined with #define is tagged as
+parser for handling them. So a language object defined with #define is tagged as
 "defines" of CPreProcessor language, not Asm language.
 
 .. code-block:: console

--- a/docs/running-multi-parsers.rst
+++ b/docs/running-multi-parsers.rst
@@ -34,7 +34,7 @@ Examples of guest/host combinations
 {CSS,JavaScript}/HTML parser combination
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 
-For a html file, you may want to run HTML parser, of course. The
+For an html file, you may want to run HTML parser, of course. The
 html file may have CSS areas and JavaScript areas. In other hand
 Universal-ctags has both CSS and JavaScript parsers. Don't you
 think it is useful if you can apply these parsers to the areas?
@@ -468,7 +468,7 @@ Making a tag in a subparser
 Via calling callback functions defined in subparsers, their base parser
 gives chance to them making tag entries.
 
-The m4 parser calls `newMacroNotify` method when it finds a m4 macro is used.
+The m4 parser calls `newMacroNotify` method when it finds an m4 macro is used.
 The Autoconf parser connects `newMacroCallback` function defined in *parser/autoconf.c*.
 
 
@@ -552,10 +552,10 @@ method. The macro and functions are declare in *main/subparser.h* .
 	    return m4found;
     }
 
-`foreachSubparser` takes an variable having type `subparser`.
+`foreachSubparser` takes a variable having type `subparser`.
 For each iteration, the value for the variable is updated.
 
-`enterSubparser` takes an variable having type `subparser`.  With the
+`enterSubparser` takes a variable having type `subparser`.  With the
 calling `enterSubparser`, the current language(the value returned from
 `getInputLanguage`) can be temporary switched to the language specified
 with the variable. One of the effect of switching is that `language`
@@ -692,7 +692,7 @@ kind "Program". The Automake parser can tag it with getting help from
 the Make parser.
 
 The Automake parser is an exclusive subparser. It is chosen in top
-down way; a input file name "Makefile.am" gives enough information for
+down way; an input file name "Makefile.am" gives enough information for
 choosing the Automake parser.
 
 To give chances to the Automake parser to capture Automake own

--- a/docs/semifuzz.rst
+++ b/docs/semifuzz.rst
@@ -51,5 +51,5 @@ following parameters:
 		``Units/\*/VALGRIND-${language}.tmp``.
 
 As the same as units target, this semi-fuzz test target also calls
-*misc/units shrink* when an test case is failed. See "*Units* test facility"
+*misc/units shrink* when a test case is failed. See "*Units* test facility"
 about the shrunk result.

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -52,7 +52,7 @@ printed. The detail can be shown in *\*.gcov*. files. *\*.gcda* files
 and *\*.gcov* files can be removed with ``make clean-gcov``.
 
 
-Reviewing the resulf of Units test
+Reviewing the result of Units test
 ------------------------------------------------------------
 
 Try misc/review. [TBW]

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -84,7 +84,7 @@ If you want to build a debug version, you must specify ``DEBUG=1`` like below::
 
 From their site: MSYS is a collection of GNU utilities such as bash, make, gawk and grep to allow building of applications and programs which depend on traditional UNIX tools to be present. It is intended to supplement MinGW and the deficiencies of the cmd shell.
 
-MSYS comes in two flavors. The original from MinGW and a MSYS2 http://sourceforge.net/projects/msys2/
+MSYS comes in two flavors. The original from MinGW and an MSYS2 http://sourceforge.net/projects/msys2/
 
 MSYS is old but still works. You can build ctags with it using ``make -f mk_mingw.mak``. The Autotools are too old on MSYS so you cannot use them.
 

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -48,7 +48,7 @@ derived from **Exuberant-ctags**. The major incompatible changes between
 Universal-ctags and Exuberant-ctags are enumerated in
 ctags-incompatibilities(7).
 
-One of the advantages of Exuberant-ctags is that it allows an user to
+One of the advantages of Exuberant-ctags is that it allows a user to
 define a new parser from command line. Extending this feature is one
 of the major topics in Universal-ctags development. ctags-optlib(7)
 describes how the feature is extended.
@@ -354,7 +354,7 @@ quickly.  However, the command line including sequence of the letters
 becomes difficult to be understood.
 
 Universal-ctags accepts names in
-addition to such letters. The names and letters can be mixed in a
+addition to such letters. The names and letters can be mixed in an
 option parameter by surrounding each name by braces. Thus, for an
 example, following three notations for ``--kinds-C`` option have
 the same meaning::
@@ -472,7 +472,7 @@ OPTION ITEMS
 	letter (e.g. "C:"), the parameter identifier-list will be interpreted as
 	a filename from which to read a list of identifiers, one per input line.
 	Otherwise, identifier-list is a list of identifiers (or identifier
-	pairs) to be specially handled, each delimited by a either a comma or
+	pairs) to be specially handled, each delimited by either a comma or
 	by white space (in which case the list should be quoted to keep the
 	entire list as one command line argument). Multiple ``-I`` options may be
 	supplied. To clear the list of ignore identifiers, supply a single
@@ -1198,7 +1198,7 @@ OPTION ITEMS
 		The number of roles this kind has. See also "Roles".
 
 	MASTER
-		The master parser controlling enablment of the kind.
+		The master parser controlling enablement of the kind.
 		A kind belongs to a language (owner) in Universal-ctags;
 		enabling and disabling a kind in a language has no effect on
 		a kind in another language even if the both kinds has the
@@ -1233,7 +1233,7 @@ OPTION ITEMS
 ``--list-languages``
 	Lists the names of the languages understood by @CTAGS_NAME_EXECUTABLE@,
 	and then exits. These language names are case insensitive and may be
-	used in the the many other options like ``--language-force``,
+	used in many other options like ``--language-force``,
 	``--languages``, ``--kinds-<LANG>``, ``--regex-<LANG>``, and so on.
 
 	Each language listed is disabled if followed by "[disabled]".
@@ -1646,7 +1646,7 @@ HOW TO USE WITH NEDIT
 NEdit version 5.1 and later can handle the new extended tag file format
 (see ``--format``). To make NEdit use the tag file, select "File->Load Tags
 File". To jump to the definition for a tag, highlight the word, then press
-Ctrl-D. NEdit 5.1 can can read multiple tag files from different
+Ctrl-D. NEdit 5.1 can read multiple tag files from different
 directories. Setting the X resource nedit.tagFile to the name of a tag
 file instructs NEdit to automatically load that tag file at startup time.
 
@@ -1699,7 +1699,7 @@ is defined outside of the class declaration (the usual case), the access
 specification (i.e. public, protected, or private) and implementation
 information (e.g. virtual, pure virtual) contained in the function
 declaration are not known when the tag is generated for the function
-definition. It will, however be available for prototypes (e.g "--c++-kinds=+p").
+definition. It will, however be available for prototypes (e.g. "--c++-kinds=+p").
 
 No qualified tags are generated for language objects inherited into a class.
 


### PR DESCRIPTION
Found using [mwic](http://jwilk.net/software/mwic) and [anorack](https://github.com/jwilk/anorack).