### PR TITLE
main: introduce TRACE_PRINT_{PREFIX|FMT|NEWLINE} macros

### DIFF
--- a/main/trace.c
+++ b/main/trace.c
@@ -54,7 +54,35 @@ void traceLeave(const char * szFunction,const char * szFormat,...)
 	fprintf(stderr,"\n");
 }
 
-void tracePrint(const char * szFunction,const char * szFormat,...)
+static void tracePrintFmtVa(const char * szFormat, va_list va)
+{
+	vfprintf(stderr,szFormat,va);
+}
+
+void tracePrint(const char * szFunction, const char * szFormat,...)
+{
+	if (!isTraced())
+		return;
+
+	tracePrintPrefix(szFormat);
+
+	va_list va;
+	va_start(va,szFormat);
+	tracePrintFmtVa (szFormat,va);
+	va_end(va);
+
+	tracePrintNewline();
+}
+
+void tracePrintFmt(const char * szFormat,...)
+{
+	va_list va;
+	va_start(va,szFormat);
+	tracePrintFmtVa (szFormat,va);
+	va_end(va);
+}
+
+void tracePrintPrefix(const char * szFunction)
 {
 	if (!isTraced())
 		return;
@@ -62,15 +90,15 @@ void tracePrint(const char * szFunction,const char * szFormat,...)
 	debugIndent();
 
 	fprintf(stderr,"[%s][at %lu] ",szFunction,getInputLineNumber());
+}
 
-	va_list va;
-	va_start(va,szFormat);
-	vfprintf(stderr,szFormat,va);
-	va_end(va);
+void tracePrintNewline(void)
+{
+	if (!isTraced())
+		return;
 
 	fprintf(stderr,"\n");
 }
-
 
 static bool tracingMain;
 

--- a/main/trace.h
+++ b/main/trace.h
@@ -31,6 +31,10 @@
 	void traceLeave(const char * szFunction,const char * szFormat,...);
 	void tracePrint(const char * szFunction,const char * szFormat,...);
 
+	void tracePrintPrefix(const char * szFunction);
+	void tracePrintFmt(const char * szFormat,...);
+	void tracePrintNewline(void);
+
 	#define TRACE_ENTER() traceEnter(__func__,"")
 	#define TRACE_LEAVE() traceLeave(__func__,"")
 
@@ -42,6 +46,21 @@
 
 	#define TRACE_PRINT(_szFormat,...) \
 		tracePrint(__func__,_szFormat,## __VA_ARGS__)
+
+	/* TRACE_PRINT prints line at once.
+	 * If you want to print a trace line incrementally,
+	 * use following macros.
+	 *
+	 * TRACE_PRINT_PREFIX: just print a trace prefix. No newline.
+	 * TRACE_PRINT_FMT: print as a format. No prefix, no newline.
+	 * TRACE_PRINT_NEWLINE: just print a newline.
+	 */
+	#define TRACE_PRINT_PREFIX() \
+		tracePrintPrefix(__func__)
+	#define TRACE_PRINT_FMT(_szFormat,...) \
+		tracePrintFmt(_szFormat,## __VA_ARGS__)
+	#define TRACE_PRINT_NEWLINE() \
+		tracePrintNewline()
 
 	#define TRACE_ASSERT(_condition,_szFormat,...) \
 		do { \
@@ -64,6 +83,10 @@
 	#define TRACE_LEAVE_TEXT(_szFormat,...) do { } while(0)
 
 	#define TRACE_PRINT(_szFormat,...) do { } while(0)
+
+	#define TRACE_PRINT_PREFIX() do { } while(0)
+	#define TRACE_PRINT_FMT(_szFormat,...) do { } while(0)
+	#define TRACE_PRINT_NEWLINE() do { } while(0)
 
 	#define TRACE_ASSERT(_condition,_szFormat,...) do { } while(0)
 


### PR DESCRIPTION
TRACE_PRINT prints a line at once; it inserts a prefix at the start and a newline at the end.
Sometimes I want to print a trace line incrementally.

TRACE_PRINT_{PREFIX|FMT|NEWLINE} are for the purpose.

TRACE_PRINT_PREFIX just prints a prefix.
TRACE_PRINT_FMT does the same as TRACE_PRINT but it doesn't print a prefix and a newline.
TRACE_PRINT_NEWLINE just prints a newline.

You can use them like:

		    TRACE_PRINT_PREFIX();
    #ifdef DO_TRACING
		    if (ctx->if_tracker)
		    {
			    for (int i = 0; i < intArrayCount (ctx->if_tracker); i++)
				    TRACE_PRINT_FMT("%d ", intArrayItem(ctx->if_tracker, i));
		    }
    #endif	/* DO_TRACING */
		    TRACE_PRINT_NEWLINE();

Signed-off-by: Masatake YAMATO <yamato@redhat.com>