### PR TITLE
Add support for Matlab classes

### DIFF
--- a/Units/review-needed.r/matlab_test.m.t/expected.tags
+++ b/Units/review-needed.r/matlab_test.m.t/expected.tags
@@ -1,5 +1,9 @@
 A	input.m	/^A = magic(4);$/;"	v
 R	input.m	/^R = randn(3,4,5);$/;"	v
+class1	input.m	/^classdef class1 < handle$/;"	c
+classfunc1	input.m	/^        function [x,y,z] = classfunc1$/;"	f
+classfunc2	input.m	/^        function x = classfunc2$/;"	f
+classfunc3	input.m	/^        function classfunc3$/;"	f
 func1	input.m	/^function [x,y,z] = func1 $/;"	f
 func2	input.m	/^function x = func2 $/;"	f
 func3	input.m	/^function func3 $/;"	f

--- a/Units/review-needed.r/matlab_test.m.t/input.m
+++ b/Units/review-needed.r/matlab_test.m.t/input.m
@@ -1,3 +1,12 @@
+classdef class1 < handle
+    methods
+        function [x,y,z] = classfunc1
+        function x = classfunc2
+        function classfunc3
+        end
+    end
+end
+
 function [x,y,z] = func1 
 function x = func2 
 function func3 

--- a/parsers/matlab.c
+++ b/parsers/matlab.c
@@ -19,17 +19,20 @@
 
 static tagRegexTable matlabTagRegexTable [] = {
 	/* function [x,y,z] = asdf */
-	{ "^function[ \t]*\\[.*\\][ \t]*=[ \t]*([a-zA-Z0-9_]+)",
+	{ "^[ \t]*function[ \t]*\\[.*\\][ \t]*=[ \t]*([a-zA-Z0-9_]+)",
 	  "\\1", "f,function", NULL},
 	/* function x = asdf */
-	{"^function[ \t]*[a-zA-Z0-9_]+[ \t]*=[ \t]*([a-zA-Z0-9_]+)",
+	{"^[ \t]*function[ \t]*[a-zA-Z0-9_]+[ \t]*=[ \t]*([a-zA-Z0-9_]+)",
 	 "\\1", "f,function", NULL},
 	/* function asdf */
-	{"^function[ \t]*([a-zA-Z0-9_]+)[^=]*$", "\\1",
+	{"^[ \t]*function[ \t]*([a-zA-Z0-9_]+)[^=]*$", "\\1",
 	 "f,function", NULL},
 	/* variables */
 	{"^[ \t]*([a-zA-Z0-9_]+)[ \t]*=[ \t]", "\\1",
 	 "v,variable", NULL},
+	/* class definitions */
+	{"^[ \t]*classdef[ \t]*([a-zA-Z0-9_]+)", "\\1",
+	 "c,class", NULL},
 };
 
 /*


### PR DESCRIPTION
Recognize the definition of a class, and allow for functions not to be
defined in the first column but to be indented by white space.