### PR TITLE
main,refactor: Don't use kindDefinition type in tagEntryInfo structure

### DIFF
--- a/main/debug.c
+++ b/main/debug.c
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include "debug.h"
+#include "entry_private.h"
 #include "options.h"
 #include "read.h"
 
@@ -77,11 +78,13 @@ extern void debugEntry (const tagEntryInfo *const tag)
 
 	if (debug (DEBUG_PARSE))
 	{
-		printf ("<#%s%s:%s", scope, tag->kind->name, tag->name);
+		kindDefinition *scopeKindDef = getLanguageKind(tag->langType,
+													   tag->extensionFields.scopeKindIndex);
+		printf ("<#%s%s:%s", scope, getTagKindName(tag), tag->name);
 
-		if (tag->extensionFields.scopeKind != NULL  &&
+		if (tag->extensionFields.scopeKindIndex != KIND_GHOST_INDEX  &&
 				tag->extensionFields.scopeName != NULL)
-			printf (" [%s:%s]", tag->extensionFields.scopeKind->name,
+			printf (" [%s:%s]", scopeKindDef->name,
 					tag->extensionFields.scopeName);
 
 		if (isFieldEnabled (FIELD_INHERITANCE) &&

--- a/main/entry.c
+++ b/main/entry.c
@@ -754,7 +754,8 @@ extern void truncateTagLineAfterTag (
 static char* getFullQualifiedScopeNameFromCorkQueue (const tagEntryInfo * inner_scope)
 {
 
-	const kindDefinition *kind = NULL;
+	int kindIndex = KIND_GHOST_INDEX;
+	langType lang;
 	const tagEntryInfo *scope = inner_scope;
 	stringList *queue = stringListNew ();
 	vString *v;
@@ -766,16 +767,17 @@ static char* getFullQualifiedScopeNameFromCorkQueue (const tagEntryInfo * inner_
 	{
 		if (!scope->placeholder)
 		{
-			if (kind)
+			if (kindIndex != KIND_GHOST_INDEX)
 			{
-				sep = scopeSeparatorFor (kind, scope->kind->letter);
+				sep = scopeSeparatorFor (lang, kindIndex, scope->kindIndex);
 				v = vStringNewInit (sep);
 				stringListAdd (queue, v);
 			}
 			/* TODO: scope field of SCOPE can be used for optimization. */
 			v = vStringNewInit (scope->name);
 			stringListAdd (queue, v);
-			kind = scope->kind;
+			kindIndex = scope->kindIndex;
+			lang = scope->langType;
 		}
 		scope =  getEntryInCorkQueue (scope->extensionFields.scopeIndex);
 	}
@@ -801,7 +803,7 @@ extern void getTagScopeInformation (tagEntryInfo *const tag,
 	if (name)
 		*name = NULL;
 
-	if (tag->extensionFields.scopeKind == NULL
+	if (tag->extensionFields.scopeKindIndex == KIND_GHOST_INDEX
 	    && tag->extensionFields.scopeName == NULL
 	    && tag->extensionFields.scopeIndex != CORK_NIL
 	    && TagFile.corkQueue.count > 0)
@@ -814,15 +816,19 @@ extern void getTagScopeInformation (tagEntryInfo *const tag,
 		Assert (full_qualified_scope_name);
 
 		/* Make the information reusable to generate full qualified entry, and xformat output*/
-		tag->extensionFields.scopeKind = scope->kind;
+		tag->extensionFields.scopeKindIndex = scope->kindIndex;
 		tag->extensionFields.scopeName = full_qualified_scope_name;
 	}
 
-	if (tag->extensionFields.scopeKind != NULL  &&
+	if (tag->extensionFields.scopeKindIndex != KIND_GHOST_INDEX  &&
 	    tag->extensionFields.scopeName != NULL)
 	{
 		if (kind)
-			*kind = tag->extensionFields.scopeKind->name;
+		{
+			kindDefinition *kdef = getLanguageKind (tag->langType,
+													tag->extensionFields.scopeKindIndex);
+			*kind = kdef->name;
+		}
 		if (name)
 			*name = tag->extensionFields.scopeName;
 	}
@@ -1086,8 +1092,6 @@ static void clearTagEntryInQueue (tagEntryInfo* slot)
 		eFree ((char *)slot->extensionFields.implementation);
 	if (slot->extensionFields.inheritance)
 		eFree ((char *)slot->extensionFields.inheritance);
-	if (slot->extensionFields.scopeKind)
-		slot->extensionFields.scopeKind = NULL;
 	if (slot->extensionFields.scopeName)
 		eFree ((char *)slot->extensionFields.scopeName);
 	if (slot->extensionFields.signature)
@@ -1155,7 +1159,12 @@ static void writeTagEntry (const tagEntryInfo *const tag)
 
 	if (tag->placeholder)
 		return;
-	if (! tag->kind->enabled)
+	if (tag->kindIndex == KIND_FILE_INDEX)
+	{
+		if (! getInputLanguageFileKind ()->enabled)
+			return;
+	}
+	else if (! isLanguageKindEnabled(tag->langType, tag->kindIndex))
 		return;
 	if (tag->extensionFields.roleIndex != ROLE_INDEX_DEFINITION
 	    && ! isXtagEnabled (XTAG_REFERENCE_TAGS))
@@ -1227,7 +1236,7 @@ extern void uncorkTagFile(void)
 		writeTagEntry (tag);
 		if (doesInputLanguageRequestAutomaticFQTag ()
 		    && isXtagEnabled (XTAG_QUALIFIED_TAGS)
-		    && tag->extensionFields.scopeKind
+		    && (tag->extensionFields.scopeKindIndex != KIND_GHOST_INDEX)
 		    && tag->extensionFields.scopeName
 		    && tag->extensionFields.scopeIndex)
 			makeQualifiedTagEntry (tag);
@@ -1307,15 +1316,16 @@ extern int makeTagEntry (const tagEntryInfo *const tag_const)
 	int r = CORK_NIL;
 	Assert (tag->name != NULL);
 
-	if (getInputLanguageFileKind() != tag->kind)
+	if (KIND_FILE_INDEX != tag->kindIndex)
 	{
 		/* TODO: don't access the internal of kind directly.
 		   Use isInputLanguageKindEnabled () instead. */
-		if (! tag->kind->enabled &&
+		if (! getLanguageKind(tag->langType, tag->kindIndex) &&
 		    (tag->extensionFields.roleIndex == ROLE_INDEX_DEFINITION))
 			return CORK_NIL;
 		if ((tag->extensionFields.roleIndex != ROLE_INDEX_DEFINITION)
-		    && (! tag->kind->roles[tag->extensionFields.roleIndex].enabled))
+		    && (! isLanguageRoleEnabled (tag->langType, tag->kindIndex,
+										 tag->extensionFields.roleIndex)))
 			return CORK_NIL;
 	}
 
@@ -1355,7 +1365,7 @@ extern int makeQualifiedTagEntry (const tagEntryInfo *const e)
 {
 	int r = CORK_NIL;
 	tagEntryInfo x;
-	char xk;
+	int xk;
 	const char *sep;
 	static vString *fqn;
 
@@ -1369,15 +1379,15 @@ extern int makeQualifiedTagEntry (const tagEntryInfo *const e)
 		if (e->extensionFields.scopeName)
 		{
 			vStringCatS (fqn, e->extensionFields.scopeName);
-			xk = e->extensionFields.scopeKind->letter;
-			sep = scopeSeparatorFor (e->kind, xk);
+			xk = e->extensionFields.scopeKindIndex;
+			sep = scopeSeparatorFor (e->langType, e->kindIndex, xk);
 			vStringCatS (fqn, sep);
 		}
 		else
 		{
 			/* This is an top level item. prepend a root separator
 			   if the kind of the item has. */
-			sep = scopeSeparatorFor (e->kind, KIND_NULL);
+			sep = scopeSeparatorFor (e->langType, e->kindIndex, KIND_GHOST_INDEX);
 			if (sep == NULL)
 			{
 				/* No root separator. The name of the
@@ -1469,8 +1479,9 @@ extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 	e->filePosition    = filePosition;
 	e->inputFileName   = inputFileName;
 	e->name            = name;
+	e->extensionFields.scopeKindIndex = KIND_GHOST_INDEX;
 	e->extensionFields.scopeIndex     = CORK_NIL;
-	e->kind = kind;
+	e->kindIndex = kindIndex;
 
 	Assert (roleIndex >= ROLE_INDEX_DEFINITION);
 	Assert (kind == NULL || roleIndex < kind->nRoles);

--- a/main/entry.h
+++ b/main/entry.h
@@ -60,7 +60,7 @@ struct sTagEntryInfo {
 	langType langType;         /* language of input file */
 	const char *inputFileName;   /* name of input file */
 	const char *name;             /* name of the tag */
-	const kindDefinition *kind;	      /* kind descriptor */
+	int kindIndex;	      /* kind descriptor */
 	uint8_t extra[ ((XTAG_COUNT) / 8) + 1 ];
 	uint8_t *extraDynamic;		/* Dynamically allocated but freed by per parser TrashBox */
 
@@ -70,7 +70,7 @@ struct sTagEntryInfo {
 		const char* implementation;
 		const char* inheritance;
 
-		const kindDefinition* scopeKind;
+		int         scopeKindIndex;
 		const char* scopeName;
 		int         scopeIndex;   /* cork queue entry for upper scope tag.
 					     This field is meaningful if the value

--- a/main/entry_private.c
+++ b/main/entry_private.c
@@ -1,0 +1,29 @@
+/*
+*   Copyright (c) 2017, Red Hat, INc.
+*   Copyright (c) 2017, Masatake YAMATO
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   main part private interface to entry.c
+*/
+
+#include "entry_private.h"
+#include "parse.h"
+
+extern kindDefinition* getTagKind(const tagEntryInfo *const tag)
+{
+	return getLanguageKind(tag->langType, tag->kindIndex);
+}
+
+extern char getTagKindLetter(const tagEntryInfo *const tag)
+{
+	kindDefinition *kdef = getLanguageKind(tag->langType, tag->kindIndex);
+	return kdef->letter;
+}
+
+extern char* getTagKindName(const tagEntryInfo *const tag)
+{
+	kindDefinition *kdef = getLanguageKind(tag->langType, tag->kindIndex);
+	return kdef->name;
+}

--- a/main/entry_private.h
+++ b/main/entry_private.h
@@ -1,0 +1,21 @@
+/*
+*   Copyright (c) 2017, Red Hat, INc.
+*   Copyright (c) 2017, Masatake YAMATO
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   main part private interface to entry.c
+*/
+#ifndef CTAGS_PRIVATE_ENTRY_H
+#define CTAGS_PRIVATE_ENTRY_H
+
+#include "general.h"
+#include "entry.h"
+#include "types.h"
+
+extern kindDefinition* getTagKind(const tagEntryInfo *const tag);
+extern char getTagKindLetter(const tagEntryInfo *const tag);
+extern char* getTagKindName(const tagEntryInfo *const tag);
+
+#endif	/* CTAGS_PRIVATE_ENTRY_H */

--- a/main/field.c
+++ b/main/field.c
@@ -19,6 +19,7 @@
 #include "ctags.h"
 #include "debug.h"
 #include "entry.h"
+#include "entry_private.h"
 #include "field.h"
 #include "kind.h"
 #include "options.h"
@@ -392,9 +393,10 @@ static const char *renderEscapedName (const char* s,
 		int c = *s;
 		if ((c > 0x00 && c <= 0x1F) || c == 0x7F)
 		{
+			kindDefinition *kdef = getTagKind (tag);
 			verbose ("Unexpected character (0 < *c && *c < 0x20) included in a tagEntryInfo: %s\n", base);
 			verbose ("File: %s, Line: %lu, Lang: %s, Kind: %c\n",
-				 tag->inputFileName, tag->lineNumber, getLanguageName(tag->langType), tag->kind->letter);
+				 tag->inputFileName, tag->lineNumber, getLanguageName(tag->langType), kdef->letter);
 			verbose ("Escape the character\n");
 			break;
 		}
@@ -571,7 +573,8 @@ static const char* renderCompactInputLine (vString *b,  const char *const line)
 static const char *renderFieldKindName (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
 										bool *rejected CTAGS_ATTR_UNUSED)
 {
-	return renderAsIs (b, tag->kind->name);
+	const char* name = getTagKindName (tag);
+	return renderAsIs (b, name);
 }
 
 static const char *renderFieldCompactInputLine (const tagEntryInfo *const tag,
@@ -626,8 +629,9 @@ static const char *renderFieldRole (const tagEntryInfo *const tag,
 		vStringClear (b);
 	else
 	{
-		Assert (rindex < tag->kind->nRoles);
-		role  = & (tag->kind->roles [rindex]);
+		kindDefinition *kdef = getTagKind(tag);
+		Assert (rindex < kdef->nRoles);
+		role  = & (kdef->roles [rindex]);
 		return renderRole (role, b);
 	}
 
@@ -664,7 +668,7 @@ static const char *renderFieldKindLetter (const tagEntryInfo *const tag,
 {
 	static char c[2] = { [1] = '\0' };
 
-	c [0] = tag->kind->letter;
+	c [0] = getTagKindLetter(tag);
 
 	return renderAsIs (b, c);
 }

--- a/main/kind.c
+++ b/main/kind.c
@@ -47,11 +47,10 @@ extern void printKind (const kindDefinition* const kind, bool indent)
 			kind->enabled ? "" : " [off]");
 }
 
-const char *scopeSeparatorFor (const kindDefinition *kind, char parentLetter)
+const char *scopeSeparatorFor (langType lang, int kindIndex, int parentKindIndex)
 {
-	scopeSeparator *table;
-	Assert (kind);
-	table = kind->separators;
+	kindDefinition *kind = getLanguageKind (lang, kindIndex);
+	scopeSeparator *table = kind->separators;
 
 	/* If no table is given, use the default generic separator ".".
 	   The exception is if a root separator is looked up. In this case,
@@ -59,7 +58,7 @@ const char *scopeSeparatorFor (const kindDefinition *kind, char parentLetter)
 
 	if (table == NULL)
 	{
-		if (parentLetter == KIND_NULL)
+		if (parentKindIndex == KIND_GHOST_INDEX)
 			return NULL;
 		else
 			return ".";
@@ -69,13 +68,13 @@ const char *scopeSeparatorFor (const kindDefinition *kind, char parentLetter)
 	{
 		/* KIND_WILDCARD cannot be used as a key for finding
 		   a root separator.*/
-		if ( (table->parentLetter == KIND_WILDCARD
-		       && parentLetter != KIND_NULL)
-		    || table->parentLetter == parentLetter)
+		if ( (table->parentKindIndex == KIND_WILDCARD_INDEX
+		       && parentKindIndex != KIND_GHOST_INDEX)
+		    || table->parentKindIndex == parentKindIndex)
 			return table->separator;
 		table++;
 	}
-	if (parentLetter == KIND_NULL)
+	if (parentKindIndex == KIND_GHOST_INDEX)
 		return NULL;
 	else
 		return ".";

--- a/main/kind.h
+++ b/main/kind.h
@@ -39,10 +39,11 @@ extern const char *renderRole (const roleDesc* const role, vString* b);
 #define KIND_FILE_DEFAULT 'F'
 #define KIND_FILE_DEFAULT_LONG "file"
 
+#define KIND_WILDCARD_INDEX -3
 #define KIND_WILDCARD '*'
 
 typedef struct sScopeSeparator {
-	char  parentLetter;
+	int parentKindIndex;
 	const char *separator;
 } scopeSeparator;
 
@@ -80,7 +81,7 @@ struct sKindDefinition {
 /* for the obsolete --list-kinds option */
 extern void printKind (const kindDefinition* const kind, bool indent);
 
-extern const char *scopeSeparatorFor (const kindDefinition *kind, char parentLetter);
+extern const char *scopeSeparatorFor (langType lang, int kindIndex, int parentKindIndex);
 
 extern void enableKind (kindDefinition *kind, bool enable);
 

--- a/main/parse.c
+++ b/main/parse.c
@@ -259,7 +259,7 @@ extern unsigned int countLanguageRoles (const langType language, int kindIndex)
 	return countRoles (LanguageTable [language].kindControlBlock, kindIndex);
 }
 
-extern kindDefinition* getLanguageKind (const langType language, signed char kindIndex)
+extern kindDefinition* getLanguageKind (const langType language, int kindIndex)
 {
 	kindDefinition* kdef;
 
@@ -3437,12 +3437,12 @@ extern bool makeKindSeparatorsPseudoTags (const langType language,
 
 			sep = kind->separators + j;
 
-			if (sep->parentLetter == KIND_WILDCARD)
+			if (sep->parentKindIndex == KIND_WILDCARD_INDEX)
 			{
 				name[1] = KIND_WILDCARD;
 				name[2] = kind->letter;
 			}
-			else if (sep->parentLetter == KIND_NULL)
+			else if (sep->parentKindIndex == KIND_GHOST_INDEX)
 			{
 				/* This is root separator: no upper item is here. */
 				name[1] = kind->letter;
@@ -3451,8 +3451,8 @@ extern bool makeKindSeparatorsPseudoTags (const langType language,
 			}
 			else
 			{
-				upperKind = langKindDefinition (language,
-							    sep->parentLetter);
+				upperKind = getLanguageKind (language,
+							    sep->parentKindIndex);
 				if (!upperKind)
 					continue;
 
@@ -3878,7 +3878,7 @@ static void createCTSTTags (void)
 				{
 					case K_BROKEN:
 						initTagEntry (&e, "one\nof\rbroken\tname", i);
-						e.extensionFields.scopeKind = & (CTST_Kinds [K_BROKEN]);
+						e.extensionFields.scopeKindIndex = K_BROKEN;
 						e.extensionFields.scopeName = "\\Broken\tContext";
 						makeTagEntry (&e);
 						break;

--- a/main/parse.h
+++ b/main/parse.h
@@ -147,7 +147,7 @@ extern bool doesLanguageRequestAutomaticFQTag (const langType language);
 extern const char *getLanguageName (const langType language);
 /* kindIndex has to be explicitly signed because char is not signed in all platforms. */
 extern kindDefinition* getLanguageKindForLetter (const langType language, char kindLetter);
-extern kindDefinition* getLanguageKind(const langType language, signed char kindIndex);
+extern kindDefinition* getLanguageKind(const langType language, int kindIndex);
 extern int defineLanguageKind (const langType language, kindDefinition *def,
 							   freeKindDefFunc freeKindDef);
 extern unsigned int countLanguageKinds (const langType language);

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -150,16 +150,17 @@ static int addExtensionFields (tagWriter *writer, MIO *mio, const tagEntryInfo *
 	int length = 0;
 
 	const char *str = NULL;;
-	const char kind_letter_str[2] = {tag->kind->letter, '\0'};
+	kindDefinition *kdef = getLanguageKind(tag->langType, tag->kindIndex);
+	const char kind_letter_str[2] = {kdef->letter, '\0'};
 
-	if (tag->kind->name != NULL && (isFieldEnabled (FIELD_KIND_LONG)  ||
-		 (isFieldEnabled (FIELD_KIND)  && tag->kind->letter == KIND_NULL)))
+	if (kdef->name != NULL && (isFieldEnabled (FIELD_KIND_LONG)  ||
+		 (isFieldEnabled (FIELD_KIND)  && kdef->letter == KIND_NULL)))
 	{
 		/* Use kind long name */
-		str = tag->kind->name;
+		str = kdef->name;
 	}
-	else if (tag->kind->letter != KIND_NULL  && (isFieldEnabled (FIELD_KIND) ||
-			(isFieldEnabled (FIELD_KIND_LONG) &&  tag->kind->name == NULL)))
+	else if (kdef->letter != KIND_NULL  && (isFieldEnabled (FIELD_KIND) ||
+			(isFieldEnabled (FIELD_KIND_LONG) &&  kdef->name == NULL)))
 	{
 		/* Use kind letter */
 		str = kind_letter_str;

--- a/parsers/ada.c
+++ b/parsers/ada.c
@@ -124,8 +124,6 @@ typedef enum eAdaParseMode
 
 typedef enum eAdaKinds
 {
-  ADA_KIND_SEPARATE = -3,   /* for defining the parent token name of a child
-                             * sub-unit */
   ADA_KIND_UNDEFINED = KIND_GHOST_INDEX,  /* for default/initialization values */
   ADA_KIND_PACKAGE_SPEC,
   ADA_KIND_PACKAGE,
@@ -152,10 +150,10 @@ typedef enum eAdaKinds
   ADA_KIND_IDENTIFIER,
   ADA_KIND_AUTOMATIC_VARIABLE,
   ADA_KIND_ANONYMOUS,      /* for non-identified loops and blocks */
+  ADA_KIND_SEPARATE,       /* for defining the parent token name of a child
+							* sub-unit */
   ADA_KIND_COUNT            /* must be last */
 } adaKind;
-
-static kindDefinition AdaSeparateKind = { true, 'S', "separate", "something separately declared/defined" };
 
 static kindDefinition AdaKinds[] =
 {
@@ -183,7 +181,9 @@ static kindDefinition AdaKinds[] =
   { true,   'b', "label",       "labels" },
   { true,   'i', "identifier",  "loop/declare identifiers"},
   { false,  'a', "autovar",     "automatic variables" },
-  { false,  'y', "anon",        "loops and blocks with no identifier" }
+  { false,  'y', "anon",        "loops and blocks with no identifier" },
+  // something separately declared/defined
+  { true,   'S', "separate",    "(ctags internal use)" }
 };
 
 typedef struct sAdaTokenList
@@ -440,11 +440,11 @@ static adaTokenInfo *newAdaToken(const char *name, int len, adaKind kind,
    * them blank because they get filled in later. */
   if(kind > ADA_KIND_UNDEFINED)
   {
-    token->tag.kind = &(AdaKinds[kind]);
+    token->tag.kindIndex = kind;
   }
   else
   {
-    token->tag.kind = NULL;
+    token->tag.kindIndex = KIND_GHOST_INDEX;
   }
 
   /* setup the parent and children pointers */
@@ -2063,7 +2063,7 @@ static void storeAdaTags(adaTokenInfo *token, const char *parentScope)
 
       if(token->kind != ADA_KIND_UNDEFINED)
       {
-        token->tag.kind = &(AdaKinds[token->kind]);
+        token->tag.kindIndex = token->kind;
       }
     }
 
@@ -2073,12 +2073,12 @@ static void storeAdaTags(adaTokenInfo *token, const char *parentScope)
       if(token->parent->kind > ADA_KIND_UNDEFINED &&
          token->parent->kind < ADA_KIND_COUNT)
       {
-        token->tag.extensionFields.scopeKind = &(AdaKinds[token->parent->kind]);
+        token->tag.extensionFields.scopeKindIndex = token->parent->kind;
         token->tag.extensionFields.scopeName = token->parent->name;
       }
       else if(token->parent->kind == ADA_KIND_SEPARATE)
       {
-        token->tag.extensionFields.scopeKind = &(AdaSeparateKind);
+        token->tag.extensionFields.scopeKindIndex = ADA_KIND_SEPARATE;
         token->tag.extensionFields.scopeName = token->parent->name;
       }
     } /* else if(token->parent->kind == ADA_KIND_ANONYMOUS) */

--- a/parsers/ant.c
+++ b/parsers/ant.c
@@ -184,7 +184,7 @@ static void makeTagForTargetName (xmlNode *node CTAGS_ATTR_UNUSED,
 	int *corkIndex = (int *)userData;
 	int parentIndex = *corkIndex;
 
-	tag->extensionFields.scopeKind  = NULL;
+	tag->extensionFields.scopeKindIndex = KIND_GHOST_INDEX;
 	tag->extensionFields.scopeName  = NULL;
 	tag->extensionFields.scopeIndex = parentIndex;
 
@@ -196,7 +196,7 @@ static void makeTagWithScope (xmlNode *node CTAGS_ATTR_UNUSED,
 			      struct sTagEntryInfo *tag,
 			      void *userData)
 {
-	tag->extensionFields.scopeKind  = NULL;
+	tag->extensionFields.scopeKindIndex = KIND_GHOST_INDEX;
 	tag->extensionFields.scopeName  = NULL;
 	tag->extensionFields.scopeIndex = *(int *)userData;
 

--- a/parsers/automake.c
+++ b/parsers/automake.c
@@ -63,7 +63,7 @@ static roleDesc AutomakeConditionRoles [] = {
 };
 
 static scopeSeparator AutomakeSeparators [] = {
-	{ 'd'          , "/" },
+	{ K_AM_DIR        , "/" },
 };
 
 static kindDefinition AutomakeKinds [] = {
@@ -199,7 +199,7 @@ static void valueCallback (makeSubparser *make, char *name)
 		return;
 
 	parent = getEntryInCorkQueue (p);
-	if (((parent->kind - AutomakeKinds) == K_AM_DIR)
+	if ((parent->kindIndex == K_AM_DIR)
 	    && (parent->extensionFields.roleIndex != ROLE_INDEX_DEFINITION))
 	{
 		k = K_AM_PROGRAM + parent->extensionFields.roleIndex;

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -1143,22 +1143,6 @@ static int kindIndexForType (const tagType type)
 	return result;
 }
 
-static const kindDefinition *kindDefForType (const tagType type)
-{
-	const kindDefinition * result;
-	if (isInputLanguage (Lang_csharp))
-		result = &(CsharpKinds [csharpTagKind (type)]);
-	else if (isInputLanguage (Lang_java))
-		result = &(JavaKinds [javaTagKind (type)]);
-	else if (isInputLanguage (Lang_d))
-		result = &(DKinds [dTagKind (type)]);
-	else if (isInputLanguage (Lang_vera))
-		result = &(VeraKinds [veraTagKind (type)]);
-	else
-		result = &(CKinds [cTagKind (type)]);
-	return result;
-}
-
 static int roleForType (const tagType type)
 {
 	int result;
@@ -1193,44 +1177,24 @@ static bool includeTag (const tagType type, const bool isFileScope)
 {
 	bool result;
 	int k;
-	kindDefinition* kdef = NULL;
 
-	if (isFileScope  &&  ! isXtagEnabled(XTAG_FILE_SCOPE))
-		result = false;
+	if (isFileScope && !isXtagEnabled(XTAG_FILE_SCOPE))
+		return false;
 	else if (isInputLanguage (Lang_csharp))
-	{
 		k = csharpTagKindNoAssert (type);
-		kdef = CsharpKinds;
-	}
 	else if (isInputLanguage (Lang_java))
-	{
 		k = javaTagKindNoAssert (type);
-		kdef = JavaKinds;
-	}
 	else if (isInputLanguage (Lang_d))
-	{
 		k = dTagKindNoAssert (type);
-		kdef = DKinds;
-	}
 	else if (isInputLanguage (Lang_vera))
-	{
 		k = veraTagKindNoAssert (type);
-		kdef = VeraKinds;
-	}
 	else
-	{
 		k = cTagKindNoAssert (type);
-		kdef = CKinds;
-	}
 
-	if (kdef)
-	{
-		Assert (k >= COMMONK_UNDEFINED);
-		if (k == COMMONK_UNDEFINED)
-			result = false;
-		else
-			result = kdef [k].enabled;
-	}
+	if (k == COMMONK_UNDEFINED)
+		result = false;
+	else
+		result = isInputLanguageKindEnabled (k);
 
 	return result;
 }
@@ -1321,13 +1285,13 @@ static void addOtherFields (tagEntryInfo* const tag, const tagType type,
 
 				if (isType (st->context, TOKEN_NAME))
 				{
-					tag->extensionFields.scopeKind = kindDefForType (TAG_CLASS);
+					tag->extensionFields.scopeKindIndex = kindIndexForType (TAG_CLASS);
 					tag->extensionFields.scopeName = vStringValue (scope);
 				}
 				else if ((ptype = declToTagType (parentDecl (st))) &&
 					 includeTag (ptype, isXtagEnabled(XTAG_FILE_SCOPE)))
 				{
-					tag->extensionFields.scopeKind = kindDefForType (ptype);
+					tag->extensionFields.scopeKindIndex = kindIndexForType (ptype);
 					tag->extensionFields.scopeName = vStringValue (scope);
 				}
 			}

--- a/parsers/ctags-aspell.c
+++ b/parsers/ctags-aspell.c
@@ -65,7 +65,7 @@ static void aspell_dictword_handler (const langType language CTAGS_ATTR_UNUSED,
 									 const char *optname CTAGS_ATTR_UNUSED,
 									 const char *arg);
 static void aspell_subwords_handler (const langType language CTAGS_ATTR_UNUSED,
-									 const char *optname CTAGS_ATTR_UNUSED,
+									 const char *optname,
 									 const char *arg);
 
 static parameterHandlerTable AspellParameterHandlerTable [] = {

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -255,7 +255,7 @@ tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken)
 
 	if(!cxxScopeIsGlobal())
 	{
-		g_oCXXTag.extensionFields.scopeKind = &(g_cxx.pKindDefinitions[cxxScopeGetKind()]);
+		g_oCXXTag.extensionFields.scopeKindIndex = cxxScopeGetKind();
 		g_oCXXTag.extensionFields.scopeName = cxxScopeGetFullName();
 	}
 

--- a/parsers/dbusintrospect.c
+++ b/parsers/dbusintrospect.c
@@ -112,7 +112,7 @@ static void makeTagWithScope (xmlNode *node CTAGS_ATTR_UNUSED,
 			      struct sTagEntryInfo *tag,
 			      void *userData)
 {
-	tag->extensionFields.scopeKind  = NULL;
+	tag->extensionFields.scopeKindIndex = KIND_GHOST_INDEX;
 	tag->extensionFields.scopeName  = NULL;
 	tag->extensionFields.scopeIndex = *(int *)userData;
 

--- a/parsers/diff.c
+++ b/parsers/diff.c
@@ -129,7 +129,7 @@ static int parseHunk (const unsigned char* cp, vString *hunk, int scope_index)
 static void markTheLastTagAsDeletedFile (int scope_index)
 {
 	tagEntryInfo *e =  getEntryInCorkQueue (scope_index);
-	e->kind = &(DiffKinds [K_DELETED_FILE]);
+	e->kindIndex = K_DELETED_FILE;
 }
 
 static void findDiffTags (void)

--- a/parsers/dtd.c
+++ b/parsers/dtd.c
@@ -21,11 +21,11 @@
 
 
 static scopeSeparator DtdParameterEntrySeparators [] = {
-	{ KIND_WILDCARD, "/%" },
+	{ KIND_WILDCARD_INDEX, "/%" },
 };
 
 static scopeSeparator DtdAttSeparators [] = {
-	{ KIND_WILDCARD, "/@" },
+	{ KIND_WILDCARD_INDEX, "/@" },
 };
 
 typedef enum {

--- a/parsers/eiffel.c
+++ b/parsers/eiffel.c
@@ -264,7 +264,7 @@ static void makeEiffelFeatureTag (tokenInfo *const token)
 		e.isFileScope = (bool) (! token->isExported);
 		if (e.isFileScope)
 			markTagExtraBit (&e, XTAG_FILE_SCOPE);
-		e.extensionFields.scopeKind = &(EiffelKinds [EKIND_CLASS]);
+		e.extensionFields.scopeKindIndex = EKIND_CLASS;
 		e.extensionFields.scopeName = vStringValue (token->className);
 
 		makeTagEntry (&e);
@@ -300,7 +300,7 @@ static void makeEiffelLocalTag (tokenInfo *const token)
 		vStringPut (scope, '.');
 		vStringCat (scope, token->featureName);
 
-		e.extensionFields.scopeKind = &(EiffelKinds [EKIND_FEATURE]);
+		e.extensionFields.scopeKindIndex = EKIND_FEATURE;
 		e.extensionFields.scopeName = vStringValue (scope);
 
 		makeTagEntry (&e);

--- a/parsers/erlang.c
+++ b/parsers/erlang.c
@@ -82,7 +82,7 @@ static void makeMemberTag (
 
 		if (module != NULL  &&  vStringLength (module) > 0)
 		{
-			tag.extensionFields.scopeKind = &(ErlangKinds [K_MODULE]);
+			tag.extensionFields.scopeKindIndex = K_MODULE;
 			tag.extensionFields.scopeName = vStringValue (module);
 		}
 		makeTagEntry (&tag);

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -535,7 +535,7 @@ static void makeFortranTag (tokenInfo *const token, tagType tag)
 			const tokenInfo* const scope = ancestorScope ();
 			if (scope != NULL)
 			{
-				e.extensionFields.scopeKind = &(FortranKinds [scope->tag]);
+				e.extensionFields.scopeKindIndex = scope->tag;
 				e.extensionFields.scopeName = vStringValue (scope->string);
 			}
 		}

--- a/parsers/itcl.c
+++ b/parsers/itcl.c
@@ -21,7 +21,7 @@ struct itclSubparser {
 };
 
 static scopeSeparator ITclGenericSeparators [] = {
-	{ KIND_WILDCARD, "::" },
+	{ KIND_WILDCARD_INDEX, "::" },
 };
 
 enum ITclKind {

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -331,7 +331,7 @@ static void makeJsTag (const tokenInfo *const token, const jsKind kind,
 			if (kind == JSTAG_FUNCTION)
 				parent_kind = JSTAG_FUNCTION;
 
-			e.extensionFields.scopeKind = &(JsKinds [parent_kind]);
+			e.extensionFields.scopeKindIndex = parent_kind;
 			e.extensionFields.scopeName = vStringValue (fullscope);
 		}
 

--- a/parsers/json.c
+++ b/parsers/json.c
@@ -134,7 +134,7 @@ static void makeJsonTag (tokenInfo *const token, const jsonKind kind)
 	{
 		Assert (token->scopeKind > TAG_NONE && token->scopeKind < TAG_COUNT);
 
-		e.extensionFields.scopeKind = &(JsonKinds[token->scopeKind]);
+		e.extensionFields.scopeKindIndex = token->scopeKind;
 		e.extensionFields.scopeName = vStringValue (token->scope);
 	}
 

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -106,7 +106,7 @@ static bool isSpecialTarget (vString *const name)
 	return true;
 }
 
-static void makeSimpleMakeTag (vString *const name, kindDefinition *MakeKinds, makeKind kind)
+static void makeSimpleMakeTag (vString *const name, makeKind kind)
 {
 	if (!isLanguageEnabled (getInputLanguage ()))
 		return;
@@ -114,7 +114,7 @@ static void makeSimpleMakeTag (vString *const name, kindDefinition *MakeKinds, m
 	makeSimpleTag (name, kind);
 }
 
-static void makeSimpleMakeRefTag (const vString* const name, kindDefinition* const kinds, const int kind,
+static void makeSimpleMakeRefTag (const vString* const name, const int kind,
 				  int roleIndex)
 {
 	if (!isLanguageEnabled (getInputLanguage ()))
@@ -130,7 +130,7 @@ static void newTarget (vString *const name)
 	{
 		return;
 	}
-	makeSimpleMakeTag (name, MakeKinds, K_TARGET);
+	makeSimpleMakeTag (name, K_TARGET);
 }
 
 static void newMacro (vString *const name, bool with_define_directive, bool appending)
@@ -138,7 +138,7 @@ static void newMacro (vString *const name, bool with_define_directive, bool appe
 	subparser *s;
 
 	if (!appending)
-		makeSimpleMakeTag (name, MakeKinds, K_MACRO);
+		makeSimpleMakeTag (name, K_MACRO);
 
 	foreachSubparser(s, false)
 	{
@@ -178,7 +178,7 @@ static void directiveFound (vString *const name)
 
 static void newInclude (vString *const name, bool optional)
 {
-	makeSimpleMakeRefTag (name, MakeKinds, K_INCLUDE,
+	makeSimpleMakeRefTag (name, K_INCLUDE,
 			      optional? R_INCLUDE_OPTIONAL: R_INCLUDE_GENERIC);
 }
 

--- a/parsers/maven2.c
+++ b/parsers/maven2.c
@@ -194,7 +194,7 @@ static void makeTagWithScope (xmlNode *node,
 	int i;
 	char* version = NULL;
 
-	if (tag->kind == Maven2Kinds + K_ARTIFACT_ID)
+	if (tag->kindIndex == K_ARTIFACT_ID)
 		version = attachVersionIfExisting (tag, node);
 
 	i = makeTagEntry (tag);
@@ -202,8 +202,8 @@ static void makeTagWithScope (xmlNode *node,
 	if (version)
 		xmlFree (version);
 
-	if ((tag->kind == Maven2Kinds + K_GROUP_ID)
-	    || (tag->kind == Maven2Kinds + K_ARTIFACT_ID))
+	if ((tag->kindIndex == K_GROUP_ID)
+	    || (tag->kindIndex == K_ARTIFACT_ID))
 		corkIndexes [spec->kind] = i;
 }
 

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -432,7 +432,7 @@ static void prepareTag (tagEntryInfo * tag, vString const *name, objcKind kind)
 
 	if (vStringLength (parentName) > 0)
 	{
-		tag->extensionFields.scopeKind = &(ObjcKinds[parentType]);
+		tag->extensionFields.scopeKindIndex = parentType;
 		tag->extensionFields.scopeName = vStringValue (parentName);
 	}
 }

--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -577,29 +577,29 @@ static int getLastNamedIndex ( void )
 	return -1;
 }
 
-static const kindDefinition* contextDescription (contextType t)
+static int contextDescription (contextType t)
 {
 	switch (t)
 	{
 	case ContextFunction:
-		return &(OcamlKinds[K_FUNCTION]);
+		return K_FUNCTION;
 	case ContextMethod:
-		return &(OcamlKinds[K_METHOD]);
+		return K_METHOD;
 	case ContextValue:
-		return &(OcamlKinds[K_VAL]);
+		return K_VAL;
 	case ContextModule:
-		return &(OcamlKinds[K_MODULE]);
+		return K_MODULE;
 	case ContextType:
-		return &(OcamlKinds[K_TYPE]);
+		return K_TYPE;
 	case ContextClass:
-		return &(OcamlKinds[K_CLASS]);
+		return K_CLASS;
 	case ContextBlock:
-		return &(OcamlKinds[K_BEGIN_END]);
+		return K_BEGIN_END;
 	case ContextMatch:
-		return &(OcamlKinds[K_MATCH]);
+		return K_MATCH;
 	}
 
-	return NULL;
+	return KIND_GHOST_INDEX;
 }
 
 static char contextTypeSuffix (contextType t)
@@ -909,7 +909,7 @@ static void prepareTag (tagEntryInfo * tag, vString const *name, int kind)
 	parentIndex = getLastNamedIndex ();
 	if (parentIndex >= 0)
 	{
-		tag->extensionFields.scopeKind =
+		tag->extensionFields.scopeKindIndex =
 			contextDescription (stack[parentIndex].type);
 		tag->extensionFields.scopeName =
 			vStringValue (stack[parentIndex].contextName);

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -499,7 +499,7 @@ static void findPerlTags (void)
 					continue;
 				}
 
-				e.kind     = &(PerlKinds[kind]); /* FIXME */
+				e.kindIndex = kind;
 
 				makeTagEntry(&e);
 

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -117,8 +117,8 @@ typedef enum {
 
 #define NAMESPACE_SEPARATOR "\\"
 static scopeSeparator PhpGenericSeparators [] = {
-	{ 'n'          , NAMESPACE_SEPARATOR },
-	{ KIND_WILDCARD, "::" },
+	{ K_NAMESPACE        , NAMESPACE_SEPARATOR },
+	{ KIND_WILDCARD_INDEX, "::" },
 };
 
 static kindDefinition PhpKinds[COUNT_KIND] = {
@@ -265,10 +265,8 @@ static objPool *TokenPool = NULL;
 static const char *phpScopeSeparatorFor (int phpKind,
 					 int phpUpperScopeKind)
 {
-	char letter;
-
-	letter = PhpKinds[phpUpperScopeKind].letter;
-	return scopeSeparatorFor (&(PhpKinds[phpKind]), letter);
+	return scopeSeparatorFor (getInputLanguage(),
+							  phpKind, phpUpperScopeKind);
 }
 
 static const char *accessToString (const accessType access)
@@ -336,7 +334,7 @@ static void initPhpEntry (tagEntryInfo *const e, const tokenInfo *const token,
 	{
 		Assert (parentKind >= 0);
 
-		e->extensionFields.scopeKind = &(PhpKinds[parentKind]);
+		e->extensionFields.scopeKindIndex = parentKind;
 		e->extensionFields.scopeName = vStringValue (FullScope);
 	}
 }

--- a/parsers/plist.c
+++ b/parsers/plist.c
@@ -145,7 +145,7 @@ static void makeTagWithScope (xmlNode *node CTAGS_ATTR_UNUSED,
 			      struct sTagEntryInfo *tag,
 			      void *userData)
 {
-	tag->extensionFields.scopeKind  = userData? PlistKinds + K_KEY: NULL;
+	tag->extensionFields.scopeKindIndex = userData? K_KEY: KIND_GHOST_INDEX;
 	tag->extensionFields.scopeName  = userData;
 	makeTagEntry (tag);
 }

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -247,11 +247,11 @@ static void initPythonEntry (tagEntryInfo *const e, const tokenInfo *const token
 		 * fucked up as there's nothing to look up.  Damn. */
 		if (nlEntry)
 		{
-			parentKind = (int) (nlEntry->kind - PythonKinds);
+			parentKind = nlEntry->kindIndex;
 
 			/* functions directly inside classes are methods, fix it up */
 			if (kind == K_FUNCTION && parentKind == K_CLASS)
-				e->kind = &(PythonKinds[K_METHOD]);
+				e->kindIndex = K_METHOD;
 		}
 	}
 
@@ -1287,7 +1287,7 @@ static void findPythonTags (void)
 			tagEntryInfo *lvEntry = getEntryOfNestingLevel (lv);
 			pythonKind kind = K_VARIABLE;
 
-			if (lvEntry && lvEntry->kind != &(PythonKinds[K_CLASS]))
+			if (lvEntry && lvEntry->kindIndex != K_CLASS)
 				kind = K_LOCAL_VARIABLE;
 
 			readNext = parseVariable (token, kind);

--- a/parsers/relaxng.c
+++ b/parsers/relaxng.c
@@ -174,7 +174,7 @@ relaxngFindTags (xmlNode *node,
 static void
 setScope (struct sTagEntryInfo *tag, int index)
 {
-	tag->extensionFields.scopeKind  = NULL;
+	tag->extensionFields.scopeKindIndex = KIND_GHOST_INDEX;
 	tag->extensionFields.scopeName  = NULL;
 	tag->extensionFields.scopeIndex = index;
 

--- a/parsers/robot.c
+++ b/parsers/robot.c
@@ -91,7 +91,7 @@ static bool changeSection (const char *const line, const regexMatch *const match
 	return true;
 }
 
-static void makeSimpleXTag (const vString* const name, kindDefinition* const kinds, const int kind,
+static void makeSimpleXTag (const vString* const name, const int kind,
 							unsigned int xtagType)
 {
 	tagEntryInfo e;
@@ -111,7 +111,7 @@ static bool tagKeywordsAndTestCases (const char *const line, const regexMatch *c
         makeSimpleTag (name, section);
         if (isXtagEnabled (RobotXtags[X_WHITESPACE_SWAPPED].xtype)
 			&& whitespaceSwap(name))
-			makeSimpleXTag (name, RobotKinds, section,
+			makeSimpleXTag (name, section,
 							RobotXtags[X_WHITESPACE_SWAPPED].xtype);
         vStringDelete (name);
 		return true;
@@ -129,7 +129,7 @@ static bool tagVariables (const char *const line, const regexMatch *const matche
         makeSimpleTag (name, K_VARIABLE);
         if (isXtagEnabled (RobotXtags[X_WHITESPACE_SWAPPED].xtype)
 			&& whitespaceSwap(name))
-			makeSimpleXTag (name, RobotKinds, K_VARIABLE,
+			makeSimpleXTag (name, K_VARIABLE,
 							RobotXtags[X_WHITESPACE_SWAPPED].xtype);
         vStringDelete (name);
 		return true;

--- a/parsers/rpmspec.c
+++ b/parsers/rpmspec.c
@@ -47,7 +47,7 @@ static roleDesc RpmSpecMacroRoles [] = {
 };
 
 static scopeSeparator RpmSpecPackageSeparators [] = {
-	{ 'p'          , "-" },
+	{ K_PACKAGE , "-" },
 };
 
 static kindDefinition RpmSpecKinds[] = {

--- a/parsers/rst.c
+++ b/parsers/rst.c
@@ -82,7 +82,7 @@ static NestingLevel *getNestingLevel(const int kind)
 	{
 		nl = nestingLevelsGetCurrent(nestingLevels);
 		e = getEntryOfNestingLevel (nl);
-		if ((nl && (e == NULL)) || (e && (e->kind - RstKinds) >= kind))
+		if ((nl && (e == NULL)) || (e && e->kindIndex >= kind))
 		{
 			if (e)
 				e->extensionFields.endLine = (getInputLineNumber() - d);
@@ -113,10 +113,10 @@ static void makeRstTag(const vString* const name, const int kind, const MIOPos f
 		e.filePosition = filepos;
 
 		parent = getEntryOfNestingLevel (nl);
-		if (parent && ((parent->kind - RstKinds) < kind))
+		if (parent && (parent->kindIndex < kind))
 		{
 #if 1
-			e.extensionFields.scopeKind = &(RstKinds [parent->kind - RstKinds]);
+			e.extensionFields.scopeKindIndex = parent->kindIndex;
 			e.extensionFields.scopeName = parent->name;
 #else
 			/* TODO

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -196,7 +196,7 @@ static void emitRubyTag (vString* name, rubyKind kind)
 	lvl = nestingLevelsGetCurrent (nesting);
 	parent = getEntryOfNestingLevel (lvl);
 	if (parent)
-		parent_kind =  parent->kind - RubyKinds;
+		parent_kind =  parent->kindIndex;
 
 	qualified_name = vStringValue (name);
 	unqualified_name = strrchr (qualified_name, SCOPE_SEPARATOR);
@@ -221,7 +221,7 @@ static void emitRubyTag (vString* name, rubyKind kind)
 		Assert (0 <= parent_kind &&
 		        (size_t) parent_kind < (ARRAY_SIZE (RubyKinds)));
 
-		tag.extensionFields.scopeKind = &(RubyKinds [parent_kind]);
+		tag.extensionFields.scopeKindIndex = parent_kind;
 		tag.extensionFields.scopeName = vStringValue (scope);
 	}
 	r = makeTagEntry (&tag);
@@ -378,8 +378,7 @@ static void enterUnnamedScope (void)
 	if (e_parent)
 	{
 		tagEntryInfo e;
-		initTagEntry (&e, "", KIND_GHOST_INDEX);
-		e.kind = e_parent->kind; /* TODO */
+		initTagEntry (&e, "", e_parent->kindIndex);
 		e.placeholder = 1;
 		r = makeTagEntry (&e);
 	}
@@ -485,7 +484,7 @@ static void findRubyTags (void)
 			 *   end
 			 * end
 			 */
-			if (e && (e->kind - RubyKinds) == K_CLASS && strlen (e->name) == 0)
+			if (e && e->kindIndex == K_CLASS && strlen (e->name) == 0)
 				kind = K_SINGLETON;
 			readAndEmitTag (&cp, kind);
 		}

--- a/parsers/rust.c
+++ b/parsers/rust.c
@@ -448,7 +448,7 @@ static void addTag (vString* ident, const char* arg_list, int kind, unsigned lon
 	/*tag.extensionFields.varType = type;*/ /* FIXME: map to typeRef[1]? */
 	if (parent_kind != K_NONE)
 	{
-		tag.extensionFields.scopeKind = &(rustKinds[parent_kind]);
+		tag.extensionFields.scopeKindIndex = parent_kind;
 		tag.extensionFields.scopeName = scope->buffer;
 	}
 	makeTagEntry(&tag);

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -431,7 +431,7 @@ static void makeSqlTag (tokenInfo *const token, const sqlKind kind)
 		if (vStringLength (token->scope) > 0)
 		{
 			Assert (token->scopeKind < SQLTAG_COUNT);
-			e.extensionFields.scopeKind = &(SqlKinds [token->scopeKind]);
+			e.extensionFields.scopeKindIndex = token->scopeKind;
 			e.extensionFields.scopeName = vStringValue (token->scope);
 
 			if (isXtagEnabled (XTAG_QUALIFIED_TAGS))

--- a/parsers/systemdunit.c
+++ b/parsers/systemdunit.c
@@ -61,13 +61,13 @@ static kindDefinition SystemdUnitKinds [] = {
 	  .referenceOnly = true, ATTACH_ROLES(SystemdUnitUnitRoles)},
 };
 
-static int roleOf (const char* key, kindDefinition* kind)
+static int roleOf (const char* key, int kind)
 {
 	int i;
 
-	for (i = 0; i < kind->nRoles; i++)
+	for (i = 0; i < SystemdUnitKinds [kind].nRoles; i++)
 	{
-		if (strcmp (kind->roles[i].name, key) == 0)
+		if (strcmp (SystemdUnitKinds [kind].roles[i].name, key) == 0)
 			return i;
 	}
 
@@ -103,7 +103,7 @@ static void newDataCallback (iniconfSubparser *s CTAGS_ATTR_UNUSED,
 
 	if (isXtagEnabled (XTAG_REFERENCE_TAGS) && value)
 	{
-		r = roleOf (key, SystemdUnitKinds + K_UNIT);
+		r = roleOf (key, K_UNIT);
 		if (r >= 0)
 			makeSystemdReferencedUnit (value, K_UNIT, r);
 	}

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -33,7 +33,7 @@
 */
 
 static scopeSeparator TclGenericSeparators [] = {
-	{ KIND_WILDCARD, "::" },
+	{ KIND_WILDCARD_INDEX, "::" },
 };
 
 typedef enum {
@@ -408,7 +408,7 @@ static void parseProc (tokenInfo *const token,
 
 			if (vStringLength(ns) > 0)
 			{
-				e.extensionFields.scopeKind = TclKinds + K_NAMESPACE;
+				e.extensionFields.scopeKindIndex = K_NAMESPACE;
 				e.extensionFields.scopeName = vStringValue (ns);
 			}
 

--- a/parsers/tcloo.c
+++ b/parsers/tcloo.c
@@ -21,7 +21,7 @@ struct tclooSubparser {
 };
 
 static scopeSeparator TclOOGenericSeparators [] = {
-	{ KIND_WILDCARD, "::" },
+	{ KIND_WILDCARD_INDEX, "::" },
 };
 
 enum TclOOKind {

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -333,12 +333,12 @@ static void pruneTokens (tokenInfo * token)
 	while ((token = popToken (token)));
 }
 
-static const kindDefinition *kindFromKind (const verilogKind kind)
+static const char *getNameForKind (const verilogKind kind)
 {
 	if (isInputLanguage (Lang_systemverilog))
-		return &(SystemVerilogKinds[kind]);
+		return (SystemVerilogKinds[kind]).name;
 	else /* isInputLanguage (Lang_verilog) */
-		return &(VerilogKinds[kind]);
+		return (VerilogKinds[kind]).name;
 }
 
 static char kindEnabled (const verilogKind kind)
@@ -556,7 +556,7 @@ static void dropEndContext (tokenInfo *const token)
 	}
 	else
 	{
-		vStringCatS (endTokenName, kindFromKind (currentContext->kind)->name);
+		vStringCatS (endTokenName, getNameForKind (currentContext->kind));
 		if (strcmp (vStringValue (token->name), vStringValue (endTokenName)) == 0)
 		{
 			verbose ("Dropping context %s\n", vStringValue (currentContext->name));
@@ -606,7 +606,7 @@ static void createTag (tokenInfo *const token)
 	{
 		verbose (" to context %s\n", vStringValue (currentContext->name));
 		currentContext->lastKind = kind;
-		tag.extensionFields.scopeKind = kindFromKind (currentContext->kind);
+		tag.extensionFields.scopeKindIndex = currentContext->kind;
 		tag.extensionFields.scopeName = vStringValue (currentContext->name);
 	}
 	verbose ("\n");

--- a/source.mak
+++ b/source.mak
@@ -17,6 +17,7 @@ MAIN_HEADS =			\
 	main/ctags.h		\
 	main/dependency.h	\
 	main/entry.h		\
+	main/entry_private.h	\
 	main/error.h		\
 	main/field.h		\
 	main/flags.h		\
@@ -63,6 +64,7 @@ MAIN_SRCS =				\
 	main/colprint.c			\
 	main/dependency.c		\
 	main/entry.c			\
+	main/entry_private.c		\
 	main/error.c			\
 	main/field.c			\
 	main/flags.c			\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -102,6 +102,7 @@
     <ClCompile Include="..\main\debug.c" />
     <ClCompile Include="..\main\dependency.c" />
     <ClCompile Include="..\main\entry.c" />
+    <ClCompile Include="..\main\entry_private.c" />
     <ClCompile Include="..\main\error.c" />
     <ClCompile Include="..\main\field.c" />
     <ClCompile Include="..\main\flags.c" />
@@ -246,6 +247,7 @@
     <ClInclude Include="..\main\dependency.h" />
     <ClInclude Include="..\main\e_msoft.h" />
     <ClInclude Include="..\main\entry.h" />
+    <ClInclude Include="..\main\entry_private.h" />
     <ClInclude Include="..\main\error.h" />
     <ClInclude Include="..\main\field.h" />
     <ClInclude Include="..\main\flags.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -60,6 +60,9 @@
     <ClCompile Include="..\main\entry.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
+    <ClCompile Include="..\main\entry_private.c">
+      <Filter>Source Files\Main</Filter>
+    </ClCompile>
     <ClCompile Include="..\main\error.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
@@ -486,6 +489,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\entry.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\main\entry_private.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\error.h">


### PR DESCRIPTION
To minimize a parser accessing kindDefinition data type, this commit
changes the type `kind' and `extensions.scopeKind' fields to int.
    
With this change, a parser can inspect a tagEntryInfo made in
another parser. In other word, communication between parsers
via tagEntryInfo is much easier.
    
Actuall example will be shown in the communiation between
JavaScript parser and VueJavaScript parser.
