### PR TITLE
C++,QtMoc: initialize uninitialized local variable

### DIFF
--- a/parsers/cxx/cxx_subparser.c
+++ b/parsers/cxx/cxx_subparser.c
@@ -16,7 +16,7 @@
 
 bool cxxSubparserNotifyParseAccessSpecifier (ptrArray *pSubparsers)
 {
-	bool bR;
+	bool bR = false;
 	subparser *pSubparser;
 
 	foreachSubparser (pSubparser, false)


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>

(Reported by valgrind.)