### PR TITLE
CXX: Improve struct parsing

### DIFF
--- a/Units/parser-cxx.r/bug-github-1675.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug-github-1675.cpp.d/expected.tags
@@ -1,0 +1,9 @@
+longlong3	input.cpp	/^struct __device_builtin__ longlong3$/;"	s	file:
+longlong4	input.cpp	/^struct __device_builtin__ __builtin_align__(16) longlong4$/;"	s	file:
+w	input.cpp	/^    long long int x, y, z, w;$/;"	m	struct:longlong4	typeref:typename:long long int	file:
+x	input.cpp	/^    long long int x, y, z, w;$/;"	m	struct:longlong4	typeref:typename:long long int	file:
+x	input.cpp	/^    long long int x, y, z;$/;"	m	struct:longlong3	typeref:typename:long long int	file:
+y	input.cpp	/^    long long int x, y, z, w;$/;"	m	struct:longlong4	typeref:typename:long long int	file:
+y	input.cpp	/^    long long int x, y, z;$/;"	m	struct:longlong3	typeref:typename:long long int	file:
+z	input.cpp	/^    long long int x, y, z, w;$/;"	m	struct:longlong4	typeref:typename:long long int	file:
+z	input.cpp	/^    long long int x, y, z;$/;"	m	struct:longlong3	typeref:typename:long long int	file:

--- a/Units/parser-cxx.r/bug-github-1675.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/bug-github-1675.cpp.d/input.cpp
@@ -1,0 +1,16 @@
+// issue #1675 opened by bfrg on 01/02/2018
+//
+// Structure declarations that contain macro functions are not parsed correctly.
+
+// structure longlong4 is completely ignored
+struct __device_builtin__ __builtin_align__(16) longlong4
+{
+    // x,y,z,w will be parsed as (global) variables and not members
+    long long int x, y, z, w;
+};
+
+// this one is parsed correctly
+struct __device_builtin__ longlong3
+{
+    long long int x, y, z;
+};

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -962,13 +962,19 @@ static bool cxxParserParseClassStructOrUnionInternal(
 			return false;
 		}
 
-		// skip alignas specifier:
-		// struct alignas(n) ...
-		//               ^ g_cxx.pToken points this.
-		if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeParenthesisChain) &&
-		   cxxTokenTypeIs(g_cxx.pToken->pPrev,CXXTokenTypeKeyword) &&
-		   g_cxx.pToken->pPrev->eKeyword == CXXKeywordALIGNAS)
-				continue;
+		if(
+			cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeParenthesisChain) &&
+			(
+				(
+					// struct alignas(n) ...
+					cxxTokenIsKeyword(g_cxx.pToken->pPrev,CXXKeywordALIGNAS)
+				) || (
+					// things like __builtin_align__(16)
+					!cxxParserTokenChainLooksLikeFunctionParameterList(g_cxx.pToken->pChain,NULL)
+				)
+			)
+		)
+			continue;
 
 		if(!cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeSmallerThanSign))
 			break;
@@ -1008,6 +1014,7 @@ static bool cxxParserParseClassStructOrUnionInternal(
 			CXX_DEBUG_LEAVE_TEXT("Found parenthesis after typedef: parsing as generic typedef");
 			return cxxParserParseGenericTypedef();
 		}
+
 		// probably a function declaration/prototype
 		// something like struct x * func()....
 		// do not clear statement


### PR DESCRIPTION
Try to detect common macro/compiler builtins when parsing structures.
Fix #1675 .