### PR TITLE
Update Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,6 +64,7 @@ ctags_CFLAGS  += $(LIBXML_CFLAGS)
 ctags_CFLAGS  += $(JANSSON_CFLAGS)
 ctags_CFLAGS  += $(LIBYAML_CFLAGS)
 ctags_CFLAGS  += $(ASPELL_CFLAGS)
+ctags_CFLAGS  += $(SECCOMP_CFLAGS)
 
 ctags_LDADD  =
 ctags_LDADD += $(LIBXML_LIBS)


### PR DESCRIPTION
add SECCOMP_CFLAGS to the Makefile.am file

IMPORTANT:

Do we have to check if SECCOMP is enabled? We have checks if libyaml and libxml are enabled but not for SECCOMP. 