### PR TITLE
 [SELF INCOMPATIBLE] main: reserver '{' in kind description as a meta character

### DIFF
--- a/Tmain/kinddef.d/run.sh
+++ b/Tmain/kinddef.d/run.sh
@@ -64,4 +64,31 @@ ${CTAGS} --kinddef-MYTEST=F --list-kinds-full=MYTEST 2>&1
 echo '# reusing the name for file kind'
 ${CTAGS} --kinddef-MYTEST=x,file,desc --list-kinds-full=MYTEST 2>&1
 
+echo '# inject a flag separator'
+${CTAGS} --kinddef-MYTEST='x,kind,desc{foo}' --list-kinds-full=MYTEST 2>&1
+
+echo '# inject a broken flag separator(1)'
+${CTAGS} --kinddef-MYTEST='x,kind,desc{foo' --list-kinds-full=MYTEST 2>&1
+
+echo '# inject a broken flag separator(2)'
+${CTAGS} --kinddef-MYTEST='x,kind,desc{' --list-kinds-full=MYTEST 2>&1
+
+echo '# use a { in description (1)'
+${CTAGS} --kinddef-MYTEST='x,kind,desc\{' --list-kinds-full=MYTEST 2>&1
+
+echo '# use a { in description (2)'
+${CTAGS} --kinddef-MYTEST='x,kind,desc\{}' --list-kinds-full=MYTEST 2>&1
+
+# echo '# use a { and \t in description'
+# ${CTAGS} --kinddef-MYTEST='x,kind,desc\{}\t' --list-kinds-full=MYTEST 2>&1
+
+echo '# use a \\ in description'
+${CTAGS} --kinddef-MYTEST='x,kind,desc\\backslash' --list-kinds-full=MYTEST 2>&1
+
+echo '# description started from {'
+${CTAGS} --kinddef-MYTEST='x,kind,{' --list-kinds-full=MYTEST 2>&1
+
+echo '# description started from \{'
+${CTAGS} --kinddef-MYTEST='x,kind,\{' --list-kinds-full=MYTEST 2>&1
+
 } | sed -e 's/\.exe//'

--- a/Tmain/kinddef.d/stdout-expected.txt
+++ b/Tmain/kinddef.d/stdout-expected.txt
@@ -37,3 +37,26 @@ ctags: the kind letter give in "--kinddef-MYTEST" option is not an alphabet or a
 ctags: the kind letter `F' in "--kinddef-MYTEST" option is reserved for "file" kind
 # reusing the name for file kind
 ctags: the kind name file in "--kinddef-MYTEST" option is reserved
+# inject a flag separator
+#LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
+x       kind yes     no      0      NONE   desc
+# inject a broken flag separator(1)
+#LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
+x       kind yes     no      0      NONE   desc
+# inject a broken flag separator(2)
+#LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
+x       kind yes     no      0      NONE   desc
+# use a { in description (1)
+#LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
+x       kind yes     no      0      NONE   desc{
+# use a { in description (2)
+#LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
+x       kind yes     no      0      NONE   desc{}
+# use a \\ in description
+#LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
+x       kind yes     no      0      NONE   desc\backslash
+# description started from {
+ctags: found an empty kind description in "--kinddef-MYTEST" option
+# description started from \{
+#LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
+x       kind yes     no      0      NONE   {

--- a/main/kind.c
+++ b/main/kind.c
@@ -144,7 +144,8 @@ extern int  defineKind (struct kindControlBlock* kcb, kindDefinition *def,
 
 extern bool isKindEnabled (struct kindControlBlock* kcb, int kindIndex)
 {
-	return kcb->kind [kindIndex].def->enabled;
+	kindDefinition *kdef = getKind (kcb, kindIndex);
+	return kdef->enabled;
 }
 
 extern bool isRoleEnabled (struct kindControlBlock* kcb, int kindIndex, int roleIndex)

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -447,7 +447,7 @@ static regexPattern * refPattern (regexPattern * ptrn)
 static regexPattern * newPattern (regex_t* const pattern,
 								  enum regexParserType regptype)
 {
-	regexPattern*ptrn = xCalloc(1, regexPattern);
+	regexPattern *ptrn = xCalloc(1, regexPattern);
 
 	ptrn->pattern = pattern;
 	ptrn->exclusive = false;

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -35,7 +35,6 @@
 #include "parse.h"
 #include "read.h"
 #include "routines.h"
-#include "ptrarray.h"
 #include "trashbox.h"
 
 static bool regexAvailable = false;

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -94,6 +94,13 @@ extern vString *vStringNewInit (const char *const s)
 	return vs;
 }
 
+extern vString *vStringNewNInit (const char *const s, const size_t length)
+{
+	vString *vs = vStringNew ();
+	vStringNCatS (vs, s, length);
+	return vs;
+}
+
 static void stringCat (
 		vString *const string, const char *const s, const size_t length)
 {

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -69,6 +69,7 @@ extern void vStringNCat (vString *const string, const vString *const s, const si
 extern void vStringNCatS (vString *const string, const char *const s, const size_t length);
 extern vString *vStringNewCopy (const vString *const string);
 extern vString *vStringNewInit (const char *const s);
+extern vString *vStringNewNInit (const char *const s, const size_t length);
 extern void vStringCopy (vString *const string, const vString *const s);
 extern void vStringCopyS (vString *const string, const char *const s);
 extern void vStringNCopy (vString *const string, const vString *const s, const size_t length);

--- a/man/ctags-optlib.7.rst.in
+++ b/man/ctags-optlib.7.rst.in
@@ -167,6 +167,12 @@ OPTION ITEMS
 	Do not use "file" as *name*. It has been reserved for representing
 	a file since Exuberant-ctags.
 
+	*description* comes from any printable ASCII characters. The
+	exception is "{" and "\". "{" is reserved for adding flags
+	this option in the future. So put "\" before "{" to include
+	"{" to a description. To include "\" itself to a description,
+	put "\" before "\".
+
 	Both *letter*, *name* and their combination must be unique in
 	a *<LANG>*.
 


### PR DESCRIPTION
These are some small fixes.

The exception is the last one.

I'm thinking about adding flags to `--kinddef-<LANG>` option. For the case, I would like to reserver the char `{`.