### PR TITLE
Rust: Include trait in impl tags

### DIFF
--- a/Units/parser-rust.r/rust-test_input.d/expected.tags
+++ b/Units/parser-rust.r/rust-test_input.d/expected.tags
@@ -3,21 +3,21 @@ Animal	input.rs	/^enum Animal {$/;"	g
 B	input.rs	/^pub struct B$/;"	s
 Bar	input.rs	/^struct Bar(isize);$/;"	s
 Baz	input.rs	/^struct Baz(isize);$/;"	s
-C	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c
 C	input.rs	/^pub struct C<T> where T: Send$/;"	s
 D	input.rs	/^pub trait D<T> where T: Send$/;"	i
+D for C	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c
 DoZ	input.rs	/^trait DoZ {$/;"	i
-Foo	input.rs	/^impl DoZ for Foo {$/;"	c
+DoZ for Foo	input.rs	/^impl DoZ for Foo {$/;"	c
 Foo	input.rs	/^impl Foo {$/;"	c
-Foo	input.rs	/^impl Testable for Foo {$/;"	c
 Foo	input.rs	/^struct Foo{foo_field_1:isize}$/;"	s
 Foo2	input.rs	/^struct Foo2 {$/;"	s
 ParametrizedTrait	input.rs	/^trait ParametrizedTrait<T> {$/;"	i
+ParametrizedTrait for TraitedStructTest	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c
 S1	input.rs	/^struct S1 {$/;"	s
 SomeStruct	input.rs	/^	pub struct SomeStruct;$/;"	s	module:test_input2
 SuperTraitTest	input.rs	/^trait SuperTraitTest:Testable+DoZ {$/;"	i
 Testable	input.rs	/^trait Testable $/;"	i
-TraitedStructTest	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c
+Testable for Foo	input.rs	/^impl Testable for Foo {$/;"	c
 TraitedStructTest	input.rs	/^struct TraitedStructTest<X> {$/;"	s
 a	input.rs	/^	a: T$/;"	m	struct:C
 a_anteater	input.rs	/^	a_anteater(isize),$/;"	e	enum:Animal
@@ -26,7 +26,7 @@ a_cat	input.rs	/^	a_cat(isize),$/;"	e	enum:Animal
 a_dog	input.rs	/^	a_dog(isize),$/;"	e	enum:Animal
 bar	input.rs	/^	bar: isize$/;"	m	struct:A
 bar	input.rs	/^	bar: isize$/;"	m	struct:B
-do_z	input.rs	/^	fn do_z(&self) {$/;"	P	implementation:Foo	signature:(&self)
+do_z	input.rs	/^	fn do_z(&self) {$/;"	P	implementation:DoZ for Foo	signature:(&self)
 do_z	input.rs	/^	fn do_z(&self);$/;"	P	interface:DoZ	signature:(&self)
 foo	input.rs	/^	foo: fn() -> isize,$/;"	m	struct:A
 foo	input.rs	/^	foo: isize,$/;"	m	struct:B
@@ -42,13 +42,13 @@ only_field	input.rs	/^	only_field: [isize; size]$/;"	m	struct:S1
 preserve_string_delims	input.rs	/^fn preserve_string_delims(_bar: extern r#"C"# fn()) {}$/;"	f	signature:(_bar: extern r#"C"# fn())
 size	input.rs	/^static size: usize = 1;$/;"	v
 some2	input.rs	/^fn some2(a:Animal) {$/;"	f	signature:(a:Animal)
-test	input.rs	/^	fn test(&self) {$/;"	P	implementation:Foo	signature:(&self)
-test	input.rs	/^	fn test(&self) {$/;"	P	implementation:TraitedStructTest	signature:(&self)
+test	input.rs	/^	fn test(&self) {$/;"	P	implementation:ParametrizedTrait for TraitedStructTest	signature:(&self)
+test	input.rs	/^	fn test(&self) {$/;"	P	implementation:Testable for Foo	signature:(&self)
 test	input.rs	/^	fn test(&self);$/;"	P	interface:ParametrizedTrait	signature:(&self)
 test	input.rs	/^{	fn test(&self);$/;"	P	interface:Testable	signature:(&self)
-test1	input.rs	/^	fn test1(&self) {$/;"	P	implementation:Foo	signature:(&self)
+test1	input.rs	/^	fn test1(&self) {$/;"	P	implementation:Testable for Foo	signature:(&self)
 test1	input.rs	/^	fn test1(&self);$/;"	P	interface:Testable	signature:(&self)
-test2	input.rs	/^	fn test2(&self) {$/;"	P	implementation:Foo	signature:(&self)
+test2	input.rs	/^	fn test2(&self) {$/;"	P	implementation:Testable for Foo	signature:(&self)
 test2	input.rs	/^	fn test2(&self);$/;"	P	interface:Testable	signature:(&self)
 test_input2	input.rs	/^mod test_input2$/;"	n
 test_macro	input.rs	/^macro_rules! test_macro$/;"	M

--- a/parsers/rust.c
+++ b/parsers/rust.c
@@ -684,8 +684,12 @@ static void parseImpl (lexerState *lexer, vString *scope, int parent_kind)
 
 	if (lexer->cur_token == TOKEN_IDENT && strcmp(lexer->token_str->buffer, "for") == 0)
 	{
+		vString *target_name = vStringNew();
 		advanceToken(lexer, true);
-		parseQualifiedType(lexer, name);
+		parseQualifiedType(lexer, target_name);
+		vStringCatS(name, " for ");
+		vStringCat(name, target_name);
+		vStringDelete(target_name);
 	}
 
 	addTag(name, NULL, K_IMPL, line, pos, scope, parent_kind);


### PR DESCRIPTION
When multiple implementations are made for the same type, it can be rapidly difficult to distinguish them.

This PR helps by adding which trait is implemented in the tag as "Trait for Type" instead of simply "Type" .