### PR TITLE
[SELF-INCOMPATIBLE] xformat-writer,json-writer: make typeref: field in xref and json output formats as same as that in tags

### DIFF
--- a/Tmain/interactive-mode.d/stdout-expected.txt
+++ b/Tmain/interactive-mode.d/stdout-expected.txt
@@ -33,8 +33,8 @@ process multiple commands
 {"_type": "tag", "name": "foobar", "path": "test.rb", "pattern": "/^  def foobar$/", "kind": "method", "scope": "Test", "scopeKind": "class"}
 {"_type": "tag", "name": "baz", "path": "test.rb", "pattern": "/^  def baz(a=1)$/", "kind": "method", "scope": "Test", "scopeKind": "class"}
 {"_type": "completed", "command": "generate-tags"}
-{"_type": "tag", "name": "say_hello", "path": "test.c", "pattern": "/^void say_hello() {$/", "typeref": "void", "kind": "function"}
-{"_type": "tag", "name": "main", "path": "test.c", "pattern": "/^int main(int argc, char **argv) {$/", "typeref": "int", "kind": "function"}
+{"_type": "tag", "name": "say_hello", "path": "test.c", "pattern": "/^void say_hello() {$/", "typeref": "typename:void", "kind": "function"}
+{"_type": "tag", "name": "main", "path": "test.c", "pattern": "/^int main(int argc, char **argv) {$/", "typeref": "typename:int", "kind": "function"}
 {"_type": "completed", "command": "generate-tags"}
 
 generate tags from data

--- a/Tmain/json-output-format.d/stdout-expected.txt
+++ b/Tmain/json-output-format.d/stdout-expected.txt
@@ -2,16 +2,16 @@
 {"_type": "tag", "name": "Foo", "path": "input.py", "pattern": "/^class Foo:$/", "kind": "class"}
 {"_type": "tag", "name": "N\tA\tM\tE", "path": "input.1", "pattern": "/^.SH \"\tN\tA\tM\tE\t\"$/", "kind": "section"}
 {"_type": "tag", "name": "doIt", "path": "input.py", "pattern": "/^    def doIt():$/", "kind": "member", "scope": "Foo", "scopeKind": "class"}
-{"_type": "tag", "name": "foo", "path": "input.c", "pattern": "/^static int foo (void)$/", "file": true, "typeref": "int", "kind": "function"}
-{"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "typeref": "int", "kind": "function"}
+{"_type": "tag", "name": "foo", "path": "input.c", "pattern": "/^static int foo (void)$/", "file": true, "typeref": "typename:int", "kind": "function"}
+{"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "typeref": "typename:int", "kind": "function"}
 {"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^func main() {$/", "kind": "func", "scope": "main", "scopeKind": "package"}
 {"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^package main$/", "kind": "package"}
 # json --languages=+man --fields=*
 {"_type": "tag", "name": "Foo", "path": "input.py", "pattern": "/^class Foo:$/", "access": "public", "inherits": false, "language": "Python", "line": 1, "kind": "class", "roles": "def", "end": 3}
 {"_type": "tag", "name": "N\tA\tM\tE", "path": "input.1", "pattern": "/^.SH \"\tN\tA\tM\tE\t\"$/", "language": "Man", "line": 1, "kind": "section", "roles": "def"}
 {"_type": "tag", "name": "doIt", "path": "input.py", "pattern": "/^    def doIt():$/", "access": "public", "language": "Python", "line": 2, "signature": "()", "kind": "member", "roles": "def", "scope": "Foo", "scopeKind": "class", "end": 3}
-{"_type": "tag", "name": "foo", "path": "input.c", "pattern": "/^static int foo (void)$/", "file": true, "language": "C", "line": 3, "signature": "(void)", "typeref": "int", "kind": "function", "roles": "def", "extras": "fileScope", "end": 6}
-{"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "language": "C", "line": 9, "signature": "(void)", "typeref": "int", "kind": "function", "roles": "def", "end": 12}
+{"_type": "tag", "name": "foo", "path": "input.c", "pattern": "/^static int foo (void)$/", "file": true, "language": "C", "line": 3, "signature": "(void)", "typeref": "typename:int", "kind": "function", "roles": "def", "extras": "fileScope", "end": 6}
+{"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "language": "C", "line": 9, "signature": "(void)", "typeref": "typename:int", "kind": "function", "roles": "def", "end": 12}
 {"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^func main() {$/", "language": "Go", "line": 3, "signature": "()", "kind": "func", "roles": "def", "scope": "main", "scopeKind": "package"}
 {"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^package main$/", "language": "Go", "line": 1, "kind": "package", "roles": "def"}
 # json --languages=+man --fields=* --extras=*-{subword}
@@ -24,12 +24,12 @@
 {"_type": "tag", "name": "Foo.doIt", "path": "input.py", "pattern": "/^    def doIt():$/", "access": "public", "language": "Python", "line": 2, "signature": "()", "kind": "member", "roles": "def", "scope": "Foo", "extras": "qualified", "scopeKind": "class", "end": 3}
 {"_type": "tag", "name": "N\tA\tM\tE", "path": "input.1", "pattern": "/^.SH \"\tN\tA\tM\tE\t\"$/", "language": "Man", "line": 1, "kind": "section", "roles": "def"}
 {"_type": "tag", "name": "doIt", "path": "input.py", "pattern": "/^    def doIt():$/", "access": "public", "language": "Python", "line": 2, "signature": "()", "kind": "member", "roles": "def", "scope": "Foo", "scopeKind": "class", "end": 3}
-{"_type": "tag", "name": "foo", "path": "input.c", "pattern": "/^static int foo (void)$/", "file": true, "language": "C", "line": 3, "signature": "(void)", "typeref": "int", "kind": "function", "roles": "def", "extras": "fileScope", "end": 6}
+{"_type": "tag", "name": "foo", "path": "input.c", "pattern": "/^static int foo (void)$/", "file": true, "language": "C", "line": 3, "signature": "(void)", "typeref": "typename:int", "kind": "function", "roles": "def", "extras": "fileScope", "end": 6}
 {"_type": "tag", "name": "input.1", "path": "input.1", "pattern": false, "language": "Man", "line": 1, "kind": "file", "roles": "def", "extras": "inputFile", "end": 1}
 {"_type": "tag", "name": "input.c", "path": "input.c", "pattern": false, "language": "C", "line": 1, "kind": "file", "roles": "def", "extras": "inputFile", "end": 12}
 {"_type": "tag", "name": "input.go", "path": "input.go", "pattern": false, "language": "Go", "line": 1, "kind": "file", "roles": "def", "extras": "inputFile", "end": 4}
 {"_type": "tag", "name": "input.py", "path": "input.py", "pattern": false, "language": "Python", "line": 1, "kind": "file", "roles": "def", "extras": "inputFile", "end": 3}
-{"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "language": "C", "line": 9, "signature": "(void)", "typeref": "int", "kind": "function", "roles": "def", "end": 12}
+{"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "language": "C", "line": 9, "signature": "(void)", "typeref": "typename:int", "kind": "function", "roles": "def", "end": 12}
 {"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^func main() {$/", "language": "Go", "line": 3, "signature": "()", "kind": "func", "roles": "def", "scope": "main", "scopeKind": "package"}
 {"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^package main$/", "language": "Go", "line": 1, "kind": "package", "roles": "def"}
 {"_type": "tag", "name": "main.main", "path": "input.go", "pattern": "/^func main() {$/", "language": "Go", "line": 3, "signature": "()", "kind": "func", "roles": "def", "scope": "main", "extras": "qualified", "scopeKind": "package"}

--- a/Tmain/json-output-to-file.d/stdout-expected.txt
+++ b/Tmain/json-output-to-file.d/stdout-expected.txt
@@ -1,2 +1,2 @@
-{"_type": "tag", "name": "foo", "path": "input.c", "pattern": "/^static int foo (void)$/", "file": true, "typeref": "int", "kind": "function"}
-{"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "typeref": "int", "kind": "function"}
+{"_type": "tag", "name": "foo", "path": "input.c", "pattern": "/^static int foo (void)$/", "file": true, "typeref": "typename:int", "kind": "function"}
+{"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "typeref": "typename:int", "kind": "function"}

--- a/Tmain/sandbox-with-eager-guessing.d/stdout-expected.txt
+++ b/Tmain/sandbox-with-eager-guessing.d/stdout-expected.txt
@@ -1,3 +1,3 @@
 {"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
-{"_type": "tag", "name": "main", "path": "input.unknown", "pattern": "/^\\/* -*- c -*- *\\/ int main(void) { return 0; }/", "typeref": "int", "kind": "function"}
+{"_type": "tag", "name": "main", "path": "input.unknown", "pattern": "/^\\/* -*- c -*- *\\/ int main(void) { return 0; }/", "typeref": "typename:int", "kind": "function"}
 {"_type": "completed", "command": "generate-tags"}

--- a/Tmain/sandbox.d/stdout-expected.txt
+++ b/Tmain/sandbox.d/stdout-expected.txt
@@ -1,3 +1,3 @@
 {"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
-{"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^int main(void) { return 0; }/", "typeref": "int", "kind": "function"}
+{"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^int main(void) { return 0; }/", "typeref": "typename:int", "kind": "function"}
 {"_type": "completed", "command": "generate-tags"}

--- a/Units/xformat-option.r/format-CfSt.d/expected.tags-x
+++ b/Units/xformat-option.r/format-CfSt.d/expected.tags-x
@@ -1,6 +1,6 @@
 S         -          -, file =>  struct S{
-T         -          S, file => typedef S T;
-func      (T x)      int,    - => int func (T x)
-i         -          int, file =>     int i;
-t0        -          S, file => static struct S t0;
-t0        -          T, file => static T t0;
+T         -          typename:S, file => typedef S T;
+func      (T x)      typename:int,    - => int func (T x)
+i         -          typename:int, file =>     int i;
+t0        -          struct:S, file => static struct S t0;
+t0        -          typename:T, file => static T t0;

--- a/main/field.c
+++ b/main/field.c
@@ -507,6 +507,13 @@ static const char *renderFieldInherits (const tagEntryInfo *const tag, const cha
 static const char *renderFieldTyperef (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
 									   bool *rejected CTAGS_ATTR_UNUSED)
 {
+	/* Return "-" instead of "-:-". */
+	if (tag->extensionFields.typeRef [0] == NULL
+		&& tag->extensionFields.typeRef [1] == NULL)
+		return renderAsIs (b, "-");
+
+	vStringCatS (b, WITH_DEFUALT_VALUE (tag->extensionFields.typeRef [0]));
+	vStringPut  (b, ':');
 	return renderEscapedName (false, WITH_DEFUALT_VALUE (tag->extensionFields.typeRef [1]), tag, b);
 }
 

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -197,9 +197,8 @@ static int addExtensionFields (tagWriter *writer, MIO *mio, const tagEntryInfo *
 
 	if (isFieldEnabled (FIELD_TYPE_REF) && doesFieldHaveValue (FIELD_TYPE_REF, tag))
 	{
-		length += mio_printf (mio, "%s\t%s:%s:%s", sep,
+		length += mio_printf (mio, "%s\t%s:%s", sep,
 				      getFieldName (FIELD_TYPE_REF),
-				      tag->extensionFields.typeRef [0],
 				      escapeFieldValue (writer, tag, FIELD_TYPE_REF));
 		sep [0] = '\0';
 	}


### PR DESCRIPTION
typeref: field has sub-fields "typeref prefix" and "typeref name" in tags format.
":" combines the two sub-fields and makes the field value.

e.g.

	typename:int
	struct:S

In xref and json output formats, only "typeref name"
sub field was printed when printing typeref: field.

This change fixes this inconsistent.
This is self-incompatible change.

If you want, "typerefPrefix" and "typerefName" fields can be introduced.
Open an issue in that case.

This change is needed to solve #1772.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>