### PR TITLE
travis: rearrange installed lcoveralls scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,19 @@ env:
 
 # Only with gcc get the mingw-w64 cross compilers
 before_install:
-  - if [ $CC = 'gcc' ] && [ $TRAVIS_OS_NAME = 'linux' ]; then gem install lcoveralls; fi
+  - |
+    if [ $CC = 'gcc' ] && [ $TRAVIS_OS_NAME = 'linux' ]; then
+    	gem install lcoveralls
+    fi
+
 # Build and run tests. Only with gcc cross compile
 script:
   - ./misc/travis-check.sh
 after_success:
-  - if [ $CC = 'gcc' ] && [ $TRAVIS_OS_NAME = 'linux' ]; then lcov -c -b . -d . -o coverage.info && lcoveralls --root . --retry-count 5 coverage.info; fi
+  - |
+    if [ $CC = 'gcc' ] && [ $TRAVIS_OS_NAME = 'linux' ]; then
+    	lcov -c -b . -d . -o coverage.info && lcoveralls --root . --retry-count 5 coverage.info
+    fi
 
 # Build Matrix configuration
 # By default Travis CI runs all possible environment/target combinations.

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,12 @@ script:
 after_success:
   - |
     if [ $CC = 'gcc' ] && [ $TRAVIS_OS_NAME = 'linux' ]; then
-    	lcov -c -b . -d . -o coverage.info && lcoveralls --root . --retry-count 5 coverage.info
+        (
+            for f in /home/travis/.rvm/gems/ruby-2*/gems/lcoveralls-*/lib/lcoveralls/color_formatter.rb; do
+                    sed -i -e 's/severity.capitalize!/severity = severity.capitalize/' $f
+            done
+        ) || :
+        lcov -c -b . -d . -o coverage.info && lcoveralls --root . --retry-count 5 coverage.info
     fi
 
 # Build Matrix configuration


### PR DESCRIPTION
It seems that strings passed to color_formatter.rb are frozen in new ruby implementation.
As the result, destructive operations on the strings cause errors like:

    Finished .info-file creation

    /home/.../lcoveralls/color_formatter.rb:46:in `capitalize!': can't modify frozen String (RuntimeError)

This change rewrites the lines not to use capitalize!.

The change is reported to https://github.com/pcolby/lcoveralls/pull/6

Signed-off-by: Masatake YAMATO <yamato@redhat.com>