### PR TITLE
main,debug: fix wrong lang field access when dumping a tag entry in debug mode

### DIFF
--- a/main/debug.c
+++ b/main/debug.c
@@ -78,7 +78,7 @@ extern void debugEntry (const tagEntryInfo *const tag)
 
 	if (debug (DEBUG_PARSE))
 	{
-		langType lang = (tag->langType == LANG_AUTO)
+		langType lang = (tag->extensionFields.scopeLangType == LANG_AUTO)
 			? tag->langType
 			: tag->extensionFields.scopeLangType;
 		kindDefinition *scopeKindDef = getLanguageKind(lang,


### PR DESCRIPTION
The bug fixed by this change:

    $ ./configure --enable-debugging; make; make -j 9
    $ ./ctags -d 2 main/main.c
    ctags: main/parse.c:271: getLanguageKind: Assertion `0 <= language && language < (int) LanguageCount' failed.
    ctags: main/parse.c:271: parsing main/main.c:704 as C
    zsh: abort (core dumped)  ./ctags -d 2 main/main.c

Signed-off-by: Masatake YAMATO <yamato@redhat.com>