### PR TITLE
ObjectiveC: don't add a protocol itself to its scope

### DIFF
--- a/Units/parser-objectivec.r/objectivec_protocol.h.d/expected.tags
+++ b/Units/parser-objectivec.r/objectivec_protocol.h.d/expected.tags
@@ -1,3 +1,3 @@
-Locking	input.h	/^@protocol Locking$/;"	P	protocol:Locking
+Locking	input.h	/^@protocol Locking$/;"	P
 lock	input.h	/^- (void)lock;$/;"	m	protocol:Locking
 unlock	input.h	/^- (void)unlock;$/;"	m	protocol:Locking

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -758,8 +758,8 @@ static void parseProtocol (vString * const ident, objcToken what)
 {
 	if (what == ObjcIDENTIFIER)
 	{
-		pushEnclosingContext (ident, K_PROTOCOL);
 		addTag (ident, K_PROTOCOL);
+		pushEnclosingContext (ident, K_PROTOCOL);
 	}
 	toDoNext = &parseMethods;
 }


### PR DESCRIPTION
Close #1532.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>