### PR TITLE
docs: don't put "the" before "both"

### DIFF
--- a/docs/internal.rst
+++ b/docs/internal.rst
@@ -161,7 +161,7 @@ Let's see the actual code from parsers/yacc.c.
 		unsigned long source;
 	};
 
-The both two fields are for recording `start`. `input` field
+Both fields are for recording `start`. `input` field
 is for recording the value returned from `getInputLineNumber`.
 `source` is for `getSourceLineNumber`. See `inputFile`_ for the
 difference of the two.

--- a/docs/running-multi-parsers.rst
+++ b/docs/running-multi-parsers.rst
@@ -260,7 +260,7 @@ API for making a combination of base parser and subparsers
 Outline
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 
-You have to work on the both sides: a base parser and subparsers.
+You have to work on both sides: a base parser and subparsers.
 
 A base parser must define a data structure type(`baseMethodTable`) for
 its subparsers by extending `struct subparser` defined in
@@ -332,7 +332,7 @@ A subparser must fill the fields of `subparser`.
 subparser runs exclusively and is chosen in top down way, set
 `SUBPARSER_SUB_RUNS_BASE` flag. If a subparser runs coexisting way and
 is chosen in bottom up way, set `SUBPARSER_BASE_RUNS_SUB`.  Use
-`SUBPARSER_BI_DIRECTION` if The both cases can be considered.
+`SUBPARSER_BI_DIRECTION` if both cases can be considered.
 
 SystemdUnit parser runs as a subparser of iniconf base parser.
 SystemdUnit parser specifies `SUBPARSER_SUB_RUNS_BASE` because
@@ -770,4 +770,3 @@ m4 parser. The most parts of tokens in input files are handled by
 M4. Autoconf parser gives hints for parsing `configure.ac` and
 registers callback functions to
 Autoconf parser.
-

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -1207,7 +1207,7 @@ are not listed here. They are experimental or debugging purpose.
 		The master parser controlling enablement of the kind.
 		A kind belongs to a language (owner) in Universal-ctags;
 		enabling and disabling a kind in a language has no effect on
-		a kind in another language even if the both kinds has the
+		a kind in another language even if both kinds has the
 		same letter and/or the same name. In other words,
 		the namespace of kinds are separated by language.
 


### PR DESCRIPTION
It seems that it is wrong English.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>