### PR TITLE
Make: ignore colon in a value as a target marker

### DIFF
--- a/Units/parser-make.r/make.variable-set-if-undefined.d/expected.tags
+++ b/Units/parser-make.r/make.variable-set-if-undefined.d/expected.tags
@@ -1,1 +1,2 @@
 FOO	input.mak	/^FOO ?= bar$/;"	m
+URL	input.mak	/^URL ?= \\$/;"	m

--- a/Units/parser-make.r/make.variable-set-if-undefined.d/input.mak
+++ b/Units/parser-make.r/make.variable-set-if-undefined.d/input.mak
@@ -1,1 +1,3 @@
 FOO ?= bar
+URL ?= \
+https://docs.ctags.io

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -262,7 +262,7 @@ static void findMakeTags (void)
 			variable_possible = (c == '=');
 			appending = true;
 		}
-		else if (variable_possible && c == ':' &&
+		else if ((! in_value) && variable_possible && c == ':' &&
 				 stringListCount (identifiers) > 0)
 		{
 			c = nextChar ();


### PR DESCRIPTION
Make parser mistakenly captures http as a target in
following input:

    URL ?= \
	http://ctags.io

Here http is in value of URL.

This change fixes this behavior.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>