### PR TITLE
OCaml: remove unused kinds

### DIFF
--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -14,8 +14,9 @@
 
 #include <string.h>
 
-#include "keyword.h"
+#include "debug.h"
 #include "entry.h"
+#include "keyword.h"
 #include "options.h"
 #include "read.h"
 #include "routines.h"
@@ -34,8 +35,6 @@ typedef enum {
 	K_CONSTRUCTOR,  /* Constructor of a sum type */
 	K_RECORDFIELD,
 	K_EXCEPTION,
-	K_BEGIN_END,		/* ??? */
-	K_MATCH,
 } ocamlKind;
 
 static kindDefinition OcamlKinds[] = {
@@ -49,8 +48,6 @@ static kindDefinition OcamlKinds[] = {
 	{true, 'C', "Constructor", "A constructor"},
 	{true, 'r', "RecordField", "A 'structure' field"},
 	{true, 'e', "Exception", "An exception"},
-	{true, 'B', "beginEnd", "A begin end ???"},
-	{true, 'A', "match", "A match ???"},
 };
 
 typedef enum {
@@ -593,13 +590,10 @@ static int contextDescription (contextType t)
 		return K_TYPE;
 	case ContextClass:
 		return K_CLASS;
-	case ContextBlock:
-		return K_BEGIN_END;
-	case ContextMatch:
-		return K_MATCH;
+	default:
+		AssertNotReached();
+		return KIND_GHOST_INDEX;
 	}
-
-	return KIND_GHOST_INDEX;
 }
 
 static char contextTypeSuffix (contextType t)


### PR DESCRIPTION
"match" and "beginEnd" kinds were introduced accidentally.
The kind is refereed when making a tag entry in prepareTag() via calling
contextDescription.

contextDescription() converts the type of context pushed on `stack' to
kind index. The kind index is refereed as a value representing parent
scope when making a tag entry.

A parent scope must have a name. getLastNamedIndex() finds a NAMED
parent context. Such context is converted by contextDescription().

A context having `ContextMatch' or `ContextBlock' as its type has
no name; when calling a function pushing a context having such type to `stack',
NULL is passed as the context name.

    ContextMatch:

	    case OcaKEYWORD_function:
		    toDoNext = &matchPattern;
		    pushSoftContext (&matchPattern, NULL, ContextMatch);
		    break;

	    case OcaKEYWORD_with:
		    popSoftContext ();
		    toDoNext = &matchPattern;
		    pushSoftContext (&matchPattern, NULL, ContextMatch);
		    break;
    ContextBlock:

	    case OcaKEYWORD_begin:
		    pushContext (ContextStrong, ContextBlock, &mayRedeclare, NULL);
		    toDoNext = &mayRedeclare;
		    break;

A context having `ContextMatch' or `ContextBlock' as its type is never converted
to a kind index with contextDescription() because the context doesn't have a name.

That means "match" and "beginEnd" kinds can be removed safely, and we should remove
them.

These two strange kinds were introduced when I changed the representation of kind
from string to int. I didn't take enough time to think the detail of OCaml parser
because the code change was so large.

This change has no impact on the behavior of the parser. Both kinds have been
never used. Its related codes are not executed. The output of --list-kinds=OCaml
is just simplified.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>