### PR TITLE
Remove non-posix make flag --no-print-directory from autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -5,7 +5,7 @@ set -xe
 type autoreconf || exit 1
 type pkg-config || exit 1
 
-ctags_files=`make -f makefiles/list-translator-input.mak --no-print-directory`
+ctags_files=`make -f makefiles/list-translator-input.mak`
 misc/dist-test-cases > makefiles/test-cases.mak && \
     if autoreconf -vfi; then
 	if type perl > /dev/null; then


### PR DESCRIPTION
This fixes the remaining BSD build issues after the recent bmake fixes
were merged into master. Discussed in #1554. Closes #1554.