### PR TITLE
circleci: use fedora:latest instead of fedora:rawhide

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
    build:
      working_directory: ~/universal-ctags
      docker:
-       - image: docker.io/fedora:rawhide
+       - image: docker.io/fedora:latest
      steps:
        - checkout
        - run:

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,10 @@ jobs:
      docker:
        - image: docker.io/fedora:latest
      steps:
+       - run:
+           name: Install Git
+           command: |
+             dnf -y install git || :
        - checkout
        - run:
            name: Install build tools


### PR DESCRIPTION
The contents of rawhide look broken.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>