### PR TITLE
Tcl fix commnet handling

### DIFF
--- a/Tmain/clear-aliases.d/stdout-expected.txt
+++ b/Tmain/clear-aliases.d/stdout-expected.txt
@@ -1,9 +1,12 @@
 # clear
 # add
 expect
+tclsh
 abc
 # reset
 expect
+tclsh
 # all clear
 # all reset
 expect
+tclsh

--- a/Units/parser-tcl.r/comments.tcl.d/args.ctags
+++ b/Units/parser-tcl.r/comments.tcl.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--fields=+neKl
+

--- a/Units/parser-tcl.r/comments.tcl.d/expected.tags
+++ b/Units/parser-tcl.r/comments.tcl.d/expected.tags
@@ -1,0 +1,5 @@
+f1	input.tcl	/^proc f1 {} {$/;"	procedure	line:1	language:Tcl	end:3
+f2	input.tcl	/^proc f2 {} {puts "hello"} ; # proc g3 {} {    puts "hello"}$/;"	procedure	line:7	language:Tcl	end:7
+f3	input.tcl	/^proc f3 {} {puts "hello"} proc g4 {} {    puts "hello"}$/;"	procedure	line:8	language:Tcl	end:8
+f4	input.tcl	/^proc f4 {} {puts "hello" # proc g5 {} {    puts "hello"}$/;"	procedure	line:9	language:Tcl	end:11
+f5	input.tcl	/^} proc g7 {} {    puts "hello"} { } # proc g8 {} {} ; proc f5 {} { puts "hello"\\$/;"	procedure	line:11	language:Tcl	end:12

--- a/Units/parser-tcl.r/comments.tcl.d/input.tcl
+++ b/Units/parser-tcl.r/comments.tcl.d/input.tcl
@@ -1,0 +1,12 @@
+proc f1 {} {
+    puts "hello"
+}
+# proc g0 {} {    puts "hello"}
+     # proc g1 {} {    puts "hello"}
+
+proc f2 {} {puts "hello"} ; # proc g3 {} {    puts "hello"}
+proc f3 {} {puts "hello"} proc g4 {} {    puts "hello"}
+proc f4 {} {puts "hello" # proc g5 {} {    puts "hello"}
+# proc g6 {} {    puts "hello"}
+} proc g7 {} {    puts "hello"} { } # proc g8 {} {} ; proc f5 {} { puts "hello"\
+ } # proc g9 {}

--- a/main/tokeninfo.c
+++ b/main/tokeninfo.c
@@ -144,13 +144,18 @@ void *newTokenByCopyingFull (tokenInfo *src, void *data)
 	return dest;
 }
 
-bool tokenSkipToType (tokenInfo *token, tokenType t)
+bool tokenSkipToTypeFull (tokenInfo *token, tokenType t, void *data)
 {
 	while (! (tokenIsEOF (token)
 			  || token->type == t))
-		tokenRead (token);
+		tokenReadFull (token, data);
 
 	return (token->type == t)? true: false;
+}
+
+bool tokenSkipToType (tokenInfo *token, tokenType t)
+{
+	return tokenSkipToTypeFull (token, t, NULL);
 }
 
 void tokenUnreadFull (tokenInfo *token, void *data)
@@ -172,6 +177,10 @@ void tokenUnread      (tokenInfo *token)
 
 bool tokenSkipOverPair (tokenInfo *token)
 {
+	return tokenSkipOverPairFull(token, NULL);
+}
+bool tokenSkipOverPairFull (tokenInfo *token, void *data)
+{
 	int start = token->type;
 	int end = token->klass->typeForUndefined;
 	unsigned int i;
@@ -185,7 +194,7 @@ bool tokenSkipOverPair (tokenInfo *token)
 
 	int depth = 1;
 	do {
-		tokenRead (token);
+		tokenReadFull (token, data);
 		if (token->type == start)
 			depth ++;
 		else if (token->type == end)

--- a/main/tokeninfo.c
+++ b/main/tokeninfo.c
@@ -54,6 +54,11 @@ static void destroyToken (void *data)
 
 void *newToken (struct tokenInfoClass *klass)
 {
+	return newTokenFull (klass, NULL);
+}
+
+void *newTokenFull (struct tokenInfoClass *klass, void *data)
+{
 	tokenInfo *token = NULL;
 
 	if (klass->nPreAlloc == 0)
@@ -72,6 +77,8 @@ void *newToken (struct tokenInfoClass *klass)
 		goto retry;
 	}
 
+	if (klass->init)
+		klass->init (token, data);
 	return token;
 }
 

--- a/main/tokeninfo.h
+++ b/main/tokeninfo.h
@@ -49,6 +49,7 @@ struct tokenInfoClass {
 	size_t extraSpace;
 	struct tokenTypePair   *pairs;
 	unsigned int        pairCount;
+	void (*init)   (tokenInfo *token, void *data);
 	void (*read)   (tokenInfo *token, void *data);
 	void (*clear)  (tokenInfo *token);
 	void (*destroy) (tokenInfo *token);
@@ -58,6 +59,7 @@ struct tokenInfoClass {
 };
 
 void *newToken       (struct tokenInfoClass *klass);
+void *newTokenFull   (struct tokenInfoClass *klass, void *data);
 void *newTokenByCopying (tokenInfo *src);
 void *newTokenByCopyingFull (tokenInfo *src, void *data);
 

--- a/main/tokeninfo.h
+++ b/main/tokeninfo.h
@@ -89,6 +89,8 @@ void tokenCopy       (tokenInfo *dest, tokenInfo *src);
    language object type t.
    return false if it reaches EOF. */
 bool tokenSkipToType (tokenInfo *token, tokenType t);
+bool tokenSkipToTypeFull (tokenInfo *token, tokenType t, void *data);
 bool tokenSkipOverPair (tokenInfo *token);
+bool tokenSkipOverPairFull (tokenInfo *token, void *data);
 
 #endif

--- a/parsers/itcl.c
+++ b/parsers/itcl.c
@@ -174,9 +174,10 @@ static void parseCommon (tokenInfo *token, int r, keywordId protection)
 	parseSubobject(token, r, K_COMMON, protection);
 }
 
-static int parseClass (tclSubparser *s CTAGS_ATTR_UNUSED, int parentIndex)
+static int parseClass (tclSubparser *s CTAGS_ATTR_UNUSED, int parentIndex,
+					   void *pstate)
 {
-	tokenInfo *token = newTclToken ();
+	tokenInfo *token = newTclToken (pstate);
 	int r = CORK_NIL;
 
 	tokenRead (token);
@@ -250,7 +251,7 @@ static int parseClass (tclSubparser *s CTAGS_ATTR_UNUSED, int parentIndex)
 }
 
 static int commandNotify (tclSubparser *s, char *command,
-						  int parentIndex)
+						  int parentIndex, void *pstate)
 {
 	struct itclSubparser *itcl = (struct itclSubparser *)s;
 	int r = CORK_NIL;
@@ -261,19 +262,21 @@ static int commandNotify (tclSubparser *s, char *command,
 	if ((itcl->foundITclNamespaceImported
 		 && (strcmp (command, "class") == 0))
 		|| (strcmp (command, "itcl::class") == 0))
-		r = parseClass (s, parentIndex);
+		r = parseClass (s, parentIndex, pstate);
 
 	return r;
 }
 
-static void packageRequirementNotify (tclSubparser *s, char *package)
+static void packageRequirementNotify (tclSubparser *s, char *package,
+									  void *pstate CTAGS_ATTR_UNUSED)
 {
 	struct itclSubparser *itcl = (struct itclSubparser *)s;
 	if (strcmp (package, "Itcl") == 0)
 		itcl->foundITclPackageRequired = true;
 }
 
-static void namespaceImportNotify (tclSubparser *s, char *namespace)
+static void namespaceImportNotify (tclSubparser *s, char *namespace,
+								   void *pstate CTAGS_ATTR_UNUSED)
 {
 	struct itclSubparser *itcl = (struct itclSubparser *)s;
 

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -623,7 +623,7 @@ static void findTclTags (void)
 extern parserDefinition* TclParser (void)
 {
 	static const char *const extensions [] = { "tcl", "tk", "wish", "exp", NULL };
-	static const char *const aliases [] = {"expect", NULL };
+	static const char *const aliases [] = {"expect", "tclsh", NULL };
 
 	parserDefinition* def = parserNew ("Tcl");
 	def->kindTable      = TclKinds;

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -70,12 +70,21 @@ static const keywordTable TclKeywordTable[] = {
 */
 
 
-static void readToken (tokenInfo *const token, void *data CTAGS_ATTR_UNUSED);
+static void initToken (tokenInfo *token, void *data);
+static void readToken (tokenInfo *const token, void *data);
 static void clearToken (tokenInfo *token);
 static void copyToken (tokenInfo *dest, tokenInfo *src, void *data CTAGS_ATTR_UNUSED);
 
+struct sTclParserState {
+	enum TclTokenType lastTokenType;
+};
+
+#define TOKEN_PSTATE(TOKEN) \
+	TOKENX(TOKEN, struct tokenExtra)->pstate
+
 struct tokenExtra {
 	int scopeIndex;
+	struct sTclParserState *pstate;
 };
 
 struct tokenTypePair typePairs [] = {
@@ -93,25 +102,29 @@ static struct tokenInfoClass tclTokenInfoClass = {
 	.extraSpace       = sizeof (struct tokenExtra),
 	.pairs            = typePairs,
 	.pairCount        = ARRAY_SIZE (typePairs),
+	.init             = initToken,
 	.read             = readToken,
 	.clear            = clearToken,
 	.copy             = copyToken,
 };
 
-extern tokenInfo *newTclToken (void)
+extern tokenInfo *newTclToken (void *pstate)
 {
-	return newToken (&tclTokenInfoClass);
+	return newTokenFull (&tclTokenInfoClass, pstate);
 }
 
 static void clearToken (tokenInfo *token)
 {
 	TOKENX (token, struct tokenExtra)->scopeIndex = CORK_NIL;
+	TOKENX (token, struct tokenExtra)->pstate = NULL;
 }
 
 static void copyToken (tokenInfo *dest, tokenInfo *src, void *data CTAGS_ATTR_UNUSED)
 {
 	TOKENX (dest, struct tokenExtra)->scopeIndex =
 		TOKENX (src, struct tokenExtra)->scopeIndex;
+	TOKENX (dest, struct tokenExtra)->pstate =
+		TOKENX (src, struct tokenExtra)->pstate;
 }
 
 static void readString (vString *string)
@@ -171,11 +184,18 @@ static keywordId resolveKeyword (vString *string)
 	return lookupKeyword (s, lang);
 }
 
-static void readToken (tokenInfo *const token, void *data CTAGS_ATTR_UNUSED)
+static void initToken (tokenInfo *token, void *data)
 {
-	int c;
-	bool escaped;
+	TOKENX (token, struct tokenExtra)->pstate = data;
+}
 
+static void readToken0 (tokenInfo *const token, struct sTclParserState *pstate)
+{
+	int c = EOF;
+	bool escaped;
+	bool bol = (pstate->lastTokenType == TOKEN_TCL_EOL
+				|| pstate->lastTokenType == ';'
+				|| pstate->lastTokenType == TOKEN_TCL_UNDEFINED);
 	token->type		= TOKEN_TCL_UNDEFINED;
 	token->keyword	= KEYWORD_NONE;
 	vStringClear (token->string);
@@ -189,6 +209,7 @@ static void readToken (tokenInfo *const token, void *data CTAGS_ATTR_UNUSED)
 
 	if (c == '\\')
 	{
+		bol = false;
 		int c0 = getcFromInputFile ();
 		switch (c0)
 		{
@@ -217,9 +238,12 @@ static void readToken (tokenInfo *const token, void *data CTAGS_ATTR_UNUSED)
 	case '#':
 		if (!escaped)
 		{
-			do
-				c = getcFromInputFile ();
-			while (c != EOF && c != '\r' && c != '\n');
+			if (bol)
+			{
+				do
+					c = getcFromInputFile ();
+				while (c != EOF && c != '\r' && c != '\n');
+			}
 			goto getNextChar;
 		}
 	case '"':
@@ -278,6 +302,14 @@ static void readToken (tokenInfo *const token, void *data CTAGS_ATTR_UNUSED)
 	}
 }
 
+static void readToken (tokenInfo *const token, void *data CTAGS_ATTR_UNUSED)
+{
+	struct sTclParserState *pstate = TOKEN_PSTATE(token);
+
+	readToken0 (token, pstate);
+
+	pstate->lastTokenType = token->type;
+}
 
 static void skipToEndOfCmdline (tokenInfo *const token)
 {
@@ -325,7 +357,8 @@ static void notifyPackageRequirement (tokenInfo *const token)
 		if (tclsub->packageRequirementNotify)
 		{
 			enterSubparser(sub);
-			tclsub->packageRequirementNotify (tclsub, vStringValue (token->string));
+			tclsub->packageRequirementNotify (tclsub, vStringValue (token->string),
+											  TOKEN_PSTATE(token));
 			leaveSubparser();
 		}
 	}
@@ -342,7 +375,8 @@ static void notifyNamespaceImport (tokenInfo *const token)
 		if (tclsub->namespaceImportNotify)
 		{
 			enterSubparser(sub);
-			tclsub->namespaceImportNotify (tclsub, vStringValue (token->string));
+			tclsub->namespaceImportNotify (tclsub, vStringValue (token->string),
+										   TOKEN_PSTATE(token));
 			leaveSubparser();
 		}
 	}
@@ -360,7 +394,8 @@ static int notifyCommand (tokenInfo *const token, unsigned int parent)
 		if (tclsub->commandNotify)
 		{
 			enterSubparser(sub);
-			r = tclsub->commandNotify (tclsub, vStringValue (token->string), parent);
+			r = tclsub->commandNotify (tclsub, vStringValue (token->string), parent,
+									   TOKEN_PSTATE(token));
 			leaveSubparser();
 			if (r != CORK_NIL)
 				break;
@@ -563,7 +598,10 @@ static void parsePackage (tokenInfo *const token)
 
 static void findTclTags (void)
 {
-	tokenInfo *const token = newTclToken ();
+	struct sTclParserState pstate = {
+		.lastTokenType = TOKEN_TCL_UNDEFINED,
+	};
+	tokenInfo *const token = newTclToken (&pstate);
 
 	do {
 		tokenRead (token);

--- a/parsers/tcl.h
+++ b/parsers/tcl.h
@@ -32,18 +32,22 @@ enum TclTokenType {
 struct sTclSubparser {
 	subparser subparser;
 
-	void (* packageRequirementNotify) (tclSubparser *s, char *package);
-	void (* namespaceImportNotify) (tclSubparser *s, char *namespace);
+	/* `pstate' is needed to call newTclToken(). */
+	void (* packageRequirementNotify) (tclSubparser *s, char *package,
+									   void *pstate);
+	void (* namespaceImportNotify) (tclSubparser *s, char *namespace,
+									void *pstate);
 	/* Return CORK_NIL if the command line is NOT consumed.
 	   If a positive integer is returned, end: field may
 	   be attached by tcl base parser.
 	   Return CORK_NIL - 1 if the command line is consumed
 	   but not tag is made. */
 	int (* commandNotify) (tclSubparser *s, char *command,
-							int parentIndex);
+						   int parentIndex,
+						   void *pstate);
 };
 
-extern tokenInfo *newTclToken (void);
+extern tokenInfo *newTclToken (void *pstate);
 extern void skipToEndOfTclCmdline (tokenInfo *const token);
 
 #endif	/* CTAGS_PARSER_TCL_H */

--- a/parsers/tcloo.c
+++ b/parsers/tcloo.c
@@ -65,9 +65,10 @@ static void parseSuperclass (tokenInfo *token, int parent)
 	skipToEndOfTclCmdline (token);
 }
 
-static int parseClass (tclSubparser *s CTAGS_ATTR_UNUSED, int parentIndex)
+static int parseClass (tclSubparser *s CTAGS_ATTR_UNUSED, int parentIndex,
+					   void *pstate)
 {
-	tokenInfo *token = newTclToken ();
+	tokenInfo *token = newTclToken (pstate);
 	int r = CORK_NIL;
 
 	tokenRead (token);
@@ -110,7 +111,7 @@ static int parseClass (tclSubparser *s CTAGS_ATTR_UNUSED, int parentIndex)
 }
 
 static int commandNotify (tclSubparser *s, char *command,
-						  int parentIndex)
+						  int parentIndex, void *pstate)
 {
 	struct tclooSubparser *tcloo = (struct tclooSubparser *)s;
 	int r = CORK_NIL;
@@ -118,12 +119,13 @@ static int commandNotify (tclSubparser *s, char *command,
 	if ((tcloo->foundTclOONamespaceImported
 		 && (strcmp (command, "class") == 0))
 		|| (strcmp (command, "oo::class") == 0))
-		r = parseClass (s, parentIndex);
+		r = parseClass (s, parentIndex, pstate);
 
 	return r;
 }
 
-static void namespaceImportNotify (tclSubparser *s, char *namespace)
+static void namespaceImportNotify (tclSubparser *s, char *namespace,
+								   void *pstate CTAGS_ATTR_UNUSED)
 {
 	struct tclooSubparser *tcloo = (struct tclooSubparser *)s;
 


### PR DESCRIPTION
`#` at the middle of line in tcl script is not a comment starter.
But ctags recognized it as a comment starter.
The changes in this pull request fixes the wrong recognition about comment starter. 