### PR TITLE
CXX: Fix 1659

### DIFF
--- a/Units/parser-cxx.r/broken-input.d/input.cc
+++ b/Units/parser-cxx.r/broken-input.d/input.cc
@@ -1,0 +1,4 @@
+__attribute__((visibility("protected")))
+        f1(int f1p1,int f1p2 __attribute__([(unused)),int f1p3)
+                __attribute__ ((warn_unused_result,always_inline,deprecated))
+{

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -1730,6 +1730,12 @@ bool cxxParserTokenChainLooksLikeFunctionParameterList(
 			"At least linitial and final parenthesis should be there"
 		);
 
+	CXX_DEBUG_ASSERT(
+			(cxxTokenChainFirst(tc)->eType == CXXTokenTypeOpeningParenthesis) &&
+			(cxxTokenChainLast(tc)->eType == CXXTokenTypeClosingParenthesis),
+			"The first and last token should be parentheses here"
+		);
+
 	if(pParamInfo)
 	{
 		pParamInfo->uParameterCount = 0;


### PR DESCRIPTION
When a mismatched subchain terminator is found, discard the whole subchain so no broken output is produced. When handling `__attribute__` attempt to resume parsing after failure so certain invariants are
preserved. Fixes #1659.
