### PR TITLE
Defining role from cmdline and capturing reference tags with regex parser

### DIFF
--- a/Tmain/broken-extradef.d/run.sh
+++ b/Tmain/broken-extradef.d/run.sh
@@ -1,0 +1,60 @@
+# Copyright: 2018 Masatake YAMATO
+# License: GPL-2
+
+CTAGS="$1 --quiet --options=NONE"
+
+{
+{
+echo '# echo unknown lang'
+${CTAGS} --extradef-NOSUCHLANG
+${CTAGS} --extradef-NOSUCHLANG=extra,desc
+
+echo '# no option value'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=
+
+echo '# wrong char in a field name'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:abc
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:abc,
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:abc,description
+
+echo '# empty extra name'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,abc
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,abc,
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,abc,description
+
+echo '# empty description'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=abc
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=abc,
+
+echo '# no input file'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=abc,desc
+
+echo '# inject a flag separator'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{foo}' --list-extras=IMAGINARY 2>&1
+
+echo '# inject a broken flag separator(1)'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{foo' --list-extras=IMAGINARY 2>&1
+
+echo '# inject a broken flag separator(2)'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{' --list-extras=IMAGINARY 2>&1
+
+echo '# use a { in description (1)'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\{' --list-extras=IMAGINARY 2>&1
+
+echo '# use a { in description (2)'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\{}' --list-extras=IMAGINARY 2>&1
+
+echo '# use a \ in description'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\\backslash' --list-extras=IMAGINARY 2>&1
+
+echo '# description started from {'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,{' --list-extras=IMAGINARY 2>&1
+
+echo '# description started from \{'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,\{' --list-extras=IMAGINARY 2>&1
+
+} 2>&1
+} | sed -e 's/\.exe//g'

--- a/Tmain/broken-extradef.d/run.sh
+++ b/Tmain/broken-extradef.d/run.sh
@@ -3,58 +3,73 @@
 
 CTAGS="$1 --quiet --options=NONE"
 
+title()
 {
+	echo
+	echo "$@"
+
+	{
+		echo
+		echo "$@"
+	} 1>&2
+}
+
 {
-echo '# echo unknown lang'
+title '# echo unknown lang'
 ${CTAGS} --extradef-NOSUCHLANG
 ${CTAGS} --extradef-NOSUCHLANG=extra,desc
 
-echo '# no option value'
+title '# no option value'
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=
 
-echo '# wrong char in a field name'
+title '# wrong char in a field name'
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:abc
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:abc,
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:abc,description
 
-echo '# empty extra name'
+title '# empty extra name'
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,abc
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,abc,
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,abc,description
 
-echo '# empty description'
+title '# empty description'
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=abc
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=abc,
 
-echo '# no input file'
+title '# no input file'
 ${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=abc,desc
 
-echo '# inject a flag separator'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{foo}' --list-extras=IMAGINARY 2>&1
+title '# inject a flag separator'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{foo}' --list-extras=IMAGINARY
 
-echo '# inject a broken flag separator(1)'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{foo' --list-extras=IMAGINARY 2>&1
+title '# inject a broken flag separator(1)'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{foo' --list-extras=IMAGINARY
 
-echo '# inject a broken flag separator(2)'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{' --list-extras=IMAGINARY 2>&1
+title '# inject a broken flag separator(2)'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{' --list-extras=IMAGINARY
 
-echo '# use a { in description (1)'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\{' --list-extras=IMAGINARY 2>&1
+title '# use a { in description (1)'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\{' --list-extras=IMAGINARY
 
-echo '# use a { in description (2)'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\{}' --list-extras=IMAGINARY 2>&1
+title '# use a { in description (2)'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\{}' --list-extras=IMAGINARY
 
-echo '# use a \ in description'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\\backslash' --list-extras=IMAGINARY 2>&1
+title '# use a \ in description'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\\backslash' --list-extras=IMAGINARY
 
-echo '# description started from {'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,{' --list-extras=IMAGINARY 2>&1
+title '# description started from {'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,{' --list-extras=IMAGINARY
 
-echo '# description started from \{'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,\{' --list-extras=IMAGINARY 2>&1
+title '# description started from \{'
+${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,\{' --list-extras=IMAGINARY
 
-} 2>&1
-} | sed -e 's/\.exe//g'
+} > /tmp/ctags-tmain-$$.stdout 2>/tmp/ctags-tmain-$$.stderr
+
+sed -e 's/\.exe//g' < /tmp/ctags-tmain-$$.stdout
+rm /tmp/ctags-tmain-$$.stdout
+
+sed -e 's/\.exe//g' < /tmp/ctags-tmain-$$.stderr 1>&2
+rm /tmp/ctags-tmain-$$.stderr

--- a/Tmain/broken-extradef.d/stderr-expected.txt
+++ b/Tmain/broken-extradef.d/stderr-expected.txt
@@ -1,0 +1,46 @@
+
+# echo unknown lang
+ctags: Unknown language "NOSUCHLANG" in "extradef-NOSUCHLANG" option
+ctags: Unknown language "NOSUCHLANG" in "extradef-NOSUCHLANG" option
+
+# no option value
+ctags: no extra definition specified in "--extradef-IMAGINARY" option
+ctags: no extra definition specified in "--extradef-IMAGINARY" option
+
+# wrong char in a field name
+ctags: no extra description specified in "--extradef-IMAGINARY" option
+ctags: no extra description specified in "--extradef-IMAGINARY" option
+ctags: unacceptable char as part of extra name in "--extradef-IMAGINARY" option
+ctags: unacceptable char as part of extra name in "--extradef-IMAGINARY" option
+
+# empty extra name
+ctags: the extra name in "--extradef-IMAGINARY" option is empty
+ctags: the extra name in "--extradef-IMAGINARY" option is empty
+ctags: the extra name in "--extradef-IMAGINARY" option is empty
+ctags: the extra name in "--extradef-IMAGINARY" option is empty
+
+# empty description
+ctags: no extra description specified in "--extradef-IMAGINARY" option
+ctags: extra description in "--extradef-IMAGINARY" option is empty
+
+# no input file
+ctags: No files specified. Try "ctags --help".
+
+# inject a flag separator
+
+# inject a broken flag separator(1)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
+
+# inject a broken flag separator(2)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
+
+# use a { in description (1)
+
+# use a { in description (2)
+
+# use a \ in description
+
+# description started from {
+ctags: extra description in "--extradef-IMAGINARY" option is empty
+
+# description started from \{

--- a/Tmain/broken-extradef.d/stdout-expected.txt
+++ b/Tmain/broken-extradef.d/stdout-expected.txt
@@ -23,9 +23,11 @@ ctags: No files specified. Try "ctags --help".
 #LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
 -       extra no      IMAGINARY no    desc
 # inject a broken flag separator(1)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
 #LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
 -       extra no      IMAGINARY no    desc
 # inject a broken flag separator(2)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 #LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
 -       extra no      IMAGINARY no    desc
 # use a { in description (1)

--- a/Tmain/broken-extradef.d/stdout-expected.txt
+++ b/Tmain/broken-extradef.d/stdout-expected.txt
@@ -1,46 +1,42 @@
+
 # echo unknown lang
-ctags: Unknown language "NOSUCHLANG" in "extradef-NOSUCHLANG" option
-ctags: Unknown language "NOSUCHLANG" in "extradef-NOSUCHLANG" option
+
 # no option value
-ctags: no extra definition specified in "--extradef-IMAGINARY" option
-ctags: no extra definition specified in "--extradef-IMAGINARY" option
+
 # wrong char in a field name
-ctags: no extra description specified in "--extradef-IMAGINARY" option
-ctags: no extra description specified in "--extradef-IMAGINARY" option
-ctags: unacceptable char as part of extra name in "--extradef-IMAGINARY" option
-ctags: unacceptable char as part of extra name in "--extradef-IMAGINARY" option
+
 # empty extra name
-ctags: the extra name in "--extradef-IMAGINARY" option is empty
-ctags: the extra name in "--extradef-IMAGINARY" option is empty
-ctags: the extra name in "--extradef-IMAGINARY" option is empty
-ctags: the extra name in "--extradef-IMAGINARY" option is empty
+
 # empty description
-ctags: no extra description specified in "--extradef-IMAGINARY" option
-ctags: extra description in "--extradef-IMAGINARY" option is empty
+
 # no input file
-ctags: No files specified. Try "ctags --help".
+
 # inject a flag separator
 #LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
 -       extra no      IMAGINARY no    desc
+
 # inject a broken flag separator(1)
-ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
 #LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
 -       extra no      IMAGINARY no    desc
+
 # inject a broken flag separator(2)
-ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 #LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
 -       extra no      IMAGINARY no    desc
+
 # use a { in description (1)
 #LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
 -       extra no      IMAGINARY no    desc{
+
 # use a { in description (2)
 #LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
 -       extra no      IMAGINARY no    desc{}
+
 # use a \ in description
 #LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
 -       extra no      IMAGINARY no    desc\backslash
+
 # description started from {
-ctags: extra description in "--extradef-IMAGINARY" option is empty
+
 # description started from \{
 #LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
 -       extra no      IMAGINARY no    {

--- a/Tmain/broken-extradef.d/stdout-expected.txt
+++ b/Tmain/broken-extradef.d/stdout-expected.txt
@@ -1,0 +1,44 @@
+# echo unknown lang
+ctags: Unknown language "NOSUCHLANG" in "extradef-NOSUCHLANG" option
+ctags: Unknown language "NOSUCHLANG" in "extradef-NOSUCHLANG" option
+# no option value
+ctags: no extra definition specified in "--extradef-IMAGINARY" option
+ctags: no extra definition specified in "--extradef-IMAGINARY" option
+# wrong char in a field name
+ctags: no extra description specified in "--extradef-IMAGINARY" option
+ctags: no extra description specified in "--extradef-IMAGINARY" option
+ctags: unacceptable char as part of extra name in "--extradef-IMAGINARY" option
+ctags: unacceptable char as part of extra name in "--extradef-IMAGINARY" option
+# empty extra name
+ctags: the extra name in "--extradef-IMAGINARY" option is empty
+ctags: the extra name in "--extradef-IMAGINARY" option is empty
+ctags: the extra name in "--extradef-IMAGINARY" option is empty
+ctags: the extra name in "--extradef-IMAGINARY" option is empty
+# empty description
+ctags: no extra description specified in "--extradef-IMAGINARY" option
+ctags: extra description in "--extradef-IMAGINARY" option is empty
+# no input file
+ctags: No files specified. Try "ctags --help".
+# inject a flag separator
+#LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
+-       extra no      IMAGINARY no    desc
+# inject a broken flag separator(1)
+#LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
+-       extra no      IMAGINARY no    desc
+# inject a broken flag separator(2)
+#LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
+-       extra no      IMAGINARY no    desc
+# use a { in description (1)
+#LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
+-       extra no      IMAGINARY no    desc{
+# use a { in description (2)
+#LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
+-       extra no      IMAGINARY no    desc{}
+# use a \ in description
+#LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
+-       extra no      IMAGINARY no    desc\backslash
+# description started from {
+ctags: extra description in "--extradef-IMAGINARY" option is empty
+# description started from \{
+#LETTER NAME  ENABLED LANGUAGE  FIXED DESCRIPTION
+-       extra no      IMAGINARY no    {

--- a/Tmain/broken-fielddef.d/run.sh
+++ b/Tmain/broken-fielddef.d/run.sh
@@ -6,8 +6,8 @@ CTAGS="$1 --quiet --options=NONE"
 {
 {
 echo '# echo unknown lang'
-${CTAGS} --_fielddef-NOSUCHLANG --_quit
-${CTAGS} --_fielddef-NOSUCHLANG=field,desc --_quit
+${CTAGS} --_fielddef-NOSUCHLANG
+${CTAGS} --_fielddef-NOSUCHLANG=field,desc
 
 echo '# no option value'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY

--- a/Tmain/broken-fielddef.d/run.sh
+++ b/Tmain/broken-fielddef.d/run.sh
@@ -32,5 +32,29 @@ ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=abc,
 echo '# no input file'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=abc,desc
 
+echo '# inject a flag separator'
+${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc{foo}' --list-fields=IMAGINARY
+
+echo '# inject a broken flag separator(1)'
+${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc{foo' --list-fields=IMAGINARY
+
+echo '# inject a broken flag separator(2)'
+${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc{' --list-fields=IMAGINARY
+
+echo '# use a { in description (1)'
+${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc\{' --list-fields=IMAGINARY
+
+echo '# use a { in description (2)'
+${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc\{}' --list-fields=IMAGINARY
+
+echo '# use a \ in description'
+${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc\\backslash' --list-fields=IMAGINARY
+
+echo '# description started from {'
+${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,{' --list-fields=IMAGINARY
+
+echo '# description started from \{'
+${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,\{' --list-fields=IMAGINARY
+
 } 2>&1
 } | sed -e 's/\.exe//g'

--- a/Tmain/broken-fielddef.d/run.sh
+++ b/Tmain/broken-fielddef.d/run.sh
@@ -3,58 +3,72 @@
 
 CTAGS="$1 --quiet --options=NONE"
 
+title()
 {
+	echo
+	echo "$@"
+
+	{
+		echo
+		echo "$@"
+	} 1>&2
+}
+
 {
-echo '# echo unknown lang'
+title '# echo unknown lang'
 ${CTAGS} --_fielddef-NOSUCHLANG
 ${CTAGS} --_fielddef-NOSUCHLANG=field,desc
 
-echo '# no option value'
+title '# no option value'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=
 
-echo '# wrong char in a field name'
+title '# wrong char in a field name'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=:
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=:abc
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=:abc,
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=:abc,description
 
-echo '# empty field name'
+title '# empty field name'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=,
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=,abc
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=,abc,
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=,abc,description
 
-echo '# empty description'
+title '# empty description'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=abc
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=abc,
 
-echo '# no input file'
+title '# no input file'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY=abc,desc
 
-echo '# inject a flag separator'
+title '# inject a flag separator'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc{foo}' --list-fields=IMAGINARY
 
-echo '# inject a broken flag separator(1)'
+title '# inject a broken flag separator(1)'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc{foo' --list-fields=IMAGINARY
 
-echo '# inject a broken flag separator(2)'
+title '# inject a broken flag separator(2)'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc{' --list-fields=IMAGINARY
 
-echo '# use a { in description (1)'
+title '# use a { in description (1)'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc\{' --list-fields=IMAGINARY
 
-echo '# use a { in description (2)'
+title '# use a { in description (2)'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc\{}' --list-fields=IMAGINARY
 
-echo '# use a \ in description'
+title '# use a \ in description'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,desc\\backslash' --list-fields=IMAGINARY
 
-echo '# description started from {'
+title '# description started from {'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,{' --list-fields=IMAGINARY
 
-echo '# description started from \{'
+title '# description started from \{'
 ${CTAGS} --langdef=IMAGINARY --_fielddef-IMAGINARY='field,\{' --list-fields=IMAGINARY
+}  > /tmp/ctags-tmain-$$.stdout 2>/tmp/ctags-tmain-$$.stderr
 
-} 2>&1
-} | sed -e 's/\.exe//g'
+sed -e 's/\.exe//g' < /tmp/ctags-tmain-$$.stdout
+rm /tmp/ctags-tmain-$$.stdout
+
+sed -e 's/\.exe//g' < /tmp/ctags-tmain-$$.stderr 1>&2
+rm /tmp/ctags-tmain-$$.stderr

--- a/Tmain/broken-fielddef.d/stderr-expected.txt
+++ b/Tmain/broken-fielddef.d/stderr-expected.txt
@@ -1,0 +1,46 @@
+
+# echo unknown lang
+ctags: Unknown language "NOSUCHLANG" in "_fielddef-NOSUCHLANG" option
+ctags: Unknown language "NOSUCHLANG" in "_fielddef-NOSUCHLANG" option
+
+# no option value
+ctags: no field definition specified in "--_fielddef-IMAGINARY" option
+ctags: no field definition specified in "--_fielddef-IMAGINARY" option
+
+# wrong char in a field name
+ctags: no field description specified in "--_fielddef-IMAGINARY" option
+ctags: no field description specified in "--_fielddef-IMAGINARY" option
+ctags: unacceptable char as part of field name in "--_fielddef-IMAGINARY" option
+ctags: unacceptable char as part of field name in "--_fielddef-IMAGINARY" option
+
+# empty field name
+ctags: the field name in "--_fielddef-IMAGINARY" option is empty
+ctags: the field name in "--_fielddef-IMAGINARY" option is empty
+ctags: the field name in "--_fielddef-IMAGINARY" option is empty
+ctags: the field name in "--_fielddef-IMAGINARY" option is empty
+
+# empty description
+ctags: no field description specified in "--_fielddef-IMAGINARY" option
+ctags: field description in "--_fielddef-IMAGINARY" option is empty
+
+# no input file
+ctags: No files specified. Try "ctags --help".
+
+# inject a flag separator
+
+# inject a broken flag separator(1)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
+
+# inject a broken flag separator(2)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
+
+# use a { in description (1)
+
+# use a { in description (2)
+
+# use a \ in description
+
+# description started from {
+ctags: field description in "--_fielddef-IMAGINARY" option is empty
+
+# description started from \{

--- a/Tmain/broken-fielddef.d/stdout-expected.txt
+++ b/Tmain/broken-fielddef.d/stdout-expected.txt
@@ -23,9 +23,11 @@ ctags: No files specified. Try "ctags --help".
 #LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
 -       field no      IMAGINARY s--    no    desc
 # inject a broken flag separator(1)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
 #LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
 -       field no      IMAGINARY s--    no    desc
 # inject a broken flag separator(2)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 #LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
 -       field no      IMAGINARY s--    no    desc
 # use a { in description (1)

--- a/Tmain/broken-fielddef.d/stdout-expected.txt
+++ b/Tmain/broken-fielddef.d/stdout-expected.txt
@@ -19,3 +19,26 @@ ctags: no field description specified in "--_fielddef-IMAGINARY" option
 ctags: field description in "--_fielddef-IMAGINARY" option is empty
 # no input file
 ctags: No files specified. Try "ctags --help".
+# inject a flag separator
+#LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
+-       field no      IMAGINARY s--    no    desc
+# inject a broken flag separator(1)
+#LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
+-       field no      IMAGINARY s--    no    desc
+# inject a broken flag separator(2)
+#LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
+-       field no      IMAGINARY s--    no    desc
+# use a { in description (1)
+#LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
+-       field no      IMAGINARY s--    no    desc{
+# use a { in description (2)
+#LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
+-       field no      IMAGINARY s--    no    desc{}
+# use a \ in description
+#LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
+-       field no      IMAGINARY s--    no    desc\backslash
+# description started from {
+ctags: field description in "--_fielddef-IMAGINARY" option is empty
+# description started from \{
+#LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
+-       field no      IMAGINARY s--    no    {

--- a/Tmain/broken-fielddef.d/stdout-expected.txt
+++ b/Tmain/broken-fielddef.d/stdout-expected.txt
@@ -1,46 +1,42 @@
+
 # echo unknown lang
-ctags: Unknown language "NOSUCHLANG" in "_fielddef-NOSUCHLANG" option
-ctags: Unknown language "NOSUCHLANG" in "_fielddef-NOSUCHLANG" option
+
 # no option value
-ctags: no field definition specified in "--_fielddef-IMAGINARY" option
-ctags: no field definition specified in "--_fielddef-IMAGINARY" option
+
 # wrong char in a field name
-ctags: no field description specified in "--_fielddef-IMAGINARY" option
-ctags: no field description specified in "--_fielddef-IMAGINARY" option
-ctags: unacceptable char as part of field name in "--_fielddef-IMAGINARY" option
-ctags: unacceptable char as part of field name in "--_fielddef-IMAGINARY" option
+
 # empty field name
-ctags: the field name in "--_fielddef-IMAGINARY" option is empty
-ctags: the field name in "--_fielddef-IMAGINARY" option is empty
-ctags: the field name in "--_fielddef-IMAGINARY" option is empty
-ctags: the field name in "--_fielddef-IMAGINARY" option is empty
+
 # empty description
-ctags: no field description specified in "--_fielddef-IMAGINARY" option
-ctags: field description in "--_fielddef-IMAGINARY" option is empty
+
 # no input file
-ctags: No files specified. Try "ctags --help".
+
 # inject a flag separator
 #LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
 -       field no      IMAGINARY s--    no    desc
+
 # inject a broken flag separator(1)
-ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
 #LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
 -       field no      IMAGINARY s--    no    desc
+
 # inject a broken flag separator(2)
-ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 #LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
 -       field no      IMAGINARY s--    no    desc
+
 # use a { in description (1)
 #LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
 -       field no      IMAGINARY s--    no    desc{
+
 # use a { in description (2)
 #LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
 -       field no      IMAGINARY s--    no    desc{}
+
 # use a \ in description
 #LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
 -       field no      IMAGINARY s--    no    desc\backslash
+
 # description started from {
-ctags: field description in "--_fielddef-IMAGINARY" option is empty
+
 # description started from \{
 #LETTER NAME  ENABLED LANGUAGE  JSTYPE FIXED DESCRIPTION
 -       field no      IMAGINARY s--    no    {

--- a/Tmain/kinddef.d/run.sh
+++ b/Tmain/kinddef.d/run.sh
@@ -91,4 +91,9 @@ ${CTAGS} --kinddef-MYTEST='x,kind,{' --list-kinds-full=MYTEST 2>&1
 echo '# description started from \{'
 ${CTAGS} --kinddef-MYTEST='x,kind,\{' --list-kinds-full=MYTEST 2>&1
 
+echo '# _refonly flag'
+${CTAGS} --kinddef-MYTEST='x,kind,desc' --list-kinds-full=MYTEST
+${CTAGS} --kinddef-MYTEST='x,kind,desc' --_roledef-MYTEST=x.role,roleDesc --list-kinds-full=MYTEST
+${CTAGS} --kinddef-MYTEST='x,kind,desc{_refonly}' --_roledef-MYTEST=x.role,roleDesc --list-kinds-full=MYTEST
+
 } | sed -e 's/\.exe//'

--- a/Tmain/kinddef.d/run.sh
+++ b/Tmain/kinddef.d/run.sh
@@ -3,97 +3,113 @@
 
 CTAGS="$1 --quiet --options=NONE"
 
+title()
 {
+	echo
+	echo "$@"
 
-echo '# NOSUCHLANG'
-${CTAGS} --kinddef-NOSUCHLANG=l,name,description --list-kinds-full=NOSUCHLANG 2>&1
+	{
+		echo
+		echo "$@"
+	} 1>&2
+}
+
+{
+title '# NOSUCHLANG'
+${CTAGS} --kinddef-NOSUCHLANG=l,name,description --list-kinds-full=NOSUCHLANG
 
 CTAGS="${CTAGS} --langdef=MYTEST"
 
-echo '# define "a"'
-${CTAGS} --kinddef-MYTEST=a,aa,aaa --list-kinds-full=MYTEST 2>&1
+title '# define "a"'
+${CTAGS} --kinddef-MYTEST=a,aa,aaa --list-kinds-full=MYTEST
 
-echo '# no description 1'
-${CTAGS} --kinddef-MYTEST=a,aa, --list-kinds-full=MYTEST 2>&1
+title '# no description 1'
+${CTAGS} --kinddef-MYTEST=a,aa, --list-kinds-full=MYTEST
 
-echo '# no description 2'
-${CTAGS} --kinddef-MYTEST=a,aa --list-kinds-full=MYTEST 2>&1
+title '# no description 2'
+${CTAGS} --kinddef-MYTEST=a,aa --list-kinds-full=MYTEST
 
-echo '# no name 1'
-${CTAGS} --kinddef-MYTEST=a, --list-kinds-full=MYTEST 2>&1
+title '# no name 1'
+${CTAGS} --kinddef-MYTEST=a, --list-kinds-full=MYTEST
 
-echo '# no name 2'
-${CTAGS} --kinddef-MYTEST=a --list-kinds-full=MYTEST 2>&1
+title '# no name 2'
+${CTAGS} --kinddef-MYTEST=a --list-kinds-full=MYTEST
 
-echo '# an empty name 1'
-${CTAGS} --kinddef-MYTEST=a,,x --list-kinds-full=MYTEST 2>&1
+title '# an empty name 1'
+${CTAGS} --kinddef-MYTEST=a,,x --list-kinds-full=MYTEST
 
-echo '# an empty name 2'
-${CTAGS} --kinddef-MYTEST=a,, --list-kinds-full=MYTEST 2>&1
+title '# an empty name 2'
+${CTAGS} --kinddef-MYTEST=a,, --list-kinds-full=MYTEST
 
-echo '# wrong letter in name 1'
-${CTAGS} --kinddef-MYTEST="a,a	x,d" --list-kinds-full=MYTEST 2>&1
+title '# wrong letter in name 1'
+${CTAGS} --kinddef-MYTEST="a,a	x,d" --list-kinds-full=MYTEST
 
-echo '# wrong letter in name 2'
-${CTAGS} --kinddef-MYTEST="a,a	x," --list-kinds-full=MYTEST 2>&1
+title '# wrong letter in name 2'
+${CTAGS} --kinddef-MYTEST="a,a	x," --list-kinds-full=MYTEST
 
-echo '# wrong letter in name 3'
-${CTAGS} --kinddef-MYTEST="a,a	x" --list-kinds-full=MYTEST 2>&1
+title '# wrong letter in name 3'
+${CTAGS} --kinddef-MYTEST="a,a	x" --list-kinds-full=MYTEST
 
-echo '# no letter 1'
-${CTAGS} --kinddef-MYTEST=,n,d --list-kinds-full=MYTEST 2>&1
+title '# no letter 1'
+${CTAGS} --kinddef-MYTEST=,n,d --list-kinds-full=MYTEST
 
-echo '# no letter 2'
-${CTAGS} --kinddef-MYTEST=,n, --list-kinds-full=MYTEST 2>&1
+title '# no letter 2'
+${CTAGS} --kinddef-MYTEST=,n, --list-kinds-full=MYTEST
 
-echo '# no letter 3'
-${CTAGS} --kinddef-MYTEST=,n --list-kinds-full=MYTEST 2>&1
+title '# no letter 3'
+${CTAGS} --kinddef-MYTEST=,n --list-kinds-full=MYTEST
 
-echo '# no letter 4'
-${CTAGS} --kinddef-MYTEST=, --list-kinds-full=MYTEST 2>&1
+title '# no letter 4'
+${CTAGS} --kinddef-MYTEST=, --list-kinds-full=MYTEST
 
-echo '# no letter 5'
-${CTAGS} --kinddef-MYTEST= --list-kinds-full=MYTEST 2>&1
+title '# no letter 5'
+${CTAGS} --kinddef-MYTEST= --list-kinds-full=MYTEST
 
-echo '# wrong letter'
-${CTAGS} --kinddef-MYTEST=^ --list-kinds-full=MYTEST 2>&1
+title '# wrong letter'
+${CTAGS} --kinddef-MYTEST=^ --list-kinds-full=MYTEST
 
-echo '# reusing the letter for file kind'
-${CTAGS} --kinddef-MYTEST=F --list-kinds-full=MYTEST 2>&1
+title '# reusing the letter for file kind'
+${CTAGS} --kinddef-MYTEST=F --list-kinds-full=MYTEST
 
-echo '# reusing the name for file kind'
-${CTAGS} --kinddef-MYTEST=x,file,desc --list-kinds-full=MYTEST 2>&1
+title '# reusing the name for file kind'
+${CTAGS} --kinddef-MYTEST=x,file,desc --list-kinds-full=MYTEST
 
-echo '# inject a flag separator'
-${CTAGS} --kinddef-MYTEST='x,kind,desc{foo}' --list-kinds-full=MYTEST 2>&1
+title '# inject a flag separator'
+${CTAGS} --kinddef-MYTEST='x,kind,desc{foo}' --list-kinds-full=MYTEST
 
-echo '# inject a broken flag separator(1)'
-${CTAGS} --kinddef-MYTEST='x,kind,desc{foo' --list-kinds-full=MYTEST 2>&1
+title '# inject a broken flag separator(1)'
+${CTAGS} --kinddef-MYTEST='x,kind,desc{foo' --list-kinds-full=MYTEST
 
-echo '# inject a broken flag separator(2)'
-${CTAGS} --kinddef-MYTEST='x,kind,desc{' --list-kinds-full=MYTEST 2>&1
+title '# inject a broken flag separator(2)'
+${CTAGS} --kinddef-MYTEST='x,kind,desc{' --list-kinds-full=MYTEST
 
-echo '# use a { in description (1)'
-${CTAGS} --kinddef-MYTEST='x,kind,desc\{' --list-kinds-full=MYTEST 2>&1
+title '# use a { in description (1)'
+${CTAGS} --kinddef-MYTEST='x,kind,desc\{' --list-kinds-full=MYTEST
 
-echo '# use a { in description (2)'
-${CTAGS} --kinddef-MYTEST='x,kind,desc\{}' --list-kinds-full=MYTEST 2>&1
+title '# use a { in description (2)'
+${CTAGS} --kinddef-MYTEST='x,kind,desc\{}' --list-kinds-full=MYTEST
 
-# echo '# use a { and \t in description'
-# ${CTAGS} --kinddef-MYTEST='x,kind,desc\{}\t' --list-kinds-full=MYTEST 2>&1
+# title '# use a { and \t in description'
+# ${CTAGS} --kinddef-MYTEST='x,kind,desc\{}\t' --list-kinds-full=MYTEST
 
-echo '# use a \ in description'
-${CTAGS} --kinddef-MYTEST='x,kind,desc\\backslash' --list-kinds-full=MYTEST 2>&1
+title '# use a \ in description'
+${CTAGS} --kinddef-MYTEST='x,kind,desc\\backslash' --list-kinds-full=MYTEST
 
-echo '# description started from {'
-${CTAGS} --kinddef-MYTEST='x,kind,{' --list-kinds-full=MYTEST 2>&1
+title '# description started from {'
+${CTAGS} --kinddef-MYTEST='x,kind,{' --list-kinds-full=MYTEST
 
-echo '# description started from \{'
-${CTAGS} --kinddef-MYTEST='x,kind,\{' --list-kinds-full=MYTEST 2>&1
+title '# description started from \{'
+${CTAGS} --kinddef-MYTEST='x,kind,\{' --list-kinds-full=MYTEST
 
-echo '# _refonly flag'
+title '# _refonly flag'
 ${CTAGS} --kinddef-MYTEST='x,kind,desc' --list-kinds-full=MYTEST
 ${CTAGS} --kinddef-MYTEST='x,kind,desc' --_roledef-MYTEST=x.role,roleDesc --list-kinds-full=MYTEST
 ${CTAGS} --kinddef-MYTEST='x,kind,desc{_refonly}' --_roledef-MYTEST=x.role,roleDesc --list-kinds-full=MYTEST
 
-} | sed -e 's/\.exe//'
+} > /tmp/ctags-tmain-$$.stdout 2>/tmp/ctags-tmain-$$.stderr
+
+sed -e 's/\.exe//g' < /tmp/ctags-tmain-$$.stdout
+rm /tmp/ctags-tmain-$$.stdout
+
+sed -e 's/\.exe//g' < /tmp/ctags-tmain-$$.stderr 1>&2
+rm /tmp/ctags-tmain-$$.stderr

--- a/Tmain/kinddef.d/stderr-expected.txt
+++ b/Tmain/kinddef.d/stderr-expected.txt
@@ -1,0 +1,77 @@
+
+# NOSUCHLANG
+ctags: Unknown language "NOSUCHLANG" in "kinddef-NOSUCHLANG" option
+
+# define "a"
+
+# no description 1
+ctags: found an empty kind description in "--kinddef-MYTEST" option
+
+# no description 2
+ctags: no kind description specified in "--kinddef-MYTEST" option
+
+# no name 1
+ctags: no kind name specified in "--kinddef-MYTEST" option
+
+# no name 2
+ctags: wrong kind definition in "--kinddef-MYTEST" option: no comma after letter
+
+# an empty name 1
+ctags: the kind name in "--kinddef-MYTEST" option is empty
+
+# an empty name 2
+ctags: the kind name in "--kinddef-MYTEST" option is empty
+
+# wrong letter in name 1
+ctags: unacceptable char as part of kind name in "--kinddef-MYTEST" option
+
+# wrong letter in name 2
+ctags: unacceptable char as part of kind name in "--kinddef-MYTEST" option
+
+# wrong letter in name 3
+ctags: no kind description specified in "--kinddef-MYTEST" option
+
+# no letter 1
+ctags: no kind letter specified in "--kinddef-MYTEST" option
+
+# no letter 2
+ctags: no kind letter specified in "--kinddef-MYTEST" option
+
+# no letter 3
+ctags: no kind letter specified in "--kinddef-MYTEST" option
+
+# no letter 4
+ctags: no kind letter specified in "--kinddef-MYTEST" option
+
+# no letter 5
+ctags: no kind definition specified in "--kinddef-MYTEST" option
+
+# wrong letter
+ctags: the kind letter give in "--kinddef-MYTEST" option is not an alphabet or a number
+
+# reusing the letter for file kind
+ctags: the kind letter `F' in "--kinddef-MYTEST" option is reserved for "file" kind
+
+# reusing the name for file kind
+ctags: the kind name file in "--kinddef-MYTEST" option is reserved
+
+# inject a flag separator
+
+# inject a broken flag separator(1)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
+
+# inject a broken flag separator(2)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
+
+# use a { in description (1)
+
+# use a { in description (2)
+
+# use a \ in description
+
+# description started from {
+ctags: found an empty kind description in "--kinddef-MYTEST" option
+
+# description started from \{
+
+# _refonly flag

--- a/Tmain/kinddef.d/stdout-expected.txt
+++ b/Tmain/kinddef.d/stdout-expected.txt
@@ -41,11 +41,11 @@ ctags: the kind name file in "--kinddef-MYTEST" option is reserved
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc
 # inject a broken flag separator(1)
-ctags: Warning: long flags specifier opened with `{' is not closed `}'
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc
 # inject a broken flag separator(2)
-ctags: Warning: long flags specifier opened with `{' is not closed `}'
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc
 # use a { in description (1)

--- a/Tmain/kinddef.d/stdout-expected.txt
+++ b/Tmain/kinddef.d/stdout-expected.txt
@@ -1,67 +1,74 @@
+
 # NOSUCHLANG
-ctags: Unknown language "NOSUCHLANG" in "kinddef-NOSUCHLANG" option
+
 # define "a"
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 a       aa   yes     no      0      NONE   aaa
+
 # no description 1
-ctags: found an empty kind description in "--kinddef-MYTEST" option
+
 # no description 2
-ctags: no kind description specified in "--kinddef-MYTEST" option
+
 # no name 1
-ctags: no kind name specified in "--kinddef-MYTEST" option
+
 # no name 2
-ctags: wrong kind definition in "--kinddef-MYTEST" option: no comma after letter
+
 # an empty name 1
-ctags: the kind name in "--kinddef-MYTEST" option is empty
+
 # an empty name 2
-ctags: the kind name in "--kinddef-MYTEST" option is empty
+
 # wrong letter in name 1
-ctags: unacceptable char as part of kind name in "--kinddef-MYTEST" option
+
 # wrong letter in name 2
-ctags: unacceptable char as part of kind name in "--kinddef-MYTEST" option
+
 # wrong letter in name 3
-ctags: no kind description specified in "--kinddef-MYTEST" option
+
 # no letter 1
-ctags: no kind letter specified in "--kinddef-MYTEST" option
+
 # no letter 2
-ctags: no kind letter specified in "--kinddef-MYTEST" option
+
 # no letter 3
-ctags: no kind letter specified in "--kinddef-MYTEST" option
+
 # no letter 4
-ctags: no kind letter specified in "--kinddef-MYTEST" option
+
 # no letter 5
-ctags: no kind definition specified in "--kinddef-MYTEST" option
+
 # wrong letter
-ctags: the kind letter give in "--kinddef-MYTEST" option is not an alphabet or a number
+
 # reusing the letter for file kind
-ctags: the kind letter `F' in "--kinddef-MYTEST" option is reserved for "file" kind
+
 # reusing the name for file kind
-ctags: the kind name file in "--kinddef-MYTEST" option is reserved
+
 # inject a flag separator
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc
+
 # inject a broken flag separator(1)
-ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc
+
 # inject a broken flag separator(2)
-ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc
+
 # use a { in description (1)
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc{
+
 # use a { in description (2)
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc{}
+
 # use a \ in description
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc\backslash
+
 # description started from {
-ctags: found an empty kind description in "--kinddef-MYTEST" option
+
 # description started from \{
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   {
+
 # _refonly flag
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc

--- a/Tmain/kinddef.d/stdout-expected.txt
+++ b/Tmain/kinddef.d/stdout-expected.txt
@@ -41,9 +41,11 @@ ctags: the kind name file in "--kinddef-MYTEST" option is reserved
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc
 # inject a broken flag separator(1)
+ctags: Warning: long flags specifier opened with `{' is not closed `}'
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc
 # inject a broken flag separator(2)
+ctags: Warning: long flags specifier opened with `{' is not closed `}'
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   desc
 # use a { in description (1)
@@ -60,3 +62,10 @@ ctags: found an empty kind description in "--kinddef-MYTEST" option
 # description started from \{
 #LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
 x       kind yes     no      0      NONE   {
+# _refonly flag
+#LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
+x       kind yes     no      0      NONE   desc
+#LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
+x       kind yes     no      1      NONE   desc
+#LETTER NAME ENABLED REFONLY NROLES MASTER DESCRIPTION
+x       kind yes     yes     1      NONE   desc

--- a/Tmain/list-kinddef-flags.d/run.sh
+++ b/Tmain/list-kinddef-flags.d/run.sh
@@ -1,0 +1,6 @@
+# Copyright: 2018 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+${CTAGS} --quiet --options=NONE --_list-kinddef-flags

--- a/Tmain/list-kinddef-flags.d/stdout-expected.txt
+++ b/Tmain/list-kinddef-flags.d/stdout-expected.txt
@@ -1,0 +1,2 @@
+#LETTER NAME     DESCRIPTION
+-       _refonly use this kind reference tags only

--- a/Tmain/list-mline-regex-flags.d/stdout-expected.txt
+++ b/Tmain/list-mline-regex-flags.d/stdout-expected.txt
@@ -5,4 +5,5 @@ i       icase                   applied in a case-insensitive manner
 -       mgroup=N                a group in pattern determining the line number of tag
 -       _advanceTo=N[start|end] a group in pattern from where the next scan starts [0end]
 -       _extra=EXTRA            record the tag only when the extra is enabled
--       _field=FIELD:VALUE      record the matched string(VALUE) to FIELD of the tag
+-       _field=FIELD:VALUE      record the matched string(VALUE) to parser own FIELD of the tag
+-       _role=ROLE              Set given ROLE to roles field

--- a/Tmain/list-regex-flags.d/stdout-expected.txt
+++ b/Tmain/list-regex-flags.d/stdout-expected.txt
@@ -6,4 +6,5 @@ x       exclusive          skip testing the other patterns if a line is matched 
 -       placeholder        don't put this tag to tags file.
 -       scope=ACTION       use scope stack: ACTION = ref|push|pop|clear|set
 -       _extra=EXTRA       record the tag only when the extra is enabled
--       _field=FIELD:VALUE record the matched string(VALUE) to FIELD of the tag
+-       _field=FIELD:VALUE record the matched string(VALUE) to parser own FIELD of the tag
+-       _role=ROLE         Set given ROLE to roles field

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -55,6 +55,7 @@ SystemdUnit    u/unit            Wants               on      referred in Wants k
 Vera           d/macro           undef               on      undefined
 Vera           h/header          local               on      local header
 Vera           h/header          system              on      system header
+elm            m/module          imported            on      imported module
 
 #
 # all.*
@@ -112,6 +113,7 @@ SystemdUnit    u/unit            Wants               on      referred in Wants k
 Vera           d/macro           undef               on      undefined
 Vera           h/header          local               on      local header
 Vera           h/header          system              on      system header
+elm            m/module          imported            on      imported module
 
 #
 # C.*

--- a/Tmain/roledef.d/run.sh
+++ b/Tmain/roledef.d/run.sh
@@ -9,9 +9,13 @@ title()
 {
 	echo
 	echo "$@"
+
+	{
+		echo
+		echo "$@"
+	} 1>&2
 }
 
-{
 {
 title '# echo unknown lang'
 ${CTAGS} --_roledef-NOSUCHLANG
@@ -92,5 +96,10 @@ for i in $(seq 0 64); do
 done
 ${CTAGS} $opts
 
-} 2>&1
-} | sed -e 's/\.exe//g'
+} > /tmp/ctags-tmain-$$.stdout 2>/tmp/ctags-tmain-$$.stderr
+
+sed -e 's/\.exe//g' < /tmp/ctags-tmain-$$.stdout
+rm /tmp/ctags-tmain-$$.stdout
+
+sed -e 's/\.exe//g' < /tmp/ctags-tmain-$$.stderr 1>&2
+rm /tmp/ctags-tmain-$$.stderr

--- a/Tmain/roledef.d/run.sh
+++ b/Tmain/roledef.d/run.sh
@@ -3,6 +3,8 @@
 
 CTAGS="$1 --quiet --options=NONE --langdef=IMAGINARY --kinddef-IMAGINARY=v,variable,variables"
 
+export MSYS2_ARG_CONV_EXCL=--_roledef-IMAGINARY
+
 title()
 {
 	echo

--- a/Tmain/roledef.d/run.sh
+++ b/Tmain/roledef.d/run.sh
@@ -1,0 +1,94 @@
+# Copyright: 2018 Masatake YAMATO
+# License: GPL-2
+
+CTAGS="$1 --quiet --options=NONE --langdef=IMAGINARY --kinddef-IMAGINARY=v,variable,variables"
+
+title()
+{
+	echo
+	echo "$@"
+}
+
+{
+{
+title '# echo unknown lang'
+${CTAGS} --_roledef-NOSUCHLANG
+${CTAGS} --_roledef-NOSUCHLANG=v.role,roles
+
+title '# no option value'
+${CTAGS} --_roledef-IMAGINARY
+${CTAGS} --_roledef-IMAGINARY=
+
+title '# echo unknown kind'
+${CTAGS} --_roledef-IMAGINARY=x            --_force-quit
+${CTAGS} --_roledef-IMAGINARY=x.           --_force-quit
+${CTAGS} --_roledef-IMAGINARY=x.role       --_force-quit
+${CTAGS} --_roledef-IMAGINARY=x.role,      --_force-quit
+${CTAGS} --_roledef-IMAGINARY=x.role,roles --_force-quit
+
+title '# wrong char in a kind letter'
+${CTAGS} --_roledef-IMAGINARY=/
+${CTAGS} --_roledef-IMAGINARY=%.
+${CTAGS} --_roledef-IMAGINARY=^.role
+${CTAGS} --_roledef-IMAGINARY=#.role,roles
+
+title '# empty role name'
+${CTAGS} --_roledef-IMAGINARY=v
+${CTAGS} --_roledef-IMAGINARY=v.
+${CTAGS} --_roledef-IMAGINARY=v.,
+
+title '# wrong char in role name'
+${CTAGS} --_roledef-IMAGINARY=v.+role+,
+
+title '# empty description'
+${CTAGS} --_roledef-IMAGINARY=v.role
+${CTAGS} --_roledef-IMAGINARY=v.role,
+
+title '# role is acceptable but no input file'
+${CTAGS} --_roledef-IMAGINARY=v.role,roles
+
+title '# listing with --list-roles'
+${CTAGS} --_roledef-IMAGINARY=v.role,roles --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY=v.role,roles \
+		 --_roledef-IMAGINARY=v.foos,foods \
+		 --list-roles=IMAGINARY
+
+title '# listing with --list-kinds-full'
+${CTAGS} --_roledef-IMAGINARY=v.role,roles --list-kinds-full=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY=v.role,roles \
+		 --_roledef-IMAGINARY=v.foos,foods \
+		 --list-kinds-full=IMAGINARY
+
+title '# inject a flag separator'
+${CTAGS} --_roledef-IMAGINARY='v.role,roles{foo}' --list-roles=IMAGINARY
+
+title '# inject a broken flag separator(1)'
+${CTAGS} --_roledef-IMAGINARY='v.role,roles{foo' --list-roles=IMAGINARY
+
+title '# inject a broken flag separator(2)'
+${CTAGS} --_roledef-IMAGINARY='v.role,roles{' --list-roles=IMAGINARY
+
+title '# use a { in description (1)'
+${CTAGS} --_roledef-IMAGINARY='v.role,roles\{' --list-roles=IMAGINARY
+
+title '# use a { in description (2)'
+${CTAGS} --_roledef-IMAGINARY='v.role,roles\{}' --list-roles=IMAGINARY
+
+title '# use a \ in description'
+${CTAGS} --_roledef-IMAGINARY='v.role,roles\\backslash' --list-roles=IMAGINARY
+
+title '# description started from {'
+${CTAGS} --_roledef-IMAGINARY='v.role,{' --list-roles=IMAGINARY
+
+title '# description started from \{'
+${CTAGS} --_roledef-IMAGINARY='v.role,\{' --list-roles=IMAGINARY
+
+title '# too many roles'
+opts=
+for i in $(seq 0 64); do
+	opts="$opts --_roledef-IMAGINARY=v.r$i,desc$i "
+done
+${CTAGS} $opts
+
+} 2>&1
+} | sed -e 's/\.exe//g'

--- a/Tmain/roledef.d/stderr-expected.txt
+++ b/Tmain/roledef.d/stderr-expected.txt
@@ -1,0 +1,62 @@
+
+# echo unknown lang
+ctags: Unknown language "NOSUCHLANG" in "_roledef-NOSUCHLANG" option
+ctags: Unknown language "NOSUCHLANG" in "_roledef-NOSUCHLANG" option
+
+# no option value
+ctags: no role definition specified in "--_roledef-IMAGINARY" option
+ctags: no role definition specified in "--_roledef-IMAGINARY" option
+
+# echo unknown kind
+ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
+ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
+ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
+ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
+ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
+
+# wrong char in a kind letter
+ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
+ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
+ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
+ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
+
+# empty role name
+ctags: wrong role definition in "--_roledef-IMAGINARY" option: no period after kind letter `v'
+ctags: no role name specified in "--_roledef-IMAGINARY" option
+ctags: the role name in "--_roledef-IMAGINARY" option is empty
+
+# wrong char in role name
+ctags: unacceptable char as part of role name in "--_roledef-IMAGINARY" option
+
+# empty description
+ctags: no role description specified in "--_roledef-IMAGINARY" option
+ctags: found an empty role description in "--_roledef-IMAGINARY" option
+
+# role is acceptable but no input file
+ctags: No files specified. Try "ctags --help".
+
+# listing with --list-roles
+
+# listing with --list-kinds-full
+
+# inject a flag separator
+
+# inject a broken flag separator(1)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
+
+# inject a broken flag separator(2)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
+
+# use a { in description (1)
+
+# use a { in description (2)
+
+# use a \ in description
+
+# description started from {
+ctags: found an empty role description in "--_roledef-IMAGINARY" option
+
+# description started from \{
+
+# too many roles
+ctags: Too many role definition for kind "variable" of language "IMAGINARY" (> 63)

--- a/Tmain/roledef.d/stdout-expected.txt
+++ b/Tmain/roledef.d/stdout-expected.txt
@@ -53,10 +53,12 @@ v       variable yes     no      2      NONE   variables
 v/variable  role on      roles
 
 # inject a broken flag separator(1)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      roles
 
 # inject a broken flag separator(2)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      roles
 

--- a/Tmain/roledef.d/stdout-expected.txt
+++ b/Tmain/roledef.d/stdout-expected.txt
@@ -1,39 +1,19 @@
 
 # echo unknown lang
-ctags: Unknown language "NOSUCHLANG" in "_roledef-NOSUCHLANG" option
-ctags: Unknown language "NOSUCHLANG" in "_roledef-NOSUCHLANG" option
 
 # no option value
-ctags: no role definition specified in "--_roledef-IMAGINARY" option
-ctags: no role definition specified in "--_roledef-IMAGINARY" option
 
 # echo unknown kind
-ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
-ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
-ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
-ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
-ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
 
 # wrong char in a kind letter
-ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
-ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
-ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
-ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
 
 # empty role name
-ctags: wrong role definition in "--_roledef-IMAGINARY" option: no period after kind letter `v'
-ctags: no role name specified in "--_roledef-IMAGINARY" option
-ctags: the role name in "--_roledef-IMAGINARY" option is empty
 
 # wrong char in role name
-ctags: unacceptable char as part of role name in "--_roledef-IMAGINARY" option
 
 # empty description
-ctags: no role description specified in "--_roledef-IMAGINARY" option
-ctags: found an empty role description in "--_roledef-IMAGINARY" option
 
 # role is acceptable but no input file
-ctags: No files specified. Try "ctags --help".
 
 # listing with --list-roles
 #KIND(L/N)  NAME ENABLED DESCRIPTION
@@ -53,12 +33,10 @@ v       variable yes     no      2      NONE   variables
 v/variable  role on      roles
 
 # inject a broken flag separator(1)
-ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      roles
 
 # inject a broken flag separator(2)
-ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      roles
 
@@ -75,11 +53,9 @@ v/variable  role on      roles{}
 v/variable  role on      roles\backslash
 
 # description started from {
-ctags: found an empty role description in "--_roledef-IMAGINARY" option
 
 # description started from \{
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      {
 
 # too many roles
-ctags: Too many role definition for kind "variable" of language "IMAGINARY" (> 63)

--- a/Tmain/roledef.d/stdout-expected.txt
+++ b/Tmain/roledef.d/stdout-expected.txt
@@ -1,0 +1,83 @@
+
+# echo unknown lang
+ctags: Unknown language "NOSUCHLANG" in "_roledef-NOSUCHLANG" option
+ctags: Unknown language "NOSUCHLANG" in "_roledef-NOSUCHLANG" option
+
+# no option value
+ctags: no role definition specified in "--_roledef-IMAGINARY" option
+ctags: no role definition specified in "--_roledef-IMAGINARY" option
+
+# echo unknown kind
+ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
+ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
+ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
+ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
+ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
+
+# wrong char in a kind letter
+ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
+ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
+ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
+ctags: the kind letter give in "--_roledef-IMAGINARY" option is not an alphabet or a number
+
+# empty role name
+ctags: wrong role definition in "--_roledef-IMAGINARY" option: no period after kind letter `v'
+ctags: no role name specified in "--_roledef-IMAGINARY" option
+ctags: the role name in "--_roledef-IMAGINARY" option is empty
+
+# wrong char in role name
+ctags: unacceptable char as part of role name in "--_roledef-IMAGINARY" option
+
+# empty description
+ctags: no role description specified in "--_roledef-IMAGINARY" option
+ctags: found an empty role description in "--_roledef-IMAGINARY" option
+
+# role is acceptable but no input file
+ctags: No files specified. Try "ctags --help".
+
+# listing with --list-roles
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  foos on      foods
+v/variable  role on      roles
+
+# listing with --list-kinds-full
+#LETTER NAME     ENABLED REFONLY NROLES MASTER DESCRIPTION
+v       variable yes     no      1      NONE   variables
+#LETTER NAME     ENABLED REFONLY NROLES MASTER DESCRIPTION
+v       variable yes     no      2      NONE   variables
+
+# inject a flag separator
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles
+
+# inject a broken flag separator(1)
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles
+
+# inject a broken flag separator(2)
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles
+
+# use a { in description (1)
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles{
+
+# use a { in description (2)
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles{}
+
+# use a \ in description
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles\backslash
+
+# description started from {
+ctags: found an empty role description in "--_roledef-IMAGINARY" option
+
+# description started from \{
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      {
+
+# too many roles
+ctags: Too many role definition for kind "variable" of language "IMAGINARY" (> 63)

--- a/Units/option-regex-attaching-role.r/extending-existing-parser.d/args.ctags
+++ b/Units/option-regex-attaching-role.r/extending-existing-parser.d/args.ctags
@@ -1,0 +1,62 @@
+#
+# This is an example of capturing reference tags by extending
+# already existing parser.
+# 
+# Gauche is an implementation Scheme language.
+# It has a module system.
+#
+# Copyright: 2018 Masatake YAMATO
+# License: GPL-2
+#
+--langdef=myGauche{base=Scheme}
+
+--kinddef-myGauche=m,module,modules
+--_roledef-myGauche=m.used,specified as argument for use
+--_roledef-myGauche=m.exported,specified as argument for export
+--_roledef-myGauche=m.selected,specified as argument for select
+
+--_tabledef-myGauche=main
+--_tabledef-myGauche=export
+
+
+#
+# MAIN TABLE
+#
+
+# Cut the corners.
+# In serious parser, You should define tables for select-module, define-module and use.
+--_mtable-regex-myGauche=main/\(define-module[ \t\n]+([-a-zA-Z0-9]+)/\1/m/{tenter=main}{scope=push}
+
+--_mtable-regex-myGauche=main/\(//{tenter=main}{scope=push}{placeholder}
+--_mtable-regex-myGauche=main/\)//{tleave}{scope=pop}
+--_mtable-regex-myGauche=main/[ \t\n]+//
+
+# Cut the corners.
+--_mtable-regex-myGauche=main/select-module[ \t\n]+([-a-zA-Z0-9]+)/\1/m/{_role=selected}{scope=set}
+--_mtable-regex-myGauche=main/use[ \t\n]+([-a-zA-Z0-9]+)/\1/m/{_role=used}{scope=ref}
+
+--_mtable-regex-myGauche=main/export[ \t\n]+//{tenter=export}
+
+# TODO: This fall-back pattern should be implementated in ctags main side as default behaviour.
+--_mtable-regex-myGauche=main/.//
+
+#
+# EXPORT TABLE
+#
+
+--_mtable-regex-myGauche=export/[ \t\n]+//
+
+# TODO: Why \0 is not allowed?
+--_mtable-regex-myGauche=export/([-a-zA-Z0-9]+)/\1/m/{_role=exported}{scope=ref}
+
+# Return to parent table with ungetc
+--_mtable-regex-myGauche=export/\)//{_advanceTo=0start}{tleave}
+--_mtable-regex-myGauche=export/.//
+
+
+--extras=+r
+--fields=+r
+
+--fields=+K{scope}{language}
+
+--sort=no

--- a/Units/option-regex-attaching-role.r/extending-existing-parser.d/expected.tags
+++ b/Units/option-regex-attaching-role.r/extending-existing-parser.d/expected.tags
@@ -1,0 +1,7 @@
+foo	input.scm	/^(define-module foo$/;"	function	language:Scheme	roles:def
+foobar	input.scm	/^(define (foobar)$/;"	function	language:Scheme	roles:def
+foo	input.scm	/^(define-module foo$/;"	module	language:myGauche	roles:def
+bar	input.scm	/^  (use bar)$/;"	module	language:myGauche	scope:module:foo	roles:used
+baz0	input.scm	/^  (export baz0 baz1))$/;"	module	language:myGauche	scope:module:foo	roles:exported
+baz1	input.scm	/^  (export baz0 baz1))$/;"	module	language:myGauche	scope:module:foo	roles:exported
+foo	input.scm	/^(select-module foo)$/;"	module	language:myGauche	roles:selected

--- a/Units/option-regex-attaching-role.r/extending-existing-parser.d/input.scm
+++ b/Units/option-regex-attaching-role.r/extending-existing-parser.d/input.scm
@@ -1,0 +1,6 @@
+(define-module foo
+  (use bar)
+  (export baz0 baz1))
+(select-module foo)
+(define (foobar)
+  1)

--- a/Units/option-regex-attaching-role.r/standing-alone-line-parser.d/args.ctags
+++ b/Units/option-regex-attaching-role.r/standing-alone-line-parser.d/args.ctags
@@ -1,0 +1,26 @@
+--langdef=FOO
+--map-FOO=.foo
+
+--kinddef-FOO=m,module,modules
+--kinddef-FOO=f,foofile,files written in FOO{_refonly}
+--kinddef-FOO=n,namespace,namespace
+
+--_fielddef-FOO=assocMod,module associated with the namespace
+
+--_roledef-FOO=m.used,refereed as an external module
+--_roledef-FOO=m.loaded,loaded into the current name space
+--_roledef-FOO=f.loaded,loaded into the current name space
+
+--regex-FOO=/^defmod +([A-Z]+)/\1/m/
+--regex-FOO=/^use +([A-Z]+)/\1/m/{_role=used}
+--regex-FOO=/^load +([A-Z]+)/\1/m/{_role=loaded}
+--regex-FOO=/^load +"([^"]+)"/\1/f/{_role=loaded}
+--regex-FOO=/^load-and-use +([A-Z]+)/\1/m/{_role=loaded}{_role=used}
+
+--regex-FOO=/^use +([A-Z]+) +as +([a-z]+)/\2/n/{_field=assocMod:\1}
+--regex-FOO=/^load-and-use +([A-Z]+) +as +([a-z]+)/\2/n/{_field=assocMod:\1}
+
+--fields=+r
+--fields-FOO=+{assocMod}
+--extras=+r
+--sort=no

--- a/Units/option-regex-attaching-role.r/standing-alone-line-parser.d/expected.tags
+++ b/Units/option-regex-attaching-role.r/standing-alone-line-parser.d/expected.tags
@@ -1,0 +1,9 @@
+A	input.foo	/^use A$/;"	m	roles:used
+B	input.foo	/^load B$/;"	m	roles:loaded
+C.foo	input.foo	/^load "C.foo"$/;"	f	roles:loaded
+D	input.foo	/^load-and-use D$/;"	m	roles:used,loaded
+E	input.foo	/^use E as e$/;"	m	roles:used
+e	input.foo	/^use E as e$/;"	n	roles:def	assocMod:E
+F	input.foo	/^load-and-use F as f$/;"	m	roles:used,loaded
+f	input.foo	/^load-and-use F as f$/;"	n	roles:def	assocMod:F
+MYMODULE	input.foo	/^defmod MYMODULE$/;"	m	roles:def

--- a/Units/option-regex-attaching-role.r/standing-alone-line-parser.d/input.foo
+++ b/Units/option-regex-attaching-role.r/standing-alone-line-parser.d/input.foo
@@ -1,0 +1,9 @@
+use A
+load B
+load "C.foo"
+load-and-use D
+
+use E as e
+load-and-use F as f
+
+defmod MYMODULE

--- a/Units/simple-elm.d/args.ctags
+++ b/Units/simple-elm.d/args.ctags
@@ -1,1 +1,3 @@
 --sort=no
+--fields=+r
+--extras=+r

--- a/Units/simple-elm.d/expected.tags
+++ b/Units/simple-elm.d/expected.tags
@@ -1,14 +1,16 @@
-Main	input.elm	/^port module Main exposing (..)$/;"	m
-Je	input.elm	/^import Json.Encode as Je$/;"	n
-Thing	input.elm	/^type Thing$/;"	t
-One	input.elm	/^    = One$/;"	c	type:Thing
-Two Int	input.elm	/^    | Two Int$/;"	c	type:Thing
-Param a	input.elm	/^type Param a$/;"	t
-Cons a	input.elm	/^    = Cons a$/;"	c	type:Param a
-Other a	input.elm	/^    | Other a$/;"	c	type:Param a
-Num	input.elm	/^type alias Num =$/;"	a
-outward	input.elm	/^port outward : String -> Cmd a$/;"	p
-inward	input.elm	/^port inward : (b -> a) -> Sub a$/;"	p
-foo	input.elm	/^foo a =$/;"	f
-bar	input.elm	/^bar =$/;"	f
-bas	input.elm	/^        bas =$/;"	f	function:bar
+Main	input.elm	/^port module Main exposing (..)$/;"	m	roles:def
+List	input.elm	/^import List$/;"	m	roles:imported
+Maybe	input.elm	/^import Maybe exposing (withDefault)$/;"	m	roles:imported
+Je	input.elm	/^import Json.Encode as Je$/;"	n	roles:def
+Thing	input.elm	/^type Thing$/;"	t	roles:def
+One	input.elm	/^    = One$/;"	c	type:Thing	roles:def
+Two Int	input.elm	/^    | Two Int$/;"	c	type:Thing	roles:def
+Param a	input.elm	/^type Param a$/;"	t	roles:def
+Cons a	input.elm	/^    = Cons a$/;"	c	type:Param a	roles:def
+Other a	input.elm	/^    | Other a$/;"	c	type:Param a	roles:def
+Num	input.elm	/^type alias Num =$/;"	a	roles:def
+outward	input.elm	/^port outward : String -> Cmd a$/;"	p	roles:def
+inward	input.elm	/^port inward : (b -> a) -> Sub a$/;"	p	roles:def
+foo	input.elm	/^foo a =$/;"	f	roles:def
+bar	input.elm	/^bar =$/;"	f	roles:def
+bas	input.elm	/^        bas =$/;"	f	function:bar	roles:def

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1053,6 +1053,10 @@ The third column shows the name of the role.
 The fourth column shows whether the role is enabled or not.
 The fifth column shows the description of the role.
 
+You can define a role in an optlib parser for capturing reference
+tags. See `Capturing reference tags <capturing_reftag>` for more
+details.
+
 Currently ctags doesn't provide the way for disabling a
 specified role.
 

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -383,6 +383,7 @@ Override the letter for file kind
 Overriding the letter for file kind is not allowed in Universal-ctags.
 
 .. IN MAN PAGE
+
 Don't use `F` as a kind letter in your parser.
 
 
@@ -479,10 +480,11 @@ Next example is based on an issue #219 posted by @andreicristianpetcu::
 	 That causes ctags allow to capture "abc".
 
 	 At the first iteration, the patterns of both
-	 *foo.ctags* and *bar.ctags" match as follows
+	 *foo.ctags* and *bar.ctags* match as follows
 	 ::
+
 		0   1       (start)
-        v   v
+		v   v
 		def def abc
 		       ^
 			   0,1  (end)
@@ -494,6 +496,7 @@ Next example is based on an issue #219 posted by @andreicristianpetcu::
 
 	 *foo.ctags*
 	 ::
+
                0end (default)
                v
 		def def abc
@@ -501,6 +504,7 @@ Next example is based on an issue #219 posted by @andreicristianpetcu::
 
 	 *bar.ctags*
 	 ::
+
             1start (as specified in _advanceTo long flag)
             v
 		def def abc
@@ -528,9 +532,9 @@ generator, which is a popular tool on Unix environment for writing a
 parser, and `RegexLexer` of Pygments. The knowledge about them
 help you understand the options.
 
-As usable, let me explain the feature with an example.  Consider a
+As usable, let me explain the feature with an example. Consider a
 imaginary language "X" has similar syntax with JavaScript; "var" is
-used as defining variable(s), , and "/* ... */" makes block comment.
+used as defining variable(s), , and "/\* ... \*/" makes block comment.
 
 *input.x*
 ::

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -888,6 +888,69 @@ about `--fields-<LANG>` option.
 `passwd` parser is a simple example that uses `--fields-<LANG>` option.
 
 
+.. _capturing_reftag:
+
+Capturing reference tags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. NOT REVIEWED YET
+
+To capture a reference tag with an optlib parser, specify a role with
+`_role` long regex flag. Let's see an example:
+
+.. code-block:: ctags
+
+	--langdef=FOO
+	--kinddef-FOO=m,module,modules
+	--_roledef-FOO=m.imported,imported module
+	--regex-FOO=/import[ \t]+([a-z]+)/\1/m/{_role=imported}
+	--extras=+r
+	--fields=+r
+
+See the line, `--regex-FOO=...`.  In this parser `FOO`, a name of
+imported module is captured as a reference tag with role `imported`.
+A role must be defined before specifying it as value for `_role` flag.
+`--_roledef-<LANG>` option is for defining a role.
+
+The parameter of the option comes from three components: a kind
+letter, the name of role, and the description of role. The kind letter
+comes first.  Following a period, give the role name. The period
+represents that the role is defined under the kind specified with the
+kind letter.  In the example, `imported` role is defined under
+`module` kind specified with `m`.
+
+Of course, the kind specified with the kind letter must be defined
+before using `--_roledef-<FOO>` option. `--kinddef-<LANG>` option
+is for defining a kind.
+
+The roles are listed with `--list-roles=<LANG>`. The name and
+description passed to `--_roledef-<LANG>` option are used in
+the output like::
+
+	$ ./ctags --langdef=FOO --kinddef-FOO=m,module,modules \
+				--_roledef-FOO='m.imported,imported module' --list-roles=FOO
+	#KIND(L/N) NAME     ENABLED DESCRIPTION
+	m/module   imported on      imported module
+
+
+With specifying `_role` regex flag multiple times with different
+roles, you can assign multiple roles to a reference tag.
+See following input of C language
+
+.. code-block:: C
+
+   i += 1;
+
+An ultra fine grained C parser may capture a variable `i` with
+`lvalue` and `incremented`. You can do it with:
+
+.. code-block:: ctags
+
+	--_roledef-C=v.lvalue,locator values
+	--_roledef-C=v.incremented,incremeted with ++ operator
+	--regex-C=/([a-zA-Z_][a-zA-Z_0-9])+ *+=/\1/v/{_role=lvalue}{_role=incremeted}
+
+
 Submitting an optlib to universal-ctags project
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -477,7 +477,7 @@ Next example is based on an issue #219 posted by @andreicristianpetcu::
 	   abc	input-0.bar	/^def def abc$/;"	a
 
 	``_advanceTo=1start`` is specified in *bar.ctags*.
-	That causes ctags allow to capture "abc".
+	This allows ctags to capture "abc".
 
 	At the first iteration, the patterns of both
 	*foo.ctags* and *bar.ctags* match as follows
@@ -489,10 +489,10 @@ Next example is based on an issue #219 posted by @andreicristianpetcu::
 			   ^
 			   0,1  (end)
 
-	"def" at the group 1 is captured as a tag in the
+	"def" at the group 1 is captured as a tag in
 	both languages. At the next iteration, the positions
 	where the pattern matching is applied to are not the
-	same in the language.
+	same in the languages.
 
 	*foo.ctags*
 	::

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -48,7 +48,7 @@ ctags visits the directories in the order as listed for loading files.
 ctags loads files having *.ctags* as file extension in alphabetical
 order(strcmp(3) is used for comparing).
 
-Quoted from man page of Exuberant-ctags:
+Quoted from man page of Exuberant-ctags::
 
 	FILES
 		   /ctags.cnf (on MSDOS, MSWindows only)
@@ -330,44 +330,44 @@ A stack is used for tracking the scope context.
 
 Example 1::
 
-    $ cat /tmp/input.foo
-    class foo:
+	$ cat /tmp/input.foo
+	class foo:
 	def bar(baz):
-	    print(baz)
-    class goo:
+		print(baz)
+	class goo:
 	def gar(gaz):
-	    print(gaz)
+		print(gaz)
 
-    $ cat /tmp/foo.ctags
-    --langdef=foo
-	    --map-foo=+.foo
-	    --regex-foo=/^class[[:blank:]]+([[:alpha:]]+):/\1/c,class/{scope=set}
-	    --regex-foo=/^[[:blank:]]+def[[:blank:]]+([[:alpha:]]+).*:/\1/d,definition/{scope=ref}
+	$ cat /tmp/foo.ctags
+	--langdef=foo
+		--map-foo=+.foo
+		--regex-foo=/^class[[:blank:]]+([[:alpha:]]+):/\1/c,class/{scope=set}
+		--regex-foo=/^[[:blank:]]+def[[:blank:]]+([[:alpha:]]+).*:/\1/d,definition/{scope=ref}
 
-    $ ~/var/ctags/ctags --options=/tmp/foo.ctags -o - /tmp/input.foo
-    bar	/tmp/input.foo	/^    def bar(baz):$/;"	d	class:foo
-    foo	/tmp/input.foo	/^class foo:$/;"	c
-    gar	/tmp/input.foo	/^    def gar(gaz):$/;"	d	class:goo
-    goo	/tmp/input.foo	/^class goo:$/;"	c
+	$ ~/var/ctags/ctags --options=/tmp/foo.ctags -o - /tmp/input.foo
+	bar	/tmp/input.foo	/^    def bar(baz):$/;"	d	class:foo
+	foo	/tmp/input.foo	/^class foo:$/;"	c
+	gar	/tmp/input.foo	/^    def gar(gaz):$/;"	d	class:goo
+	goo	/tmp/input.foo	/^class goo:$/;"	c
 
 
 Example 2::
 
-    $ cat /tmp/input.pp
-    class foo {
+	$ cat /tmp/input.pp
+	class foo {
 	include bar
-    }
+	}
 
-    $ cat /tmp/pp.ctags
-    --langdef=pp
-	    --map-pp=+.pp
-	    --regex-pp=/^class[[:blank:]]*([[:alnum:]]+)[[[:blank:]]]*\{/\1/c,class,classes/{scope=push}
-	    --regex-pp=/^[[:blank:]]*include[[:blank:]]*([[:alnum:]]+).*/\1/i,include,includes/{scope=ref}
-	    --regex-pp=/^[[:blank:]]*\}.*//{scope=pop}{exclusive}
+	$ cat /tmp/pp.ctags
+	--langdef=pp
+		--map-pp=+.pp
+		--regex-pp=/^class[[:blank:]]*([[:alnum:]]+)[[[:blank:]]]*\{/\1/c,class,classes/{scope=push}
+		--regex-pp=/^[[:blank:]]*include[[:blank:]]*([[:alnum:]]+).*/\1/i,include,includes/{scope=ref}
+		--regex-pp=/^[[:blank:]]*\}.*//{scope=pop}{exclusive}
 
-    $ ~/var/ctags/ctags --options=/tmp/pp.ctags -o - /tmp/input.pp
-    bar	/tmp/input.pp	/^    include bar$/;"	i	class:foo
-    foo	/tmp/input.pp	/^class foo {$/;"	c
+	$ ~/var/ctags/ctags --options=/tmp/pp.ctags -o - /tmp/input.pp
+	bar	/tmp/input.pp	/^    include bar$/;"	i	class:foo
+	foo	/tmp/input.pp	/^class foo {$/;"	c
 
 
 NOTE: Giving a scope long flag implies setting `useCork` of the parser
@@ -397,31 +397,31 @@ but the pattern is applied to whole file contents, not line by line.
 
 Next example is based on an issue #219 posted by @andreicristianpetcu::
 
-    $ cat input.java
-    @Subscribe
-    public void catchEvent(SomeEvent e)
-    {
+	$ cat input.java
+	@Subscribe
+	public void catchEvent(SomeEvent e)
+	{
 	return;
-    }
+	}
 
 
-    @Subscribe
-    public void
+	@Subscribe
+	public void
 	recover(Exception e)
-    {
+	{
 	return;
-    }
+	}
 
-    $ cat spring.ctags
-    --langdef=javaspring
-    --langmap=javaspring:.java
-    --mline-regex-javaspring=/@Subscribe([[:space:]])*([a-z ]+)[[:space:]]*([a-zA-Z]*)\(([a-zA-Z]*)/\3-\4/s,subscription/{mgroup=3}
-    --excmd=mixed
-    --fields=+ln
+	$ cat spring.ctags
+	--langdef=javaspring
+	--langmap=javaspring:.java
+	--mline-regex-javaspring=/@Subscribe([[:space:]])*([a-z ]+)[[:space:]]*([a-zA-Z]*)\(([a-zA-Z]*)/\3-\4/s,subscription/{mgroup=3}
+	--excmd=mixed
+	--fields=+ln
 
-    $ ./ctags -o - --options=./spring.ctags input.java
-    Event-SomeEvent	input.java	/^public void catchEvent(SomeEvent e)$/;"	s	line:2	language:javaspring
-    recover-Exception	input.java	/^    recover(Exception e)$/;"	s	line:10	language:javaspring
+	$ ./ctags -o - --options=./spring.ctags input.java
+	Event-SomeEvent	input.java	/^public void catchEvent(SomeEvent e)$/;"	s	line:2	language:javaspring
+	recover-Exception	input.java	/^    recover(Exception e)$/;"	s	line:10	language:javaspring
 
 ``{mgroup=N}``
 
@@ -459,54 +459,54 @@ Next example is based on an issue #219 posted by @andreicristianpetcu::
 	   --mline-regex-foo=/def *([a-z]+)/\1/a/{mgroup=1}
 
 
-	 *bar.ctags*
-	 ::
+	*bar.ctags*
+	::
 
-		--langdef=bar
-		--langmap=bar:.bar
-		--kinddef-bar=a,something,something
-		--mline-regex-bar=/def *([a-z]+)/\1/a/{mgroup=1}{_advanceTo=1start}
+	   --langdef=bar
+	   --langmap=bar:.bar
+	   --kinddef-bar=a,something,something
+	   --mline-regex-bar=/def *([a-z]+)/\1/a/{mgroup=1}{_advanceTo=1start}
 
-	 *foo.ctags* emits following tags output::
+	*foo.ctags* emits following tags output::
 
 	   def	input.foo	/^def def abc$/;"	a
 
-	 *bar.ctgs* emits following tags output::
+	*bar.ctgs* emits following tags output::
 
 	   def	input-0.bar	/^def def abc$/;"	a
 	   abc	input-0.bar	/^def def abc$/;"	a
 
-	 ``_advanceTo=1start`` is specified in *bar.ctags*.
-	 That causes ctags allow to capture "abc".
+	``_advanceTo=1start`` is specified in *bar.ctags*.
+	That causes ctags allow to capture "abc".
 
-	 At the first iteration, the patterns of both
-	 *foo.ctags* and *bar.ctags* match as follows
-	 ::
+	At the first iteration, the patterns of both
+	*foo.ctags* and *bar.ctags* match as follows
+	::
 
 		0   1       (start)
 		v   v
 		def def abc
-		       ^
+			   ^
 			   0,1  (end)
 
-	 "def" at the group 1 is captured as a tag in the
-	 both languages. At the next iteration, the positions
-	 where the pattern matching is applied to are not the
-	 same in the language.
+	"def" at the group 1 is captured as a tag in the
+	both languages. At the next iteration, the positions
+	where the pattern matching is applied to are not the
+	same in the language.
 
-	 *foo.ctags*
-	 ::
+	*foo.ctags*
+	::
 
-               0end (default)
-               v
+			   0end (default)
+			   v
 		def def abc
 
 
-	 *bar.ctags*
-	 ::
+	*bar.ctags*
+	::
 
-            1start (as specified in _advanceTo long flag)
-            v
+			1start (as specified in _advanceTo long flag)
+			v
 		def def abc
 
 	This difference of positions makes the difference of tags output.
@@ -822,9 +822,9 @@ value of the fields of a tagEntry.
 Let's think about *Unknown*, an imaginary language.
 Here is a source file(``input.unknown``) written in *Unknown*:
 
-    public func foo(n, m);
-    protected func bar(n);
-    private func baz(n,...);
+	public func foo(n, m);
+	protected func bar(n);
+	private func baz(n,...);
 
 With `--regex-Unknown=...` Exuberant-ctags can capture `foo`, `bar`, and `baz`
 as names. Universal-ctags can attach extra context information to the
@@ -838,16 +838,16 @@ With following optlib file(``unknown.ctags``)), ctags can attach
 
 .. code-block:: ctags
 
-    --langdef=unknown
-    --kinddef-unknown=f,func,functions
-    --map-unknown=+.unknown
+	--langdef=unknown
+	--kinddef-unknown=f,func,functions
+	--map-unknown=+.unknown
 
-    --_fielddef-unknown=protection,access scope
-    --_fielddef-unknown=signature,signatures
+	--_fielddef-unknown=protection,access scope
+	--_fielddef-unknown=signature,signatures
 
-    --regex-unknown=/^((public|protected|private) +)?func ([^\(]+)\((.*)\)/\3/f/{_field=protection:\1}{_field=signature:(\4)}
+	--regex-unknown=/^((public|protected|private) +)?func ([^\(]+)\((.*)\)/\3/f/{_field=protection:\1}{_field=signature:(\4)}
 
-    --fields-unknown=+'{protection}{signature}'
+	--fields-unknown=+'{protection}{signature}'
 
 For the line `    protected func bar(n);` you will get following tags output::
 
@@ -857,7 +857,7 @@ Let's see the detail of ``unknown.ctags``.
 
 .. code-block:: ctags
 
-    --_fielddef-unknown=protection,access scope
+	--_fielddef-unknown=protection,access scope
 
 `--_fielddef-<LANG>=name,description` defines a new field for a parser
 specified by `<LANG>`.  Before defining a new field for the parser,
@@ -867,13 +867,13 @@ used in the output of ``--list-fields`` and ``--list-fields=Unknown``.
 
 .. code-block:: ctags
 
-    --_fielddef-unknown=signature,signatures
+	--_fielddef-unknown=signature,signatures
 
 This defines a field named `signature`.
 
 .. code-block:: ctags
 
-    --regex-unknown=/^((public|protected|private) +)?func ([^\(]+)\((.*)\)/\3/f/{_field=protection:\1}{_field=signature:(\4)}
+	--regex-unknown=/^((public|protected|private) +)?func ([^\(]+)\((.*)\)/\3/f/{_field=protection:\1}{_field=signature:(\4)}
 
 This option requests making a tag for the name that is specified with the group 3 of the
 pattern, attaching the group 1 as a value for `protection` field to the tag, and attaching
@@ -984,30 +984,30 @@ Put these information at the header of *swine.ctags*.
 
 An example taken from *data/optlib/ctags.ctags* ::
 
-    #
-    #
-    #  Copyright (c) 2014, Red Hat, Inc.
-    #  Copyright (c) 2014, Masatake YAMATO
-    #
-    #  Author: Masatake YAMATO <yamato@redhat.com>
-    #
-    # This program is free software; you can redistribute it and/or
-    # modify it under the terms of the GNU General Public License
-    # as published by the Free Software Foundation; either version 2
-    # of the License, or (at your option) any later version.
-    #
-    # This program is distributed in the hope that it will be useful,
-    # but WITHOUT ANY WARRANTY; without even the implied warranty of
-    # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    # GNU General Public License for more details.
-    #
-    # You should have received a copy of the GNU General Public License
-    # along with this program; if not, write to the Free Software
-    # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
-    # USA.
-    #
-    #
-    ...
+	#
+	#
+	#  Copyright (c) 2014, Red Hat, Inc.
+	#  Copyright (c) 2014, Masatake YAMATO
+	#
+	#  Author: Masatake YAMATO <yamato@redhat.com>
+	#
+	# This program is free software; you can redistribute it and/or
+	# modify it under the terms of the GNU General Public License
+	# as published by the Free Software Foundation; either version 2
+	# of the License, or (at your option) any later version.
+	#
+	# This program is distributed in the hope that it will be useful,
+	# but WITHOUT ANY WARRANTY; without even the implied warranty of
+	# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	# GNU General Public License for more details.
+	#
+	# You should have received a copy of the GNU General Public License
+	# along with this program; if not, write to the Free Software
+	# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+	# USA.
+	#
+	#
+	...
 
 "GPL version 2 or later version" is needed here.  Option file is not
 linked to ctags command. However, I have a plan to write a translator

--- a/main/entry_private.c
+++ b/main/entry_private.c
@@ -27,3 +27,11 @@ extern const char* getTagKindName(const tagEntryInfo *const tag)
 	kindDefinition *kdef = getLanguageKind(tag->langType, tag->kindIndex);
 	return kdef->name;
 }
+
+extern const roleDefinition* getTagRole(const tagEntryInfo *const tag,
+										int roleIndex)
+{
+	if (roleIndex == ROLE_INDEX_DEFINITION)
+		return NULL;
+	return getLanguageRole(tag->langType, tag->kindIndex, roleIndex);
+}

--- a/main/entry_private.h
+++ b/main/entry_private.h
@@ -18,4 +18,6 @@ extern const kindDefinition* getTagKind(const tagEntryInfo *const tag);
 extern char getTagKindLetter(const tagEntryInfo *const tag);
 extern const char* getTagKindName(const tagEntryInfo *const tag);
 
+extern const roleDefinition* getTagRole(const tagEntryInfo *const tag, int roleIndex);
+
 #endif	/* CTAGS_PRIVATE_ENTRY_H */

--- a/main/field.c
+++ b/main/field.c
@@ -631,10 +631,9 @@ static const char *renderFieldRoles (const tagEntryInfo *const tag,
 					bool *rejected CTAGS_ATTR_UNUSED)
 {
 	roleBitsType rbits = tag->extensionFields.roleBits;
-	const roleDesc * role;
+	const roleDefinition * role;
 	if (rbits)
 	{
-		const kindDefinition *kdef = getTagKind(tag);
 		int roleCount = countLanguageRoles (tag->langType, tag->kindIndex);
 		int nRoleWritten = 0;
 
@@ -646,7 +645,7 @@ static const char *renderFieldRoles (const tagEntryInfo *const tag,
 				if (nRoleWritten > 0)
 					vStringPut(b, ',');
 
-				role  = & (kdef->roles [roleIndex]);
+				role = getTagRole(tag, roleIndex);
 				renderRole (role, b);
 				nRoleWritten++;
 			}

--- a/main/flags.c
+++ b/main/flags.c
@@ -28,8 +28,6 @@ void flagsEval (const char* flags_original, flagDefinition* defs, unsigned int n
 
 	if (!flags_original)
 		return;
-	if (!defs)
-		return;
 
 	flags = eStrdup (flags_original);
 	for (i = 0 ; flags [i] != '\0' ; ++i)
@@ -43,8 +41,8 @@ void flagsEval (const char* flags_original, flagDefinition* defs, unsigned int n
 
 			if (needle_close_paren == NULL)
 			{
-				error (WARNING, "long flags specifier opened with `%c' is not closed `%c'",
-				       LONG_FLAGS_OPEN, LONG_FLAGS_CLOSE);
+				error (WARNING, "long flags specifier opened with `%c' is not closed `%c': \"%s\"",
+				       LONG_FLAGS_OPEN, LONG_FLAGS_CLOSE, flags_original);
 				break;
 			}
 

--- a/main/kind.c
+++ b/main/kind.c
@@ -22,9 +22,21 @@
 #include "options.h"
 #include "vstring.h"
 
+typedef struct sRoleObject {
+	roleDefinition *def;
+	freeRoleDefFunc free;
+} roleObject;
+
+struct roleControlBlock {
+	roleObject *role;
+	unsigned int count;
+	int owner;
+};
+
 typedef struct sKindObject {
 	kindDefinition *def;
 	freeKindDefFunc free;
+	struct roleControlBlock *rcb;
 } kindObject;
 
 struct kindControlBlock {
@@ -33,7 +45,7 @@ struct kindControlBlock {
 	langType owner;
 };
 
-extern const char *renderRole (const roleDesc* const role, vString* b)
+extern const char *renderRole (const roleDefinition* const role, vString* b)
 {
 	vStringCatS (b, role->name);
 	return vStringValue (b);
@@ -94,6 +106,26 @@ extern void enableKind (kindDefinition *kind, bool enable)
 	}
 }
 
+static struct roleControlBlock* allocRoleControlBlock (kindObject *kind)
+{
+	unsigned int j;
+	struct roleControlBlock* rcb;
+
+	rcb = xMalloc(1, struct roleControlBlock);
+	rcb->count = kind->def->nRoles;
+	rcb->owner = kind->def->id;
+	rcb->role = xMalloc(rcb->count, roleObject);
+	for (j = 0; j < rcb->count; j++)
+	{
+		roleObject *role = rcb->role + j;
+		role->def = kind->def->roles + j;
+		role->free = NULL;
+		role->def->id = j;
+	}
+
+	return rcb;
+}
+
 extern struct kindControlBlock* allocKindControlBlock (parserDefinition *parser)
 {
 	unsigned int i;
@@ -106,12 +138,26 @@ extern struct kindControlBlock* allocKindControlBlock (parserDefinition *parser)
 
 	for (i = 0; i < parser->kindCount; ++i)
 	{
-		kcb->kind [i].def = parser->kindTable + i;
-		kcb->kind [i].free = NULL;
-		kcb->kind [i].def->id = i;
+		kindObject *kind = kcb->kind + i;
+		kind->def = parser->kindTable + i;
+		kind->free = NULL;
+		kind->def->id = i;
+		kind->rcb = allocRoleControlBlock (kind);
 	}
 
 	return kcb;
+}
+
+static void freeRoleControlBlock (struct roleControlBlock *rcb)
+{
+	unsigned int i;
+	for (i = 0; i < rcb->count; ++i)
+	{
+		if (rcb->role[i].free)
+			rcb->role [i].free (rcb->role [i].def);
+	}
+	eFree (rcb->role);
+	eFree (rcb);
 }
 
 extern void freeKindControlBlock (struct kindControlBlock* kcb)
@@ -122,6 +168,7 @@ extern void freeKindControlBlock (struct kindControlBlock* kcb)
 	{
 		if (kcb->kind [i].free)
 			kcb->kind [i].free (kcb->kind [i].def);
+		freeRoleControlBlock (kcb->kind [i].rcb);
 	}
 	eFree (kcb->kind);
 	eFree (kcb);
@@ -134,6 +181,7 @@ extern int  defineKind (struct kindControlBlock* kcb, kindDefinition *def,
 	kcb->kind = xRealloc (kcb->kind, kcb->count, kindObject);
 	kcb->kind [def->id].def = def;
 	kcb->kind [def->id].free = freeKindDef;
+	kcb->kind [def->id].rcb = allocRoleControlBlock(kcb->kind + def->id);
 
 	verbose ("Add kind[%d] \"%c,%s,%s\" to %s\n", def->id,
 			 def->letter, def->name, def->description,
@@ -144,7 +192,8 @@ extern int  defineKind (struct kindControlBlock* kcb, kindDefinition *def,
 
 extern bool isRoleEnabled (struct kindControlBlock* kcb, int kindIndex, int roleIndex)
 {
-	return kcb->kind [kindIndex].def->roles[roleIndex].enabled;
+	roleDefinition *rdef = getRole (kcb, kindIndex, roleIndex);
+	return rdef->enabled;
 }
 
 extern unsigned int countKinds (struct kindControlBlock* kcb)
@@ -154,7 +203,7 @@ extern unsigned int countKinds (struct kindControlBlock* kcb)
 
 extern unsigned int countRoles (struct kindControlBlock* kcb, int kindIndex)
 {
-	return kcb->kind [kindIndex].def->nRoles;
+	return kcb->kind [kindIndex].rcb->count;
 }
 
 extern kindDefinition *getKind (struct kindControlBlock* kcb, int kindIndex)
@@ -189,6 +238,12 @@ extern kindDefinition *getKindForName (struct kindControlBlock* kcb, const char*
 			return kdef;
 	}
 	return NULL;
+}
+
+extern roleDefinition* getRole(struct kindControlBlock* kcb, int kindIndex, int roleIndex)
+{
+	struct roleControlBlock *rcb = kcb->kind[kindIndex].rcb;
+	return rcb->role [roleIndex].def;
 }
 
 static void linkKinds (langType master, kindDefinition *masterKind, kindDefinition *slaveKind)
@@ -261,17 +316,19 @@ extern struct colprintTable * kindColprintTableNew (void)
 }
 
 static void kindColprintFillLine (struct colprintLine *line,
-								  const char *lang,
+								  const char *langName,
 								  kindDefinition *kdef)
 {
-	colprintLineAppendColumnCString (line, lang);
+	langType lang = getNamedLanguage (langName, 0);
+	unsigned int count = countLanguageRoles(lang, kdef->id);
+	colprintLineAppendColumnCString (line, langName);
 	colprintLineAppendColumnChar (line, kdef->letter);
 	colprintLineAppendColumnCString (line, kdef->name
 									 ? kdef->name
 									 : "ThisShouldNotBePrintedKindNameMustBeGiven");
 	colprintLineAppendColumnBool (line, kdef->enabled);
 	colprintLineAppendColumnBool (line, kdef->referenceOnly);
-	colprintLineAppendColumnInt (line, kdef->nRoles);
+	colprintLineAppendColumnInt (line, count);
 	colprintLineAppendColumnCString (line, (kdef->master
 											|| kdef->slave ) ?
 									 getLanguageName (kdef->syncWith): RSV_NONE);
@@ -364,9 +421,10 @@ extern void roleColprintAddRoles (struct colprintTable *table, struct kindContro
 				|| (!kname && *c == k->letter)
 				|| (!kname && *c == KIND_WILDCARD))
 			{
-				for (int j = 0; j < k->nRoles; j++)
+				unsigned int nRoles = countRoles(kcb, i);
+				for (int j = 0; j < nRoles; j++)
 				{
-					const roleDesc *r = k->roles + j;
+					const roleDefinition *r = getRole (kcb, i, j);
 					struct colprintLine *line = colprintTableGetNewLine(table);
 
 					colprintLineAppendColumnCString (line, lang);

--- a/main/kind.h
+++ b/main/kind.h
@@ -13,13 +13,16 @@
 #include "routines.h"
 #include "vstring.h"
 
-typedef struct sRoleDesc {
+struct sRoleDefinition {
 	bool enabled;
 	const char* name;		  /* role name */
 	const char* description;	  /* displayed in --help output */
-} roleDesc;
 
-extern const char *renderRole (const roleDesc* const role, vString* b);
+	int id;
+};
+
+typedef void (* freeRoleDefFunc) (roleDefinition *);
+extern const char *renderRole (const roleDefinition* const def, vString* b);
 
 /*
  * Predefined kinds
@@ -54,7 +57,7 @@ struct sKindDefinition {
 	char* description;	  /* displayed in --help output */
 	bool referenceOnly;
 	int nRoles;		/* The number of role elements. */
-	roleDesc *roles;
+	roleDefinition *roles;
 	scopeSeparator *separators;
 	unsigned int separatorCount;
 
@@ -98,6 +101,7 @@ extern unsigned int countRoles (struct kindControlBlock* kcb, int kindIndex);
 extern kindDefinition *getKind (struct kindControlBlock* kcb, int kindIndex);
 extern kindDefinition *getKindForLetter (struct kindControlBlock* kcb, int letter);
 extern kindDefinition *getKindForName (struct kindControlBlock* kcb, const char* name);
+extern roleDefinition* getRole(struct kindControlBlock* kcb, int kindIndex, int roleIndex);
 extern void linkKindDependency (struct kindControlBlock *masterKCB,
 								struct kindControlBlock *slaveKCB);
 

--- a/main/kind.h
+++ b/main/kind.h
@@ -15,8 +15,8 @@
 
 struct sRoleDefinition {
 	bool enabled;
-	const char* name;		  /* role name */
-	const char* description;	  /* displayed in --help output */
+	char* name;		  /* role name */
+	char* description;	  /* displayed in --help output */
 
 	int id;
 };
@@ -94,6 +94,8 @@ extern struct kindControlBlock* allocKindControlBlock (parserDefinition *parser)
 extern void freeKindControlBlock (struct kindControlBlock* kcb);
 extern int  defineKind (struct kindControlBlock* kcb, kindDefinition *def,
 						freeKindDefFunc freeKindDef);
+extern int defineRole (struct kindControlBlock* kcb, int kindIndex,
+					   roleDefinition *def, freeRoleDefFunc freeRoleDef);
 extern bool isRoleEnabled (struct kindControlBlock* kcb, int kindIndex, int roleIndex);
 
 extern unsigned int countKinds (struct kindControlBlock* kcb);
@@ -102,6 +104,7 @@ extern kindDefinition *getKind (struct kindControlBlock* kcb, int kindIndex);
 extern kindDefinition *getKindForLetter (struct kindControlBlock* kcb, int letter);
 extern kindDefinition *getKindForName (struct kindControlBlock* kcb, const char* name);
 extern roleDefinition* getRole(struct kindControlBlock* kcb, int kindIndex, int roleIndex);
+extern roleDefinition* getRoleForName(struct kindControlBlock* kcb, int kindIndex, const char* name);
 extern void linkKindDependency (struct kindControlBlock *masterKCB,
 								struct kindControlBlock *slaveKCB);
 

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -98,6 +98,7 @@ typedef struct {
 	union {
 		struct {
 			int kindIndex;
+			roleBitsType roleBits;
 			char *name_pattern;
 		} tag;
 		struct {
@@ -231,13 +232,13 @@ extern void freeLregexControlBlock (struct lregexControlBlock* lcb)
 */
 
 static bool initRegexTag (tagEntryInfo *e,
-		const vString* const name, int kindIndex, int scopeIndex, int placeholder,
+		const vString* const name, int kindIndex, int roleIndex, int scopeIndex, int placeholder,
 		unsigned long line, MIOPos *pos, int xtag_type)
 {
 	if (isInputLanguageKindEnabled (kindIndex))
 	{
 		Assert (name != NULL  &&  ((vStringLength (name) > 0) || placeholder));
-		initTagEntry (e, vStringValue (name), kindIndex);
+		initRefTagEntry (e, vStringValue (name), kindIndex, roleIndex);
 		e->extensionFields.scopeIndex = scopeIndex;
 		e->placeholder = !!placeholder;
 		if (line)
@@ -458,6 +459,7 @@ static regexPattern * newPattern (regex_t* const pattern,
 	if (regptype == REG_PARSER_MULTI_TABLE)
 		initTaction(&ptrn->taction);
 
+	ptrn->u.tag.roleBits = 0;
 	ptrn->refcount = 1;
 	return ptrn;
 }
@@ -667,7 +669,7 @@ static void pre_ptrn_flag_field_long (const char* const s CTAGS_ATTR_UNUSED, con
 static flagDefinition fieldSpecFlagDef[] = {
 #define EXPERIMENTAL "_"
 	{ '\0',  EXPERIMENTAL "field", NULL, pre_ptrn_flag_field_long ,
-	  "FIELD:VALUE", "record the matched string(VALUE) to FIELD of the tag"},
+	  "FIELD:VALUE", "record the matched string(VALUE) to parser own FIELD of the tag"},
 };
 
 
@@ -752,6 +754,38 @@ static flagDefinition multitablePtrnFlagDef[] = {
 	  NULL, "stop the parsing with this parser"},
 };
 
+struct roleFlagData {
+	langType owner;
+	int kindIndex;
+	roleBitsType roleBits;
+};
+
+static void pre_ptrn_flag_role_long (const char* const s CTAGS_ATTR_UNUSED, const char* const v, void* data)
+{
+	struct roleFlagData *rdata = data;
+	roleDefinition * role;
+
+	if (!v)
+	{
+		error (WARNING, "no value is given for: %s", s);
+		return;
+	}
+
+	role = getLanguageRoleForName(rdata->owner,
+								  rdata->kindIndex, v);
+	if (!role)
+	{
+		error (WARNING, "no such role: %s", v);
+		return;
+	}
+
+	rdata->roleBits |= makeRoleBit(role->id);
+}
+
+static flagDefinition roleSpecFlagDef[] = {
+	{ '\0',  EXPERIMENTAL "role", NULL, pre_ptrn_flag_role_long,
+	  "ROLE", "Set given ROLE to roles field"},
+};
 
 static regexPattern *addCompiledTagPattern (struct lregexControlBlock *lcb,
 											int table_index,
@@ -774,6 +808,10 @@ static regexPattern *addCompiledTagPattern (struct lregexControlBlock *lcb,
 
 	struct mtableFlagData mtableFlagData = {
 		.lcb = lcb,
+	};
+
+	struct roleFlagData roleFlagData = {
+		.owner = lcb->owner,
 	};
 
 	if (regptype == REG_PARSER_SINGLE_LINE)
@@ -826,6 +864,13 @@ static regexPattern *addCompiledTagPattern (struct lregexControlBlock *lcb,
 
 		ptrn->u.tag.kindIndex = kdef->id;
 	}
+
+	roleFlagData.kindIndex = ptrn->u.tag.kindIndex;
+	roleFlagData.roleBits = 0;
+
+	flagsEval (flags, roleSpecFlagDef, ARRAY_SIZE(roleSpecFlagDef), &roleFlagData);
+	ptrn->u.tag.roleBits = roleFlagData.roleBits;
+
 	return ptrn;
 }
 
@@ -1066,6 +1111,7 @@ static void matchTagPattern (struct lregexControlBlock *lcb,
 		MIOPos pos;
 		tagEntryInfo e;
 		int kind;
+		roleBitsType roleBits;
 
 		if ((patbuf->regptype == REG_PARSER_MULTI_LINE)
 			|| (patbuf->regptype == REG_PARSER_MULTI_TABLE))
@@ -1076,8 +1122,9 @@ static void matchTagPattern (struct lregexControlBlock *lcb,
 
 		n = CORK_NIL;
 		kind = patbuf->u.tag.kindIndex;
+		roleBits = patbuf->u.tag.roleBits;
 
-		if (initRegexTag (&e, name, kind, scope, placeholder,
+		if (initRegexTag (&e, name, kind, ROLE_INDEX_DEFINITION, scope, placeholder,
 						  ln, ln == 0? NULL: &pos, patbuf->xtagType))
 		{
 			static TrashBox* field_trashbox;
@@ -1100,6 +1147,19 @@ static void matchTagPattern (struct lregexControlBlock *lcb,
 						trashBoxPut (field_trashbox, value,
 									 (TrashBoxDestroyItemProc)vStringDelete);
 					}
+				}
+			}
+
+			if (roleBits)
+			{
+				int roleIndex;
+
+				for (roleIndex = 0;
+					 roleIndex < countLanguageRoles(e.langType, kind);
+					 roleIndex++)
+				{
+					if (roleBits & makeRoleBit(roleIndex))
+						assignRole (&e, roleIndex);
 				}
 			}
 			n = makeTagEntry (&e);
@@ -1546,6 +1606,7 @@ extern void printRegexFlags (bool withListHeader, bool machinable, FILE *fp)
 	flagsColprintAddDefinitions (table, scopePtrnFlagDef, ARRAY_SIZE (scopePtrnFlagDef));
 	flagsColprintAddDefinitions (table, extraSpecFlagDef, ARRAY_SIZE (extraSpecFlagDef));
 	flagsColprintAddDefinitions (table, fieldSpecFlagDef, ARRAY_SIZE (fieldSpecFlagDef));
+	flagsColprintAddDefinitions (table, roleSpecFlagDef, ARRAY_SIZE (roleSpecFlagDef));
 
 	flagsColprintTablePrint (table, withListHeader, machinable, fp);
 	colprintTableDelete(table);
@@ -1561,6 +1622,7 @@ extern void printMultilineRegexFlags (bool withListHeader, bool machinable, FILE
 	flagsColprintAddDefinitions (table, multilinePtrnFlagDef, ARRAY_SIZE (multilinePtrnFlagDef));
 	flagsColprintAddDefinitions (table, extraSpecFlagDef, ARRAY_SIZE (extraSpecFlagDef));
 	flagsColprintAddDefinitions (table, fieldSpecFlagDef, ARRAY_SIZE (fieldSpecFlagDef));
+	flagsColprintAddDefinitions (table, roleSpecFlagDef, ARRAY_SIZE (roleSpecFlagDef));
 
 	flagsColprintTablePrint (table, withListHeader, machinable, fp);
 	colprintTableDelete(table);
@@ -1578,6 +1640,7 @@ extern void printMultitableRegexFlags (bool withListHeader, bool machinable, FIL
 	flagsColprintAddDefinitions (table, scopePtrnFlagDef, ARRAY_SIZE (scopePtrnFlagDef));
 	flagsColprintAddDefinitions (table, extraSpecFlagDef, ARRAY_SIZE (extraSpecFlagDef));
 	flagsColprintAddDefinitions (table, fieldSpecFlagDef, ARRAY_SIZE (fieldSpecFlagDef));
+	flagsColprintAddDefinitions (table, roleSpecFlagDef, ARRAY_SIZE (roleSpecFlagDef));
 
 	flagsColprintTablePrint (table, withListHeader, machinable, fp);
 	colprintTableDelete(table);

--- a/main/options.c
+++ b/main/options.c
@@ -450,6 +450,8 @@ static optionDescription LongOptionDescription [] = {
  {0,"       Enter file I/O limited interactive mode if sandbox is specified. [default]"},
 #endif
 #endif
+ {1,"  --_list-kinddef-flags"},
+ {1,"       Output list of flags which can be used with --kinddef option."},
  {1,"  --_list-mtable-regex-flags"},
  {1,"       Output list of flags which can be used in a multitable regex parser definition."},
  {1,"  --_mtable-extend-<LANG>=disttable+srctable."},
@@ -2073,6 +2075,13 @@ static void processListLangdefFlagsOptions (
 	exit (0);
 }
 
+static void processListKinddefFlagsOptions (
+		const char *const option CTAGS_ATTR_UNUSED,
+		const char *const parameter CTAGS_ATTR_UNUSED)
+{
+	printKinddefFlags (localOption.withListHeader, localOption.machinable, stdout);
+	exit (0);
+}
 
 static void processListRolesOptions (const char *const option CTAGS_ATTR_UNUSED,
 				     const char *const parameter)
@@ -2618,6 +2627,7 @@ static parametricOption ParametricOptions [] = {
 #ifdef HAVE_JANSSON
 	{ "_interactive",           processInteractiveOption,       true,   STAGE_ANY },
 #endif
+	{ "_list-kinddef-flags",     processListKinddefFlagsOptions, true,   STAGE_ANY },
 	{ "_list-mtable-regex-flags", processListMultitableRegexFlagsOptions, true, STAGE_ANY },
 	{ "_xformat",               processXformatOption,           false,  STAGE_ANY },
 };

--- a/main/options.c
+++ b/main/options.c
@@ -456,6 +456,8 @@ static optionDescription LongOptionDescription [] = {
  {1,"       Copy patterns of a regex table to another regex table."},
  {1,"  --_mtable-regex-<LANG>=table/line_pattern/name_pattern/[flags]"},
  {1,"       Define multitable regular expression for locating tags in specific language."},
+ {1,"  --_roledef-<LANG>=kind_letter.role_name,role_desc"},
+ {1,"       Define new role for kind specified with <kind_letter> in <LANG>."},
  {1,"  --_tabledef-<LANG>=name"},
  {1,"       Define new regex table for <LANG>."},
  {1,"  --_xformat=field_format"},
@@ -3058,6 +3060,8 @@ static void processLongOption (
 	else if (strcmp (option, "recurse") == 0)
 		error (WARNING, "%s option not supported on this host", option);
 #endif
+	else if (processRoledefOption (option, parameter))
+		;
 	else
 		error (FATAL, "Unknown option: --%s", option);
 }

--- a/main/options.h
+++ b/main/options.h
@@ -176,6 +176,7 @@ extern bool processTabledefOption (const char *const option, const char *const p
 #ifdef HAVE_ICONV
 extern bool processLanguageEncodingOption (const char *const option, const char *const parameter);
 #endif
+extern bool processRoledefOption (const char *const option, const char *const parameter);
 
 typedef void (* mainLoopFunc) (cookedArgs *args, void *data);
 extern void setMainLoop (mainLoopFunc func, void *data);

--- a/main/parse.c
+++ b/main/parse.c
@@ -314,6 +314,12 @@ extern roleDefinition* getLanguageRole(const langType language, int kindIndex, i
 	return getRole (LanguageTable [language].kindControlBlock, kindIndex, roleIndex);
 }
 
+extern roleDefinition* getLanguageRoleForName (const langType language, int kindIndex,
+											   const char *roleName)
+{
+	return getRoleForName (LanguageTable [language].kindControlBlock, kindIndex, roleName);
+}
+
 extern langType getNamedLanguage (const char *const name, size_t len)
 {
 	langType result = LANG_IGNORE;

--- a/main/parse.c
+++ b/main/parse.c
@@ -309,6 +309,11 @@ extern kindDefinition* getLanguageKindForName (const langType language, const ch
 		return getKindForName (LanguageTable [language].kindControlBlock, kindName);
 }
 
+extern roleDefinition* getLanguageRole(const langType language, int kindIndex, int roleIndex)
+{
+	return getRole (LanguageTable [language].kindControlBlock, kindIndex, roleIndex);
+}
+
 extern langType getNamedLanguage (const char *const name, size_t len)
 {
 	langType result = LANG_IGNORE;
@@ -3947,7 +3952,7 @@ typedef enum {
 	R_BROKEN_REF,
 } CTST_BrokenRole;
 
-static roleDesc CTST_BrokenRoles [] = {
+static roleDefinition CTST_BrokenRoles [] = {
 	{true, "broken", "broken" },
 };
 
@@ -3956,7 +3961,7 @@ typedef enum {
 	R_DISABLED_KIND_ENABLED_ROLE,
 } CTST_DisabledKindRole;
 
-static roleDesc CTST_DisabledKindRoles [] = {
+static roleDefinition CTST_DisabledKindRoles [] = {
 	{ false, "disabled", "disbaled role attached to disabled kind" },
 	{ true,  "enabled",  "enabled role attached to disabled kind"  },
 };
@@ -3966,7 +3971,7 @@ typedef enum {
 	R_ENABLED_KIND_ENABLED_ROLE,
 } CTST_EnabledKindRole;
 
-static roleDesc CTST_EnabledKindRoles [] = {
+static roleDefinition CTST_EnabledKindRoles [] = {
 	{ false, "disabled", "disbaled role attached to enabled kind" },
 	{ true,  "enabled",  "enabled role attached to enabled kind"  },
 };
@@ -3978,7 +3983,7 @@ typedef enum {
 	R_ROLES_KIND_D_ROLE,
 } CTST_RolesKindRole;
 
-static roleDesc CTST_RolesKindRoles [] = {
+static roleDefinition CTST_RolesKindRoles [] = {
 	{ true,  "a", "A role" },
 	{ true,  "b", "B role" },
 	{ false, "c", "C role" },
@@ -3991,7 +3996,7 @@ typedef enum {
 } CTST_RolesDisableKindRole;
 
 
-static roleDesc CTST_RolesDisabledKindRoles [] = {
+static roleDefinition CTST_RolesDisabledKindRoles [] = {
 	{ true,  "A", "A role" },
 	{ true,  "B", "B role" },
 };

--- a/main/parse.c
+++ b/main/parse.c
@@ -4020,6 +4020,18 @@ extern void printLangdefFlags (bool withListHeader, bool machinable, FILE *fp)
 	colprintTableDelete(table);
 }
 
+extern void printKinddefFlags (bool withListHeader, bool machinable, FILE *fp)
+{
+	struct colprintTable * table;
+
+	table = flagsColprintTableNew ();
+
+	flagsColprintAddDefinitions (table, PreKindDefFlagDef, ARRAY_SIZE (PreKindDefFlagDef));
+
+	flagsColprintTablePrint (table, withListHeader, machinable, fp);
+	colprintTableDelete(table);
+}
+
 extern void printLanguageMultitableStatistics (langType language, FILE *vfp)
 {
 	parserObject* const parser = LanguageTable + language;

--- a/main/parse.c
+++ b/main/parse.c
@@ -2126,6 +2126,18 @@ static char *extractDescriptionAndFlags(const char *input, const char **flags)
 	return vStringDeleteUnwrap(vdesc);
 }
 
+static void pre_kind_def_flag_refonly_long (const char* const optflag,
+											const char* const param, void* data)
+{
+	kindDefinition *kdef = data;
+	kdef->referenceOnly = true;
+}
+
+static flagDefinition PreKindDefFlagDef [] = {
+	{ '\0', "_refonly", NULL, pre_kind_def_flag_refonly_long,
+	  NULL, "use this kind reference tags only"},
+};
+
 static bool processLangDefineKind(const langType language,
 								  const char *const option,
 								  const char *const parameterx)
@@ -2213,7 +2225,7 @@ static bool processLangDefineKind(const langType language,
 	kdef->name = name;
 	kdef->description = description;
 	if (flags)
-		flagsEval (flags, NULL, 0, kdef);
+		flagsEval (flags, PreKindDefFlagDef, ARRAY_SIZE (PreKindDefFlagDef), kdef);
 
 	defineKind (parser->kindControlBlock, kdef, freeKdef);
 	return true;

--- a/main/parse.h
+++ b/main/parse.h
@@ -201,6 +201,7 @@ extern void printLanguageParameters (const langType language,
 extern void printLanguageSubparsers (const langType language,
 									 bool withListHeader, bool machinable, FILE *fp);
 extern void printLangdefFlags (bool withListHeader, bool machinable, FILE *fp);
+extern void printKinddefFlags (bool withListHeader, bool machinable, FILE *fp);
 extern bool doesParserRequireMemoryStream (const langType language);
 extern bool parseFile (const char *const fileName);
 extern bool parseFileWithMio (const char *const fileName, MIO *mio);

--- a/main/parse.h
+++ b/main/parse.h
@@ -150,6 +150,8 @@ extern kindDefinition* getLanguageKind(const langType language, int kindIndex);
 extern kindDefinition* getLanguageKindForLetter (const langType language, char kindLetter);
 extern kindDefinition* getLanguageKindForName (const langType language, const char *kindName);
 extern roleDefinition* getLanguageRole(const langType language, int kindIndex, int roleIndex);
+extern roleDefinition* getLanguageRoleForName (const langType language, int kindIndex,
+											   const char *roleName);
 extern int defineLanguageKind (const langType language, kindDefinition *def,
 							   freeKindDefFunc freeKindDef);
 extern unsigned int countLanguageKinds (const langType language);

--- a/main/parse.h
+++ b/main/parse.h
@@ -149,6 +149,7 @@ extern const char *getLanguageKindName (const langType language, const int kindI
 extern kindDefinition* getLanguageKind(const langType language, int kindIndex);
 extern kindDefinition* getLanguageKindForLetter (const langType language, char kindLetter);
 extern kindDefinition* getLanguageKindForName (const langType language, const char *kindName);
+extern roleDefinition* getLanguageRole(const langType language, int kindIndex, int roleIndex);
 extern int defineLanguageKind (const langType language, kindDefinition *def,
 							   freeKindDefFunc freeKindDef);
 extern unsigned int countLanguageKinds (const langType language);

--- a/main/types.h
+++ b/main/types.h
@@ -18,6 +18,9 @@ typedef struct sTagEntryInfo tagEntryInfo;
 struct sPtagDesc;
 typedef struct sPtagDesc ptagDesc;
 
+struct sRoleDefinition;
+typedef struct sRoleDefinition roleDefinition;
+
 struct sKindDefinition;
 typedef struct sKindDefinition kindDefinition;
 

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -55,7 +55,8 @@ my $options =
 	     if (! defined $_[0]->{'langdef'});
 	 die "Adding a kind is allowed only to the language specified with --langdef: $1"
 	   unless ($_[0]->{'langdef'} eq $1);
-	 push @{$_[0]->{'kinddefs'}}, { letter => $2, name => $3, desc => $4 };
+	 push @{$_[0]->{'kinddefs'}}, { letter => $2, name => $3, desc => $4,
+					refonly => 0, roles => [] };
        } ],
      [ qr/^--extradef-(.*)=([^,]+),(.+)/, sub {
 	 die "Don't use --extradef-<LANG>=+ option before defining the language"
@@ -70,6 +71,23 @@ my $options =
 	 die "Adding a field is allowed only to the language specified with --langdef: $1"
 	     unless ($_[0]->{'langdef'} eq $1);
 	 push @{$_[0]->{'fielddefs'}}, { name => $2, desc => $3 };
+       } ],
+     [ qr/^--_roledef-(.*)=([a-zA-Z])\.([a-zA-Z][a-zA-Z0-9]*),(.+)/, sub {
+	   die "Don't use --_roledef-<LANG>=+ option before defining the language"
+	     if (! defined $_[0]->{'langdef'});
+	   die "Adding a field is allowed only to the language specified with --langdef: $1"
+	     unless ($_[0]->{'langdef'} eq $1);
+
+	   my $kind_found = 0;
+	   for (@{$_[0]->{'kinddefs'}}) {
+	       if ($_->{'letter'} eq $2) {
+		   my $role = { name => $3, desc => $4, owner => $_ };
+		   push @{$_->{'roles'}}, $role;
+		   $kind_found = 1;
+		   last;
+	       }
+	   }
+	   die "no such kind, \"$2\" where role \"$3\" is attached to" if (! $kind_found);
        } ],
      [ qr/^--languages=-(.*)/, sub {
 	   die "Don't use --languages=- option before defining the language"
@@ -490,6 +508,30 @@ sub emit_patterns {
     emit_list $_[0], "patterns";
 }
 
+sub emit_roledefs {
+    my $opts = shift;
+
+
+    for (@{$opts->{'kinddefs'}}) {
+	next unless @{$_->{'roles'}};
+	my $Kind = capitalize($_->{'name'});
+	print <<EOF;
+	static roleDefinition $opts->{'Clangdef'}${Kind}RoleTable [] = {
+EOF
+	for (@{$_->{'roles'}}) {
+	    print <<EOF;
+		{ true, "$_->{'name'}", "$_->{'desc'}" },
+EOF
+	}
+
+	print <<EOF;
+	};
+EOF
+    }
+    print <<EOF;
+EOF
+}
+
 sub emit_kinddefs {
     my $opts = shift;
 
@@ -500,7 +542,24 @@ sub emit_kinddefs {
 EOF
     for (@{$opts->{'kinddefs'}}) {
       print <<EOF;
-		{ true, \'$_->{'letter'}\', "$_->{'name'}", "$_->{'desc'}" },
+		{
+EOF
+      print <<EOF;
+		  true, \'$_->{'letter'}\', "$_->{'name'}", "$_->{'desc'}",
+EOF
+      if ($_->{'refonly'}) {
+	  print <<EOF;
+		  .referenceOnly = true,
+EOF
+      }
+      my $Kind = capitalize($_->{'name'});
+      if (@{$_->{'roles'}}) {
+	  print <<EOF;
+		  ATTACH_ROLES($opts->{'Clangdef'}${Kind}RoleTable),
+EOF
+      }
+      print <<EOF;
+		},
 EOF
     }
     print <<EOF;
@@ -686,6 +745,7 @@ EOF
     emit_extensions      $opts;
     emit_aliases         $opts;
     emit_patterns        $opts;
+    emit_roledefs        $opts;
     emit_kinddefs        $opts;
     emit_fields          $opts;
     emit_xtags           $opts;

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -50,13 +50,15 @@ my $options =
 	   $_[0]->{'base'} = $5 if defined $5;
 	   $_[0]->{'direction'} = $7 if defined $7;
        } ],
-     [ qr/^--kinddef-(.*)=([^,]),([^,]+),(.*)/, sub {
+     [ qr/^--kinddef-(.*)=([^,]),([^,]+),([^\{]+)({_refonly})?/, sub {
 	 die "Don't use --kinddef-<LANG>=+ option before defining the language"
 	     if (! defined $_[0]->{'langdef'});
 	 die "Adding a kind is allowed only to the language specified with --langdef: $1"
 	   unless ($_[0]->{'langdef'} eq $1);
+	 my $refonly = 0;
+	 $refonly = 1 if defined $5;
 	 push @{$_[0]->{'kinddefs'}}, { letter => $2, name => $3, desc => $4,
-					refonly => 0, roles => [] };
+					refonly => $refonly, roles => [] };
        } ],
      [ qr/^--extradef-(.*)=([^,]+),(.+)/, sub {
 	 die "Don't use --extradef-<LANG>=+ option before defining the language"

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -713,14 +713,19 @@ EOF
 #
 ########################################################################
 
-sub rearrange {
-    my ($opts) = @_;
-    my $langdef = $opts -> {'langdef'};
-    my $c = substr ($langdef, 0, 1);
+sub capitalize {
+    my ($str) = $_[0];
+    my $c = substr ($str, 0, 1);
 
     $c =~ tr/a-z/A-Z/;
 
-    $opts -> {'Clangdef'} = $c . substr ($langdef, 1);
+    return $c . substr($str, 1);
+}
+
+sub rearrange {
+    my ($opts) = @_;
+    my $langdef = $opts -> {'langdef'};
+    $opts -> {'Clangdef'} = capitalize ($langdef);
 }
 
 

--- a/optlib/RSpec.c
+++ b/optlib/RSpec.c
@@ -26,8 +26,12 @@ extern parserDefinition* RSpecParser (void)
 	};
 
 	static kindDefinition RSpecKindTable [] = {
-		{ true, 'd', "describe", "describes" },
-		{ true, 'c', "context", "contexts" },
+		{
+		  true, 'd', "describe", "describes",
+		},
+		{
+		  true, 'c', "context", "contexts",
+		},
 	};
 	static tagRegexTable RSpecTagRegexTable [] = {
 		{"^[ \t]*RSpec\\.describe[ \t]+([^\"']+)[ \t]+do", "\\1",

--- a/optlib/ctags-optlib.c
+++ b/optlib/ctags-optlib.c
@@ -26,8 +26,12 @@ extern parserDefinition* CtagsParser (void)
 	};
 
 	static kindDefinition CtagsKindTable [] = {
-		{ true, 'l', "langdef", "language definitions" },
-		{ true, 'k', "kind", "kind definitions" },
+		{
+		  true, 'l', "langdef", "language definitions",
+		},
+		{
+		  true, 'k', "kind", "kind definitions",
+		},
 	};
 	static tagRegexTable CtagsTagRegexTable [] = {
 		{"^--langdef=([^ \t]+)$", "\\1",

--- a/optlib/elm.c
+++ b/optlib/elm.c
@@ -25,24 +25,42 @@ extern parserDefinition* ElmParser (void)
 		NULL
 	};
 
+	static roleDefinition ElmModuleRoleTable [] = {
+		{ true, "imported", "imported module" },
+	};
 	static kindDefinition ElmKindTable [] = {
-		{ true, 'm', "module", "Module" },
-		{ true, 'n', "namespace", "Renamed Imported Module" },
-		{ true, 'p', "port", "Port" },
-		{ true, 't', "type", "Type Definition" },
-		{ true, 'c', "constructor", "Type Constructor" },
-		{ true, 'a', "alias", "Type Alias" },
-		{ true, 'f', "function", "Functions" },
+		{
+		  true, 'm', "module", "Module",
+		  ATTACH_ROLES(ElmModuleRoleTable),
+		},
+		{
+		  true, 'n', "namespace", "Renamed Imported Module",
+		},
+		{
+		  true, 'p', "port", "Port",
+		},
+		{
+		  true, 't', "type", "Type Definition",
+		},
+		{
+		  true, 'c', "constructor", "Type Constructor",
+		},
+		{
+		  true, 'a', "alias", "Type Alias",
+		},
+		{
+		  true, 'f', "function", "Functions",
+		},
 	};
 	static tagRegexTable ElmTagRegexTable [] = {
 		{"^(port[[:blank:]]+)?module[[:blank:]]+([[:upper:]][[:alnum:]_.]*)", "\\2",
 		"m", "{scope=push}{exclusive}", NULL, false},
 		{"^import[[:blank:]]+[[:alnum:]_.]+[[:blank:]]+as[[:blank:]]+([[:alnum:]]+)", "\\1",
 		"n", "{scope=clear}{exclusive}", NULL, false},
-		{"^import[[:blank:]]+([[:alnum:]_.]+)[[:blank:]]exposing", "",
-		"", "{scope=clear}{exclusive}", NULL, false},
-		{"^import[[:blank:]]+([[:alnum:]_.]+)", "",
-		"", "{scope=clear}{exclusive}", NULL, false},
+		{"^import[[:blank:]]+([[:alnum:]_.]+)[[:blank:]]exposing", "\\1",
+		"m", "{scope=clear}{exclusive}{_role=imported}", NULL, false},
+		{"^import[[:blank:]]+([[:alnum:]_.]+)", "\\1",
+		"m", "{scope=clear}{exclusive}{_role=imported}", NULL, false},
 		{"^port[[:blank:]]+([[:lower:]][[:alnum:]_]*).*", "\\1",
 		"p", "{scope=clear}{exclusive}", NULL, false},
 		{"^type +([[:upper:]][[:alnum:]_]*.*)", "\\1",

--- a/optlib/elm.ctags
+++ b/optlib/elm.ctags
@@ -27,6 +27,7 @@
 --kinddef-elm=c,constructor,Type Constructor
 --kinddef-elm=a,alias,Type Alias
 --kinddef-elm=f,function,Functions
+--_roledef-elm=m.imported,imported module
 
 --regex-elm=/^(port[[:blank:]]+)?module[[:blank:]]+([[:upper:]][[:alnum:]_.]*)/\2/m/{scope=push}{exclusive}
 --regex-elm=/^import[[:blank:]]+[[:alnum:]_.]+[[:blank:]]+as[[:blank:]]+([[:alnum:]]+)/\1/n/{scope=clear}{exclusive}
@@ -34,8 +35,8 @@
 # Following two patterns are just for clearing scope stack.
 # X in "import X" should be captured as a reference tag in the future.
 #
---regex-elm=/^import[[:blank:]]+([[:alnum:]_.]+)[[:blank:]]exposing///{scope=clear}{exclusive}
---regex-elm=/^import[[:blank:]]+([[:alnum:]_.]+)///{scope=clear}{exclusive}
+--regex-elm=/^import[[:blank:]]+([[:alnum:]_.]+)[[:blank:]]exposing/\1/m/{scope=clear}{exclusive}{_role=imported}
+--regex-elm=/^import[[:blank:]]+([[:alnum:]_.]+)/\1/m/{scope=clear}{exclusive}{_role=imported}
 --regex-elm=/^port[[:blank:]]+([[:lower:]][[:alnum:]_]*).*/\1/p/{scope=clear}{exclusive}
 --regex-elm=/^type +([[:upper:]][[:alnum:]_]*.*)/\1/t/{scope=set}{exclusive}
 --regex-elm=/^[[:blank:]]+[|=][[:blank:]]+([[:upper:]][[:alnum:]_]*.*)$/\1/c/{scope=ref}{exclusive}

--- a/optlib/gdbinit.c
+++ b/optlib/gdbinit.c
@@ -35,10 +35,18 @@ extern parserDefinition* GdbinitParser (void)
 	};
 
 	static kindDefinition GdbinitKindTable [] = {
-		{ true, 'd', "definition", "definitions" },
-		{ true, 'D', "document", "documents" },
-		{ true, 't', "toplevelVariable", "toplevel variables" },
-		{ true, 'l', "localVariable", "local variables" },
+		{
+		  true, 'd', "definition", "definitions",
+		},
+		{
+		  true, 'D', "document", "documents",
+		},
+		{
+		  true, 't', "toplevelVariable", "toplevel variables",
+		},
+		{
+		  true, 'l', "localVariable", "local variables",
+		},
 	};
 	static tagRegexTable GdbinitTagRegexTable [] = {
 		{"^#.*", "",

--- a/optlib/man.c
+++ b/optlib/man.c
@@ -34,8 +34,12 @@ extern parserDefinition* ManParser (void)
 	};
 
 	static kindDefinition ManKindTable [] = {
-		{ true, 't', "title", "titles" },
-		{ true, 's', "section", "sections" },
+		{
+		  true, 't', "title", "titles",
+		},
+		{
+		  true, 's', "section", "sections",
+		},
 	};
 	static tagRegexTable ManTagRegexTable [] = {
 		{"^\\.TH[[:space:]]{1,}\"([^\"]{1,})\".*", "\\1",

--- a/optlib/pod.c
+++ b/optlib/pod.c
@@ -26,10 +26,18 @@ extern parserDefinition* PodParser (void)
 	};
 
 	static kindDefinition PodKindTable [] = {
-		{ true, 'c', "chapter", "chapters" },
-		{ true, 's', "section", "sections" },
-		{ true, 'S', "subsection", "subsections" },
-		{ true, 't', "subsubsection", "subsubsections" },
+		{
+		  true, 'c', "chapter", "chapters",
+		},
+		{
+		  true, 's', "section", "sections",
+		},
+		{
+		  true, 'S', "subsection", "subsections",
+		},
+		{
+		  true, 't', "subsubsection", "subsubsections",
+		},
 	};
 	static tagRegexTable PodTagRegexTable [] = {
 		{"^=head1[ \t]+(.+)", "\\1",

--- a/optlib/puppetManifest.c
+++ b/optlib/puppetManifest.c
@@ -593,11 +593,21 @@ extern parserDefinition* PuppetManifestParser (void)
 	};
 
 	static kindDefinition PuppetManifestKindTable [] = {
-		{ true, 'c', "class", "classes" },
-		{ true, 'd', "definition", "definitions" },
-		{ true, 'n', "node", "nodes" },
-		{ true, 'r', "resource", "resources" },
-		{ true, 'v', "variable", "variables" },
+		{
+		  true, 'c', "class", "classes",
+		},
+		{
+		  true, 'd', "definition", "definitions",
+		},
+		{
+		  true, 'n', "node", "nodes",
+		},
+		{
+		  true, 'r', "resource", "resources",
+		},
+		{
+		  true, 'v', "variable", "variables",
+		},
 	};
 
 	parserDefinition* const def = parserNew ("puppetManifest");

--- a/optlib/qemuhx.c
+++ b/optlib/qemuhx.c
@@ -26,8 +26,12 @@ extern parserDefinition* QemuHXParser (void)
 	};
 
 	static kindDefinition QemuHXKindTable [] = {
-		{ true, 'q', "qmp", "QEMU Management Protocol dispatch table entries" },
-		{ true, 'i', "infoitem", "item in texinfo doc" },
+		{
+		  true, 'q', "qmp", "QEMU Management Protocol dispatch table entries",
+		},
+		{
+		  true, 'i', "infoitem", "item in texinfo doc",
+		},
 	};
 	static xtagDefinition QemuHXXtagTable [] = {
 		{

--- a/parsers/ant.c
+++ b/parsers/ant.c
@@ -56,7 +56,7 @@ typedef enum {
 	R_IMPORT_GENERIC,
 } antAntfileRole;
 
-static roleDesc AntAntfileRoles [] = {
+static roleDefinition AntAntfileRoles [] = {
         { true, "imported", "imported" },
 };
 

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -69,7 +69,7 @@ typedef struct {
 */
 static langType Lang_asm;
 
-static roleDesc asmSectionRoles [] = {
+static roleDefinition asmSectionRoles [] = {
 	{ true, "placement", "placement where the assembled code goes" },
 };
 

--- a/parsers/automake.c
+++ b/parsers/automake.c
@@ -45,7 +45,7 @@ typedef enum {
 	R_AM_DIR_DATA,
 } makeAMDirectoryRole;
 
-static roleDesc AutomakeDirectoryRoles [] = {
+static roleDefinition AutomakeDirectoryRoles [] = {
 	{ true, "program",   "directory for PROGRAMS primary" },
 	{ true, "man",       "directory for MANS primary" },
 	{ true, "ltlibrary", "directory for LTLIBRARIES primary"},
@@ -58,7 +58,7 @@ typedef enum {
 	R_AM_CONDITION_BRANCHED,
 } makeAMConditionRole;
 
-static roleDesc AutomakeConditionRoles [] = {
+static roleDefinition AutomakeConditionRoles [] = {
 	{ true, "branched",  "used for branching" },
 };
 

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -311,7 +311,7 @@ typedef enum {
 	CR_MACRO_UNDEF,
 } cMacroRole;
 
-static roleDesc CMacroRoles [] = {
+static roleDefinition CMacroRoles [] = {
 	RoleTemplateUndef,
 };
 
@@ -320,7 +320,7 @@ typedef enum {
 	CR_HEADER_LOCAL,
 } cHeaderRole;
 
-static roleDesc CHeaderRoles [] = {
+static roleDefinition CHeaderRoles [] = {
 	RoleTemplateSystem,
 	RoleTemplateLocal,
 };
@@ -412,7 +412,7 @@ typedef enum {
 	JAVAR_PACKAGE_IMPORTED,
 } javaPackageRole;
 
-static roleDesc JavaPackageRoles [] = {
+static roleDefinition JavaPackageRoles [] = {
 	{ true, "imported", "imported package"},
 };
 
@@ -440,7 +440,7 @@ typedef enum {
 	VR_MACRO_UNDEF,
 } veraMacroRole;
 
-static roleDesc VeraMacroRoles [] = {
+static roleDefinition VeraMacroRoles [] = {
 	RoleTemplateUndef,
 };
 
@@ -450,7 +450,7 @@ typedef enum {
 	VR_HEADER_LOCAL,
 } veraHeaderRole;
 
-static roleDesc VeraHeaderRoles [] = {
+static roleDefinition VeraHeaderRoles [] = {
 	RoleTemplateSystem,
 	RoleTemplateLocal,
 };

--- a/parsers/cobol.c
+++ b/parsers/cobol.c
@@ -28,7 +28,7 @@ typedef enum {
 	COBOL_SOURCEFILE_COPIED,
 } cobolSourcefileRole;
 
-static roleDesc CobolSourcefileRoles [] = {
+static roleDefinition CobolSourcefileRoles [] = {
 	{ true, "copied", "copied in source file" },
 };
 

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -105,7 +105,7 @@ typedef enum {
 	CPREPRO_MACRO_KIND_UNDEF_ROLE,
 } cPreProMacroRole;
 
-static roleDesc CPREPROMacroRoles [] = {
+static roleDefinition CPREPROMacroRoles [] = {
 	RoleTemplateUndef,
 };
 
@@ -115,7 +115,7 @@ typedef enum {
 	CPREPRO_HEADER_KIND_LOCAL_ROLE,
 } cPreProHeaderRole;
 
-static roleDesc CPREPROHeaderRoles [] = {
+static roleDefinition CPREPROHeaderRoles [] = {
 	RoleTemplateSystem,
 	RoleTemplateLocal,
 };

--- a/parsers/ctags-aspell.c
+++ b/parsers/ctags-aspell.c
@@ -47,7 +47,7 @@ typedef enum {
 	R_WORD_TRACED
 } AspellWordRole;
 
-static roleDesc AspellWordRoles [] = {
+static roleDefinition AspellWordRoles [] = {
 	{ true,       "misspelled", "misspelled" },
 	{ DEBUG_WORD, "traced", "traced by this parser (enabling/disabling in build-time)" },
 };

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -19,7 +19,7 @@
 #include "xtag.h"
 
 #define CXX_COMMON_MACRO_ROLES(__langPrefix) \
-	static roleDesc __langPrefix##MacroRoles [] = { \
+	static roleDefinition __langPrefix##MacroRoles [] = { \
 		RoleTemplateUndef, \
 	}
 
@@ -28,7 +28,7 @@ CXX_COMMON_MACRO_ROLES(CXX);
 CXX_COMMON_MACRO_ROLES(CUDA);
 
 #define CXX_COMMON_HEADER_ROLES(__langPrefix) \
-	static roleDesc __langPrefix##HeaderRoles [] = { \
+	static roleDefinition __langPrefix##HeaderRoles [] = { \
 		RoleTemplateSystem, \
 		RoleTemplateLocal, \
 	}

--- a/parsers/dtd.c
+++ b/parsers/dtd.c
@@ -34,7 +34,7 @@ typedef enum {
 	DTD_PARAMETER_ENTITY_PART_OF_ATT_DEF,
 } dtdEntityRole;
 
-static roleDesc DtdEntityRoles [] = {
+static roleDefinition DtdEntityRoles [] = {
 	{ true, "elementName", "element names" },
 	{ true, "condition",    "conditions" },
 	{ true, "partOfAttDef", "part of attribute definition" },
@@ -44,7 +44,7 @@ typedef enum {
 	DTD_ELEMENT_ATT_OWNER,
 } dtdElementRole;
 
-static roleDesc DtdElementRoles [] = {
+static roleDefinition DtdElementRoles [] = {
 	{ true, "attOwner", "attributes owner" },
 };
 

--- a/parsers/glade.c
+++ b/parsers/glade.c
@@ -25,11 +25,11 @@ typedef enum {
 	R_HANDLER_HANDLER,
 } gladeHandleRoler;
 
-static roleDesc GladeClassRoles [] = {
+static roleDefinition GladeClassRoles [] = {
 	{ true, "widget", "specified as a widget constructor" },
 };
 
-static roleDesc GladeHandlerRoles [] = {
+static roleDefinition GladeHandlerRoles [] = {
 	{ true, "handler", "specified as a callback for signal emission" },
 };
 

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -101,7 +101,7 @@ typedef enum {
 	R_GOTAG_UNKNOWN_RECEIVER,
 } GoUnknownRole;
 
-static roleDesc GoUnknownRoles [] = {
+static roleDefinition GoUnknownRoles [] = {
 	{ true, "receiverType", "receiver type" },
 };
 

--- a/parsers/ldscript.c
+++ b/parsers/ldscript.c
@@ -28,7 +28,7 @@ typedef enum {
 	LD_SCRIPT_SYMBOL_ENTRYPOINT,
 } ldScriptSymbolRole;
 
-static roleDesc LdScriptSymbolRoles [] = {
+static roleDefinition LdScriptSymbolRoles [] = {
 	{ true, "entrypoint", "entry points" },
 };
 
@@ -37,7 +37,7 @@ typedef enum {
 	LD_SCRIPT_INPUT_SECTION_DISCARDED,
 } ldScriptInputSectionRole;
 
-static roleDesc LdScriptInputSectionRoles [] = {
+static roleDefinition LdScriptInputSectionRoles [] = {
 	{ true, "mapped",  "mapped to output section" },
 	{ true, "discarded", "discarded when linking" },
 };

--- a/parsers/m4.c
+++ b/parsers/m4.c
@@ -38,11 +38,11 @@ enum M4MacrofileRole {
 };
 
 
-static roleDesc M4MacroRoles [] = {
+static roleDefinition M4MacroRoles [] = {
 	{ true, "undef", "undefined" },
 };
 
-static roleDesc M4MacrofileRoles [] = {
+static roleDefinition M4MacrofileRoles [] = {
 	{ true, "included", "included macro" },
 	{ true, "sincluded", "silently included macro" },
 };

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -38,7 +38,7 @@ typedef enum {
 	R_INCLUDE_OPTIONAL,
 } makeMakefileRole;
 
-static roleDesc MakeMakefileRoles [] = {
+static roleDefinition MakeMakefileRoles [] = {
 	{ true, "included", "included" },
 	{ true, "optional", "optionally included"},
 };

--- a/parsers/maven2.c
+++ b/parsers/maven2.c
@@ -41,12 +41,12 @@ typedef enum {
 	R_ARTIFACT_ID_DEPENDENCY,
 } maven2ArtifactIdRole;
 
-static roleDesc Maven2GroupIdRoles [] = {
+static roleDefinition Maven2GroupIdRoles [] = {
 	{ true, "parent", "parent" },
 	{ true, "dependency", "dependency" },
 };
 
-static roleDesc Maven2ArtifactIdRoles [] = {
+static roleDefinition Maven2ArtifactIdRoles [] = {
 	{ true, "parent", "parent" },
 	{ true, "dependency", "dependency" },
 };

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -113,7 +113,7 @@ typedef enum {
  *                       Y = (kind:unknown, role:indirectly-imported, [scope:X])
  *                       Z = (kind:unknown, [nameref:X.Y]) */
 
-static roleDesc PythonModuleRoles [] = {
+static roleDefinition PythonModuleRoles [] = {
 	{ true, "imported",
 	  "imported modules" },
 	{ true, "namespace",
@@ -122,7 +122,7 @@ static roleDesc PythonModuleRoles [] = {
 	  "module imported in alternative name" },
 };
 
-static roleDesc PythonUnknownRoles [] = {
+static roleDefinition PythonUnknownRoles [] = {
 	{ true, "imported",   "imported from the other module" },
 	{ true, "indirectly-imported",
 	  "classes/variables/functions/modules imported in alternative name" },

--- a/parsers/rpmspec.c
+++ b/parsers/rpmspec.c
@@ -42,7 +42,7 @@ enum rpmSpecMacroRole {
 };
 typedef int rpmSpecMacroRole; /* to allow ROLE_INDEX_* */
 
-static roleDesc RpmSpecMacroRoles [] = {
+static roleDefinition RpmSpecMacroRoles [] = {
 	{ true, "undef", "undefined" },
 };
 

--- a/parsers/sh.c
+++ b/parsers/sh.c
@@ -39,7 +39,7 @@ typedef enum {
 	R_SCRIPT_LOADED,
 } shScriptRole;
 
-static roleDesc ShScriptRoles [] = {
+static roleDefinition ShScriptRoles [] = {
 	{ true, "loaded", "loaded" },
 };
 
@@ -47,7 +47,7 @@ typedef enum {
 	R_HEREDOC_ENDMARKER,
 } shHeredocRole;
 
-static roleDesc ShHeredocRoles [] = {
+static roleDefinition ShHeredocRoles [] = {
 	{ true, "endmarker", "end marker" },
 };
 

--- a/parsers/systemdunit.c
+++ b/parsers/systemdunit.c
@@ -46,7 +46,7 @@ typedef enum {
 
 } systemdUnitRole;
 
-static roleDesc SystemdUnitUnitRoles [] = {
+static roleDefinition SystemdUnitUnitRoles [] = {
 	{ true, "Requires", "referred in Requires key" },
 	{ true, "Wants", "referred in Wants key" },
 	{ true, "After", "referred in After key" },

--- a/parsers/xslt.c
+++ b/parsers/xslt.c
@@ -35,7 +35,7 @@ typedef enum {
 	R_STYLESHEET_IMPORTED,
 	R_STYLESHEET_INCLUDED,
 } xsltStylesheetRole;
-static roleDesc XsltStylesheetRoles [] = {
+static roleDefinition XsltStylesheetRoles [] = {
 	{ true, "imported", "imported" },
 	{ true, "included", "included" },
 };
@@ -43,21 +43,21 @@ static roleDesc XsltStylesheetRoles [] = {
 typedef enum {
 	R_PARAMETER_BOUND,
 } xsltParameterRole;
-static roleDesc XsltParameterRoles [] = {
+static roleDefinition XsltParameterRoles [] = {
 	{ true, "bound", "bound to value" },
 };
 
 typedef enum {
 	R_MATCHED_TEMPLATE_APPLIED,
 } xsltMatchedTemplateRole;
-static roleDesc XsltMatchedTemplateRoles [] = {
+static roleDefinition XsltMatchedTemplateRoles [] = {
 	{ true, "applied", "applied" },
 };
 
 typedef enum {
 	R_NAMED_TEMPLATE_CALLED,
 } xsltNamedTemplateRole;
-static roleDesc XsltNamedTemplateRoles [] = {
+static roleDefinition XsltNamedTemplateRoles [] = {
 	{ true, "called", "called" },
 };
 

--- a/parsers/yaml.c
+++ b/parsers/yaml.c
@@ -88,7 +88,7 @@ enum YamlAnchorRole {
 	R_ANCHOR_ALIAS,
 };
 
-static roleDesc YamlAnchorRoles [] = {
+static roleDefinition YamlAnchorRoles [] = {
 	{ true, "alias", "alias" },
 };
 


### PR DESCRIPTION
This change set introduces three things:

* --_roledef-<LANG>=<kindletter>.<rolename>,<roleDescription> option,
* _role flag for --regex-<LANG> option, and
* _refonly flag for --kinddef-<LANG> option

They allow to a user to define a role and capture reference tags.
The web document is written in progress. 
The usage is illustrated in "Units: add a case for testing the combination of --_roledef-<LANG> op…".

With this change set, we can improve elm parser (See #1260).
We can also improve puppet parser as I wrote in https://github.com/rodjek/vim-puppet/pull/84#issuecomment-370303183 .

I will not explain them in the man page till releasing 6.0.