### PR TITLE
[SELF INCOMPATIBLE] main: introduce version 3 format and remove --out…

### DIFF
--- a/Tmain/input-encoding-option.d/tags-expected.txt
+++ b/Tmain/input-encoding-option.d/tags-expected.txt
@@ -1,7 +1,6 @@
 !_TAG_FILE_ENCODING	UTF-8	//
-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_FORMAT	3	/extended format with meta character escaping/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
 !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/

--- a/Tmain/json-output-format.d/stdout-expected.txt
+++ b/Tmain/json-output-format.d/stdout-expected.txt
@@ -16,7 +16,6 @@
 {"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^package main$/", "language": "Go", "line": 1, "kind": "package"}
 # json --languages=+man --fields=* --extras=*-{subword}
 {"_type": "ptag", "name": "JSON_OUTPUT_VERSION", "path": "0.0", "pattern": "in development"}
-{"_type": "ptag", "name": "TAG_FILE_FORMAT", "path": "2", "pattern": "extended format; --format=1 will not append ;\" to lines"}
 {"_type": "ptag", "name": "TAG_FILE_SORTED", "path": "1", "pattern": "0=unsorted, 1=sorted, 2=foldcase"}
 {"_type": "ptag", "name": "TAG_PROGRAM_AUTHOR", "path": "Universal Ctags Team", "pattern": ""}
 {"_type": "ptag", "name": "TAG_PROGRAM_NAME", "path": "Universal Ctags", "pattern": "Derived from Exuberant Ctags"}

--- a/Tmain/list-pseudo-tags.d/stdout-expected.txt
+++ b/Tmain/list-pseudo-tags.d/stdout-expected.txt
@@ -4,7 +4,6 @@ TAG_FILE_FORMAT       on      the version of tags file format
 TAG_FILE_SORTED       on      how tags are sorted
 TAG_KIND_DESCRIPTION  off     the letters, names and descriptions of kinds in a parser
 TAG_KIND_SEPARATOR    off     the separators used in kinds
-TAG_OUTPUT_MODE       on      the output mode: u-ctags or e-ctags
 TAG_PROGRAM_AUTHOR    on      the author of this ctags implementation
 TAG_PROGRAM_NAME      on      the name of this ctags implementation
 TAG_PROGRAM_URL       on      the official site URL of this ctags implementation

--- a/Tmain/output-encoding-option.d/tags-expected.txt
+++ b/Tmain/output-encoding-option.d/tags-expected.txt
@@ -1,7 +1,6 @@
 !_TAG_FILE_ENCODING	cp932	//
-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_FORMAT	3	/extended format with meta character escaping/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
 !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/

--- a/Tmain/output-format-option.d/run.sh
+++ b/Tmain/output-format-option.d/run.sh
@@ -5,6 +5,6 @@ CTAGS=$1
 
 . ../utils.sh
 
-run_with_format u-ctags
+run_with_format ctags
 run_with_format etags
 run_with_format xref

--- a/Tmain/output-format-option.d/stdout-expected.txt
+++ b/Tmain/output-format-option.d/stdout-expected.txt
@@ -1,4 +1,4 @@
-# u-ctags
+# ctags
 main	input.c	/^main(void)$/;"	f	typeref:typename:int
 # etags
 

--- a/Tmain/output-input-field-with-no-escape.d/run.sh
+++ b/Tmain/output-input-field-with-no-escape.d/run.sh
@@ -12,9 +12,9 @@ if ! ( echo '#define foo' > 'a\b.c' ) 2> /dev/null; then
 fi
 
 echo '# u-ctags'
-${CTAGS} --options=NONE --pseudo-tags=TAG_OUTPUT_MODE --extras=+p --output-format=u-ctags -o - 'a\b.c'
+${CTAGS} --options=NONE --pseudo-tags=TAG_FILE_FORMAT --extras=+p --format=3 -o - 'a\b.c'
 
 echo '# e-ctags'
-${CTAGS} --options=NONE --pseudo-tags=TAG_OUTPUT_MODE --extras=+p --output-format=e-ctags -o - 'a\b.c'
+${CTAGS} --options=NONE --pseudo-tags=TAG_FILE_FORMAT --extras=+p --format=2 -o - 'a\b.c'
 
 rm 'a\b.c'

--- a/Tmain/output-input-field-with-no-escape.d/stdout-expected.txt
+++ b/Tmain/output-input-field-with-no-escape.d/stdout-expected.txt
@@ -1,6 +1,6 @@
 # u-ctags
-!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_FILE_FORMAT	3	/extended format with meta character escaping/
 foo	a\\b.c	/^#define foo$/;"	d	file:
 # e-ctags
-!_TAG_OUTPUT_MODE	e-ctags	/u-ctags or e-ctags/
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
 foo	a\b.c	/^#define foo$/;"	d	file:

--- a/Tmain/ptag-kind-desc.d/stdout-expected.txt
+++ b/Tmain/ptag-kind-desc.d/stdout-expected.txt
@@ -1,19 +1,17 @@
 # BUILTIN
-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_FORMAT	3	/extended format with meta character escaping/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
 !_TAG_KIND_DESCRIPTION!Sh	a,alias	/aliases/
 !_TAG_KIND_DESCRIPTION!Sh	f,function	/functions/
 !_TAG_KIND_DESCRIPTION!Sh	h,heredoc	/label for here document/
 !_TAG_KIND_DESCRIPTION!Sh	s,script	/script files/
-!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
 !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/
 # REGEX
-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_FORMAT	3	/extended format with meta character escaping/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
 !_TAG_KIND_DESCRIPTION!foo	k,kind	/kinds/
-!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
 !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/

--- a/Tmain/tags-pseudo-tags.d/stdout-expected.txt
+++ b/Tmain/tags-pseudo-tags.d/stdout-expected.txt
@@ -1,5 +1,5 @@
 !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_FORMAT	3	/extended format with meta character escaping/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
 !_TAG_KIND_SEPARATOR!PHP	::	/*a/
 !_TAG_KIND_SEPARATOR!PHP	::	/*c/
@@ -19,7 +19,6 @@
 !_TAG_KIND_SEPARATOR!PHP	\\	/nn/
 !_TAG_KIND_SEPARATOR!PHP	\\	/nt/
 !_TAG_KIND_SEPARATOR!PHP	\\	/nv/
-!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
 !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/

--- a/Tmain/xref-ptag-in-list-extras.d/run.sh
+++ b/Tmain/xref-ptag-in-list-extras.d/run.sh
@@ -6,13 +6,13 @@ CTAGS=$1
 O=/tmp/ctags-tmain-$$
 
 echo '#' tags regular file
-"${CTAGS}" --options=NONE --output-format=u-ctags -o $O --list-extras | grep pseudo
+"${CTAGS}" --options=NONE --output-format=ctags -o $O --list-extras | grep pseudo
 
 echo '#' tags -
-"${CTAGS}" --options=NONE --output-format=u-ctags -o - --list-extras | grep pseudo
+"${CTAGS}" --options=NONE --output-format=ctags -o - --list-extras | grep pseudo
 
 echo '#' tags NOTHING
-"${CTAGS}" --options=NONE --output-format=u-ctags --list-extras | grep pseudo
+"${CTAGS}" --options=NONE --output-format=ctags --list-extras | grep pseudo
 
 echo '#' xref regular file
 "${CTAGS}" --options=NONE --output-format=xref -o $O --list-extras | grep pseudo

--- a/Units/parser-php.r/php-full-qualified-tags-no-esc.d/args.ctags
+++ b/Units/parser-php.r/php-full-qualified-tags-no-esc.d/args.ctags
@@ -1,4 +1,2 @@
---extras=+qp
---output-format=e-ctags
---pseudo-tags=TAG_OUTPUT_MODE
-
+--extras=+q
+--format=2

--- a/Units/parser-php.r/php-full-qualified-tags-no-esc.d/expected.tags
+++ b/Units/parser-php.r/php-full-qualified-tags-no-esc.d/expected.tags
@@ -1,4 +1,3 @@
-!_TAG_OUTPUT_MODE	e-ctags	/u-ctags or e-ctags/
 __construct	input.php	/^    public function __construct() {$/;"	f	class:foo\bar
 bar	input.php	/^class bar {$/;"	c	namespace:foo
 foo	input.php	/^namespace foo;$/;"	n

--- a/configure.ac
+++ b/configure.ac
@@ -54,8 +54,9 @@ AH_VERBATIM([DEFAULT_FILE_FORMAT], [
 /* Define this as desired.
  * 1:  Original ctags format
  * 2:  Extended ctags format with extension flags in EX-style comment.
+ * 3:  Use backslash for escaping meta characters like tab
  */
-#define DEFAULT_FILE_FORMAT	2
+#define DEFAULT_FILE_FORMAT	3
 ])
 AH_TEMPLATE([CASE_INSENSITIVE_FILENAMES],
 	[Define this label if your system uses case-insensitive file names])
@@ -167,7 +168,7 @@ AC_ARG_ENABLE(etags,
 AC_ARG_ENABLE(extended-format,
 	[AS_HELP_STRING([--disable-extended-format],
 		[disable extension flags; use original ctags file format only])],
-	AC_DEFINE(DEFAULT_FILE_FORMAT, 1), AC_DEFINE(DEFAULT_FILE_FORMAT, 2))
+	AC_DEFINE(DEFAULT_FILE_FORMAT, 1), AC_DEFINE(DEFAULT_FILE_FORMAT, 3))
 
 AC_ARG_ENABLE(external-sort,
 	[AS_HELP_STRING([--disable-external-sort],

--- a/docs/format.rst
+++ b/docs/format.rst
@@ -485,10 +485,10 @@ Compatible output and weakness
 
 .. NOT REVIEWED YET
 
-Default behavior (``--output-format=u-ctags`` option) has the
-exceptions.  In other hand, with ``--output-format=e-ctags`` option
+Default behavior (``--format=3`` option) has the
+exceptions.  In other hand, with ``--format=2`` option
 ctags has no exception; Universal-ctags command may use the same file
-format as Exuberant-ctags. However, ``--output-format=e-ctags`` throws
+format as Exuberant-ctags. However, ``--format=2`` throws
 away a tag entry which name includes a space or a tab
-character. ``TAG_OUTPUT_MODE`` pseudo tag tells which format is
+character. ``TAG_FILE_FORMAT`` pseudo tag tells which format is
 used when ctags generating tags file.

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -912,6 +912,23 @@ Changes to the tags file format
 ---------------------------------------------------------------------
 
 
+
+version 3 format for handling meta characters in tag entry
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. REVIEWED
+
+To allow recording names including tab characters and other control
+characters in a tag file, version 3 of the file format extends version
+2 with extra escape sequences.
+
+You can use ``--format=2`` to keep compatibility with the output of
+Exuberant-ctags; however, this version of the format cannot record
+names which include tab characters.
+
+See also :ref:`Compatible output and weakness <compat-output>`.
+
+
 Truncating the pattern for long input lines
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 To prevent generating overly large tags files, a pattern field is
@@ -1194,15 +1211,6 @@ The third line means `\\` is used when for combining a namespace item
 
 Of course, ctags uses the more specific line when choosing a
 separator; the third line has higher priority than the first.
-
-``TAG_OUTPUT_MODE``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. NOT REVIEWED YET
-
-This pseudo tag represents output mode: u-ctags or e-ctags.
-
-See also :ref:`Compatible output and weakness <compat-output>`.
 
 .. _parser-own-fields:
 

--- a/main/entry.c
+++ b/main/entry.c
@@ -1447,7 +1447,9 @@ extern void initTagEntryFull (tagEntryInfo *const e, const char *const name,
 			      long sourceLineNumberDifference)
 {
 	int i;
+#if DEBUG
 	kindDefinition *kind = getLanguageKind(langType_, kindIndex);
+#endif
 
 	Assert (getInputFileName() != NULL);
 

--- a/main/entry.h
+++ b/main/entry.h
@@ -31,6 +31,7 @@
 */
 #define WHOLE_FILE  -1L
 #define includeExtensionFlags()         (Option.tagFileFormat > 1)
+#define escapeMetacharacters()          (Option.tagFileFormat > 2)
 
 /*
 *   DATA DECLARATIONS

--- a/main/field.c
+++ b/main/field.c
@@ -99,21 +99,19 @@ static fieldDefinition fieldDefinitionsFixed [] = {
 	DEFINE_FIELD ('N', "name",     true,
 			  "tag name",
 			  FIELDTYPE_STRING,
-			  [WRITER_U_CTAGS] = renderFieldName,
-			  [WRITER_E_CTAGS] = renderFieldNameNoEscape,
-			  [WRITER_JSON]    = renderFieldNameNoEscape,
+			  [WRITER_CTAGS] = renderFieldName,
+			  [WRITER_JSON]  = renderFieldNameNoEscape,
 			  ),
 	DEFINE_FIELD ('F', "input",    true,
 			   "input file",
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldInput,
-			   [WRITER_E_CTAGS] = renderFieldInputNoEscape,
-			   [WRITER_JSON]    = renderFieldInputNoEscape,
+			   [WRITER_CTAGS] = renderFieldInput,
+			   [WRITER_JSON]  = renderFieldInputNoEscape,
 		),
 	DEFINE_FIELD ('P', "pattern",  true,
 			   "pattern",
 			   FIELDTYPE_STRING|FIELDTYPE_BOOL,
-			   [WRITER_U_CTAGS] = renderFieldPatternCtags,
+			   [WRITER_CTAGS] = renderFieldPatternCtags,
 			   [WRITER_XREF]    = renderFieldPatternCommon,
 			   [WRITER_JSON]    = renderFieldPatternCommon,
 		),
@@ -123,68 +121,67 @@ static fieldDefinition fieldDefinitionsExuberant [] = {
 	DEFINE_FIELD ('C', "compact",        false,
 			   "compact input line (used only in xref output)",
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldCompactInputLine),
+			   [WRITER_CTAGS] = renderFieldCompactInputLine),
 
 	/* EXTENSION FIELDS */
 	DEFINE_FIELD_FULL ('a', "access",         false,
 		      "Access (or export) of class members",
 			  isAccessFieldAvailable,
 			  FIELDTYPE_STRING,
-		      [WRITER_U_CTAGS] = renderFieldAccess),
+		      [WRITER_CTAGS] = renderFieldAccess),
 	DEFINE_FIELD_FULL ('f', "file",           true,
 		      "File-restricted scoping",
 			  isFileFieldAvailable,
 			  FIELDTYPE_BOOL,
-		      [WRITER_U_CTAGS] = renderFieldFile),
+		      [WRITER_CTAGS] = renderFieldFile),
 	DEFINE_FIELD_FULL ('i', "inherits",       false,
 		      "Inheritance information",
 			  isInheritsFieldAvailable,
 			  FIELDTYPE_STRING|FIELDTYPE_BOOL,
-		      [WRITER_U_CTAGS] = renderFieldInherits),
+		      [WRITER_CTAGS] = renderFieldInherits),
 	DEFINE_FIELD ('K', NULL,             false,
 		      "Kind of tag as full name",
 		      FIELDTYPE_STRING,
-		      [WRITER_U_CTAGS] = renderFieldKindName),
+		      [WRITER_CTAGS] = renderFieldKindName),
 	DEFINE_FIELD ('k', NULL,             true,
 			   "Kind of tag as a single letter",
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldKindLetter),
+			   [WRITER_CTAGS] = renderFieldKindLetter),
 	DEFINE_FIELD_FULL ('l', "language",       false,
 			   "Language of input file containing tag",
 			   isLanguageFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldLanguage),
+			   [WRITER_CTAGS] = renderFieldLanguage),
 	DEFINE_FIELD_FULL ('m', "implementation", false,
 			   "Implementation information",
 			   isImplementationFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldImplementation),
+			   [WRITER_CTAGS] = renderFieldImplementation),
 	DEFINE_FIELD ('n', "line",           false,
 			   "Line number of tag definition",
 			   FIELDTYPE_INTEGER,
-			   [WRITER_U_CTAGS] = renderFieldLineNumber),
+			   [WRITER_CTAGS] = renderFieldLineNumber),
 	DEFINE_FIELD_FULL ('S', "signature",	     false,
 			   "Signature of routine (e.g. prototype or parameter list)",
 			   isSignatureFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldSignature),
+			   [WRITER_CTAGS] = renderFieldSignature),
 	DEFINE_FIELD ('s', NULL,             true,
 			   "Scope of tag definition (`p' can be used for printing its kind)",
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldScope,
-			   [WRITER_E_CTAGS] = renderFieldScopeNoEscape,
+			   [WRITER_CTAGS] = renderFieldScope,
 			   [WRITER_JSON]    = renderFieldScopeNoEscape),
 	DEFINE_FIELD_FULL ('t', "typeref",        true,
 			   "Type and name of a variable or typedef",
 			   isTyperefFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldTyperef),
+			   [WRITER_CTAGS] = renderFieldTyperef),
 	DEFINE_FIELD ('z', "kind",           false,
 			   "Include the \"kind:\" key in kind field (use k or K) in tags output, kind full name in xref output",
 			   FIELDTYPE_STRING,
 			   /* Following renderer is for handling --_xformat=%{kind};
 			      and is not for tags output. */
-			   [WRITER_U_CTAGS] = renderFieldKindName),
+			   [WRITER_CTAGS] = renderFieldKindName),
 };
 
 static fieldDefinition fieldDefinitionsUniversal [] = {
@@ -192,38 +189,37 @@ static fieldDefinition fieldDefinitionsUniversal [] = {
 			   "Role",
 			   isRoleFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldRole),
+			   [WRITER_CTAGS] = renderFieldRole),
 	DEFINE_FIELD ('R',  NULL,     false,
 			   "Marker (R or D) representing whether tag is definition or reference",
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldRefMarker),
+			   [WRITER_CTAGS] = renderFieldRefMarker),
 	DEFINE_FIELD ('Z', "scope",   false,
 			  "Include the \"scope:\" key in scope field (use s) in tags output, scope name in xref output",
 			   FIELDTYPE_STRING,
 			   /* Following renderer is for handling --_xformat=%{scope};
 			      and is not for tags output. */
-			   [WRITER_U_CTAGS] = renderFieldScope,
-			   [WRITER_E_CTAGS] = renderFieldScopeNoEscape,
-			   [WRITER_JSON]    = renderFieldScopeNoEscape),
+			   [WRITER_CTAGS] = renderFieldScope,
+			   [WRITER_JSON]  = renderFieldScopeNoEscape),
 	DEFINE_FIELD_FULL ('E', "extras",   false,
 			   "Extra tag type information",
 			   isExtrasFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldExtras),
+			   [WRITER_CTAGS] = renderFieldExtras),
 	DEFINE_FIELD_FULL ('x', "xpath",   false,
 			   "xpath for the tag",
 			   isXpathFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldXpath),
+			   [WRITER_CTAGS] = renderFieldXpath),
 	DEFINE_FIELD ('p', "scopeKind", false,
 			   "Kind of scope as full name",
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldScopeKindName),
+			   [WRITER_CTAGS] = renderFieldScopeKindName),
 	DEFINE_FIELD_FULL ('e', "end", false,
 			   "end lines of various items",
 			   isEndFieldAvailable,
 			   FIELDTYPE_INTEGER,
-			   [WRITER_U_CTAGS] = renderFieldEnd),
+			   [WRITER_CTAGS] = renderFieldEnd),
 };
 
 
@@ -427,7 +423,10 @@ static const char *renderEscapedName (const bool isTagName,
 static const char *renderFieldName (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
 									bool *rejected CTAGS_ATTR_UNUSED)
 {
-	return renderEscapedName (true, tag->name, tag, b);
+	if (escapeMetacharacters())
+		return renderEscapedName (true, tag->name, tag, b);
+	else
+		return renderFieldNameNoEscape(tag, value, b, rejected);
 }
 
 static const char *renderFieldNameNoEscape (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
@@ -444,11 +443,17 @@ static const char *renderFieldNameNoEscape (const tagEntryInfo *const tag, const
 static const char *renderFieldInput (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
 									 bool *rejected CTAGS_ATTR_UNUSED)
 {
-	const char *f = tag->inputFileName;
 
-	if (Option.lineDirectives && tag->sourceFileName)
-		f = tag->sourceFileName;
-	return renderEscapedString (f, tag, b);
+	if (escapeMetacharacters())
+	{
+		const char *f = tag->inputFileName;
+
+		if (Option.lineDirectives && tag->sourceFileName)
+			f = tag->sourceFileName;
+		return renderEscapedString (f, tag, b);
+	}
+	else
+		return renderFieldInputNoEscape(tag, value, b, rejected);
 }
 
 static const char *renderFieldInputNoEscape (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
@@ -478,10 +483,15 @@ static const char *renderFieldSignature (const tagEntryInfo *const tag, const ch
 static const char *renderFieldScope (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
 									 bool *rejected CTAGS_ATTR_UNUSED)
 {
-	const char* scope;
+	if (escapeMetacharacters())
+	{
+		const char* scope;
 
-	getTagScopeInformation ((tagEntryInfo *const)tag, NULL, &scope);
-	return scope? renderEscapedName (false, scope, tag, b): NULL;
+		getTagScopeInformation ((tagEntryInfo *const)tag, NULL, &scope);
+		return scope? renderEscapedName (false, scope, tag, b): NULL;
+	}
+	else
+		return renderFieldScopeNoEscape(tag, value, b, rejected);
 }
 
 static const char *renderFieldScopeNoEscape (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,

--- a/main/main.c
+++ b/main/main.c
@@ -651,7 +651,7 @@ extern int main (int argc CTAGS_ATTR_UNUSED, char **argv)
 
 	setErrorPrinter (stderrDefaultErrorPrinter, NULL);
 	setMainLoop (batchMakeTags, NULL);
-	setTagWriter (WRITER_U_CTAGS);
+	setTagWriter (WRITER_CTAGS);
 
 	setCurrentDirectory ();
 	setExecutableName (*argv++);

--- a/main/options.c
+++ b/main/options.c
@@ -792,6 +792,7 @@ static void setJsonMode (void)
 {
 	enablePtag (PTAG_JSON_OUTPUT_VERSION, true);
 	enablePtag (PTAG_OUTPUT_MODE, false);
+	enablePtag (PTAG_FILE_FORMAT, false);
 	setTagWriter (WRITER_JSON);
 }
 #endif

--- a/main/options.c
+++ b/main/options.c
@@ -60,7 +60,7 @@
 #define IGNORE_SEPARATORS   ", \t\n"
 
 #ifndef DEFAULT_FILE_FORMAT
-# define DEFAULT_FILE_FORMAT  2
+# define DEFAULT_FILE_FORMAT  3
 #endif
 
 #if defined (HAVE_OPENDIR) || defined (HAVE__FINDFIRST)
@@ -85,7 +85,7 @@
 
 enum eOptionLimits {
 	MaxHeaderExtensions	= 100,  /* maximum number of extensions in -h option */
-	MaxSupportedTagFormat = 2
+	MaxSupportedTagFormat = 3
 };
 
 typedef struct sOptionDescription {
@@ -265,11 +265,7 @@ static optionDescription LongOptionDescription [] = {
  {1,"       Specify string to print to stdout following the tags for each file"},
  {1,"       parsed when --filter is enabled."},
  {0,"  --format=level"},
-#if DEFAULT_FILE_FORMAT == 1
- {0,"       Force output of specified tag file format [1]."},
-#else
- {0,"       Force output of specified tag file format [2]."},
-#endif
+ {0,"       Force output of specified tag file format [" STRINGIFY(DEFAULT_FILE_FORMAT) "]."},
  {1,"  --guess-language-eagerly"},
  {1,"       Guess the language of input file more eagerly"},
  {1,"       (but taking longer time for guessing):"},
@@ -374,12 +370,12 @@ static optionDescription LongOptionDescription [] = {
  {1,"      The encoding to write the tag file in. Defaults to UTF-8 if --input-encoding"},
  {1,"      is specified, otherwise no conversion is performed."},
 #endif
- {0,"  --output-format=u-ctags|e-ctags|etags|xref"
+ {0,"  --output-format=ctags|etags|xref"
 #ifdef HAVE_JANSSON
   "|json"
 #endif
  },
- {0,"      Specify the output format. [u-ctags]"},
+ {0,"      Specify the output format. [ctags]"},
  {1,"  --param-<LANG>:name=argument"},
  {1,"       Set <LANG> specific parameter. Available parameters can be listed with --list-params."},
  {0,"  --pattern-length-limit=N"},
@@ -791,7 +787,6 @@ static void setXrefMode (void)
 static void setJsonMode (void)
 {
 	enablePtag (PTAG_JSON_OUTPUT_VERSION, true);
-	enablePtag (PTAG_OUTPUT_MODE, false);
 	enablePtag (PTAG_FILE_FORMAT, false);
 	setTagWriter (WRITER_JSON);
 }
@@ -2236,10 +2231,8 @@ static void processOutputFormat (const char *const option CTAGS_ATTR_UNUSED,
 	if (parameter [0] == '\0')
 		error (FATAL, "no output format name supplied for \"%s\"", option);
 
-	if (strcmp (parameter, "u-ctags") == 0)
-		;
-	else if (strcmp (parameter, "e-ctags") == 0)
-		setTagWriter (WRITER_E_CTAGS);
+	if (strcmp (parameter, "ctags") == 0)
+		setTagWriter (WRITER_CTAGS);
 	else if (strcmp (parameter, "etags") == 0)
 		setEtagsMode ();
 	else if (strcmp (parameter, "xref") == 0)

--- a/main/parse.c
+++ b/main/parse.c
@@ -3236,7 +3236,7 @@ extern void processLanguageMultitableExtendingOption (langType language, const c
 	eFree (dist);
 }
 
-static bool lregexQueryParserAndSubparesrs (const langType language, bool (* predicate) (struct lregexControlBlock *))
+static bool lregexQueryParserAndSubparsers (const langType language, bool (* predicate) (struct lregexControlBlock *))
 {
 	bool r;
 	subparser *tmp;
@@ -3248,7 +3248,7 @@ static bool lregexQueryParserAndSubparesrs (const langType language, bool (* pre
 		{
 			langType t = getSubparserLanguage (tmp);
 			enterSubparser (tmp);
-			r = lregexQueryParserAndSubparesrs (t, predicate);
+			r = lregexQueryParserAndSubparsers (t, predicate);
 			leaveSubparser ();
 
 			if (r)
@@ -3261,7 +3261,7 @@ static bool lregexQueryParserAndSubparesrs (const langType language, bool (* pre
 
 extern bool hasLanguageMultilineRegexPatterns (const langType language)
 {
-	return lregexQueryParserAndSubparesrs (language, regexNeedsMultilineBuffer);
+	return lregexQueryParserAndSubparsers (language, regexNeedsMultilineBuffer);
 }
 
 
@@ -3276,7 +3276,7 @@ extern bool hasLanguageScopeActionInRegex (const langType language)
 	bool hasScopeAction;
 
 	pushLanguage (language);
-	hasScopeAction = lregexQueryParserAndSubparesrs (language, hasScopeActionInRegex);
+	hasScopeAction = lregexQueryParserAndSubparsers (language, hasScopeActionInRegex);
 	popLanguage ();
 
 	return hasScopeAction;

--- a/main/parse.c
+++ b/main/parse.c
@@ -3843,7 +3843,7 @@ extern void addLanguageTagMultiTableRegex(const langType language,
  * A parser for CTagsSelfTest (CTST)
  */
 #define SELF_TEST_PARSER "CTagsSelfTest"
-#ifdef DEBUG
+#if defined(DEBUG) && defined(HAVE_SECCOMP)
 extern void getppid(void);
 #endif
 
@@ -3854,7 +3854,7 @@ typedef enum {
 	K_NOTHING_SPECIAL,
 	K_GUEST_BEGINNING,
 	K_GUEST_END,
-#ifdef DEBUG
+#if defined(DEBUG) && defined(HAVE_SECCOMP)
 	K_CALL_GETPPID,
 #endif
 	K_DISABLED,
@@ -3901,7 +3901,7 @@ static kindDefinition CTST_Kinds[KIND_COUNT] = {
 	{true, 'N', "nothingSpecial", "emit a normal tag" },
 	{true, 'B', NULL, "beginning of an area for a guest" },
 	{true, 'E', NULL, "end of an area for a guest" },
-#ifdef DEBUG
+#if defined(DEBUG) && defined(HAVE_SECCOMP)
 	{true, 'P', "callGetPPid", "trigger calling getppid(2) that seccomp sandbox disallows"},
 #endif
 	{false,'d', "disabled", "a kind disabled by default",
@@ -3959,7 +3959,7 @@ static void createCTSTTags (void)
 						le = getInputLineNumber ();
 						makePromise (SELF_TEST_PARSER, lb + 1, 0, le, 0, lb + 1);
 						break;
-#ifdef DEBUG
+#if defined(DEBUG) && defined(HAVE_SECCOMP)
 				    case K_CALL_GETPPID:
 						getppid();
 						break;

--- a/main/ptag.c
+++ b/main/ptag.c
@@ -34,6 +34,9 @@ static bool ptagMakeFormat (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED)
 	else if (Option.tagFileFormat == 2)
 		formatComment =
 			"extended format; --format=1 will not append ;\" to lines";
+	else if (Option.tagFileFormat == 3)
+		formatComment =
+			"extended format with meta character escaping";
 	return writePseudoTag (desc, format, formatComment, NULL);
 }
 
@@ -139,10 +142,6 @@ static ptagDesc ptagDescs [] = {
 	  "the letters, names and descriptions of kinds in a parser",
 	  ptagMakeKindDescriptions,
 	  false },
-	{ true, "TAG_OUTPUT_MODE",
-	  "the output mode: u-ctags or e-ctags",
-	  ptagMakeCtagsOutputMode,
-	  true },
 };
 
 extern bool makePtagIfEnabled (ptagType type, void *data)

--- a/main/ptag.h
+++ b/main/ptag.h
@@ -35,7 +35,6 @@ typedef enum ePtagType { /* pseudo tag content control */
 #endif
 	PTAG_KIND_SEPARATOR,
 	PTAG_KIND_DESCRIPTION,
-	PTAG_OUTPUT_MODE,
 	PTAG_COUNT
 } ptagType;
 

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -34,31 +34,31 @@ struct rejection {
 	bool rejectedInThisInput;
 };
 
-tagWriter uCtagsWriter = {
-	.writeEntry = writeCtagsEntry,
-	.writePtagEntry = writeCtagsPtagEntry,
-	.preWriteEntry = NULL,
-	.postWriteEntry = NULL,
-	.buildFqTagCache = buildCtagsFqTagCache,
-	.defaultFileName = CTAGS_FILE,
-};
-
 static void *beginECtagsFile (tagWriter *writer CTAGS_ATTR_UNUSED, MIO * mio CTAGS_ATTR_UNUSED)
 {
 	static struct rejection rej;
 
-	rej.rejectedInThisInput = false;
-
-	return &rej;
+	if (escapeMetacharacters())
+		return NULL;
+	else
+	{
+		rej.rejectedInThisInput = false;
+		return &rej;
+	}
 }
 
 static bool endECTagsFile (tagWriter *writer, MIO * mio CTAGS_ATTR_UNUSED, const char* filename CTAGS_ATTR_UNUSED)
 {
-	struct rejection *rej = writer->private;
-	return rej->rejectedInThisInput;
+	if (escapeMetacharacters())
+		return false;
+	else
+	{
+		struct rejection *rej = writer->private;
+		return rej->rejectedInThisInput;
+	}
 }
 
-tagWriter eCtagsWriter = {
+tagWriter ctagsWriter = {
 	.writeEntry = writeCtagsEntry,
 	.writePtagEntry = writeCtagsPtagEntry,
 	.preWriteEntry = beginECtagsFile,

--- a/main/writer.c
+++ b/main/writer.c
@@ -11,15 +11,14 @@
 #include "entry.h"
 #include "writer.h"
 
-extern tagWriter uCtagsWriter;
+extern tagWriter ctagsWriter;
 extern tagWriter eCtagsWriter;
 extern tagWriter etagsWriter;
 extern tagWriter xrefWriter;
 extern tagWriter jsonWriter;
 
 static tagWriter *writerTable [WRITER_COUNT] = {
-	[WRITER_U_CTAGS] = &uCtagsWriter,
-	[WRITER_E_CTAGS] = &eCtagsWriter,
+	[WRITER_CTAGS] = &ctagsWriter,
 	[WRITER_ETAGS] = &etagsWriter,
 	[WRITER_XREF]  = &xrefWriter,
 	[WRITER_JSON]  = &jsonWriter,
@@ -76,22 +75,6 @@ extern void writerBuildFqTagCache (tagEntryInfo *const tag)
 {
 	if (writer->buildFqTagCache)
 		writer->buildFqTagCache (writer, tag);
-}
-
-
-extern bool ptagMakeCtagsOutputMode (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED)
-{
-	const char *mode ="";
-
-	if (&uCtagsWriter == writer)
-		mode = "u-ctags";
-	else if (&eCtagsWriter == writer)
-		mode = "e-ctags";
-
-	return writePseudoTag (desc,
-						   mode,
-						   "u-ctags or e-ctags",
-						   NULL);
 }
 
 extern const char *outputDefaultFileName (void)

--- a/main/writer.h
+++ b/main/writer.h
@@ -20,8 +20,7 @@
 
 typedef enum eWriterType {
 	WRITER_DEFAULT,
-	WRITER_U_CTAGS = WRITER_DEFAULT,
-	WRITER_E_CTAGS,
+	WRITER_CTAGS = WRITER_DEFAULT,
 	WRITER_ETAGS,
 	WRITER_XREF,
 	WRITER_JSON,
@@ -71,7 +70,6 @@ extern void truncateTagLineAfterTag (char *const line, const char *const token,
 extern void abort_if_ferror(MIO *const fp);
 
 extern bool ptagMakeJsonOutputVersion (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED);
-extern bool ptagMakeCtagsOutputMode (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED);
 
 extern bool writerCanPrintPtag (void);
 

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -33,7 +33,7 @@ endif
 #
 # Silent/verbose commands
 #
-# when V is not set the output of commands is omited or simplified
+# when V is not set the output of commands is omitted or simplified
 #
 V	 ?= 0
 

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -391,7 +391,7 @@ static void notifyNamespaceImport (tokenInfo *const token)
 static int notifyCommand (tokenInfo *const token, unsigned int parent)
 {
 	subparser *sub;
-	int r;
+	int r = CORK_NIL;
 
 	foreachSubparser (sub, false)
 	{


### PR DESCRIPTION
…put-format=u-ctags|e-ctags option

To record meta characters like tab in a name, we have designed new file format.

The file format itself was already introduced. TAG_OUTPUT_MODE pseudo tag was used
as marker telling which format is used in a tag file: Exuberant-ctags(e-ctags)
compatible format or Universal-ctags(u-ctags) file format. u-ctags was the default
format. A user could choose the format with --output-format option.

However, we recognize that the hack using TAG_OUTPUT_MODE pseudo doesn't work well
with readtags command. A data structure of readtags doesn't have a field for
recording TAG_OUTPUT_MODE. It means readtags cannot switch the file format version
dynamically. The pseudo tags can be used in readtags for the purpose, recognizing
the file format is only TAG_FILE_FORMAT.

This commit introduces following SELF INCOMPATIBLE changes:

1. --output-format=u-ctags and --output-format=e-ctags are removed.
   They are unified to --output-format=ctags.

2. TAG_OUTPUT_MODE pseudo tag is removed.
   Instead TAG_FILE_FORMAT=3 is introduced.
   TAG_FILE_FORMAT=2 is compatible with e-ctags.
   TAG_FILE_FORMAT=3 is default. A user can choose one of the formats
   with --format=3 or --format=2.

The new version 3 may break many client tools.
If you are just user of such client tools, use --format=2 option to generate
tags file with compatible file format.
If you are a developer of such client tools, please, consider to support
--format=3.

The rest of work are:

1. more Tmain test cases,
2. more precise documentation about the format 3.
3. updating readtags to support format 3.

About readtags, the most of all work is done by @b4n.
I must merge his changes(#1605).

Signed-off-by: Masatake YAMATO <yamato@redhat.com>