### PR TITLE
QtMoc: fix using wrong struct for defining qtMocSubparser

### DIFF
--- a/parsers/cxx/cxx_qtmoc.c
+++ b/parsers/cxx/cxx_qtmoc.c
@@ -303,18 +303,21 @@ extern parserDefinition* QtMocParser (void)
 {
 	parserDefinition* const def = parserNew("QtMoc");
 
-	static struct sCxxSubparser qtMocSubparser = {
-		.subparser = {
-			.direction = SUBPARSER_BI_DIRECTION,
-			.inputStart = inputStart,
-			.makeTagEntryNotify = makeTagEntryNotify,
-		},
-		.enterBlockNotify = enterBlockNotify,
-		.leaveBlockNotify = leaveBlockNotify,
-		.newIdentifierAsHeadOfMemberNotify = newIdentifierAsHeadOfMemberNotify,
-		.unknownIdentifierInClassNotify = unknownIdentifierInClassNotify,
-		.parseAccessSpecifierNotify = parseAccessSpecifierNotify,
-		.foundExtraIdentifierAsAccessSpecifier = foundExtraIdentifierAsAccessSpecifier,
+	static struct sQtMocSubparser qtMocSubparser = {
+		.cxx = {
+			.subparser = {
+				.direction = SUBPARSER_BI_DIRECTION,
+				.inputStart = inputStart,
+				.makeTagEntryNotify = makeTagEntryNotify,
+			},
+			.enterBlockNotify = enterBlockNotify,
+			.leaveBlockNotify = leaveBlockNotify,
+			.newIdentifierAsHeadOfMemberNotify = newIdentifierAsHeadOfMemberNotify,
+			.unknownIdentifierInClassNotify = unknownIdentifierInClassNotify,
+			.parseAccessSpecifierNotify = parseAccessSpecifierNotify,
+			.foundExtraIdentifierAsAccessSpecifier = foundExtraIdentifierAsAccessSpecifier,
+		}
+		/* The rest fields are initialized in inputStart(). */
 	};
 	static parserDependency dependencies [] = {
 		[0] = { DEPTYPE_SUBPARSER, "C++", &qtMocSubparser },


### PR DESCRIPTION
This bug fixed by this commit appears when running ctags built with -O0 as
CFALGS. The result of Tmain/extra-field.d is different from what
ctags built with -O2 prints.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>