### PR TITLE
circleci: ignore errors in "install build tools" step

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ jobs:
        - run:
            name: Install build tools
            command: |
-             dnf -y install gcc automake autoconf pkgconfig make aspell-devel aspell-en libxml2-devel jansson-devel libyaml-devel
+             dnf -y install gcc automake autoconf pkgconfig make aspell-devel aspell-en libxml2-devel jansson-devel libyaml-devel || :
        - run:
            name: Build
            command: |


### PR DESCRIPTION
Randomly following error has been reporeted in "Install build tools" step:

	BDB1539 Build signature doesn't match environment
	failed loading RPMDB

Though the error is reported packges which are needed for building
ctags bunary are ready to be used. So this change makes the build
step ignore the error.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>