### PR TITLE
Rust: fill inherits and end fields

### DIFF
--- a/Units/parser-rust.r/rust-simple.d/args.ctags
+++ b/Units/parser-rust.r/rust-simple.d/args.ctags
@@ -1,1 +1,1 @@
---fields=afikmsS
+--fields=afikmsSe

--- a/Units/parser-rust.r/rust-simple.d/expected.tags
+++ b/Units/parser-rust.r/rust-simple.d/expected.tags
@@ -1,4 +1,4 @@
-Circle	input.rs	/^impl Circle {$/;"	c
+Circle	input.rs	/^impl Circle {$/;"	c	end:17
 Circle	input.rs	/^struct Circle {$/;"	s
 area	input.rs	/^    fn area(&self) -> f64 {$/;"	P	implementation:Circle	signature:(&self) -> f64
 main	input.rs	/^fn main() {$/;"	f	signature:()

--- a/Units/parser-rust.r/rust-test_input.d/args.ctags
+++ b/Units/parser-rust.r/rust-test_input.d/args.ctags
@@ -1,1 +1,1 @@
---fields=afikmsS
+--fields=afikmsSe

--- a/Units/parser-rust.r/rust-test_input.d/expected.tags
+++ b/Units/parser-rust.r/rust-test_input.d/expected.tags
@@ -3,13 +3,13 @@ Animal	input.rs	/^enum Animal {$/;"	g
 B	input.rs	/^pub struct B$/;"	s
 Bar	input.rs	/^struct Bar(isize);$/;"	s
 Baz	input.rs	/^struct Baz(isize);$/;"	s
-C	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c	inherits:D
+C	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c	inherits:D	end:42
 C	input.rs	/^pub struct C<T> where T: Send$/;"	s
 D	input.rs	/^pub trait D<T> where T: Send$/;"	i
 DoZ	input.rs	/^trait DoZ {$/;"	i
-Foo	input.rs	/^impl DoZ for Foo {$/;"	c	inherits:DoZ
-Foo	input.rs	/^impl Foo {$/;"	c
-Foo	input.rs	/^impl Testable for Foo {$/;"	c	inherits:Testable
+Foo	input.rs	/^impl DoZ for Foo {$/;"	c	inherits:DoZ	end:157
+Foo	input.rs	/^impl Foo {$/;"	c	end:120
+Foo	input.rs	/^impl Testable for Foo {$/;"	c	inherits:Testable	end:151
 Foo	input.rs	/^struct Foo{foo_field_1:isize}$/;"	s
 Foo2	input.rs	/^struct Foo2 {$/;"	s
 ParametrizedTrait	input.rs	/^trait ParametrizedTrait<T> {$/;"	i
@@ -17,7 +17,7 @@ S1	input.rs	/^struct S1 {$/;"	s
 SomeStruct	input.rs	/^	pub struct SomeStruct;$/;"	s	module:test_input2
 SuperTraitTest	input.rs	/^trait SuperTraitTest:Testable+DoZ {$/;"	i
 Testable	input.rs	/^trait Testable $/;"	i
-TraitedStructTest	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c	inherits:ParametrizedTrait
+TraitedStructTest	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c	inherits:ParametrizedTrait	end:182
 TraitedStructTest	input.rs	/^struct TraitedStructTest<X> {$/;"	s
 a	input.rs	/^	a: T$/;"	m	struct:C
 a_anteater	input.rs	/^	a_anteater(isize),$/;"	e	enum:Animal

--- a/Units/parser-rust.r/rust-test_input.d/expected.tags
+++ b/Units/parser-rust.r/rust-test_input.d/expected.tags
@@ -3,13 +3,13 @@ Animal	input.rs	/^enum Animal {$/;"	g
 B	input.rs	/^pub struct B$/;"	s
 Bar	input.rs	/^struct Bar(isize);$/;"	s
 Baz	input.rs	/^struct Baz(isize);$/;"	s
-C	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c
+C	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c	inherits:D
 C	input.rs	/^pub struct C<T> where T: Send$/;"	s
 D	input.rs	/^pub trait D<T> where T: Send$/;"	i
 DoZ	input.rs	/^trait DoZ {$/;"	i
-Foo	input.rs	/^impl DoZ for Foo {$/;"	c
+Foo	input.rs	/^impl DoZ for Foo {$/;"	c	inherits:DoZ
 Foo	input.rs	/^impl Foo {$/;"	c
-Foo	input.rs	/^impl Testable for Foo {$/;"	c
+Foo	input.rs	/^impl Testable for Foo {$/;"	c	inherits:Testable
 Foo	input.rs	/^struct Foo{foo_field_1:isize}$/;"	s
 Foo2	input.rs	/^struct Foo2 {$/;"	s
 ParametrizedTrait	input.rs	/^trait ParametrizedTrait<T> {$/;"	i
@@ -17,7 +17,7 @@ S1	input.rs	/^struct S1 {$/;"	s
 SomeStruct	input.rs	/^	pub struct SomeStruct;$/;"	s	module:test_input2
 SuperTraitTest	input.rs	/^trait SuperTraitTest:Testable+DoZ {$/;"	i
 Testable	input.rs	/^trait Testable $/;"	i
-TraitedStructTest	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c
+TraitedStructTest	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c	inherits:ParametrizedTrait
 TraitedStructTest	input.rs	/^struct TraitedStructTest<X> {$/;"	s
 a	input.rs	/^	a: T$/;"	m	struct:C
 a_anteater	input.rs	/^	a_anteater(isize),$/;"	e	enum:Animal

--- a/Units/parser-rust.r/rust-test_input2.d/args.ctags
+++ b/Units/parser-rust.r/rust-test_input2.d/args.ctags
@@ -1,1 +1,1 @@
---fields=afikmsS
+--fields=afikmsSe

--- a/Units/parser-rust.r/rust-test_input2.d/expected.tags
+++ b/Units/parser-rust.r/rust-test_input2.d/expected.tags
@@ -1,4 +1,4 @@
-SomeLongStructName	input.rs	/^impl SomeLongStructName {$/;"	c
+SomeLongStructName	input.rs	/^impl SomeLongStructName {$/;"	c	end:27
 SomeLongStructName	input.rs	/^pub struct SomeLongStructName {v:isize}$/;"	s
 SomeStruct	input.rs	/^	pub struct SomeStruct{$/;"	s	module:fruit
 another_function	input.rs	/^	pub fn another_function(a:isize,b:isize,c:isize)->isize {$/;"	f	module:veg	signature:(a:isize,b:isize,c:isize)->isize


### PR DESCRIPTION
(This is based on pull request #1601 submitted by @ithinuel.)

For the input

    impl A for B {

Rust parser emits:

     B	foo.rs	/^impl A for B {$/;"	kind:implementation	inherits:A

This on on the analogy of what Java parser does:

    interface A {
    }
    class B implements A {
    }

For the above input ctags emits for class B:

    B	foo.java	/^class B implements A {$/;"	inherits:A
