### PR TITLE
CXX: Improve parsing of function-try-blocks and try/catch in general

### DIFF
--- a/Units/parser-cxx.r/function_try_block.d/args.ctags
+++ b/Units/parser-cxx.r/function_try_block.d/args.ctags
@@ -1,4 +1,4 @@
---c++-kinds=+pflz
+--kinds-c++=+pflz
 --fields=+SsKe
 --fields-c++=+{captures}+{properties}
 --sort=no

--- a/Units/parser-cxx.r/function_try_block.d/args.ctags
+++ b/Units/parser-cxx.r/function_try_block.d/args.ctags
@@ -1,1 +1,4 @@
+--c++-kinds=+pflz
+--fields=+SsKe
+--fields-c++=+{captures}+{properties}
 --sort=no

--- a/Units/parser-cxx.r/function_try_block.d/expected.tags
+++ b/Units/parser-cxx.r/function_try_block.d/expected.tags
@@ -9,6 +9,6 @@ f2	input.cxx	/^int f2() try {$/;"	function	typeref:typename:int	signature:()	end
 f2v1	input.cxx	/^} catch(SomeKindOfException &f2v1)$/;"	local	function:f2	typeref:typename:SomeKindOfException &	file:
 f2v2	input.cxx	/^} catch(SomeOtherKindOfException &f2v2)$/;"	local	function:f2	typeref:typename:SomeOtherKindOfException &	file:
 f3	input.cxx	/^int f3()$/;"	function	typeref:typename:int	signature:()	end:38
-f2v1	input.cxx	/^		int f2v1 = 10;$/;"	local	function:f3	typeref:typename:int	file:
-f2v2	input.cxx	/^	} catch(std::exception & f2v2)$/;"	local	function:f3	typeref:typename:std::exception &	file:
+f3v1	input.cxx	/^		int f3v1 = 10;$/;"	local	function:f3	typeref:typename:int	file:
+f3v2	input.cxx	/^	} catch(std::exception & f3v2)$/;"	local	function:f3	typeref:typename:std::exception &	file:
 f4	input.cxx	/^auto f4() -> void try {$/;"	function	typeref:typename:void try	signature:()	end:43	properties:fntryblock

--- a/Units/parser-cxx.r/function_try_block.d/expected.tags
+++ b/Units/parser-cxx.r/function_try_block.d/expected.tags
@@ -1,4 +1,14 @@
-S	input.cxx	/^struct S {$/;"	s	file:
-m	input.cxx	/^    std::string m;$/;"	m	struct:S	typeref:typename:std::string	file:
-S	input.cxx	/^    S(const std::string& arg) try : m(arg, 100) {$/;"	f	struct:S	file:
-f	input.cxx	/^int f(int n = 2) try {$/;"	f	typeref:typename:int
+S	input.cxx	/^struct S {$/;"	struct	file:	end:11
+m	input.cxx	/^    std::string m;$/;"	member	struct:S	typeref:typename:std::string	file:
+S	input.cxx	/^    S(const std::string& arg) try : m(arg, 100) {$/;"	function	struct:S	file:	signature:(const std::string & arg)	end:10	properties:fntryblock
+arg	input.cxx	/^    S(const std::string& arg) try : m(arg, 100) {$/;"	parameter	function:S::S	typeref:typename:const std::string &	file:
+e	input.cxx	/^    } catch(const std::exception& e) {$/;"	local	function:S::S	typeref:typename:const std::exception &	file:
+f	input.cxx	/^int f(int n = 2) try {$/;"	function	typeref:typename:int	signature:(int n=2)	end:20	properties:fntryblock
+n	input.cxx	/^int f(int n = 2) try {$/;"	parameter	function:f	typeref:typename:int	file:
+f2	input.cxx	/^int f2() try {$/;"	function	typeref:typename:int	signature:()	end:28	properties:fntryblock
+f2v1	input.cxx	/^} catch(SomeKindOfException &f2v1)$/;"	local	function:f2	typeref:typename:SomeKindOfException &	file:
+f2v2	input.cxx	/^} catch(SomeOtherKindOfException &f2v2)$/;"	local	function:f2	typeref:typename:SomeOtherKindOfException &	file:
+f3	input.cxx	/^int f3()$/;"	function	typeref:typename:int	signature:()	end:38
+f2v1	input.cxx	/^		int f2v1 = 10;$/;"	local	function:f3	typeref:typename:int	file:
+f2v2	input.cxx	/^	} catch(std::exception & f2v2)$/;"	local	function:f3	typeref:typename:std::exception &	file:
+f4	input.cxx	/^auto f4() -> void try {$/;"	function	typeref:typename:void try	signature:()	end:43	properties:fntryblock

--- a/Units/parser-cxx.r/function_try_block.d/input.cxx
+++ b/Units/parser-cxx.r/function_try_block.d/input.cxx
@@ -18,3 +18,26 @@ int f(int n = 2) try {
    assert(n == 4);
    return n;
 }
+
+int f2() try {
+} catch(SomeKindOfException &f2v1)
+{
+} catch(SomeOtherKindOfException &f2v2)
+{
+} catch(...) {
+}
+
+int f3()
+{
+	// This is NOT a function-try-block
+	try {
+		int f2v1 = 10;
+	} catch(std::exception & f2v2)
+	{
+	}
+}
+
+auto f4() -> void try {
+} catch(...)
+{
+}

--- a/Units/parser-cxx.r/function_try_block.d/input.cxx
+++ b/Units/parser-cxx.r/function_try_block.d/input.cxx
@@ -31,8 +31,8 @@ int f3()
 {
 	// This is NOT a function-try-block
 	try {
-		int f2v1 = 10;
-	} catch(std::exception & f2v2)
+		int f3v1 = 10;
+	} catch(std::exception & f3v2)
 	{
 	}
 }

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -404,12 +404,7 @@ bool cxxParserParseToEndOfQualifedName(void)
 	return true;
 }
 
-
-//
-// Attach the current position of input file as "end" field of
-// the specified tag in the cork queue
-//
-void cxxParserMarkEndLineForTagInCorkQueue(int iCorkQueueIndex)
+void cxxParserSetEndLineForTagInCorkQueue(int iCorkQueueIndex,unsigned long lEndLine)
 {
 	CXX_DEBUG_ASSERT(iCorkQueueIndex > CORK_NIL,"The cork queue index is not valid");
 
@@ -417,8 +412,18 @@ void cxxParserMarkEndLineForTagInCorkQueue(int iCorkQueueIndex)
 
 	CXX_DEBUG_ASSERT(tag,"No tag entry in the cork queue");
 
-	tag->extensionFields.endLine = getInputLineNumber();
+	tag->extensionFields.endLine = lEndLine;
 }
+
+//
+// Attach the current position of input file as "end" field of
+// the specified tag in the cork queue
+//
+void cxxParserMarkEndLineForTagInCorkQueue(int iCorkQueueIndex)
+{
+	cxxParserSetEndLineForTagInCorkQueue(iCorkQueueIndex,getInputLineNumber());
+}
+
 
 // Make sure that the token chain contains only the specified keyword and eventually
 // the "const" or "volatile" type modifiers.
@@ -1617,76 +1622,114 @@ bool cxxParserParseAccessSpecifier(void)
 	return true;
 }
 
-bool cxxParserParseIfForWhileSwitch(void)
+bool cxxParserParseIfForWhileSwitchCatchParenthesis(void)
 {
 	CXX_DEBUG_ENTER();
-
+	
+	CXX_DEBUG_ASSERT(
+			cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeKeyword),
+			"This function should be called only after encountering one of the keywords"
+		);
+	
+	CXXKeyword eKeyword = g_cxx.pToken->eKeyword;
+	
 	if(!cxxParserParseUpToOneOf(
 			CXXTokenTypeParenthesisChain | CXXTokenTypeSemicolon |
 				CXXTokenTypeOpeningBracket | CXXTokenTypeEOF,
 			false
 		))
 	{
-		CXX_DEBUG_LEAVE_TEXT("Failed to parse if/for/while/switch up to parenthesis");
+		CXX_DEBUG_LEAVE_TEXT("Failed to parse if/for/while/switch/catch up to parenthesis");
 		return false;
 	}
 
-	if(cxxTokenTypeIsOneOf(g_cxx.pToken,CXXTokenTypeEOF | CXXTokenTypeSemicolon))
+	if(cxxTokenTypeIsOneOf(
+			g_cxx.pToken,
+			CXXTokenTypeEOF | CXXTokenTypeSemicolon | CXXTokenTypeOpeningBracket
+		))
 	{
-		CXX_DEBUG_LEAVE_TEXT("Found EOF/semicolon while parsing if/for/while/switch");
+		CXX_DEBUG_LEAVE_TEXT(
+				"Found EOF/semicolon/opening bracket while parsing if/for/while/switch/catch"
+			);
 		return true;
 	}
 
-	if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeParenthesisChain))
+	CXX_DEBUG_ASSERT(
+			cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeParenthesisChain),
+			"Expected a parenthesis chain here"
+		);
+	
+	CXX_DEBUG_PRINT("Found if/for/while/switch/catch parenthesis chain");
+
+	// Extract variables from the parenthesis chain
+
+	CXXTokenChain * pChain = g_cxx.pToken->pChain;
+
+	CXX_DEBUG_ASSERT(
+			pChain->iCount >= 2,
+			"The parenthesis chain must have initial and final parenthesis"
+		);
+
+	// There are several constructs that can fool the parser here.
+	// The most notable ones are:
+	//     if(a & b)
+	//     if(a * b)
+	//     if(a && b)
+	// Too bad that these constructs are also used to declare variables.
+
+	// catch() always contains variable declarations
+	bool bOkToExtractVariables = eKeyword == CXXKeywordCATCH;
+
+	if(!bOkToExtractVariables)
 	{
-		// Extract variables from the parenthesis chain
-		// We handle only simple cases.
-		CXXTokenChain * pChain = g_cxx.pToken->pChain;
-
-		CXX_DEBUG_ASSERT(
-				pChain->iCount >= 2,
-				"The parenthesis chain must have initial and final parenthesis"
+		// Parenthesis contents start with a keyword. Things like:
+		//   if(const std::exception & e)
+		//   if(int i ...
+		bOkToExtractVariables = cxxTokenTypeIs(
+				cxxTokenChainAt(pChain,1),
+				CXXTokenTypeKeyword
 			);
-
-		// Simple check for cases like if(a & b), if(a * b).
-		// If there is &, && or * then we expect there to be also a = or a ;.
-		if(
-				// & && * not present
-				!cxxTokenChainFirstTokenOfType(
+		
+		if(!bOkToExtractVariables)
+		{
+			// If there is &, && or * then we expect there to be also a = or
+			// a semicolon that comes after it.
+			// This is not 100% foolproof but works most of the times.
+	
+			CXXToken * pAndOrStar = cxxTokenChainFirstTokenOfType(
 						pChain,
 						CXXTokenTypeAnd | CXXTokenTypeMultipleAnds |
 						CXXTokenTypeStar
-					) ||
-				// or [=;] present
-				cxxTokenChainFirstTokenOfType(
-						pChain,
+					);
+			
+			if(!pAndOrStar)
+			{
+				bOkToExtractVariables = true;
+			} else {
+				bOkToExtractVariables = cxxTokenChainNextTokenOfType(
+						pAndOrStar,
 						CXXTokenTypeAssignment | CXXTokenTypeSemicolon
-					)
-			)
-		{
-			// Kill the initial parenthesis
-			cxxTokenChainDestroyFirst(pChain);
-			// Fake the final semicolon
-			CXXToken * t = cxxTokenChainLast(pChain);
-			t->eType = CXXTokenTypeSemicolon;
-			vStringClear(t->pszWord);
-			vStringPut(t->pszWord,';');
-
-			// and extract variable declarations if possible
-			cxxParserExtractVariableDeclarations(pChain,0);
+					);
+			}
 		}
+	}
+	
+	if(bOkToExtractVariables)
+	{
+		// Kill the initial parenthesis
+		cxxTokenChainDestroyFirst(pChain);
+		// Fake the final semicolon
+		CXXToken * t = cxxTokenChainLast(pChain);
+		t->eType = CXXTokenTypeSemicolon;
+		vStringClear(t->pszWord);
+		vStringPut(t->pszWord,';');
 
-		CXX_DEBUG_LEAVE_TEXT("Found if/for/while/switch parenthesis chain");
-		return true;
+		// and extract variable declarations if possible
+		cxxParserExtractVariableDeclarations(pChain,0);
 	}
 
-	// must be opening bracket: parse it here.
-
-	bool bRet = cxxParserParseBlock(true);
-
 	CXX_DEBUG_LEAVE();
-
-	return bRet;
+	return true;
 }
 
 static rescanReason cxxParserMain(const unsigned int passCount)
@@ -1836,6 +1879,8 @@ void cxxParserCleanup(langType language CTAGS_ATTR_UNUSED,bool initialized CTAGS
 	// The next line forces this function to be called only once
 	g_bFirstRun = true;
 
+	if(g_cxx.pUngetToken)
+		cxxTokenDestroy(g_cxx.pUngetToken);
 	if(g_cxx.pTokenChain)
 		cxxTokenChainDestroy(g_cxx.pTokenChain);
 	if(g_cxx.pTemplateTokenChain)

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1706,10 +1706,10 @@ bool cxxParserParseIfForWhileSwitchCatchParenthesis(void)
 			{
 				bOkToExtractVariables = true;
 			} else {
-				bOkToExtractVariables = cxxTokenChainNextTokenOfType(
+				bOkToExtractVariables = (cxxTokenChainNextTokenOfType(
 						pAndOrStar,
 						CXXTokenTypeAssignment | CXXTokenTypeSemicolon
-					);
+					) ? true : false); // ternary ?: needed because of MSVC
 			}
 		}
 	}

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -121,10 +121,12 @@ bool cxxParserParseBlockHandleOpeningBracket(void)
 	// FIXME: Why the invalid cork queue entry index is CORK_NIL?
 	int iCorkQueueIndex = CORK_NIL;
 
+	CXXFunctionSignatureInfo oInfo;
+
 	if(eScopeType != CXXScopeTypeFunction)
 	{
 		// very likely a function definition
-		iScopes = cxxParserExtractFunctionSignatureBeforeOpeningBracket(&iCorkQueueIndex);
+		iScopes = cxxParserExtractFunctionSignatureBeforeOpeningBracket(&oInfo,&iCorkQueueIndex);
 
 		// FIXME: Handle syntax (5) of list initialization:
 		//        Class::Class() : member { arg1, arg2, ... } {...
@@ -147,6 +149,8 @@ bool cxxParserParseBlockHandleOpeningBracket(void)
 		}
 
 		iScopes = 0;
+
+		oInfo.uFlags = 0;
 	}
 
 	cxxParserNewStatement();
@@ -157,8 +161,69 @@ bool cxxParserParseBlockHandleOpeningBracket(void)
 		return false;
 	}
 
+	unsigned long uEndPosition = getInputLineNumber();
+	
+	// If the function contained a "try" keyword before the opening bracket
+	// then it's likely to be a function-try-block and should be followed by a catch
+	// block that is in the same scope.
+
+	if(oInfo.uFlags & CXXFunctionSignatureInfoFunctionTryBlock)
+	{	
+		// look for the catch blocks.
+		CXX_DEBUG_PRINT("The function is a function-try-block: looking for catch blocks");
+
+		for(;;)
+		{
+			CXX_DEBUG_PRINT("Looking ahead for a catch block...");
+
+			if(!cxxParserParseNextToken())
+				break; // EOF
+
+			if(!cxxTokenIsKeyword(g_cxx.pToken,CXXKeywordCATCH))
+			{
+				// No more catches. Unget and exit.
+				CXX_DEBUG_PRINT("No more catch blocks");
+				cxxParserUngetCurrentToken();
+				break;
+			}
+
+			// assume it's a catch block.
+
+			CXX_DEBUG_PRINT("Found catch block");
+
+			if(!cxxParserParseIfForWhileSwitchCatchParenthesis())
+			{
+				CXX_DEBUG_LEAVE_TEXT("Failed to parse the catch parenthesis");
+				return false;
+			}
+			
+			// the standard requires a bracket here (catch block is always a compound statement).
+			
+			cxxParserNewStatement();
+			
+			if(!cxxParserParseNextToken())
+			{
+				CXX_DEBUG_LEAVE_TEXT("Found EOF while looking for catch() block: playing nice");
+				break; // EOF (would be a syntax error!)
+			}
+			
+			if(!cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeOpeningBracket))
+			{
+				// Aargh...
+				CXX_DEBUG_LEAVE_TEXT("Found something unexpected while looking for catch() block: playing nice");
+				cxxParserUngetCurrentToken();
+				break; // (would be a syntax error!)
+			}
+			
+			if(!cxxParserParseBlock(true))
+				return false;
+
+ 			uEndPosition = getInputLineNumber();
+ 		}
+ 	}
+
 	if(iCorkQueueIndex > CORK_NIL)
-		cxxParserMarkEndLineForTagInCorkQueue(iCorkQueueIndex);
+		cxxParserSetEndLineForTagInCorkQueue(iCorkQueueIndex,uEndPosition);
 
 	while(iScopes > 0)
 	{
@@ -169,7 +234,6 @@ bool cxxParserParseBlockHandleOpeningBracket(void)
 	CXX_DEBUG_LEAVE();
 	return true;
 }
-
 
 static bool cxxParserParseBlockInternal(bool bExpectClosingBracket)
 {
@@ -345,25 +409,34 @@ process_token:
 					case CXXKeywordFOR:
 					case CXXKeywordWHILE:
 					case CXXKeywordSWITCH:
-						if(!cxxParserParseIfForWhileSwitch())
+					case CXXKeywordCATCH:
+						if(!cxxParserParseIfForWhileSwitchCatchParenthesis())
 						{
-							CXX_DEBUG_LEAVE_TEXT("Failed to parse if/for/while/switch");
+							CXX_DEBUG_LEAVE_TEXT("Failed to parse if/for/while/switch/catch parenthesis");
 							return false;
 						}
+						// Now we're just before the block that follows the parenthesis.
 						cxxParserNewStatement();
 						// Force the cpp preprocessor to think that we're in the middle of a statement.
 						cppBeginStatement();
 					break;
 					case CXXKeywordTRY:
-						if (g_cxx.pToken->pPrev
-							&& cxxTokenTypeIs(g_cxx.pToken->pPrev, CXXTokenTypeParenthesisChain))
+						// We parse try in different ways depending on the context.
+						// Inside a function, and without preceeding tokens it's assumed to be
+						// a plain try {} catch {} block. This is easy.
+						// Out of a function it's likely to be a function try block:
+						//    int f(int n = 2) try { ... } catch { ... }
+						// Inside a function but with some preceeding tokens it's likely to be a
+						// lambda expressed as function-try-block.
+						//    auto f() -> void try { ... } catch { ... }
+						if((cxxScopeGetType() != CXXScopeTypeFunction) || g_cxx.pToken->pPrev)
 						{
-							/* Maybe we are at "try" of "Function-try-block" like
-							   int f(int n = 2) try { ...
-							   Let's ignore this "try". */
+							CXX_DEBUG_PRINT("Found try that looks like a function-try-block");
+							// Maybe function-try-block.
+							// Keep in the chain and continue parsing.
 							continue;
 						}
-						/* Fall through */
+						// Fall through.
 					case CXXKeywordELSE:
 					case CXXKeywordDO:
 						// parse as normal statement/block

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -286,6 +286,9 @@ vString * cxxTagSetProperties(unsigned int uProperties)
 		vStringCatS(pszProperties,_szProperty); \
 	} while(0)
 
+	// FIXME: The property names might be too verbose. Maybe it could be a good idea
+	//        to a switch to shorten them to 1-2 letter codes?
+
 	if(uProperties & CXXTagPropertyConst)
 		ADD_PROPERTY("const");
 	if(uProperties & CXXTagPropertyDefault)
@@ -320,6 +323,8 @@ vString * cxxTagSetProperties(unsigned int uProperties)
 		ADD_PROPERTY("deprecated");
 	if(uProperties & CXXTagPropertyScopedEnum)
 		ADD_PROPERTY("scopedenum");
+	if(uProperties & CXXTagPropertyFunctionTryBlock)
+		ADD_PROPERTY("fntryblock");
 
 	cxxTagSetField(CXXTagFieldProperties,vStringValue(pszProperties));
 

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -286,9 +286,6 @@ vString * cxxTagSetProperties(unsigned int uProperties)
 		vStringCatS(pszProperties,_szProperty); \
 	} while(0)
 
-	// FIXME: The property names might be too verbose. Maybe it could be a good idea
-	//        to a switch to shorten them to 1-2 letter codes?
-
 	if(uProperties & CXXTagPropertyConst)
 		ADD_PROPERTY("const");
 	if(uProperties & CXXTagPropertyDefault)

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -144,7 +144,9 @@ typedef enum _CXXTagProperty
 	// __attribute__((deprecated)) has been seen
 	CXXTagPropertyDeprecated = (1 << 15),
 	// scoped enum (C++11)
-	CXXTagPropertyScopedEnum = (1 << 16)
+	CXXTagPropertyScopedEnum = (1 << 16),
+	// function-try-block: int f() try { ... } catch { ... }
+	CXXTagPropertyFunctionTryBlock = (1 << 17)
 } CXXTagProperty;
 
 // Set the modifiers field of the tag.


### PR DESCRIPTION
Improved solution for #1746.

-  catch() is part of the function-try-block:
-- the variables declared inside now have proper scope
-- the function ends after the last catch()
- variables declared in the catch() parenthesis are extracted
- function-try-blocks are reported as properties
