### PR TITLE
Fix an off-by-one error in the tag stack traversing

### DIFF
--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -750,7 +750,7 @@ static contextType popStrongContext ( void )
 static void jumpToMatchContext ( void )
 {
 	int i;
-	for (i = stackIndex; i >= 0; --i)
+	for (i = stackIndex - 1; i >= 0; --i)
 	{
 		if (stack[i].type == ContextMatch)
 		{


### PR DESCRIPTION
Since the whole `stack` array isn't completely cleared by the
`initStack` routine ctags would sometimes segfault after reading stale
or invalid data off the topmost item.

Writing a test is slightly complicated by the fact you have to "poison" the stack first.