### PR TITLE
[SELF INCOMPATIBLE]: mark --extradef option "experimental" by renaming it to --_extradef

### DIFF
--- a/Tmain/broken-extradef.d/run.sh
+++ b/Tmain/broken-extradef.d/run.sh
@@ -16,55 +16,55 @@ title()
 
 {
 title '# echo unknown lang'
-${CTAGS} --extradef-NOSUCHLANG
-${CTAGS} --extradef-NOSUCHLANG=extra,desc
+${CTAGS} --_extradef-NOSUCHLANG
+${CTAGS} --_extradef-NOSUCHLANG=extra,desc
 
 title '# no option value'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=
 
 title '# wrong char in a field name'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:abc
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:abc,
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=:abc,description
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=:
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=:abc
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=:abc,
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=:abc,description
 
 title '# empty extra name'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,abc
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,abc,
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=,abc,description
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=,
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=,abc
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=,abc,
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=,abc,description
 
 title '# empty description'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=abc
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=abc,
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=abc
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=abc,
 
 title '# no input file'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY=abc,desc
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY=abc,desc
 
 title '# inject a flag separator'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{foo}' --list-extras=IMAGINARY
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY='extra,desc{foo}' --list-extras=IMAGINARY
 
 title '# inject a broken flag separator(1)'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{foo' --list-extras=IMAGINARY
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY='extra,desc{foo' --list-extras=IMAGINARY
 
 title '# inject a broken flag separator(2)'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc{' --list-extras=IMAGINARY
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY='extra,desc{' --list-extras=IMAGINARY
 
 title '# use a { in description (1)'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\{' --list-extras=IMAGINARY
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY='extra,desc\{' --list-extras=IMAGINARY
 
 title '# use a { in description (2)'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\{}' --list-extras=IMAGINARY
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY='extra,desc\{}' --list-extras=IMAGINARY
 
 title '# use a \ in description'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,desc\\backslash' --list-extras=IMAGINARY
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY='extra,desc\\backslash' --list-extras=IMAGINARY
 
 title '# description started from {'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,{' --list-extras=IMAGINARY
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY='extra,{' --list-extras=IMAGINARY
 
 title '# description started from \{'
-${CTAGS} --langdef=IMAGINARY --extradef-IMAGINARY='extra,\{' --list-extras=IMAGINARY
+${CTAGS} --langdef=IMAGINARY --_extradef-IMAGINARY='extra,\{' --list-extras=IMAGINARY
 
 } > /tmp/ctags-tmain-$$.stdout 2>/tmp/ctags-tmain-$$.stderr
 

--- a/Tmain/broken-extradef.d/stderr-expected.txt
+++ b/Tmain/broken-extradef.d/stderr-expected.txt
@@ -1,27 +1,27 @@
 
 # echo unknown lang
-ctags: Unknown language "NOSUCHLANG" in "extradef-NOSUCHLANG" option
-ctags: Unknown language "NOSUCHLANG" in "extradef-NOSUCHLANG" option
+ctags: Unknown language "NOSUCHLANG" in "_extradef-NOSUCHLANG" option
+ctags: Unknown language "NOSUCHLANG" in "_extradef-NOSUCHLANG" option
 
 # no option value
-ctags: no extra definition specified in "--extradef-IMAGINARY" option
-ctags: no extra definition specified in "--extradef-IMAGINARY" option
+ctags: no extra definition specified in "--_extradef-IMAGINARY" option
+ctags: no extra definition specified in "--_extradef-IMAGINARY" option
 
 # wrong char in a field name
-ctags: no extra description specified in "--extradef-IMAGINARY" option
-ctags: no extra description specified in "--extradef-IMAGINARY" option
-ctags: unacceptable char as part of extra name in "--extradef-IMAGINARY" option
-ctags: unacceptable char as part of extra name in "--extradef-IMAGINARY" option
+ctags: no extra description specified in "--_extradef-IMAGINARY" option
+ctags: no extra description specified in "--_extradef-IMAGINARY" option
+ctags: unacceptable char as part of extra name in "--_extradef-IMAGINARY" option
+ctags: unacceptable char as part of extra name in "--_extradef-IMAGINARY" option
 
 # empty extra name
-ctags: the extra name in "--extradef-IMAGINARY" option is empty
-ctags: the extra name in "--extradef-IMAGINARY" option is empty
-ctags: the extra name in "--extradef-IMAGINARY" option is empty
-ctags: the extra name in "--extradef-IMAGINARY" option is empty
+ctags: the extra name in "--_extradef-IMAGINARY" option is empty
+ctags: the extra name in "--_extradef-IMAGINARY" option is empty
+ctags: the extra name in "--_extradef-IMAGINARY" option is empty
+ctags: the extra name in "--_extradef-IMAGINARY" option is empty
 
 # empty description
-ctags: no extra description specified in "--extradef-IMAGINARY" option
-ctags: extra description in "--extradef-IMAGINARY" option is empty
+ctags: no extra description specified in "--_extradef-IMAGINARY" option
+ctags: extra description in "--_extradef-IMAGINARY" option is empty
 
 # no input file
 ctags: No files specified. Try "ctags --help".
@@ -41,6 +41,6 @@ ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 # use a \ in description
 
 # description started from {
-ctags: extra description in "--extradef-IMAGINARY" option is empty
+ctags: extra description in "--_extradef-IMAGINARY" option is empty
 
 # description started from \{

--- a/Units/option-extradef.d/args.ctags
+++ b/Units/option-extradef.d/args.ctags
@@ -1,4 +1,4 @@
---extradef-Python=main,__main__ entry points
+--_extradef-Python=main,__main__ entry points
 --extras-Python=+{main}
 --regex-Python=/^if __name__ == '__main__':/__main__/f/{_extra=main}
 --fields=+E

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -704,7 +704,7 @@ We can say now "kind" is a first class object in Universal-ctags.
 Defining an extra
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A new ``--extradef-<LANG>=name,description`` option allows you to
+A new ``--_extradef-<LANG>=name,description`` option allows you to
 defining a parser own extra which turning on and off can be
 referred from a regex based parser for ``<LANG>``.
 

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -784,7 +784,7 @@ Conditional tagging with extras
 
 If a pattern matching should be done only when an extra is enabled,
 mark a pattern with ``{_extra=XNAME}``. Here ``XNAME`` is the name of
-extra. You must define ``XNAME`` with ``--extradef-<LANG>=XNAME,DESCRIPTION`` option
+extra. You must define ``XNAME`` with ``--_extradef-<LANG>=XNAME,DESCRIPTION`` option
 before defining a pattern marked ``{_extra=XNAME}``.
 
 .. code-block:: python
@@ -796,7 +796,7 @@ To capture above lines in a python program(*input.py*), an extra can be used.
 
 .. code-block:: ctags
 
-	--extradef-Python=main,__main__ entry points
+	--_extradef-Python=main,__main__ entry points
 	--regex-Python=/^if __name__ == '__main__':/__main__/f/{_extra=main}
 
 The above optlib(*python-main.ctags*) introduces ``main`` extra to Python parser.

--- a/main/options.c
+++ b/main/options.c
@@ -243,8 +243,6 @@ static optionDescription LongOptionDescription [] = {
 #else
  {0,"       Uses the specified type of EX command to locate tags [mix]."},
 #endif
- {1,"  --extradef-<LANG>=name,desc"},
- {1,"       Define new extra for <LANG>. \"--extra-<LANG>=+{name}\" enables it."},
  {1,"  --extras=[+|-]flags"},
  {1,"      Include extra tag entries for selected information (flags: \"Ffq.\") [F]."},
  {1,"  --extras-<LANG|*>=[+|-]flags"},
@@ -430,6 +428,8 @@ static optionDescription LongOptionDescription [] = {
  {1,"  --_echo=msg"},
  {1,"       Echo MSG to standard error. Useful to debug the chain"},
  {1,"       of loading option files."},
+ {1,"  --_extradef-<LANG>=name,desc"},
+ {1,"       Define new extra for <LANG>. \"--extra-<LANG>=+{name}\" enables it."},
  {1,"  --_fatal-warnings"},
  {1,"       Make all warnings fatal."},
  {1,"  --_fielddef-<LANG>=name,description"},

--- a/main/parse.c
+++ b/main/parse.c
@@ -2908,7 +2908,7 @@ extern bool processExtradefOption (const char *const option, const char *const p
 {
 	langType language;
 
-	language = getLanguageComponentInOption (option, "extradef-");
+	language = getLanguageComponentInOption (option, "_" "extradef-");
 	if (language == LANG_IGNORE)
 		return false;
 

--- a/man/ctags-optlib.7.rst.in
+++ b/man/ctags-optlib.7.rst.in
@@ -31,8 +31,6 @@ options are for defining (or customizing) a parser:
 
 * ``--langdef=``
 * ``--kindedef-<LANG>=``
-* ``--fielddef-<LANG>=``
-* ``--extradef-<LANG>=``
 * ``--map-<LANG>=``
 * ``--regex-<LANG>=``
 
@@ -140,12 +138,6 @@ This is the definition (pod.ctags) used in ctags for parsing pod
 
 OPTION ITEMS
 ------------
-
-``--extradef-<LANG>=...``
-	TBW
-
-``--fielddef-<LANG>=...``
-	TBW
 
 ``--langdef=name``
 	Defines a new user-defined language, *name*, to be parsed with regular

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -60,8 +60,8 @@ my $options =
 	 push @{$_[0]->{'kinddefs'}}, { letter => $2, name => $3, desc => $4,
 					refonly => $refonly, roles => [] };
        } ],
-     [ qr/^--extradef-(.*)=([^,]+),(.+)/, sub {
-	 die "Don't use --extradef-<LANG>=+ option before defining the language"
+     [ qr/^--_extradef-(.*)=([^,]+),(.+)/, sub {
+	 die "Don't use --_extradef-<LANG>=+ option before defining the language"
 	     if (! defined $_[0]->{'langdef'});
 	 die "Adding an extra is allowed only to the language specified with --langdef: $1"
 	     unless ($_[0]->{'langdef'} eq $1);

--- a/optlib/qemuhx.ctags
+++ b/optlib/qemuhx.ctags
@@ -26,14 +26,14 @@
 #
 # `.hx' is the suffix for the tool.
 #
-# This optlib is a testbed for --extradef option and `extra' regex long flag.
+# This optlib is a testbed for --_extradef option and `extra' regex long flag.
 #
 
 --langdef=QemuHX
 	--kinddef-QemuHX=q,qmp,QEMU Management Protocol dispatch table entries
 	--kinddef-QemuHX=i,infoitem,item in texinfo doc
 	--map-QemuHX=+.hx
-	--extradef-QemuHX=funcmap,Include mapping SQMP to C function name
+	--_extradef-QemuHX=funcmap,Include mapping SQMP to C function name
 	--extras-QemuHX=+{funcmap}
 	--mline-regex-QemuHX=/^SQMP[[:space:]]([-a-z_0-9A-Z]+)[[:space:]]---/\1/q/{mgroup=1}
 	--mline-regex-QemuHX=/^SQMP[[:space:]]([-a-z_0-9A-Z]+)[[:space:]]---/qmp_\1/q/{mgroup=1}{_extra=funcmap}


### PR DESCRIPTION
I would like to delay writing the documents for this option.