### PR TITLE
extras: add full file name along with base file name

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -177,6 +177,7 @@ static void addCommonPseudoTags (void)
 extern void makeFileTag (const char *const fileName)
 {
 	tagEntryInfo tag;
+	unsigned long endLine = 0;
 
 	if (!isXtagEnabled(XTAG_FILE_NAMES))
 		return;
@@ -195,9 +196,19 @@ extern void makeFileTag (const char *const fileName)
 		   unnecessary read line loop. */
 		while (readLineFromInputFile () != NULL)
 			; /* Do nothing */
-		tag.extensionFields.endLine = getInputLineNumber ();
+		endLine = getInputLineNumber ();
 	}
 
+	tag.extensionFields.endLine = endLine;
+	makeTagEntry (&tag);
+
+	/* add the full filename too */
+	initTagEntry (&tag, fileName, KIND_FILE_INDEX);
+	tag.isFileEntry     = true;
+	tag.lineNumberEntry = true;
+	markTagExtraBit (&tag, XTAG_FILE_NAMES);
+	tag.lineNumber = 1;
+	tag.extensionFields.endLine = endLine;
 	makeTagEntry (&tag);
 }
 

--- a/main/xtag.c
+++ b/main/xtag.c
@@ -56,7 +56,7 @@ static xtagDefinition xtagDefinitions [] = {
 	{ true, 'F',  "fileScope",
 	  "Include tags of file scope" },
 	{ false, 'f', "inputFile",
-	  "Include an entry for the base file name of every input file",
+	  "Include an entry for the base and full file names of every input file",
 	  NULL,
 	  NULL,
 	  enableFileKind},


### PR DESCRIPTION
For --extras=+f, add the full file name along with the base file name.

For example, this allows using vim's -t argument without worrying
whether it is necessary:
        vim -t main/entry.c
rather than requiring the -t be dropped:
        vim main/entry.c