### PR TITLE
Asciidoc: new parser

### DIFF
--- a/Units/parser-asciidoc.r/anchor-asciidoc.d/expected.tags
+++ b/Units/parser-asciidoc.r/anchor-asciidoc.d/expected.tags
@@ -1,0 +1,15 @@
+Chapter 1 (Level 0)	input.asciidoc	/^= Chapter 1 (Level 0)$/;"	c
+Chapter 2	input.asciidoc	/^Chapter 2$/;"	c
+Level 3 Section 1.1.1.1 Title	input.asciidoc	/^==== Level 3 Section 1.1.1.1 Title$/;"	t	subsection:Subsection 1.1.1
+Section 1.1	input.asciidoc	/^== Section 1.1$/;"	s	chapter:Chapter 1 (Level 0)
+Section 1.2	input.asciidoc	/^== Section 1.2$/;"	s	chapter:Chapter 1 (Level 0)
+Section 2.1	input.asciidoc	/^Section 2.1$/;"	s	chapter:Chapter 2
+Subsection 1.1.1	input.asciidoc	/^=== Subsection 1.1.1$/;"	S	section:Section 1.1
+Subsection 2.1.1	input.asciidoc	/^Subsection 2.1.1$/;"	S	section:Section 2.1
+chapter_2_anchor	input.asciidoc	/^[[chapter_2_anchor]]$/;"	a	section:Section 1.2
+section_1_1_1_1_anchor	input.asciidoc	/^[#section_1_1_1_1_anchor]$/;"	a	subsection:Subsection 1.1.1
+section_1_1_1_anchor	input.asciidoc	/^[[section_1_1_1_anchor]]$/;"	a	section:Section 1.1
+section_1_1_anchor	input.asciidoc	/^[[section_1_1_anchor]]$/;"	a	chapter:Chapter 1 (Level 0)
+section_1_2_anchor	input.asciidoc	/^[#section_1_2_anchor]$/;"	a	subsubsection:Level 3 Section 1.1.1.1 Title
+section_2_1_1_anchor	input.asciidoc	/^[#section_2_1_1_anchor]$/;"	a	section:Section 2.1
+section_2_1_anchor	input.asciidoc	/^[[section_2_1_anchor]]$/;"	a	chapter:Chapter 2

--- a/Units/parser-asciidoc.r/anchor-asciidoc.d/input.asciidoc
+++ b/Units/parser-asciidoc.r/anchor-asciidoc.d/input.asciidoc
@@ -1,0 +1,42 @@
+= Chapter 1 (Level 0)
+
+Intro text of chapter 1
+
+[[section_1_1_anchor]]
+== Section 1.1
+
+Text of section 1.1
+
+[[section_1_1_1_anchor]]
+=== Subsection 1.1.1
+
+Text of subsection 1.1.1
+
+[#section_1_1_1_1_anchor]
+==== Level 3 Section 1.1.1.1 Title
+
+Text of subsection 1.1.1.1
+
+[#section_1_2_anchor]
+== Section 1.2
+
+Text of section 1.2
+
+// and now two-line titles:
+
+[[chapter_2_anchor]]
+Chapter 2
+=========
+
+Intro text of chapter 2
+
+[[section_2_1_anchor]]
+Section 2.1
+------------
+
+Text of section 2.1
+
+[#section_2_1_1_anchor]
+Subsection 2.1.1
+~~~~~~~~~~~~~~~
+

--- a/Units/parser-asciidoc.r/simple-asciidoc.d/expected.tags
+++ b/Units/parser-asciidoc.r/simple-asciidoc.d/expected.tags
@@ -4,6 +4,7 @@ Level 3 Section 1.1.1.1 Title	input.asciidoc	/^==== Level 3 Section 1.1.1.1 Titl
 Level 3 Section 2.1.1.1 Title	input.asciidoc	/^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^$/;"	t	subsection:Subsection 2.1.1
 Level 4 Section 1.1.1.1.1 Title	input.asciidoc	/^===== Level 4 Section 1.1.1.1.1 Title$/;"	T	subsubsection:Level 3 Section 1.1.1.1 Title
 Level 4 Section 2.1.1.1.1 Title	input.asciidoc	/^+++++++++++++++++++++++++++++++$/;"	T	subsubsection:Level 3 Section 2.1.1.1 Title
+Level 5 Section 1.1.1.1.1.1 Title	input.asciidoc	/^====== Level 5 Section 1.1.1.1.1.1 Title$/;"	u	l4subsection:Level 4 Section 1.1.1.1.1 Title
 Section 1.1	input.asciidoc	/^== Section 1.1$/;"	s	chapter:Chapter 1 (Level 0)
 Section 1.2	input.asciidoc	/^== Section 1.2$/;"	s	chapter:Chapter 1 (Level 0)
 Section 2.1	input.asciidoc	/^------------$/;"	s	chapter:Chapter 2

--- a/Units/parser-asciidoc.r/simple-asciidoc.d/expected.tags
+++ b/Units/parser-asciidoc.r/simple-asciidoc.d/expected.tags
@@ -1,0 +1,12 @@
+Chapter 1 (Level 0)	input.asciidoc	/^= Chapter 1 (Level 0)$/;"	c
+Chapter 2	input.asciidoc	/^=========$/;"	c
+Level 3 Section 1.1.1.1 Title	input.asciidoc	/^==== Level 3 Section 1.1.1.1 Title$/;"	t	subsection:Subsection 1.1.1
+Level 3 Section 2.1.1.1 Title	input.asciidoc	/^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^$/;"	t	subsection:Subsection 2.1.1
+Level 4 Section 1.1.1.1.1 Title	input.asciidoc	/^===== Level 4 Section 1.1.1.1.1 Title$/;"	T	subsubsection:Level 3 Section 1.1.1.1 Title
+Level 4 Section 2.1.1.1.1 Title	input.asciidoc	/^+++++++++++++++++++++++++++++++$/;"	T	subsubsection:Level 3 Section 2.1.1.1 Title
+Section 1.1	input.asciidoc	/^== Section 1.1$/;"	s	chapter:Chapter 1 (Level 0)
+Section 1.2	input.asciidoc	/^== Section 1.2$/;"	s	chapter:Chapter 1 (Level 0)
+Section 2.1	input.asciidoc	/^------------$/;"	s	chapter:Chapter 2
+Section 2.2	input.asciidoc	/^-----------$/;"	s	chapter:Chapter 2
+Subsection 1.1.1	input.asciidoc	/^=== Subsection 1.1.1$/;"	S	section:Section 1.1
+Subsection 2.1.1	input.asciidoc	/^~~~~~~~~~~~~~~~$/;"	S	section:Section 2.1

--- a/Units/parser-asciidoc.r/simple-asciidoc.d/expected.tags
+++ b/Units/parser-asciidoc.r/simple-asciidoc.d/expected.tags
@@ -1,13 +1,13 @@
 Chapter 1 (Level 0)	input.asciidoc	/^= Chapter 1 (Level 0)$/;"	c
-Chapter 2	input.asciidoc	/^=========$/;"	c
+Chapter 2	input.asciidoc	/^Chapter 2$/;"	c
 Level 3 Section 1.1.1.1 Title	input.asciidoc	/^==== Level 3 Section 1.1.1.1 Title$/;"	t	subsection:Subsection 1.1.1
-Level 3 Section 2.1.1.1 Title	input.asciidoc	/^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^$/;"	t	subsection:Subsection 2.1.1
+Level 3 Section 2.1.1.1 Title	input.asciidoc	/^Level 3 Section 2.1.1.1 Title$/;"	t	subsection:Subsection 2.1.1
 Level 4 Section 1.1.1.1.1 Title	input.asciidoc	/^===== Level 4 Section 1.1.1.1.1 Title$/;"	T	subsubsection:Level 3 Section 1.1.1.1 Title
-Level 4 Section 2.1.1.1.1 Title	input.asciidoc	/^+++++++++++++++++++++++++++++++$/;"	T	subsubsection:Level 3 Section 2.1.1.1 Title
+Level 4 Section 2.1.1.1.1 Title	input.asciidoc	/^Level 4 Section 2.1.1.1.1 Title$/;"	T	subsubsection:Level 3 Section 2.1.1.1 Title
 Level 5 Section 1.1.1.1.1.1 Title	input.asciidoc	/^====== Level 5 Section 1.1.1.1.1.1 Title$/;"	u	l4subsection:Level 4 Section 1.1.1.1.1 Title
 Section 1.1	input.asciidoc	/^== Section 1.1$/;"	s	chapter:Chapter 1 (Level 0)
 Section 1.2	input.asciidoc	/^== Section 1.2$/;"	s	chapter:Chapter 1 (Level 0)
-Section 2.1	input.asciidoc	/^------------$/;"	s	chapter:Chapter 2
-Section 2.2	input.asciidoc	/^-----------$/;"	s	chapter:Chapter 2
+Section 2.1	input.asciidoc	/^Section 2.1$/;"	s	chapter:Chapter 2
+Section 2.2	input.asciidoc	/^Section 2.2$/;"	s	chapter:Chapter 2
 Subsection 1.1.1	input.asciidoc	/^=== Subsection 1.1.1$/;"	S	section:Section 1.1
-Subsection 2.1.1	input.asciidoc	/^~~~~~~~~~~~~~~~$/;"	S	section:Section 2.1
+Subsection 2.1.1	input.asciidoc	/^Subsection 2.1.1$/;"	S	section:Section 2.1

--- a/Units/parser-asciidoc.r/simple-asciidoc.d/input.asciidoc
+++ b/Units/parser-asciidoc.r/simple-asciidoc.d/input.asciidoc
@@ -1,0 +1,55 @@
+= Chapter 1 (Level 0)
+
+Intro text of chapter 1
+
+== Section 1.1
+
+Text of section 1.1
+
+=== Subsection 1.1.1
+
+Text of subsection 1.1.1
+
+==== Level 3 Section 1.1.1.1 Title
+
+Text of subsection 1.1.1.1
+
+===== Level 4 Section 1.1.1.1.1 Title
+
+Text of subsection 1.1.1.1.1
+
+== Section 1.2
+
+Text of section 1.2
+
+// and now two-line titles:
+
+Chapter 2
+=========
+
+Intro text of chapter 2
+
+Section 2.1
+------------
+
+Text of section 2.1
+
+Subsection 2.1.1
+~~~~~~~~~~~~~~~
+
+Level 3 Section 2.1.1.1 Title
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Text of subsection 2.1.1.1
+
+Level 4 Section 2.1.1.1.1 Title
++++++++++++++++++++++++++++++++
+
+Text of subsection 2.1.1.1.1
+
+
+Section 2.2
+-----------
+
+Text of section 2.2
+

--- a/Units/parser-asciidoc.r/simple-asciidoc.d/input.asciidoc
+++ b/Units/parser-asciidoc.r/simple-asciidoc.d/input.asciidoc
@@ -18,6 +18,10 @@ Text of subsection 1.1.1.1
 
 Text of subsection 1.1.1.1.1
 
+====== Level 5 Section 1.1.1.1.1.1 Title
+
+Text of subsection 1.1.1.1.1.1
+
 == Section 1.2
 
 Text of section 1.2

--- a/Units/parser-asciidoc.r/utf8-asciidoc.d/expected.tags
+++ b/Units/parser-asciidoc.r/utf8-asciidoc.d/expected.tags
@@ -1,4 +1,4 @@
-@Ѐ–𐀀	input.asc	/^=== @Ѐ–𐀀$/;"	S	section:Chàptěr 1.Šéçtiön 1.1
-Chàptěr 1	input.asc	/^=========$/;"	c
-Subsubsection 1.1.1.1	input.asc	/^==== Subsubsection 1.1.1.1$/;"	t	subsection:Chàptěr 1.Šéçtiön 1.1.@Ѐ–𐀀
-Šéçtiön 1.1	input.asc	/^-----------$/;"	s	chapter:Chàptěr 1
+@Ѐ–𐀀	input.asc	/^=== @Ѐ–𐀀$/;"	S	section:Šéçtiön 1.1
+Chàptěr 1	input.asc	/^Chàptěr 1$/;"	c
+Subsubsection 1.1.1.1	input.asc	/^==== Subsubsection 1.1.1.1$/;"	t	subsection:@Ѐ–𐀀
+Šéçtiön 1.1	input.asc	/^Šéçtiön 1.1$/;"	s	chapter:Chàptěr 1

--- a/Units/parser-asciidoc.r/utf8-asciidoc.d/expected.tags
+++ b/Units/parser-asciidoc.r/utf8-asciidoc.d/expected.tags
@@ -1,0 +1,4 @@
+@Ѐ–𐀀	input.asc	/^=== @Ѐ–𐀀$/;"	S	section:Chàptěr 1.Šéçtiön 1.1
+Chàptěr 1	input.asc	/^=========$/;"	c
+Subsubsection 1.1.1.1	input.asc	/^==== Subsubsection 1.1.1.1$/;"	t	subsection:Chàptěr 1.Šéçtiön 1.1.@Ѐ–𐀀
+Šéçtiön 1.1	input.asc	/^-----------$/;"	s	chapter:Chàptěr 1

--- a/Units/parser-asciidoc.r/utf8-asciidoc.d/input.asc
+++ b/Units/parser-asciidoc.r/utf8-asciidoc.d/input.asc
@@ -1,0 +1,16 @@
+Chàptěr 1
+=========
+
+Intro text of chapter 1
+
+Šéçtiön 1.1
+-----------
+
+Text of section 1.1
+
+=== @Ѐ–𐀀
+
+Text of subsection 1.1.1
+
+==== Subsubsection 1.1.1.1
+

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -38,6 +38,7 @@ The following parsers have been added:
 
 * Ada
 * AnsiblePlaybook *libyaml*
+* Asciidoc
 * Autoconf
 * Automake
 * AutoIt

--- a/main/parsers.h
+++ b/main/parsers.h
@@ -38,6 +38,7 @@
 #define PARSER_LIST \
 	AdaParser, \
 	AntParser, \
+	AsciidocParser, \
 	AsmParser, \
 	AspParser, \
 	AutoconfParser, \

--- a/parsers/asciidoc.c
+++ b/parsers/asciidoc.c
@@ -1,12 +1,14 @@
 /*
  *
+ *  Copyright (c) 2007-2011, Nick Treleaven
  * 	Copyright (c) 2012, Lex Trotman
- *   Based on Rest code by Nick Treleaven, see rest.c
  *
  *   This source code is released for free distribution under the terms of the
- *   GNU General Public License.
+ *   GNU General Public License version 2 or (at your option) any later version.
  *
- *   This module contains functions for generating tags for asciidoc files.
+ * This module contains functions for generating tags for asciidoc files.
+ *
+ * Based on Rest code by Nick Treleaven, see rest.c
  *
  * This code was ported from geany git commit 40396a3 at:
  *   https://github.com/geany/geany/blob/master/ctags/parsers/asciidoc.c

--- a/parsers/asciidoc.c
+++ b/parsers/asciidoc.c
@@ -14,7 +14,6 @@
  *
  * TODO:
  *   - tag anchors (both long and short form)
- *   - add support for 5th level single-line title
  *   - for two-line titles, tag the first not second line pattern (i.e., fix filePosition)
  */
 
@@ -42,6 +41,7 @@ typedef enum {
 	K_SUBSECTION,
 	K_SUBSUBSECTION,
 	K_LEVEL4SECTION,
+	/* level-5 section not in here because it only works for one-line */
 	SECTION_COUNT
 } asciidocKind;
 
@@ -54,7 +54,8 @@ static kindDefinition AsciidocKinds[] = {
 	{ true, 's', "section",       "sections" },
 	{ true, 'S', "subsection",    "level 2 sections" },
 	{ true, 't', "subsubsection", "level 3 sections" },
-	{ true, 'T', "l4subsection",  "level 4 sections" }
+	{ true, 'T', "l4subsection",  "level 4 sections" },
+	{ true, 'u', "l5subsection",  "level 5 sections" }
 };
 
 static char kindchars[SECTION_COUNT]={ '=', '-', '~', '^', '+' };
@@ -218,7 +219,7 @@ static void findAsciidocTags(void)
 			}
 
 			/* otherwise is it a one line title */
-			else if (line[0] == '=' && n_same <= 5 && isspace(line[n_same]) &&
+			else if (line[0] == '=' && n_same <= 6 && isspace(line[n_same]) &&
 					!in_block)
 			{
 				int kind = n_same - 1;

--- a/parsers/asciidoc.c
+++ b/parsers/asciidoc.c
@@ -1,0 +1,260 @@
+/*
+ *
+ * 	Copyright (c) 2012, Lex Trotman
+ *   Based on Rest code by Nick Treleaven, see rest.c
+ *
+ *   This source code is released for free distribution under the terms of the
+ *   GNU General Public License.
+ *
+ *   This module contains functions for generating tags for asciidoc files.
+ *
+ * This code was ported from geany git commit 40396a3 at:
+ *   https://github.com/geany/geany/blob/master/ctags/parsers/asciidoc.c
+ * with the changes in geany's PR #1263, with some changes to work in uctags.
+ *
+ * TODO:
+ *   - tag anchors (both long and short form)
+ *   - add support for 5th level single-line title
+ *   - for two-line titles, tag the first not second line pattern (i.e., fix filePosition)
+ */
+
+/*
+ *   INCLUDE FILES
+ */
+#include "general.h"	/* must always come first */
+
+#include <ctype.h>
+#include <string.h>
+
+#include "entry.h"
+#include "parse.h"
+#include "read.h"
+#include "vstring.h"
+#include "nestlevel.h"
+#include "routines.h"
+
+/*
+ *   DATA DEFINITIONS
+ */
+typedef enum {
+	K_CHAPTER = 0,
+	K_SECTION,
+	K_SUBSECTION,
+	K_SUBSUBSECTION,
+	K_LEVEL4SECTION,
+	SECTION_COUNT
+} asciidocKind;
+
+/*
+ * The following kind letters are based on the markdown parser kinds,
+ * and thus different than geany's.
+ */
+static kindDefinition AsciidocKinds[] = {
+	{ true, 'c', "chapter",       "chapters"},
+	{ true, 's', "section",       "sections" },
+	{ true, 'S', "subsection",    "level 2 sections" },
+	{ true, 't', "subsubsection", "level 3 sections" },
+	{ true, 'T', "l4subsection",  "level 4 sections" }
+};
+
+static char kindchars[SECTION_COUNT]={ '=', '-', '~', '^', '+' };
+
+static NestingLevels *nestingLevels = NULL;
+
+/*
+*   FUNCTION DEFINITIONS
+*/
+
+static NestingLevel *getNestingLevel(const int kind)
+{
+	NestingLevel *nl;
+	tagEntryInfo *e;
+
+	while (1)
+	{
+		nl = nestingLevelsGetCurrent(nestingLevels);
+		e = getEntryOfNestingLevel (nl);
+		if ((nl && (e == NULL)) || (e && (e->kindIndex >= kind)))
+			nestingLevelsPop(nestingLevels);
+		else
+			break;
+	}
+	return nl;
+}
+
+static int makeAsciidocTag (const vString* const name, const int kind)
+{
+	const NestingLevel *const nl = getNestingLevel(kind);
+	int r = CORK_NIL;
+
+	if (vStringLength (name) > 0)
+	{
+		tagEntryInfo *parent = getEntryOfNestingLevel (nl);
+		tagEntryInfo e;
+
+		initTagEntry (&e, vStringValue (name), kind);
+
+		e.lineNumber--;	/* we want the line before the '---' underline chars */
+
+		if (parent && (parent->kindIndex < kind))
+		{
+			/*
+			 * This doesn't use Cork, but in this case I think this is better,
+			 * because Cork would record the scopes of all parents in the chain
+			 * which is weird for text section identifiers, and also this is
+			 * what the rst.c reStructuredText parser does.
+			 */
+			e.extensionFields.scopeKindIndex = parent->kindIndex;
+			e.extensionFields.scopeName = parent->name;
+		}
+
+		r = makeTagEntry (&e);
+	}
+	nestingLevelsPush(nestingLevels, r);
+	return r;
+}
+
+
+static int get_kind(char c)
+{
+	int i;
+
+	for (i = 0; i < SECTION_COUNT; i++)
+	{
+		if (kindchars[i] == c)
+			return i;
+	}
+	return -1;
+}
+
+
+/* computes the length of an UTF-8 string
+ * if the string doesn't look like UTF-8, return -1
+ * FIXME consider East_Asian_Width Unicode property */
+static int utf8_strlen(const char *buf, int buf_len)
+{
+	int len = 0;
+	const char *end = buf + buf_len;
+
+	for (len = 0; buf < end; len ++)
+	{
+		/* perform quick and naive validation (no sub-byte checking) */
+		if (! (*buf & 0x80))
+			buf ++;
+		else if ((*buf & 0xe0) == 0xc0)
+			buf += 2;
+		else if ((*buf & 0xf0) == 0xe0)
+			buf += 3;
+		else if ((*buf & 0xf8) == 0xf0)
+			buf += 4;
+		else /* not a valid leading UTF-8 byte, abort */
+			return -1;
+
+		if (buf > end) /* incomplete last byte */
+			return -1;
+	}
+
+	return len;
+}
+
+
+static void findAsciidocTags(void)
+{
+	vString *name = vStringNew();
+	const unsigned char *line;
+	unsigned char in_block = '\0';  /* holds the block marking char or \0 if not in block */
+
+	nestingLevels = nestingLevelsNew(0);
+
+	while ((line = readLineFromInputFile()) != NULL)
+	{
+		int line_len = strlen((const char*) line);
+		int name_len_bytes = vStringLength(name);
+		int name_len = utf8_strlen(vStringValue(name), name_len_bytes);
+
+		/* if the name doesn't look like UTF-8, assume one-byte charset */
+		if (name_len < 0) name_len = name_len_bytes;
+
+		/* if its a title underline, or a delimited block marking character */
+		if (line[0] == '=' || line[0] == '-' || line[0] == '~' ||
+			line[0] == '^' || line[0] == '+' || line[0] == '.' ||
+			line[0] == '*' || line[0] == '_' || line[0] == '/')
+		{
+			int n_same;
+			for (n_same = 1; line[n_same] == line[0]; ++n_same);
+
+			/* is it a two line title or a delimited block */
+			if (n_same == line_len)
+			{
+				/* if in a block, can't be block start or title, look for block end */
+				if (in_block)
+				{
+					if (line[0] == in_block) in_block = '\0';
+				}
+
+				/* if its a =_~^+ and the same length +-2 as the line before then its a title */
+				/* (except in the special case its a -- open block start line) */
+				else if ((line[0] == '=' || line[0] == '-' || line[0] == '~' ||
+							line[0] == '^' || line[0] == '+') &&
+						line_len <= name_len + 2 && line_len >= name_len - 2 &&
+						!(line_len == 2 && line[0] == '-'))
+				{
+					int kind = get_kind((char)(line[0]));
+					if (kind >= 0)
+					{
+						makeAsciidocTag(name, kind);
+						continue;
+					}
+				}
+
+				/* else if its 4 or more /+-.*_= (plus the -- special case) its a block start */
+				else if (((line[0] == '/' || line[0] == '+' || line[0] == '-' ||
+						   line[0] == '.' || line[0] == '*' || line[0] == '_' ||
+						   line[0] == '=') && line_len >= 4 )
+						 || (line[0] == '-' && line_len == 2))
+				{
+					in_block = line[0];
+				}
+			}
+
+			/* otherwise is it a one line title */
+			else if (line[0] == '=' && n_same <= 5 && isspace(line[n_same]) &&
+					!in_block)
+			{
+				int kind = n_same - 1;
+				int start = n_same;
+				int end = line_len - 1;
+				while (line[end] == line[0])--end;
+				while (isspace(line[start]))++start;
+				while (isspace(line[end]))--end;
+				vStringClear(name);
+				vStringNCatS(name, (const char*)(&(line[start])), end - start + 1);
+				makeAsciidocTag(name, kind);
+				continue;
+			}
+		}
+		vStringClear(name);
+		if (! isspace(*line))
+			vStringCatS(name, (const char*) line);
+	}
+	vStringDelete(name);
+	nestingLevelsFree(nestingLevels);
+}
+
+extern parserDefinition* AsciidocParser (void)
+{
+	static const char *const patterns [] = { "*.asc", "*.adoc", "*.asciidoc", NULL };
+	static const char *const extensions [] = { "asc", "adoc", "asciidoc", NULL };
+
+	parserDefinition* const def = parserNew ("Asciidoc");
+
+	def->kindTable = AsciidocKinds;
+	def->kindCount = ARRAY_SIZE (AsciidocKinds);
+	def->patterns = patterns;
+	def->extensions = extensions;
+	def->parser = findAsciidocTags;
+	/* do we even need to use Cork? */
+	def->useCork = true;
+
+	return def;
+}

--- a/source.mak
+++ b/source.mak
@@ -135,6 +135,7 @@ PARSER_HEADS = \
 PARSER_SRCS =				\
 	parsers/ada.c			\
 	parsers/ant.c			\
+	parsers/asciidoc.c		\
 	parsers/asm.c			\
 	parsers/asp.c			\
 	parsers/autoconf.c		\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -152,6 +152,7 @@
     <ClCompile Include="..\optlib\qemuhx.c" />
     <ClCompile Include="..\parsers\ada.c" />
     <ClCompile Include="..\parsers\ant.c" />
+    <ClCompile Include="..\parsers\asciidoc.c" />
     <ClCompile Include="..\parsers\asm.c" />
     <ClCompile Include="..\parsers\asp.c" />
     <ClCompile Include="..\parsers\autoconf.c" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -210,6 +210,9 @@
     <ClCompile Include="..\parsers\ant.c">
       <Filter>Source Files\Parsers</Filter>
     </ClCompile>
+    <ClCompile Include="..\parsers\asciidoc.c">
+      <Filter>Source Files\Parsers</Filter>
+    </ClCompile>
     <ClCompile Include="..\parsers\asm.c">
       <Filter>Source Files\Parsers</Filter>
     </ClCompile>


### PR DESCRIPTION
This ports the Asciidoc parser from geany, fixes a bug in it, and adds tagging of anchors. (other than anchors inline in one-line titles)