### PR TITLE
Allow using '/' as a part of tag name

### DIFF
--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -193,6 +193,7 @@ if "%APPVEYOR_REPO_TAG_NAME%"=="" (
 ) else (
   set ver=%APPVEYOR_REPO_TAG_NAME%
 )
+set ver=%ver:/=_%
 
 :: Create zip package
 set filelist=ctags.exe readtags.exe README.md


### PR DESCRIPTION
Replace it with '_' when creating package files.
(I just want to use this in the ctags-win32 project.)