### PR TITLE
CXX: Improve namespace parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.od
 *.pdf
 *.ssexwsp
+*.ssexwsp.user
 *.TMP
 *.tmp
 *~

--- a/Units/parser-cxx.r/namespace.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/namespace.cpp.d/expected.tags
@@ -27,4 +27,7 @@ d4	input.cpp	/^	inline namespace d3::d4 {$/;"	n	namespace:d1::d2::d3	file:	end:4
 d1_d2_d3_d4_f	input.cpp	/^		void d1_d2_d3_d4_f() { }$/;"	f	namespace:d1::d2::d3::d4	typeref:typename:void	end:44
 e1	input.cpp	/^namespace e1 = a1::a2::a3;$/;"	A	file:	name:a1::a2::a3
 e2	input.cpp	/^namespace e2 = b1::b2 __attribute__((abi_tag("blah")));$/;"	A	file:	name:b1::b2
-z1	input.cpp	/^namespace z1 { };$/;"	n	file:	end:52
+f1	input.cpp	/^namespace f1 _SOME_MACRO(default)$/;"	n	file:	end:54
+f2	input.cpp	/^namespace f2::f3 _SOME_MACRO("blah","foo")$/;"	n	file:	end:58
+f3	input.cpp	/^namespace f2::f3 _SOME_MACRO("blah","foo")$/;"	n	namespace:f2	file:	end:58
+z1	input.cpp	/^namespace z1 { };$/;"	n	file:	end:60

--- a/Units/parser-cxx.r/namespace.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/namespace.cpp.d/input.cpp
@@ -49,7 +49,14 @@ namespace e1 = a1::a2::a3;
 
 namespace e2 = b1::b2 __attribute__((abi_tag("blah")));
 
-namespace z1 { };
+namespace f1 _SOME_MACRO(default)
+{
+}
 
+namespace f2::f3 _SOME_MACRO("blah","foo")
+{
+}
+
+namespace z1 { };
 
 

--- a/parsers/cxx/cxx_parser_namespace.c
+++ b/parsers/cxx/cxx_parser_namespace.c
@@ -184,13 +184,9 @@ bool cxxParserParseNamespace(void)
 					if(!cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeOpeningBracket))
 					{
 						// tolerate syntax error
-						CXX_DEBUG_LEAVE_TEXT("Found semicolon just after namespace declaration");
+						CXX_DEBUG_LEAVE_TEXT("Found semicolon/EOF just after namespace declaration");
 						return true;
 					}
-
-					CXX_DEBUG_LEAVE_TEXT("Was expecting an opening bracket here");
-					// FIXME: Maybe we could attempt to recover here?
-					return true;
 				}
 			break;
 			case CXXTokenTypeOpeningBracket:
@@ -201,6 +197,24 @@ bool cxxParserParseNamespace(void)
 				// tolerate syntax error
 				CXX_DEBUG_LEAVE_TEXT("Found semicolon just after namespace declaration");
 				return true;
+			break;
+			case CXXTokenTypeIdentifier:
+				// Probably some kind of macro
+				if(!cxxParserParseUpToOneOf(
+						CXXTokenTypeOpeningBracket | CXXTokenTypeSemicolon | CXXTokenTypeEOF,
+						false
+					))
+				{
+					CXX_DEBUG_LEAVE_TEXT("Failed to parse up to an opening bracket");
+					return false;
+				}
+
+				if(!cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeOpeningBracket))
+				{
+					// tolerate syntax error
+					CXX_DEBUG_LEAVE_TEXT("Found semicolon/EOF just after namespace declaration");
+					return true;
+				}
 			break;
 			default:
 				CXX_DEBUG_LEAVE_TEXT("Some kind of syntax error here");


### PR DESCRIPTION
Be more tolerant when parsing namespaces.
Fixes parsing of stl headers which contain a macro after the namespace name.
Fixes #1539 .