### PR TITLE
Introduced protected attribute for Fortran

### DIFF
--- a/Units/parser-fortran.r/fortran-protected.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-protected.d/expected.tags
@@ -1,0 +1,2 @@
+i	input.f90	/^  in/;"	v	module:test_implementation
+test_implementation	input.f90	/^module test_implementation$/;"	m

--- a/Units/parser-fortran.r/fortran-protected.d/input.f90
+++ b/Units/parser-fortran.r/fortran-protected.d/input.f90
@@ -1,0 +1,3 @@
+module test_implementation
+  integer, public, protected :: i
+end module test_implementation

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -118,6 +118,7 @@ enum eKeywordId {
 	KEYWORD_private,
 	KEYWORD_procedure,
 	KEYWORD_program,
+	KEYWORD_protected,
 	KEYWORD_public,
 	KEYWORD_pure,
 	KEYWORD_real,
@@ -317,6 +318,7 @@ static const keywordTable FortranKeywordTable [] = {
 	{ "private",        KEYWORD_private      },
 	{ "procedure",      KEYWORD_procedure    },
 	{ "program",        KEYWORD_program      },
+	{ "protected",      KEYWORD_protected    },
 	{ "public",         KEYWORD_public       },
 	{ "pure",           KEYWORD_pure         },
 	{ "real",           KEYWORD_real         },
@@ -1428,6 +1430,7 @@ static tokenInfo *parseQualifierSpecList (tokenInfo *const token)
 			case KEYWORD_optional:
 			case KEYWORD_private:
 			case KEYWORD_pointer:
+			case KEYWORD_protected:
 			case KEYWORD_public:
 			case KEYWORD_save:
 			case KEYWORD_target:
@@ -1823,6 +1826,7 @@ static bool parseSpecificationStmt (tokenInfo *const token)
 		case KEYWORD_optional:
 		case KEYWORD_pointer:
 		case KEYWORD_private:
+		case KEYWORD_protected:
 		case KEYWORD_public:
 		case KEYWORD_save:
 		case KEYWORD_target:


### PR DESCRIPTION
The protected attribute in Fortran is used to make a module variable readable, but not editable from outside. However, public module variables marked with the protected attribute were omitted when the file was parsed. Therefore, I added the protected attribute.