### PR TITLE
main,refactor: simplify the usage of loccal variable for specifying fied

### DIFF
--- a/main/fmt.c
+++ b/main/fmt.c
@@ -77,7 +77,7 @@ static int printTagField (fmtSpec* fspec, MIO* fp, const tagEntryInfo * tag)
 			str = "";
 		else if (isFieldEnabled (f->ftype))
 			/* TODO: Don't use WRITER_XREF directly */
-			str = renderFieldEscaped (WRITER_XREF, tag->parserFields [findex].ftype,
+			str = renderFieldEscaped (WRITER_XREF, f->ftype,
 						  tag, findex, NULL);
 	}
 


### PR DESCRIPTION
Spotted by @b4n.

`tag->parserFields [findex].ftype` is used in printTagField().
What it specifies is the same as what `f->type` specifies.
I forgot replacing it in 4e9e52c2d6903ac4704c84358d40b56b28c55d10.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>