### PR TITLE
Ruby block assign: handle variables with sigils

### DIFF
--- a/Units/parser-ruby.r/ruby-block-assign.d/expected.tags
+++ b/Units/parser-ruby.r/ruby-block-assign.d/expected.tags
@@ -8,3 +8,6 @@ method_c	input.rb	/^  def method_c$/;"	f	class:Bar
 method_d	input.rb	/^  def method_d$/;"	f	class:Bar
 method_e	input.rb	/^  def method_e$/;"	f	class:Bar
 method_f	input.rb	/^  def method_f$/;"	f	class:Bar
+method_g	input.rb	/^  def method_g$/;"	f	class:Bar
+method_h	input.rb	/^  def method_h$/;"	f	class:Bar
+method_j	input.rb	/^  def method_j$/;"	f	class:Bar

--- a/Units/parser-ruby.r/ruby-block-assign.d/input.rb
+++ b/Units/parser-ruby.r/ruby-block-assign.d/input.rb
@@ -36,6 +36,24 @@ c = class Bar
   end
 
   def method_f
+    @x = if 1
+    else
+    end
+  end
+  
+  def method_g
+    @@x = if 1
+    else
+    end
+  end
+  
+  def method_h
+    $x = if 1
+    else
+    end
+  end
+  
+  def method_j
   end
 end
 

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -122,7 +122,7 @@ static bool notIdentChar (int c)
 	return ! isIdentChar (c);
 }
 
-static bool operatorChar (int c)
+static bool isOperatorChar (int c)
 {
 	return (c == '[' || c == ']' ||
 	        c == '=' || c == '!' || c == '~' ||
@@ -134,7 +134,12 @@ static bool operatorChar (int c)
 
 static bool notOperatorChar (int c)
 {
-	return ! operatorChar (c);
+	return ! isOperatorChar (c);
+}
+
+static bool isSigilChar (int c)
+{
+	return (c == '@' || c == '$');
 }
 
 static bool isWhitespace (int c)
@@ -181,6 +186,8 @@ static bool canMatchKeywordWithAssign (const unsigned char** s, const char* lite
 		return true;
 	}
 
+	advanceWhile (s, isSigilChar);
+
 	if (! advanceWhile (s, isIdentChar))
 	{
 		*s = original_pos;
@@ -189,7 +196,7 @@ static bool canMatchKeywordWithAssign (const unsigned char** s, const char* lite
 
 	advanceWhile (s, isWhitespace);
 
-	if (! (advanceWhile (s, operatorChar) && *(*s - 1) == '='))
+	if (! (advanceWhile (s, isOperatorChar) && *(*s - 1) == '='))
 	{
 		*s = original_pos;
 		return false;


### PR DESCRIPTION
When assigning blocks in Ruby, handle assignment to variables prefixed by `@`, `@@` or `$`.

This is an improvement to #1734.