### PR TITLE
main: don't allow to use number ([0-9]) as part of a field name

### DIFF
--- a/main/field.c
+++ b/main/field.c
@@ -1004,7 +1004,7 @@ extern int defineField (fieldDefinition *def, langType language)
 	Assert (def->name);
 	for (i = 0; i < strlen (def->name); i++)
 	{
-		Assert ( isalnum (def->name [i]) );
+		Assert ( isalpha (def->name [i]) );
 	}
 	def->letter = NUL_FIELD_LETTER;
 

--- a/main/parse.c
+++ b/main/parse.c
@@ -2754,7 +2754,7 @@ static bool processLangDefineField (const langType language,
 
 	for (; p < desc; p++)
 	{
-		if (!isalnum (*p))
+		if (!isalpha (*p))
 			error (FATAL, "unacceptable char as part of field name in \"--%s\" option",
 				   option);
 	}


### PR DESCRIPTION
isalnum was used to check the acceptable characters as field name.
This commit switches it to isalpha to follow the rule in format.rst:

    A tagfield has a name, a colon, and a value: "name:value".

    * The name consist only out of alphabetical characters.  Upper and lower case
      are allowed.  Lower case is recommended.  Case matters ("kind:" and "Kind:
      are different tagfields).

I also check a client implementation, vim-7.4.160:

parse_match() of src/tag.c:

		while (ASCII_ISALPHA(*p))
		{
		    if (STRNCMP(p, "kind:", 5) == 0)
		    {

vim uses isalpha alike function to detect a field name.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>