### PR TITLE
go: Make struct parsing a little easier to read

### DIFF
--- a/Units/parser-go.r/go-anonmember.d/expected.tags
+++ b/Units/parser-go.r/go-anonmember.d/expected.tags
@@ -17,3 +17,13 @@ lang3	input.go	/^	lang3, lang4 *P.Q.LANG$/;"	m	struct:X
 lang4	input.go	/^	lang3, lang4 *P.Q.LANG$/;"	m	struct:X
 T11	input.go	/^	P.Q.T11$/;"	M	struct:X	typeref:typename:P.Q.T11
 T12	input.go	/^	*P.Q.T12$/;"	M	struct:X	typeref:typename:*P.Q.T12
+Y	input.go	/^type Y struct {$/;"	s
+byte	input.go	/^	byte$/;"	M	struct:Y	typeref:typename:byte
+b	input.go	/^	b byte$/;"	m	struct:Y
+ss	input.go	/^	ss []string$/;"	m	struct:Y
+bss	input.go	/^	bss [][]byte$/;"	m	struct:Y
+f	input.go	/^	f func() error$/;"	m	struct:Y
+ifaces	input.go	/^	ifaces []interface{}$/;"	m	struct:Y
+tags	input.go	/^	tags  map[string]struct{}$/;"	m	struct:Y
+notify	input.go	/^	notify chan<- struct{}$/;"	m	struct:Y
+p	input.go	/^	p *struct {$/;"	m	struct:Y

--- a/Units/parser-go.r/go-anonmember.d/input.go
+++ b/Units/parser-go.r/go-anonmember.d/input.go
@@ -14,3 +14,19 @@ type X struct {
 	P.Q.T11
 	*P.Q.T12
 }
+
+type Y struct {
+	byte
+	b byte
+	ss []string
+	bss [][]byte
+	f func() error
+	ifaces []interface{}
+	tags  map[string]struct{}
+	notify chan<- struct{}
+	p *struct {
+		x int
+		y int
+		z int
+	}
+}

--- a/Units/parser-go.r/go-funcs.d/expected.tags
+++ b/Units/parser-go.r/go-funcs.d/expected.tags
@@ -4,5 +4,6 @@ f2	input.go	/^func f2(a int) {$/;"	f	package:main	signature:(a int)
 f3	input.go	/^func f3(a int) string {$/;"	f	package:main	signature:(a int)
 f4	input.go	/^func f4(a, b, c <-chan int, d, e, f string) (A, B, C int, D string) {$/;"	f	package:main	signature:(a, b, c <-chan int, d, e, f string)
 f5	input.go	/^func (t *T) f5(\/* comment *\/ a, \/*comment*\/ \/*comment*\/       b string, $/;"	f	unknown:main.T	signature:( a, b string, c []int)
+f6	input.go	/^func (t *(T)) f6(r struct {a int `foo`; b string `bar`}) net.IP {$/;"	f	unknown:main.T	signature:(r struct {a int `foo`; b string `bar`})
 main	input.go	/^func main() {$/;"	f	package:main	signature:()
 main	input.go	/^package main$/;"	p

--- a/Units/parser-go.r/go-funcs.d/input.go
+++ b/Units/parser-go.r/go-funcs.d/input.go
@@ -1,5 +1,7 @@
 package main
 
+import "net"
+
 func f1() {
 }
 
@@ -19,6 +21,10 @@ type T int
 func (t *T) f5(/* comment */ a, /*comment*/ /*comment*/       b string, 
 	c  		[]int) (  /* */ int, string ) {
 	return 1, ""
+}
+
+func (t *(T)) f6(r struct {a int `foo`; b string `bar`}) net.IP {
+	return net.IP{}
 }
 
 func main() {


### PR DESCRIPTION
The code right now isn't very easy to read. This patch tries to improve
that by being more explicit what is being parsed - memberCandidate
isn't reused for cases which have nothing to do with being member
candidate and type parsing is performed the same way both for
anonymous and non-anonymous members (right now tag is generated only
for the anonymous case).