### PR TITLE
Fixed build script for BSD systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ a.out
 aclocal.m4
 autom4te.cache
 badinput
+BSDmakefile
 commit-stamp
 compile
 config.cache

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ See [Homebrew Tap for Universal Ctags](https://github.com/universal-ctags/homebr
 
 ## How to build and install ##
 
-To build with Autotools, see `docs/autotools.rst` for more information.
-(To build on GNU/Linux, Autotools is your choice.)
+To build with Autotools (GNU/Linux, \*BSD, etc.), see `docs/autotools.rst` for more information.
 To build on Windows, see `docs/windows.rst` for more information.
 To build on OSX, see `docs/osx.rst` for more information.
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -5,7 +5,31 @@ set -xe
 type autoreconf || exit 1
 type pkg-config || exit 1
 
-ctags_files=`make -f makefiles/list-translator-input.mak --no-print-directory`
+gen_bsdmakefile() {
+	set +xe
+	echo -e '.DONE:\n\t@echo "Please use GNU Make (gmake) to build this project"\n.DEFAULT:\n\t@echo "Please use GNU Make (gmake) to build this project"' > BSDmakefile
+	set -xe
+}
+
+is_bsd() {
+	UNAME=`uname`
+	if echo $UNAME | grep -i bsd >/dev/null; then
+		#return true
+		return 0
+	else
+		#return false
+		return 1
+	fi
+}
+
+if is_bsd; then
+	MAKE="gmake"
+	gen_bsdmakefile
+else
+	MAKE="make"
+fi
+
+ctags_files=`${MAKE} -f makefiles/list-translator-input.mak --no-print-directory`
 misc/dist-test-cases > makefiles/test-cases.mak && \
     if autoreconf -vfi; then
 	if type perl > /dev/null; then

--- a/docs/autotools.rst
+++ b/docs/autotools.rst
@@ -4,7 +4,7 @@ Like most Autotools-based projects, you need to do::
 
     $ ./autogen.sh
     $ ./configure --prefix=/where/you/want # defaults to /usr/local
-    $ make
+    $ make # under BSD, GNU Make (`gmake`) should be used instead
     $ make install # may require extra privileges depending on where to install
 
 After installation the `ctags` executable will be in `$prefix/bin/`.


### PR DESCRIPTION
In autogen.sh, don't assume that the correct Makefile interpreter is
`make`. The syntax of the Makefile generated by autotools is not
compatible with BSD Make, and must be built with GNU Make (gmake)
instead.

In addition to detecting BSD platforms (via uname) and using gmake
instead of make, autogen.sh also generates a BSDmakefile in the
top-level directory. In its presence, BSD Make will use it instead of a
generic Makefile, and BSD users will be informed that they should use
gmake instead of make to buil the project.

Tested on FreeBSD.