### PR TITLE
main: add numArray template data structure

### DIFF
--- a/main/numarray.c
+++ b/main/numarray.c
@@ -1,0 +1,173 @@
+/*
+*   Copyright (c) 1999-2002, Darren Hiebert
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   This module contains functions managing resizable pointer arrays.
+*/
+
+/*
+*   INCLUDE FILES
+*/
+#include "general.h"  /* must always come first */
+
+#include "debug.h"
+#include "numarray.h"
+#include <string.h>
+
+
+#define impNumArray(prefix,Prefix,type)									\
+																		\
+	struct s##Prefix##Array {											\
+		unsigned int max;												\
+		unsigned int count;												\
+		type *array;													\
+	};																	\
+																		\
+	extern prefix##Array *prefix##ArrayNew (void)						\
+	{																	\
+		prefix##Array* const result = xMalloc (1, prefix##Array);		\
+		result->max = 8;												\
+		result->count = 0;												\
+		result->array = xMalloc (result->max, type);					\
+		return result;													\
+	}																	\
+																		\
+	extern void prefix##ArrayAdd (prefix##Array *const current, type num) \
+	{																	\
+		Assert (current != NULL);										\
+		if (current->count == current->max)								\
+		{																\
+			current->max *= 2;											\
+			current->array = xRealloc (current->array, current->max, type);	\
+		}																\
+		current->array [current->count++] = num;						\
+	}																	\
+																		\
+	extern void prefix##ArrayRemoveLast (prefix##Array *const current)	\
+	{																	\
+		Assert (current != NULL);										\
+		Assert (current->count > 0);									\
+		--current->count;												\
+	}																	\
+																		\
+	extern void prefix##ArrayCombine (prefix##Array *const current, prefix##Array *const from) \
+	{																	\
+		unsigned int i;													\
+		Assert (current != NULL);										\
+		Assert (from != NULL);											\
+		for (i = 0  ;  i < from->count  ;  ++i)							\
+			prefix##ArrayAdd (current, from->array [i]);				\
+		from->count = 0;												\
+		prefix##ArrayDelete (from);										\
+	}																	\
+																		\
+	extern unsigned int prefix##ArrayCount (const prefix##Array *const current)	\
+	{																	\
+		Assert (current != NULL);										\
+		return current->count;											\
+	}																	\
+																		\
+	extern type prefix##ArrayItem (const prefix##Array *const current, const unsigned int indx)	\
+	{																	\
+		Assert (current != NULL);										\
+		return current->array [indx];									\
+	}																	\
+																		\
+	extern type prefix##ArrayLast (const prefix##Array *const current)	\
+	{																	\
+		Assert (current != NULL);										\
+		Assert (current->count > 0);									\
+		return current->array [current->count - 1];						\
+	}																	\
+																		\
+	extern void prefix##ArrayClear (prefix##Array *const current)		\
+	{																	\
+		Assert (current != NULL);										\
+		current->count = 0;												\
+	}																	\
+																		\
+	extern void prefix##ArrayDelete (prefix##Array *const current)		\
+	{																	\
+		if (current != NULL)											\
+		{																\
+			prefix##ArrayClear (current);								\
+			eFree (current->array);										\
+			eFree (current);											\
+		}																\
+	}																	\
+																		\
+	extern bool prefix##ArrayHasTest (const prefix##Array *const current, \
+									  bool (*test)(const type num, void *userData),	\
+									  void *userData)					\
+	{																	\
+		bool result = false;											\
+		unsigned int i;													\
+		Assert (current != NULL);										\
+		for (i = 0  ;  ! result  &&  i < current->count  ;  ++i)		\
+			result = (*test)(current->array [i], userData);				\
+		return result;													\
+	}																	\
+																		\
+	static bool prefix##Eq (const type num, void *userData)				\
+	{																	\
+		type *num0 = userData;											\
+		return (num == *num0);											\
+	}																	\
+																		\
+	extern bool prefix##ArrayHas (const prefix##Array *const current, type num)	\
+	{																	\
+		return prefix##ArrayHasTest (current, prefix##Eq, &num);		\
+	}																	\
+																		\
+	extern void prefix##ArrayReverse (const prefix##Array *const current) \
+	{																	\
+		unsigned int i, j;												\
+		type tmp;														\
+																		\
+		Assert (current != NULL);										\
+		for (i = 0, j = current->count - 1 ; i <  (current->count / 2); ++i, --j) \
+		{																\
+			tmp = current->array[i];									\
+			current->array[i] = current->array[j];						\
+			current->array[j] = tmp;									\
+		}																\
+	}																	\
+																		\
+	extern void prefix##ArrayDeleteItem (prefix##Array* const current, unsigned int indx) \
+	{																	\
+		memmove (current->array + indx, current->array + indx + 1,		\
+				 (current->count - indx) * sizeof (*current->array));	\
+		--current->count;												\
+	}																	\
+	static int prefix##GreaterThan(const void *a, const void *b)		\
+    {																	\
+		type an = *(type *)a;											\
+		type bn = *(type *)b;											\
+		if (an > bn)													\
+			return 1;													\
+		else if (an == bn)												\
+			return 0;													\
+		else															\
+			return -1;													\
+	}																	\
+	static int prefix##LessThan(const void *a, const void *b)			\
+	{																	\
+		return prefix##GreaterThan (b, a);								\
+	}																	\
+	extern void prefix##ArraySort (prefix##Array *const current, bool descendingOrder) \
+	{																	\
+		if (descendingOrder)											\
+			qsort (current->array, current->count, sizeof (type), prefix##GreaterThan); \
+		else															\
+			qsort (current->array, current->count, sizeof (type), prefix##LessThan); \
+	}
+
+/* We expect the linker we use is enough clever to delete dead code. */
+impNumArray(char, Char, char);
+impNumArray(uchar, Uchar, unsigned char);
+impNumArray(int, Int, int);
+impNumArray(uint, Uint, unsigned int);
+impNumArray(long, Long, long);
+impNumArray(ulong, Ulong, unsigned long);

--- a/main/numarray.h
+++ b/main/numarray.h
@@ -1,0 +1,48 @@
+/*
+*   Copyright (c) 1999-2002, Darren Hiebert
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   Defines external interface to resizable pointer arrays.
+*/
+#ifndef CTAGS_MAIN_NUMARRAY_H
+#define CTAGS_MAIN_NUMARRAY_H
+
+/*
+*   INCLUDE FILES
+*/
+#include "general.h"  /* must always come first */
+
+
+#define declNumArray(prefix,Prefix,type)								\
+																		\
+	struct s##Prefix##Array;											\
+	typedef struct s##Prefix##Array prefix##Array;						\
+																		\
+	extern prefix##Array *prefix##ArrayNew (void);						\
+	extern void prefix##ArrayAdd (prefix##Array *const current, type num); \
+	extern void prefix##ArrayRemoveLast (prefix##Array *const current);	\
+	extern void prefix##ArrayCombine (prefix##Array *const current, prefix##Array *const from);	\
+	extern void prefix##ArrayClear (prefix##Array *const current);		\
+	extern unsigned int prefix##ArrayCount (const prefix##Array *const current); \
+	extern type prefix##ArrayItem (const prefix##Array *const current, const unsigned int indx); \
+	extern type prefix##ArrayLast (const prefix##Array *const current); \
+	extern void prefix##ArrayDelete (prefix##Array *const current);		\
+	extern bool prefix##ArrayHasTest (const prefix##Array *const current, \
+									  bool (*test)(const type num, void *userData), \
+									  void *userData);					\
+	extern bool prefix##ArrayHas (const prefix##Array *const current, type num); \
+	extern void prefix##ArrayReverse (const prefix##Array *const current); \
+	extern void prefix##ArrayDeleteItem (prefix##Array* const current, unsigned int indx); \
+	\
+	extern void prefix##ArraySort (prefix##Array *const current, bool descendingOrder);
+
+declNumArray(char, Char, char);
+declNumArray(uchar, Uchar, unsigned char);
+declNumArray(int, Int, int);
+declNumArray(uint, Uint, unsigned int);
+declNumArray(long, Long, long);
+declNumArray(ulong, Ulong, unsigned long);
+
+#endif  /* CTAGS_MAIN_NUMARRAY_H */

--- a/source.mak
+++ b/source.mak
@@ -34,6 +34,7 @@ MAIN_HEADS =			\
 	main/main.h		\
 	main/mbcs.h		\
 	main/nestlevel.h	\
+	main/numarray.h		\
 	main/objpool.h		\
 	main/options.h		\
 	main/param.h		\
@@ -77,6 +78,7 @@ MAIN_SRCS =				\
 	main/main.c			\
 	main/mbcs.c			\
 	main/nestlevel.c		\
+	main/numarray.c			\
 	main/objpool.c			\
 	main/options.c			\
 	main/param.c			\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -115,6 +115,7 @@
     <ClCompile Include="..\main\main.c" />
     <ClCompile Include="..\main\mio.c" />
     <ClCompile Include="..\main\nestlevel.c" />
+    <ClCompile Include="..\main\numarray.c" />
     <ClCompile Include="..\main\objpool.c" />
     <ClCompile Include="..\main\options.c" />
     <ClCompile Include="..\main\param.c" />
@@ -267,6 +268,7 @@
     <ClInclude Include="..\main\main.h" />
     <ClInclude Include="..\main\mio.h" />
     <ClInclude Include="..\main\nestlevel.h" />
+    <ClInclude Include="..\main\numarray.h" />
     <ClInclude Include="..\main\objpool.h" />
     <ClInclude Include="..\main\options.h" />
     <ClInclude Include="..\main\param.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -99,6 +99,9 @@
     <ClCompile Include="..\main\nestlevel.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
+    <ClCompile Include="..\main\numarray.c">
+      <Filter>Source Files\Main</Filter>
+    </ClCompile>
     <ClCompile Include="..\main\objpool.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
@@ -549,6 +552,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\nestlevel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\main\numarray.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\objpool.h">


### PR DESCRIPTION
numArray is derrived from ptrArray.  ptrArray is for storing pointers.
numArray is for store numbers like int and long.

numArray is implemented in macro. You can use it after expanding the
macro by giving actual data type. The declaration and implementation
for char, unsigned char, int, unsigned int, long and unsigned long are
expanded already.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>