### PR TITLE
buildsys: add check for asprintf to enable alt implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -485,6 +485,7 @@ AC_SUBST([FNMATCH_CPPFLAGS])
 AC_CHECK_HEADERS(fnmatch.h)
 AM_CONDITIONAL([HAVE_FNMATCH], [test "x$have_fnmatch" = "xyes"])
 
+AC_CHECK_FUNCS(asprintf)
 AC_CHECK_FUNCS(strstr)
 AC_CHECK_FUNCS(strcasecmp stricmp, break)
 AC_CHECK_FUNCS(strncasecmp strnicmp, break)

--- a/main/e_msoft.h
+++ b/main/e_msoft.h
@@ -66,6 +66,10 @@ typedef enum { false, true } bool;
 # define FA_DIREC _A_SUBDIR
 # define ff_name name
 
+# if defined(__USE_MINGW_ANSI_STDIO) && defined(__MINGW64_VERSION_MAJOR)
+#  define HAVE_ASPRINTF 1
+# endif
+
 #endif
 
 #endif

--- a/main/options.c
+++ b/main/options.c
@@ -597,7 +597,7 @@ static vString* getHome (void)
 	}
 }
 
-#if defined(_WIN32) && !(defined(__USE_MINGW_ANSI_STDIO) && defined(__MINGW64_VERSION_MAJOR))
+#ifndef HAVE_ASPRINTF
 
 /* Some versions of MinGW are missing _vscprintf's declaration, although they
  * still provide the symbol in the import library.


### PR DESCRIPTION
Some platforms (like Solaris 10) lack asprintf.  The implementation made
for Windows works fine there, so use autoconf to determine whether
asprintf exists, and if not, enable compiling the replacement
implementation.

These are the relevant build messages:
```
 main/options.c: In function ‘parseConfigurationFileOptionsInDirectory’:
main/options.c:3383:6: warning: implicit declaration of function ‘asprintf’ [-Wimplicit-function-declaration]
  if (asprintf (&leafname,".%s",(Option.configFilename)?Option.configFilename:"ctags") == -1)
      ^

main/ctags-options.o: In function `parseConfigurationFileOptionsInDirectory':
/net/ptah/export/gentoo/working-repos/ctags/main/options.c:3383: undefined reference to `asprintf'
main/ctags-options.o: In function `parseConfigurationFileOptions':
/net/ptah/export/gentoo/working-repos/ctags/main/options.c:3522: undefined reference to `asprintf'
/net/ptah/export/gentoo/working-repos/ctags/main/options.c:3530: undefined reference to `asprintf'
collect2: error: ld returned 1 exit status
```