### PR TITLE
CXX: Improve friend declarations

### DIFF
--- a/Units/parser-cxx.r/class.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/class.cpp.d/expected.tags
@@ -1,1 +1,1 @@
-C01	input.cpp	/^MACRO03 __attribute__("fancy") __declspec(dllexport) class MY_API C01$/;"	c	file:	end:12
+C01	input.cpp	/^MACRO03 __attribute__("fancy") __declspec(dllexport) class MY_API C01$/;"	c	file:	end:15

--- a/Units/parser-cxx.r/class.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/class.cpp.d/input.cpp
@@ -3,10 +3,13 @@
 MACRO01 MACRO02() class N01;
 MACRO03 class __attribute__("cool") N02;
 
+namespace X;
+
 // This should be reported.
 MACRO03 __attribute__("fancy") __declspec(dllexport) class MY_API C01
 {
 	// These should be ignored.
 	friend class N03;
 	MACRO04 friend class N04;
+	friend class X::N05;
 };

--- a/Units/parser-cxx.r/operators.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/operators.cpp.d/expected.tags
@@ -9,8 +9,7 @@ operator ()	input.cpp	/^	inline void *** operator()()$/;"	f	class:X	typeref:type
 operator ++	input.cpp	/^	inline X & operator++()$/;"	f	class:X	typeref:typename:X &	file:
 operator --	input.cpp	/^	X & operator--()$/;"	f	class:X	typeref:typename:X &	file:
 operator []	input.cpp	/^	int operator[](int)$/;"	f	class:X	typeref:typename:int	file:
-operator *	input.cpp	/^	inline friend X operator*(const X &a, const X &b)$/;"	f	class:X	typeref:typename:X	file:
-operator &&	input.cpp	/^	friend X operator && (const X &a,const X & b);$/;"	p	class:X	typeref:typename:X	file:
+operator *	input.cpp	/^	inline friend X operator*(const X &a, const X &b)$/;"	f	typeref:typename:X	file:
 operator new	input.cpp	/^	void * operator new(size_t);$/;"	p	class:X	typeref:typename:void *	file:
 operator delete	input.cpp	/^	void operator delete(void *);$/;"	p	class:X	typeref:typename:void	file:
 operator new[]	input.cpp	/^	void * operator new[](size_t);$/;"	p	class:X	typeref:typename:void *	file:

--- a/Units/parser-cxx.r/operators.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/operators.cpp.d/input.cpp
@@ -51,11 +51,13 @@ public:
 		return 0;
 	}
 	
+	// This should appear as member of the global namespace
 	inline friend X operator*(const X &a, const X &b)
 	{
 		return *this;
 	}
 	
+	// This should NOT appear at all
 	friend X operator && (const X &a,const X & b);
 	
 	void * operator new(size_t);

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -469,6 +469,9 @@ process_token:
 						g_cxx.uKeywordState |= CXXParserKeywordStateSeenMutable;
 						cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 					break;
+					case CXXKeywordFRIEND:
+						g_cxx.uKeywordState |= CXXParserKeywordStateSeenFriend;
+					break;
 					// "const" and "volatile" are part of the type. Don't treat them specially
 					// and don't attempt to extract an eventual typedef yet,
 					// as there might be a struct/class/union keyword following.

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -255,6 +255,8 @@ typedef enum _CXXParserKeywordState
 	CXXParserKeywordStateSeenVolatile = (1 << 10),
 	// __attribute__((deprecated)) has been seen
 	CXXParserKeywordStateSeenAttributeDeprecated = (1 << 11),
+	// "friend" has been seen at block level
+	CXXParserKeywordStateSeenFriend = (1 << 12),
 } CXXParserKeywordState;
 
 

--- a/parsers/cxx/cxx_scope.c
+++ b/parsers/cxx/cxx_scope.c
@@ -213,11 +213,7 @@ void cxxScopeSetAccess(enum CXXScopeAccess eAccess)
 	g_pScope->pTail->uInternalScopeAccess = (unsigned char)eAccess;
 }
 
-void cxxScopePush(
-		CXXToken * t,
-		enum CXXScopeType eScopeType,
-		enum CXXScopeAccess eInitialAccess
-	)
+void cxxScopePushTop(CXXToken * t)
 {
 	CXX_DEBUG_ASSERT(
 			t->eType == CXXTokenTypeIdentifier,
@@ -227,9 +223,8 @@ void cxxScopePush(
 			t->pszWord,
 			"The scope name should have a text"
 		);
+
 	cxxTokenChainAppend(g_pScope,t);
-	t->uInternalScopeType = (unsigned char)eScopeType;
-	t->uInternalScopeAccess = (unsigned char)eInitialAccess;
 	g_bScopeNameDirty = true;
 
 #ifdef CXX_DO_DEBUGGING
@@ -239,14 +234,14 @@ void cxxScopePush(
 #endif
 }
 
-void cxxScopePop(void)
+CXXToken * cxxScopeTakeTop(void)
 {
 	CXX_DEBUG_ASSERT(
 			g_pScope->iCount > 0,
 			"When popping as scope there must be a scope to pop"
 		);
 
-	cxxTokenDestroy(cxxTokenChainTakeLast(g_pScope));
+	CXXToken * t = cxxTokenChainTakeLast(g_pScope);
 	g_bScopeNameDirty = true;
 
 #ifdef CXX_DO_DEBUGGING
@@ -254,4 +249,21 @@ void cxxScopePop(void)
 
 	CXX_DEBUG_PRINT("Popped scope: '%s'",szScopeName ? szScopeName : "");
 #endif
+	return t;
+}
+
+void cxxScopePush(
+		CXXToken * t,
+		enum CXXScopeType eScopeType,
+		enum CXXScopeAccess eInitialAccess
+	)
+{
+	t->uInternalScopeType = (unsigned char)eScopeType;
+	t->uInternalScopeAccess = (unsigned char)eInitialAccess;
+	cxxScopePushTop(t);
+}
+
+void cxxScopePop(void)
+{
+	cxxTokenDestroy(cxxScopeTakeTop());
 }

--- a/parsers/cxx/cxx_scope.h
+++ b/parsers/cxx/cxx_scope.h
@@ -71,8 +71,12 @@ void cxxScopePush(
 		enum CXXScopeAccess eInitialAccess
 	);
 void cxxScopeSetAccess(enum CXXScopeAccess eAccess);
+// Remove the last token from the scope chain
 void cxxScopePop(void);
 
-
+// Special management: pop one scope level but keep it so it can be pushed back
+CXXToken * cxxScopeTakeTop(void);
+// Special management: push back a scope taken earlier via cxxScopeTakeTop()
+void cxxScopePushTop(CXXToken * t);
 
 #endif //!ctags_cxx_scope_h_


### PR DESCRIPTION
C++ friend declarations are messy. Sometimes they act as a forward declaration and sometimes they do not. Their scope is not easy to find out and certainly is not the one we were emitting until now. It is better to ignore them.

There is one special exception: the friend function definition form for which the scope is clear (it's the enclosing namespace). We can handle that.