### PR TITLE
Tmain: don't use two backslashes(\\) in the test case

### DIFF
--- a/Tmain/kinddef.d/run.sh
+++ b/Tmain/kinddef.d/run.sh
@@ -82,7 +82,7 @@ ${CTAGS} --kinddef-MYTEST='x,kind,desc\{}' --list-kinds-full=MYTEST 2>&1
 # echo '# use a { and \t in description'
 # ${CTAGS} --kinddef-MYTEST='x,kind,desc\{}\t' --list-kinds-full=MYTEST 2>&1
 
-echo '# use a \\ in description'
+echo '# use a \ in description'
 ${CTAGS} --kinddef-MYTEST='x,kind,desc\\backslash' --list-kinds-full=MYTEST 2>&1
 
 echo '# description started from {'

--- a/Tmain/kinddef.d/stdout-expected.txt
+++ b/Tmain/kinddef.d/stdout-expected.txt
@@ -52,7 +52,7 @@ x       kind yes     no      0      NONE   desc{
 # use a { in description (2)
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc{}
-# use a \\ in description
+# use a \ in description
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc\backslash
 # description started from {


### PR DESCRIPTION
Use one (\\) instead.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>