### PR TITLE
Java,JSON,TTCN: use "boolean" instead of "bool"

### DIFF
--- a/parsers/c.c
+++ b/parsers/c.c
@@ -503,7 +503,7 @@ static const keywordDesc KeywordTable [] = {
      { "bit",             KEYWORD_BIT,             { 0, 0, 0, 0, 0, 1 } },
      { "body",            KEYWORD_BODY,            { 0, 0, 0, 1, 0, 0 } },
      { "bool",            KEYWORD_BOOL,            { 0, 0, 0, 1, 0, 0 } },
-     { "bool",         KEYWORD_BOOLEAN,         { 0, 0, 0, 0, 1, 0 } },
+     { "boolean",         KEYWORD_BOOLEAN,         { 0, 0, 0, 0, 1, 0 } },
      { "break",           KEYWORD_BREAK,           { 0, 0, 0, 1, 0, 0 } },
      { "byte",            KEYWORD_BYTE,            { 0, 0, 0, 1, 1, 0 } },
      { "case",            KEYWORD_CASE,            { 1, 1, 1, 1, 1, 0 } },

--- a/parsers/json.c
+++ b/parsers/json.c
@@ -77,7 +77,7 @@ static kindDefinition JsonKinds [] = {
 	{ true,  'a', "array",		"arrays"	},
 	{ true,  'n', "number",		"numbers"	},
 	{ true,  's', "string",		"strings"	},
-	{ true,  'b', "bool",	"booleans"	},
+	{ true,  'b', "boolean",	"booleans"	},
 	{ true,  'z', "null",		"nulls"		}
 };
 

--- a/parsers/ttcn.c
+++ b/parsers/ttcn.c
@@ -122,7 +122,7 @@ static struct s_ttcnKeyword {
 	{T_ANY,         "any",          K_NONE},
 	{T_ANYTYPE,     "anytype",      K_NONE},
 	{T_BITSTRING,   "bitstring",    K_NONE},
-	{T_BOOLEAN,     "bool",      K_NONE},
+	{T_BOOLEAN,     "boolean",      K_NONE},
 	{T_CASE,        "case",         K_NONE},
 	{T_CALL,        "call",         K_NONE},
 	{T_CATCH,       "catch",        K_NONE},


### PR DESCRIPTION
All "boolean" were replaced with "bool" in
the commit "Prefer stdbool.h over mybool.h" (ce990805).

String literals for recognizing "boolean" keywords in Java and TTCN
parsers were also replaced. This should not be done.

About JSON parser, "boolean" was used as a name for a kind.  Changing
back from "bool" to "boolean" is not must. However, "boolean" may be
more popular word than "bool" for JSON users to represent a boolean
object. Actually geany'c json.c chooses "boolean" as the kind name.

(This change is not needed to be ported to geany's ctags.
 geany uses "boolean" correctly in the all places.)

Signed-off-by: Masatake YAMATO <yamato@redhat.com>