### PR TITLE
Python: fix wrong role assignments

### DIFF
--- a/parsers/python.c
+++ b/parsers/python.c
@@ -1040,7 +1040,7 @@ static bool parseImport (tokenInfo *const token)
 						   Y = (kind:unknown, role:imported) */
 						/* Y */
 						makeSimplePythonRefTag (name, NULL, K_UNKNOWN,
-						                        PYTHON_MODULE_IMPORTED,
+						                        PYTHON_UNKNOWN_IMPORTED,
 						                        XTAG_UNKNOWN);
 						/* x.Y */
 						if (isXtagEnabled (XTAG_QUALIFIED_TAGS))
@@ -1049,7 +1049,7 @@ static bool parseImport (tokenInfo *const token)
 							vStringPut (fq, '.');
 							vStringCat (fq, name->string);
 							makeSimplePythonRefTag (name, fq, K_UNKNOWN,
-							                        PYTHON_MODULE_IMPORTED,
+							                        PYTHON_UNKNOWN_IMPORTED,
 							                        XTAG_QUALIFIED_TAGS);
 							vStringDelete (fq);
 						}


### PR DESCRIPTION
When making a reference tag of "unknown" kind,
PYTHON_MODULE_IMPORTED is used to assign a role for the tag.
PYTHON_UNKNOWN_IMPORTED should be used instead.

Our test cases could not detect the mistake because, The integer
representation of PYTHON_UNKNOWN_IMPORTED role enumerator and that of
PYTHON_MODULE_IMPORTED role enumerator are the same (== 1). In other
hand the string representation of the roles are the same (==
"imported"), too.

The API for defining and assigning roles must be improved in the
future.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>