### PR TITLE
build-sys: set both -x and -e options in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -xe
+
 type autoreconf || exit 1
 type pkg-config || exit 1
 


### PR DESCRIPTION
@KazuakiM, this change may help us to fix https://github.com/universal-ctags/homebrew-universal-ctags/issues/23.


----

The are enabled to make remote debugging of build-system easier.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>


