### PR TITLE
Rust: trait for impl to inherits and end fields

### DIFF
--- a/Units/parser-rust.r/rust-simple.d/args.ctags
+++ b/Units/parser-rust.r/rust-simple.d/args.ctags
@@ -1,1 +1,1 @@
---fields=afikmsS
+--fields=afikmsSe

--- a/Units/parser-rust.r/rust-simple.d/expected.tags
+++ b/Units/parser-rust.r/rust-simple.d/expected.tags
@@ -1,4 +1,4 @@
-Circle	input.rs	/^impl Circle {$/;"	c
+Circle	input.rs	/^impl Circle {$/;"	c	end:17
 Circle	input.rs	/^struct Circle {$/;"	s
 area	input.rs	/^    fn area(&self) -> f64 {$/;"	P	implementation:Circle	signature:(&self) -> f64
 main	input.rs	/^fn main() {$/;"	f	signature:()

--- a/Units/parser-rust.r/rust-test_input.d/args.ctags
+++ b/Units/parser-rust.r/rust-test_input.d/args.ctags
@@ -1,1 +1,1 @@
---fields=afikmsS
+--fields=afikmsSe

--- a/Units/parser-rust.r/rust-test_input.d/expected.tags
+++ b/Units/parser-rust.r/rust-test_input.d/expected.tags
@@ -3,13 +3,13 @@ Animal	input.rs	/^enum Animal {$/;"	g
 B	input.rs	/^pub struct B$/;"	s
 Bar	input.rs	/^struct Bar(isize);$/;"	s
 Baz	input.rs	/^struct Baz(isize);$/;"	s
-C	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c	inherits:D
+C	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c	inherits:D	end:42
 C	input.rs	/^pub struct C<T> where T: Send$/;"	s
 D	input.rs	/^pub trait D<T> where T: Send$/;"	i
 DoZ	input.rs	/^trait DoZ {$/;"	i
-Foo	input.rs	/^impl DoZ for Foo {$/;"	c	inherits:DoZ
-Foo	input.rs	/^impl Foo {$/;"	c
-Foo	input.rs	/^impl Testable for Foo {$/;"	c	inherits:Testable
+Foo	input.rs	/^impl DoZ for Foo {$/;"	c	inherits:DoZ	end:157
+Foo	input.rs	/^impl Foo {$/;"	c	end:120
+Foo	input.rs	/^impl Testable for Foo {$/;"	c	inherits:Testable	end:151
 Foo	input.rs	/^struct Foo{foo_field_1:isize}$/;"	s
 Foo2	input.rs	/^struct Foo2 {$/;"	s
 ParametrizedTrait	input.rs	/^trait ParametrizedTrait<T> {$/;"	i
@@ -17,7 +17,7 @@ S1	input.rs	/^struct S1 {$/;"	s
 SomeStruct	input.rs	/^	pub struct SomeStruct;$/;"	s	module:test_input2
 SuperTraitTest	input.rs	/^trait SuperTraitTest:Testable+DoZ {$/;"	i
 Testable	input.rs	/^trait Testable $/;"	i
-TraitedStructTest	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c	inherits:ParametrizedTrait
+TraitedStructTest	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c	inherits:ParametrizedTrait	end:182
 TraitedStructTest	input.rs	/^struct TraitedStructTest<X> {$/;"	s
 a	input.rs	/^	a: T$/;"	m	struct:C
 a_anteater	input.rs	/^	a_anteater(isize),$/;"	e	enum:Animal

--- a/Units/parser-rust.r/rust-test_input.d/expected.tags
+++ b/Units/parser-rust.r/rust-test_input.d/expected.tags
@@ -3,21 +3,21 @@ Animal	input.rs	/^enum Animal {$/;"	g
 B	input.rs	/^pub struct B$/;"	s
 Bar	input.rs	/^struct Bar(isize);$/;"	s
 Baz	input.rs	/^struct Baz(isize);$/;"	s
-C	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c	inherits:D	end:42
 C	input.rs	/^pub struct C<T> where T: Send$/;"	s
 D	input.rs	/^pub trait D<T> where T: Send$/;"	i
+D<T> for C<T>	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c	end:42
 DoZ	input.rs	/^trait DoZ {$/;"	i
-Foo	input.rs	/^impl DoZ for Foo {$/;"	c	inherits:DoZ	end:157
+DoZ for Foo	input.rs	/^impl DoZ for Foo {$/;"	c	end:157
 Foo	input.rs	/^impl Foo {$/;"	c	end:120
-Foo	input.rs	/^impl Testable for Foo {$/;"	c	inherits:Testable	end:151
 Foo	input.rs	/^struct Foo{foo_field_1:isize}$/;"	s
 Foo2	input.rs	/^struct Foo2 {$/;"	s
 ParametrizedTrait	input.rs	/^trait ParametrizedTrait<T> {$/;"	i
+ParametrizedTrait<T> for TraitedStructTest<T>	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c	end:182
 S1	input.rs	/^struct S1 {$/;"	s
 SomeStruct	input.rs	/^	pub struct SomeStruct;$/;"	s	module:test_input2
 SuperTraitTest	input.rs	/^trait SuperTraitTest:Testable+DoZ {$/;"	i
 Testable	input.rs	/^trait Testable $/;"	i
-TraitedStructTest	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c	inherits:ParametrizedTrait	end:182
+Testable for Foo	input.rs	/^impl Testable for Foo {$/;"	c	end:151
 TraitedStructTest	input.rs	/^struct TraitedStructTest<X> {$/;"	s
 a	input.rs	/^	a: T$/;"	m	struct:C
 a_anteater	input.rs	/^	a_anteater(isize),$/;"	e	enum:Animal
@@ -26,7 +26,7 @@ a_cat	input.rs	/^	a_cat(isize),$/;"	e	enum:Animal
 a_dog	input.rs	/^	a_dog(isize),$/;"	e	enum:Animal
 bar	input.rs	/^	bar: isize$/;"	m	struct:A
 bar	input.rs	/^	bar: isize$/;"	m	struct:B
-do_z	input.rs	/^	fn do_z(&self) {$/;"	P	implementation:Foo	signature:(&self)
+do_z	input.rs	/^	fn do_z(&self) {$/;"	P	implementation:DoZ for Foo	signature:(&self)
 do_z	input.rs	/^	fn do_z(&self);$/;"	P	interface:DoZ	signature:(&self)
 foo	input.rs	/^	foo: fn() -> isize,$/;"	m	struct:A
 foo	input.rs	/^	foo: isize,$/;"	m	struct:B
@@ -42,13 +42,13 @@ only_field	input.rs	/^	only_field: [isize; size]$/;"	m	struct:S1
 preserve_string_delims	input.rs	/^fn preserve_string_delims(_bar: extern r#"C"# fn()) {}$/;"	f	signature:(_bar: extern r#"C"# fn())
 size	input.rs	/^static size: usize = 1;$/;"	v
 some2	input.rs	/^fn some2(a:Animal) {$/;"	f	signature:(a:Animal)
-test	input.rs	/^	fn test(&self) {$/;"	P	implementation:Foo	signature:(&self)
-test	input.rs	/^	fn test(&self) {$/;"	P	implementation:TraitedStructTest	signature:(&self)
+test	input.rs	/^	fn test(&self) {$/;"	P	implementation:ParametrizedTrait<T> for TraitedStructTest<T>	signature:(&self)
+test	input.rs	/^	fn test(&self) {$/;"	P	implementation:Testable for Foo	signature:(&self)
 test	input.rs	/^	fn test(&self);$/;"	P	interface:ParametrizedTrait	signature:(&self)
 test	input.rs	/^{	fn test(&self);$/;"	P	interface:Testable	signature:(&self)
-test1	input.rs	/^	fn test1(&self) {$/;"	P	implementation:Foo	signature:(&self)
+test1	input.rs	/^	fn test1(&self) {$/;"	P	implementation:Testable for Foo	signature:(&self)
 test1	input.rs	/^	fn test1(&self);$/;"	P	interface:Testable	signature:(&self)
-test2	input.rs	/^	fn test2(&self) {$/;"	P	implementation:Foo	signature:(&self)
+test2	input.rs	/^	fn test2(&self) {$/;"	P	implementation:Testable for Foo	signature:(&self)
 test2	input.rs	/^	fn test2(&self);$/;"	P	interface:Testable	signature:(&self)
 test_input2	input.rs	/^mod test_input2$/;"	n
 test_macro	input.rs	/^macro_rules! test_macro$/;"	M

--- a/Units/parser-rust.r/rust-test_input.d/expected.tags
+++ b/Units/parser-rust.r/rust-test_input.d/expected.tags
@@ -3,13 +3,13 @@ Animal	input.rs	/^enum Animal {$/;"	g
 B	input.rs	/^pub struct B$/;"	s
 Bar	input.rs	/^struct Bar(isize);$/;"	s
 Baz	input.rs	/^struct Baz(isize);$/;"	s
-C	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c
+C	input.rs	/^impl<T> D<T> for C<T> where T: Send$/;"	c	inherits:D
 C	input.rs	/^pub struct C<T> where T: Send$/;"	s
 D	input.rs	/^pub trait D<T> where T: Send$/;"	i
 DoZ	input.rs	/^trait DoZ {$/;"	i
-Foo	input.rs	/^impl DoZ for Foo {$/;"	c
+Foo	input.rs	/^impl DoZ for Foo {$/;"	c	inherits:DoZ
 Foo	input.rs	/^impl Foo {$/;"	c
-Foo	input.rs	/^impl Testable for Foo {$/;"	c
+Foo	input.rs	/^impl Testable for Foo {$/;"	c	inherits:Testable
 Foo	input.rs	/^struct Foo{foo_field_1:isize}$/;"	s
 Foo2	input.rs	/^struct Foo2 {$/;"	s
 ParametrizedTrait	input.rs	/^trait ParametrizedTrait<T> {$/;"	i
@@ -17,7 +17,7 @@ S1	input.rs	/^struct S1 {$/;"	s
 SomeStruct	input.rs	/^	pub struct SomeStruct;$/;"	s	module:test_input2
 SuperTraitTest	input.rs	/^trait SuperTraitTest:Testable+DoZ {$/;"	i
 Testable	input.rs	/^trait Testable $/;"	i
-TraitedStructTest	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c
+TraitedStructTest	input.rs	/^impl<T: Clone> ParametrizedTrait<T> for TraitedStructTest<T> {$/;"	c	inherits:ParametrizedTrait
 TraitedStructTest	input.rs	/^struct TraitedStructTest<X> {$/;"	s
 a	input.rs	/^	a: T$/;"	m	struct:C
 a_anteater	input.rs	/^	a_anteater(isize),$/;"	e	enum:Animal

--- a/Units/parser-rust.r/rust-test_input2.d/args.ctags
+++ b/Units/parser-rust.r/rust-test_input2.d/args.ctags
@@ -1,1 +1,1 @@
---fields=afikmsS
+--fields=afikmsSe

--- a/Units/parser-rust.r/rust-test_input2.d/expected.tags
+++ b/Units/parser-rust.r/rust-test_input2.d/expected.tags
@@ -1,4 +1,4 @@
-SomeLongStructName	input.rs	/^impl SomeLongStructName {$/;"	c
+SomeLongStructName	input.rs	/^impl SomeLongStructName {$/;"	c	end:27
 SomeLongStructName	input.rs	/^pub struct SomeLongStructName {v:isize}$/;"	s
 SomeStruct	input.rs	/^	pub struct SomeStruct{$/;"	s	module:fruit
 another_function	input.rs	/^	pub fn another_function(a:isize,b:isize,c:isize)->isize {$/;"	f	module:veg	signature:(a:isize,b:isize,c:isize)->isize

--- a/parsers/rust.c
+++ b/parsers/rust.c
@@ -638,27 +638,25 @@ static void skipTypeBlock (lexerState *lexer)
 	}
 }
 
-/* Essentially grabs the last ident before 'for', '<' and '{', which
+/* Essentially grabs everything between impl<...> and '{', which
  * tends to correspond to what we want as the impl tag entry name */
 static void parseQualifiedType (lexerState *lexer, vString* name)
 {
+	vStringClear(name);
 	while (lexer->cur_token != TOKEN_EOF)
 	{
 		if (lexer->cur_token == TOKEN_IDENT)
 		{
-			if (strcmp(vStringValue(lexer->token_str), "for") == 0
-				|| strcmp(vStringValue(lexer->token_str), "where") == 0)
+			if (strcmp(vStringValue(lexer->token_str), "where") == 0)
 				break;
-			vStringClear(name);
-			vStringCat(name, lexer->token_str);
 		}
-		else if (lexer->cur_token == '<' || lexer->cur_token == '{')
+		else if (lexer->cur_token == '{')
 		{
 			break;
 		}
-		advanceToken(lexer, true);
+		writeCurTokenToStr(lexer, name);
+		advanceToken(lexer, false);
 	}
-	skipTypeBlock(lexer);
 }
 
 /* Impl format:
@@ -690,7 +688,7 @@ static void parseImpl (lexerState *lexer, vString *scope, int parent_kind)
 		advanceToken(lexer, true);
 		parseQualifiedType(lexer, name);
 	}
-
+	vStringStripTrailing(name);
 	corkInex = addTag(name, NULL, K_IMPL, line, pos, scope, parent_kind);
 	addToScope(scope, name);
 


### PR DESCRIPTION
This PR follows #1603 #1601.

The intent is to have fully qualified trait names associated to type for implementations.

A good use case is [vec.rs](https://github.com/rust-lang/rust/blob/master/src/liballoc/vec.rs) from rust's sources.
Drop, FromIter and other traits are implemented multiple times for the same type but with different type arguments.