### PR TITLE
CXX: Ignore scopes when the current language is not C++

### DIFF
--- a/Units/parser-c.r/broken-input-cxx-operator.d/input.c
+++ b/Units/parser-c.r/broken-input-cxx-operator.d/input.c
@@ -1,0 +1,1 @@
+struct a::b{

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -787,8 +787,13 @@ bool cxxParserParseEnum(void)
 			{
 				CXXToken * pNext = pNamespaceBegin->pNext;
 				cxxTokenChainTake(g_cxx.pTokenChain,pNamespaceBegin);
-				// FIXME: We don't really know if it's a class!
-				cxxScopePush(pNamespaceBegin,CXXScopeTypeClass,CXXScopeAccessUnknown);
+				if(cxxParserCurrentLanguageIsCPP())
+				{
+					// FIXME: We don't really know if it's a class!
+					cxxScopePush(pNamespaceBegin,CXXScopeTypeClass,CXXScopeAccessUnknown);
+				} else {
+					// it's a syntax error, but be tolerant
+				}
 				iPushedScopes++;
 				pNamespaceBegin = pNext->pNext;
 			}
@@ -1151,9 +1156,14 @@ static bool cxxParserParseClassStructOrUnionInternal(
 		{
 			CXXToken * pNext = pNamespaceBegin->pNext;
 			cxxTokenChainTake(g_cxx.pTokenChain,pNamespaceBegin);
-			// FIXME: We don't really know if it's a class!
-			cxxScopePush(pNamespaceBegin,CXXScopeTypeClass,CXXScopeAccessUnknown);
-			iPushedScopes++;
+			if(cxxParserCurrentLanguageIsCPP())
+			{
+				// FIXME: We don't really know if it's a class!
+				cxxScopePush(pNamespaceBegin,CXXScopeTypeClass,CXXScopeAccessUnknown);
+				iPushedScopes++;
+			} else {
+				// it's a syntax error, but be tolerant
+			}
 			pNamespaceBegin = pNext->pNext;
 		}
 


### PR DESCRIPTION
Scopes are supported only by C++. In other languages we silently
skip them.

Fixes #1664.