### PR TITLE
Yacc: don't call readLineFromInputFile from callback functions

### DIFF
--- a/parsers/yacc.c
+++ b/parsers/yacc.c
@@ -140,6 +140,8 @@ static bool leave_union (const char *line CTAGS_ATTR_UNUSED,
 	return true;
 }
 
+static struct yaccParserState yaccState;
+
 static void initializeYaccParser (langType language)
 {
 	/*
@@ -153,23 +155,21 @@ static void initializeYaccParser (langType language)
 		C language
 	*/
 
-	static struct yaccParserState state;
-
-	memset (&state, 0, sizeof (state));
-
-	addLanguageCallbackRegex (language, "^%\\{", "{exclusive}", enter_c_prologue, NULL, &state);
-	addLanguageCallbackRegex (language, "^%\\}", "{exclusive}", leave_c_prologue, NULL, &state);
+	addLanguageCallbackRegex (language, "^%\\{", "{exclusive}", enter_c_prologue, NULL, &yaccState);
+	addLanguageCallbackRegex (language, "^%\\}", "{exclusive}", leave_c_prologue, NULL, &yaccState);
 
 	addLanguageCallbackRegex (language, "^%%", "{exclusive}", change_section, NULL, NULL);
 
-	addLanguageCallbackRegex (language, "^%union", "{exclusive}", enter_union, NULL, &state);
-	addLanguageCallbackRegex (language, "^}",      "{exclusive}", leave_union, NULL, &state);
+	addLanguageCallbackRegex (language, "^%union", "{exclusive}", enter_union, NULL, &yaccState);
+	addLanguageCallbackRegex (language, "^}",      "{exclusive}", leave_union, NULL, &yaccState);
 }
 
 static void runYaccParser (void)
 {
 	in_union = false;
 	not_in_grammar_rules = true;
+
+	memset (&yaccState, 0, sizeof (yaccState));
 
 	findRegexTags ();
 }

--- a/parsers/yacc.c
+++ b/parsers/yacc.c
@@ -30,8 +30,8 @@ static tagRegexTable yaccTagRegexTable [] = {
 };
 
 struct cStart {
-	unsigned long input;
-	unsigned long source;
+	unsigned long c_input;
+	unsigned long c_source;
 };
 
 static  bool change_section (const char *line CTAGS_ATTR_UNUSED,
@@ -81,8 +81,8 @@ static bool enter_c_prologue (const char *line CTAGS_ATTR_UNUSED,
 
 
 	readLineFromInputFile ();
-	cstart->input  = getInputLineNumber ();
-	cstart->source = getSourceLineNumber ();
+	cstart->c_input  = getInputLineNumber ();
+	cstart->c_source = getSourceLineNumber ();
 	return true;
 }
 
@@ -95,7 +95,7 @@ static bool leave_c_prologue (const char *line CTAGS_ATTR_UNUSED,
 	unsigned long c_end;
 
 	c_end = getInputLineNumber ();
-	makePromise ("C", cstart->input, 0, c_end, 0, cstart->source);
+	makePromise ("C", cstart->c_input, 0, c_end, 0, cstart->c_source);
 	memset (cstart, 0, sizeof (*cstart));
 
 	return true;
@@ -111,8 +111,8 @@ static bool enter_union (const char *line CTAGS_ATTR_UNUSED,
 	if (not_in_grammar_rules)
 	{
 		in_union = true;
-		cstart->input = getInputLineNumber ();
-		cstart->source = getInputLineNumber ();
+		cstart->c_input = getInputLineNumber ();
+		cstart->c_source = getInputLineNumber ();
 	}
 	return true;
 }
@@ -124,15 +124,15 @@ static bool leave_union (const char *line CTAGS_ATTR_UNUSED,
 {
 	struct cStart *cstart = data;
 
-	if (not_in_grammar_rules && in_union && cstart->input && cstart->source)
+	if (not_in_grammar_rules && in_union && cstart->c_input && cstart->c_source)
 	{
 		unsigned long c_end;
 
 		c_end = getInputLineNumber ();
 
-		makePromise ("C", cstart->input, strlen ("%"),
+		makePromise ("C", cstart->c_input, strlen ("%"),
 			     c_end, strlen ("}"),
-			     cstart->source);
+			     cstart->c_source);
 
 		memset (cstart, 0, sizeof (*cstart));
 		in_union = false;

--- a/parsers/yacc.c
+++ b/parsers/yacc.c
@@ -29,7 +29,7 @@ static tagRegexTable yaccTagRegexTable [] = {
 	 "l,label,labels", NULL, &not_in_grammar_rules },
 };
 
-struct cStart {
+struct yaccParserState {
 	unsigned long c_input;
 	unsigned long c_source;
 };
@@ -77,7 +77,7 @@ static bool enter_c_prologue (const char *line CTAGS_ATTR_UNUSED,
 			      unsigned int count CTAGS_ATTR_UNUSED,
 			      void *data)
 {
-	struct cStart *cstart = data;
+	struct yaccParserState *cstart = data;
 
 
 	readLineFromInputFile ();
@@ -91,7 +91,7 @@ static bool leave_c_prologue (const char *line CTAGS_ATTR_UNUSED,
 			      unsigned int count CTAGS_ATTR_UNUSED,
 			      void *data)
 {
-	struct cStart *cstart = data;
+	struct yaccParserState *cstart = data;
 	unsigned long c_end;
 
 	c_end = getInputLineNumber ();
@@ -106,7 +106,7 @@ static bool enter_union (const char *line CTAGS_ATTR_UNUSED,
 			 unsigned int count CTAGS_ATTR_UNUSED,
 			 void *data)
 {
-	struct cStart *cstart = data;
+	struct yaccParserState *cstart = data;
 
 	if (not_in_grammar_rules)
 	{
@@ -122,7 +122,7 @@ static bool leave_union (const char *line CTAGS_ATTR_UNUSED,
 			 unsigned int count CTAGS_ATTR_UNUSED,
 			 void *data)
 {
-	struct cStart *cstart = data;
+	struct yaccParserState *cstart = data;
 
 	if (not_in_grammar_rules && in_union && cstart->c_input && cstart->c_source)
 	{
@@ -153,17 +153,17 @@ static void initializeYaccParser (langType language)
 		C language
 	*/
 
-	static struct cStart cStart;
+	static struct yaccParserState state;
 
-	memset (&cStart, 0, sizeof (cStart));
+	memset (&state, 0, sizeof (state));
 
-	addLanguageCallbackRegex (language, "^%\\{", "{exclusive}", enter_c_prologue, NULL, &cStart);
-	addLanguageCallbackRegex (language, "^%\\}", "{exclusive}", leave_c_prologue, NULL, &cStart);
+	addLanguageCallbackRegex (language, "^%\\{", "{exclusive}", enter_c_prologue, NULL, &state);
+	addLanguageCallbackRegex (language, "^%\\}", "{exclusive}", leave_c_prologue, NULL, &state);
 
 	addLanguageCallbackRegex (language, "^%%", "{exclusive}", change_section, NULL, NULL);
 
-	addLanguageCallbackRegex (language, "^%union", "{exclusive}", enter_union, NULL, &cStart);
-	addLanguageCallbackRegex (language, "^}",      "{exclusive}", leave_union, NULL, &cStart);
+	addLanguageCallbackRegex (language, "^%union", "{exclusive}", enter_union, NULL, &state);
+	addLanguageCallbackRegex (language, "^}",      "{exclusive}", leave_union, NULL, &state);
 }
 
 static void runYaccParser (void)

--- a/parsers/yacc.c
+++ b/parsers/yacc.c
@@ -170,7 +170,8 @@ static void runYaccParser (void)
 	parserState.c_input = 0;
 	parserState.c_source = 0;
 
-	findRegexTags ();
+	while (readLineFromInputFile () != NULL)
+		;
 }
 
 extern parserDefinition* YaccParser (void)


### PR DESCRIPTION
Calling readLineFromInputFile from callback functions of regex causes a trouble as reported in
#1631 and #1640.

NOTE: rpmspec has the same issue.