### PR TITLE
circleci: run db_recover in "Install build tools" step

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,9 @@ jobs:
        - run:
            name: Install build tools
            command: |
+             # See https://bugzilla.redhat.com/show_bug.cgi?id=555315
+             #     https://bugzilla.redhat.com/show_bug.cgi?id=553998
+             cd /var/lib/rpm; db_recover; db_recover
              dnf -y install gcc automake autoconf pkgconfig make aspell-devel aspell-en libxml2-devel jansson-devel libyaml-devel
        - run:
            name: Build


### PR DESCRIPTION
Building at circleci fails randomly with following message:

    BDB1539 Build signature doesn't match environment
    failed loading RPMDB

As far as reading [1] and [2], running db_recover may
fix the failure.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=555315
[2] https://bugzilla.redhat.com/show_bug.cgi?id=553998

Signed-off-by: Masatake YAMATO <yamato@redhat.com>