### PR TITLE
Git ignore .DS_Store files generated by Mac-OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 *~
 .deps
 .dirstamp
+.DS_Store
 a.out
 aclocal.m4
 autom4te.cache


### PR DESCRIPTION
Mac OSX generates `.DS_Store` files in directories, which most projects add to `.gitignore` to ignore. So this does that.