### PR TITLE
Fixes invoking autogen.sh from a makefile again

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,7 +3,7 @@
 type autoreconf || exit 1
 type pkg-config || exit 1
 
-ctags_files=`make -f makefiles/list-translator-input.mak`
+ctags_files=`make -s -f makefiles/list-translator-input.mak`
 misc/dist-test-cases > makefiles/test-cases.mak && \
     if autoreconf -vfi; then
 	if type perl > /dev/null; then


### PR DESCRIPTION
This is the same problem that 637f3d8da5abc60a26b03d7cb1dfbbf171522e7f fixed, but with a cross platform solution.

It was my mistake for using a GNU specific flag.