### PR TITLE
C++: introduce "using" role to "namespace" kind

### DIFF
--- a/Tmain/list-kinds-full.d/stdout-expected.txt
+++ b/Tmain/list-kinds-full.d/stdout-expected.txt
@@ -18,7 +18,6 @@ z	parameter	no	no	0	C	function parameters inside function definitions
 A	alias	no	no	0	NONE	namespace aliases
 L	label	no	no	0	C	goto labels
 N	name	no	no	0	NONE	names imported via using scope::symbol
-U	using	no	yes	0	NONE	using namespace statements
 c	class	yes	no	0	NONE	classes
 d	macro	yes	no	1	C	macro definitions
 e	enumerator	yes	no	0	C	enumerators (values inside an enumeration)
@@ -27,7 +26,7 @@ g	enum	yes	no	0	C	enumeration names
 h	header	yes	yes	2	C	included header files
 l	local	no	no	0	C	local variables
 m	member	yes	no	0	C	class, struct, and union members
-n	namespace	yes	no	0	NONE	namespaces
+n	namespace	yes	no	1	NONE	namespaces
 p	prototype	no	no	0	C	function prototypes
 s	struct	yes	no	0	C	structure names
 t	typedef	yes	no	0	C	typedefs

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -17,6 +17,7 @@ C              h/header          system              on      system header
 C++            d/macro           undef               on      undefined
 C++            h/header          local               on      local header
 C++            h/header          system              on      system header
+C++            n/namespace       using               on      specified with "using namespace"
 CPreProcessor  d/macro           undef               on      undefined
 CPreProcessor  h/header          local               on      local header
 CPreProcessor  h/header          system              on      system header
@@ -75,6 +76,7 @@ C              h/header          system              on      system header
 C++            d/macro           undef               on      undefined
 C++            h/header          local               on      local header
 C++            h/header          system              on      system header
+C++            n/namespace       using               on      specified with "using namespace"
 CPreProcessor  d/macro           undef               on      undefined
 CPreProcessor  h/header          local               on      local header
 CPreProcessor  h/header          system              on      system header

--- a/Units/parser-cxx.r/bug1093123.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1093123.cpp.d/expected.tags
@@ -1,3 +1,2 @@
 main	input.cpp	/^int main() {$/;"	f	typeref:typename:int
-std	input.cpp	/^using namespace std;$/;"	U	function:main
 m	input.cpp	/^int m;$/;"	l	function:main	typeref:typename:int	file:

--- a/Units/parser-cxx.r/bug834.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug834.cpp.d/expected.tags
@@ -1,4 +1,3 @@
-std	input.cpp	/^using namespace std;$/;"	U	file:
 C	input.cpp	/^vector<vector<int>> C;$/;"	v	typeref:typename:vector<vector<int>>
 A	input.cpp	/^struct A {$/;"	s	file:
 a	input.cpp	/^    int a;$/;"	m	struct:A	typeref:typename:int	file:

--- a/Units/parser-cxx.r/using.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/using.cpp.d/expected.tags
@@ -1,6 +1,6 @@
 A	input.cpp	/^class A$/;"	class	file:	roles:def
 B	input.cpp	/^class B : public A$/;"	class	file:	roles:def
-std	input.cpp	/^using namespace std;$/;"	using	file:	roles:def
+std	input.cpp	/^using namespace std;$/;"	namespace	file:	roles:using
 string	input.cpp	/^#include <string>/;"	header	roles:system
 string	input.cpp	/^using std::string;$/;"	name	file:	roles:def
 test	input.cpp	/^	using A::test;$/;"	name	class:B	roles:def

--- a/parsers/cxx/cxx_parser_using.c
+++ b/parsers/cxx/cxx_parser_using.c
@@ -131,7 +131,9 @@ bool cxxParserParseUsingClause(void)
 						"Found using clause '%s' which extends scope",
 						vStringValue(t->pszWord)
 					);
-				tag = cxxTagBegin(CXXTagCPPKindUSING,t);
+				tag = cxxRefTagBegin(CXXTagCPPKindNAMESPACE,
+									 CXXTagCPPNamespaceRoleUSING,t);
+
 			} else {
 
 				t = cxxTokenChainLast(g_cxx.pTokenChain);

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -66,14 +66,17 @@ static kindDefinition g_aCXXCKinds [] = {
 	CXX_COMMON_KINDS(C,"struct, and union members", LANG_IGNORE)
 };
 
+static roleDefinition g_aCXXCPPNamespaceRoles [] = {
+	{ true, "using", "specified with \"using namespace\"" },
+};
+
 static kindDefinition g_aCXXCPPKinds [] = {
 	CXX_COMMON_KINDS(CXX,"class, struct, and union members", LANG_AUTO),
 	{ true,  'c', "class",      "classes" },
-	{ true,  'n', "namespace",  "namespaces" },
+	{ true,  'n', "namespace",  "namespaces",
+	  .referenceOnly = false, ATTACH_ROLES(g_aCXXCPPNamespaceRoles) },
 	{ false, 'A', "alias",      "namespace aliases" },
 	{ false, 'N', "name",       "names imported via using scope::symbol" },
-	{ false, 'U', "using",      "using namespace statements",
-			.referenceOnly = true },
 };
 
 static kindDefinition g_aCXXCUDAKinds [] = {
@@ -233,7 +236,7 @@ bool cxxTagFieldEnabled(unsigned int uField)
 static tagEntryInfo g_oCXXTag;
 
 
-tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken)
+static tagEntryInfo * cxxTagBeginCommon(unsigned int uKind,unsigned int uRole,CXXToken * pToken)
 {
 	kindDefinition * pKindDefinitions = g_cxx.pKindDefinitions;
 
@@ -243,10 +246,11 @@ tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken)
 		return NULL;
 	}
 
-	initTagEntry(
+	initRefTagEntry(
 			&g_oCXXTag,
 			vStringValue(pToken->pszWord),
-			uKind
+			uKind,
+			uRole
 		);
 
 	g_oCXXTag.lineNumber = pToken->iLineNumber;
@@ -263,6 +267,16 @@ tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken)
 	g_oCXXTag.extensionFields.access = g_aCXXAccessStrings[cxxScopeGetAccess()];
 
 	return &g_oCXXTag;
+}
+
+tagEntryInfo * cxxRefTagBegin(unsigned int uKind, unsigned int uRole, CXXToken * pToken)
+{
+	return cxxTagBeginCommon(uKind, uRole, pToken);
+}
+
+tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken)
+{
+	return cxxTagBeginCommon(uKind, ROLE_INDEX_DEFINITION, pToken);
 }
 
 vString * cxxTagSetProperties(unsigned int uProperties)

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -45,7 +45,11 @@ enum CXXTagCPPKind
 	CXXTagCPPKindNAMESPACE,
 	CXXTagCPPKindALIAS,
 	CXXTagCPPKindNAME,
-	CXXTagCPPKindUSING
+};
+
+enum CXXTagCPPNamespaceRole
+{
+	CXXTagCPPNamespaceRoleUSING,
 };
 
 // The fields common to all (sub)languages this parser supports.
@@ -94,6 +98,10 @@ bool cxxTagKindEnabled(unsigned int uTagKind);
 // Must be followed by cxxTagCommit() if it returns a non-NULL value.
 // The pToken ownership is NOT transferred.
 tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken);
+
+// Do the same as cxxTagBegin but attaching  a role for making a
+// reference tag.
+tagEntryInfo * cxxRefTagBegin(unsigned int uKind,unsigned int uRole,CXXToken * pToken);
 
 // Set the type of the current tag from the specified token sequence
 // (which must belong to the same chain!).


### PR DESCRIPTION
"foo" in "using namespace foo;" was captured as using kind.
However, "foo" is not defined in the statement.
"foo" is referred as a namespace defined somewhere.

Therefore, ctags should not capture "foo" as a definition tag.
Instead, ctags should capture it as a reference tag.

The original code captures "foo" as a definition tag of "using" kind.
This change captures "foo" as a reference tag of "using" role of
"namespace" kind.

  $ cat /tmp/foo.hh
  using namespace std::cout;
  $ ./ctags -o - /tmp/foo.hh
  $ ./ctags -o - --extras=+r /tmp/foo.hh
  std::cout	/tmp/foo.hh	/^using namespace std::cout;$/;"	n
  $ ./ctags -o - --extras=+r --fields=+K /tmp/foo.hh
  std::cout	/tmp/foo.hh	/^using namespace std::cout;$/;"	namespace
  $ ./ctags -o - --extras=+r --fields=+Kr /tmp/foo.hh
  std::cout	/tmp/foo.hh	/^using namespace std::cout;$/;"	namespace	roles:using

  $ ./ctags --list-roles=C++.namespace
  #KIND(L/N)   NAME  ENABLED DESCRIPTION
  n/namespace  using on      specified with "using namespace"

Signed-off-by: Masatake YAMATO <yamato@redhat.com>