### PR TITLE
Tmain: initialize "V" variable explicitly

### DIFF
--- a/Tmain/parser-own-fields.d/run.sh
+++ b/Tmain/parser-own-fields.d/run.sh
@@ -4,7 +4,10 @@
 . ../utils.sh
 
 CTAGS=$1
+
+V=
 # V=valgrind
+
 echo '#' disabling fields
 ${V} ${CTAGS} --options=NONE --options=./unknown.ctags -o - input.unknown
 


### PR DESCRIPTION
"V" variable was introduced as a placeholder that is used when I want
to run the test case under valgrind; the valgrind command line is set
to "V".

It seems that "Ubuntu PPA build" environment defines V as an environment
variable with value "1". See #1761.

As the result, the test case doesn't work well on the environment.

This commit clears the value for "V" to allow the test case works
on the environment.