### PR TITLE
[HEADS-UP,WIP] peg based new java parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 *.TMP
 *.tmp
 *~
+/packcc
 .deps
 .dirstamp
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "misc/packcc"]
+	path = misc/packcc
+	url = https://github.com/masatake/packcc.git
+	branch = ctags

--- a/Makefile.am
+++ b/Makefile.am
@@ -79,14 +79,17 @@ nodist_ctags_SOURCES = $(REPOINFO_HEADS)
 BUILT_SOURCES = $(REPOINFO_HEADS)
 CLEANFILES = $(REPOINFO_HEADS)
 $(REPOINFO_OBJS): $(REPOINFO_SRCS) $(REPOINFO_HEADS)
+repoinfo_verbose = $(repoinfo_verbose_@AM_V@)
+repoinfo_verbose_ = $(repoinfo_verbose_@AM_DEFAULT_V@)
+repoinfo_verbose_0 = @echo REPOINFO "  $@";
 if BUILD_IN_GIT_REPO
 GEN_REPOINFO = $(srcdir)/misc/gen-repoinfo
 $(REPOINFO_HEADS): FORCE
-	$(GEN_REPOINFO) $@
+	$(repoinfo_verbose)$(GEN_REPOINFO) $@
 FORCE:
 else
 $(REPOINFO_HEADS):
-	echo > $@
+	$(repoinfo_verbose)echo > $@
 endif
 
 if RUN_OPTLIB2C

--- a/Makefile.am
+++ b/Makefile.am
@@ -99,8 +99,10 @@ optlib2c_verbose = $(optlib2c_verbose_@AM_V@)
 optlib2c_verbose_ = $(optlib2c_verbose_@AM_DEFAULT_V@)
 optlib2c_verbose_0 = @echo OPTLIB2C "  $@";
 OPTLIB2C = $(srcdir)/misc/optlib2c
-%.c: %.ctags $(OPTLIB2C) Makefile
+SUFFIXES += .ctags
+.ctags.c:
 	$(optlib2c_verbose)$(OPTLIB2C) $< > $@
+$(OPTLIB2C_INPUT): $(OPTLIB2C) Makefile
 endif
 dist_ctags_SOURCES = $(ALL_HEADS) $(ALL_SRCS)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,27 @@ EXTRA_DIST   = README.md autogen.sh \
 	       win32/ctags_vs2013.vcxproj win32/ctags_vs2013.vcxproj.filters \
 	       win32/gen-repoinfo.bat
 
+noinst_PROGRAMS = packcc
 bin_PROGRAMS = ctags
+
+packcc_CPPFLAGS =
+packcc_CFLAGS =
+dist_packcc_SOURCES = $(PACKCC_SRCS)
+
+if HAVE_STRNLEN
+packcc_CPPFLAGS += -DUSE_SYSTEM_STRNLEN
+endif
+
+if USE_NO_FORMATTER_FOR_SIZE_T
+packcc_CPPFLAGS += -DSIZE_T_FMT_CHAR='""'
+endif
+if USE_ULONG_FORMATTER_FOR_SIZE_T
+packcc_CPPFLAGS += -DSIZE_T_FMT_CHAR='"l"'
+endif
+if USE_ULONGLONG_FORMATTER_FOR_SIZE_T
+packcc_CPPFLAGS += -DSIZE_T_FMT_CHAR='"ll"'
+endif
+
 
 if USE_READCMD
 bin_PROGRAMS+= readtags
@@ -48,9 +68,15 @@ PARSER_SRCS += $(YAML_SRCS)
 PARSER_HEADS += $(YAML_HEADS)
 endif
 
-ctags_CPPFLAGS = -I. -I$(srcdir) -I$(srcdir)/main
+PARSER_SRCS += $(PEG_SRCS)
+PARSER_HEADS += $(PEG_HEADS) $(PEG_EXTRA_HEADS)
+
+ctags_CPPFLAGS = -I. -I$(srcdir) -I$(srcdir)/main -DHAVE_PACKCC
 if ENABLE_DEBUGGING
 ctags_CPPFLAGS+= $(DEBUG_CPPFLAGS)
+endif
+if HAVE_STRNLEN
+ctags_CPPFLAGS += -DUSE_SYSTEM_STRNLEN
 endif
 ctags_CPPFLAGS+= $(FNMATCH_CPPFLAGS)
 ctags_CPPFLAGS+= $(REGCOMP_CPPFLAGS)
@@ -104,6 +130,19 @@ SUFFIXES += .ctags
 	$(optlib2c_verbose)$(OPTLIB2C) $< > $@
 $(OPTLIB2C_INPUT): $(OPTLIB2C) Makefile
 endif
+
+packcc_verbose = $(packcc_verbose_@AM_V@)
+packcc_verbose_ = $(packcc_verbose_@AM_DEFAULT_V@)
+packcc_verbose_0 = @echo PACKCC "    $@";
+PACKCC = $(srcdir)/packcc$(EXEEXT)
+SUFFIXES += .peg
+.peg.c:
+	$(packcc_verbose)$(PACKCC) $<
+.peg.h:
+	$(packcc_verbose)$(PACKCC) $<
+# You cannot use $(PACKCC) as a target name here.
+$(PEG_INPUT): packcc$(EXEEXT) Makefile
+$(PEG_HEADS): packcc$(EXEEXT) Makefile
 dist_ctags_SOURCES = $(ALL_HEADS) $(ALL_SRCS)
 
 if INSTALL_ETAGS

--- a/Makefile.am
+++ b/Makefile.am
@@ -92,6 +92,8 @@ $(REPOINFO_HEADS):
 	$(repoinfo_verbose)echo > $@
 endif
 
+SUFFIXES=
+
 if RUN_OPTLIB2C
 optlib2c_verbose = $(optlib2c_verbose_@AM_V@)
 optlib2c_verbose_ = $(optlib2c_verbose_@AM_DEFAULT_V@)
@@ -120,7 +122,7 @@ man_MANS = man/ctags.1 man/ctags-incompatibilities.7 man/ctags-optlib.7
 rst2man_verbose = $(rst2man_verbose_@AM_V@)
 rst2man_verbose_ = $(rst2man_verbose_@AM_DEFAULT_V@)
 rst2man_verbose_0 = @echo RST2MAN "  $@";
-SUFFIXES = .1.rst .1 .7.rst .7
+SUFFIXES += .1.rst .1 .7.rst .7
 # See man/Makefile
 RST2MAN_OPTIONS=--syntax-highlight=none
 .1.rst.1:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,27 @@ The goal of the project is preparing and maintaining common/unified working
 space where people interested in making ctags better can work
 together.
 
+## Getting PACKCC compiler-compiler ##
+
+Packcc is a compiler-compiler; it translates .peg grammar file to .c
+file.  packcc was originally written by Arihiro Yoshida. Its source
+repository is at sourceforge. It seems that packcc at sourceforge is
+not actively maintained. Some derived repositories are at
+github. Currently, our choice is
+https://github.com/enechaev/packcc. It is the most active one in the
+derived repositories.
+
+The source tree of packcc is grafted at misc/packcc directory.
+Building packcc and ctags are integrated in the build-scripts of
+Universal-ctags.
+
+If misc/packcc directory is empty, run following command to get
+source code before building ctags:
+```
+$ git submodule init misc/packcc
+$ git submodule update misc/packcc
+```
+
 ## The latest build and package ##
 
 If you want to try the latest universal-ctags without building it yourself...

--- a/README.md
+++ b/README.md
@@ -85,3 +85,45 @@ site and man pages
 source tree).
 
 Pull-requests are welcome!
+
+## peg-based-java-parser branch ##
+
+This is an experimental branch for testing "packcc" parser generator
+and peg based "NewJava" parser.  Only building with Autotools is
+supported. Volunteers for the other build-system are welcome.
+
+packcc is registred as a git submodule. It is taken from https://github.com/enechaev/packcc.
+The peg definition for Java 1.7 is taken from https://github.com/pointlander/peg/blob/master/grammars/java/java_1_7.peg.
+
+git submodule handling is done in ./autogen.sh.
+
+How to switch the branch:
+
+```
+[yamato@master]/tmp% git clone https://github.com/masatake/ctags.git
+Cloning into 'ctags'...
+remote: Counting objects: 38867, done.
+remote: Compressing objects: 100% (48/48), done.
+remote: Total 38867 (delta 18), reused 43 (delta 16), pack-reused 38802
+Receiving objects: 100% (38867/38867), 11.80 MiB | 4.41 MiB/s, done.
+Resolving deltas: 100% (24486/24486), done.
+[yamato@master]/tmp% cd ctags
+[yamato@master]/tmp/ctags% git checkout peg-based-java-parser
+Branch 'peg-based-java-parser' set up to track remote branch 'peg-based-java-parser' from 'origin'.
+Switched to a new branch 'peg-based-java-parser'
+```
+
+How to try the new java parser:
+```
+[yamato@master]~/var/ctags-peg% ./ctags --fields=+l -o - --languages=+NewJava --language-force=NewJava foo.java
+A	foo.java	/^    A;$/;"	e	language:NewJava	enum:e
+e	foo.java	/^public enum e {$/;"	g	language:NewJava
+getString	foo.java	/^    public String getString() {$/;"	m	language:NewJava	enum:e
+```
+
+TODO:
+
+* Improve or modify packcc to make ctags pass the test case parser-java.r/accented-latin1-identifiers.java.d,
+* Build a ctags executable on non-Autotools platform,
+* Support Java-1.9 (See http://www.romanredz.se/Mouse/index.htm#parsing), and
+* Add a parser for peg itself.

--- a/Tmain/list-params.d/run.sh
+++ b/Tmain/list-params.d/run.sh
@@ -4,6 +4,13 @@
 CTAGS=$1
 C="${CTAGS} --quiet --options=NONE"
 
+# The layout of outputs are very different whether NewJava, a packcc
+# based parser, is available or not. The stdout-expected.txt of
+# this test case assumes the target ctags has the NewJava parser.
+# Skip this test case if the target ctags doesn't have the parser,
+. ../utils.sh
+is_feature_available $CTAGS packcc
+
 echo '# ALL'
 ${C} --with-list-header=yes --list-params
 echo

--- a/Tmain/list-params.d/stdout-expected.txt
+++ b/Tmain/list-params.d/stdout-expected.txt
@@ -1,9 +1,10 @@
 # ALL
-#LANGUAGE      NAME   DESCRIPTION
-CPreProcessor  define define replacement for an identifier
-CPreProcessor  if0    examine code within "#if 0" branch (true or [false])
-CPreProcessor  ignore a token to be specially handled
-Fypp           guest  parser run after Fypp parser parses the original input ("NONE" or a parser name [Fortran])
+#LANGUAGE      NAME                DESCRIPTION
+CPreProcessor  define              define replacement for an identifier
+CPreProcessor  if0                 examine code within "#if 0" branch (true or [false])
+CPreProcessor  ignore              a token to be specially handled
+Fypp           guest               parser run after Fypp parser parses the original input ("NONE" or a parser name [Fortran])
+NewJava        includeTypeArgument include type arguments to inheritance field: true or [false]
 
 # ALL MACHINABLE
 #LANGUAGE	NAME	DESCRIPTION
@@ -11,12 +12,14 @@ CPreProcessor	define	define replacement for an identifier
 CPreProcessor	if0	examine code within "#if 0" branch (true or [false])
 CPreProcessor	ignore	a token to be specially handled
 Fypp	guest	parser run after Fypp parser parses the original input ("NONE" or a parser name [Fortran])
+NewJava	includeTypeArgument	include type arguments to inheritance field: true or [false]
 
 # ALL MACHINABLE NOHEADER
 CPreProcessor	define	define replacement for an identifier
 CPreProcessor	if0	examine code within "#if 0" branch (true or [false])
 CPreProcessor	ignore	a token to be specially handled
 Fypp	guest	parser run after Fypp parser parses the original input ("NONE" or a parser name [Fortran])
+NewJava	includeTypeArgument	include type arguments to inheritance field: true or [false]
 
 # CPP
 #NAME   DESCRIPTION

--- a/Tmain/list-roles.d/run.sh
+++ b/Tmain/list-roles.d/run.sh
@@ -22,20 +22,26 @@ ignore_yaml()
 }
 
 # When introducing newly rewritten parser, we would like to provide
-# the both new parser and old parser for debugging and providing
+# both new parser and old parser for debugging and providing
 # migration period to users. In such case the prefix "Old" will be
-# used to the name of old parser. The old parser should be ignored
+# used to the name of old parser, or "New" will be used to the same name of
+# new experimental parser. The old and new parsers should be ignored
 # in this test case.
 ignore_old()
 {
     grep -v '^Old'
 }
 
+ignore_new()
+{
+    grep -v '^New'
+}
+
 title ''
-${CTAGS} --quiet --options=NONE --list-roles= | ignore_xml | ignore_old | ignore_yaml
+${CTAGS} --quiet --options=NONE --list-roles= | ignore_xml | ignore_old | ignore_yaml | ignore_new
 
 title 'all.*'
-${CTAGS} --quiet --options=NONE --list-roles='all.*' | ignore_xml | ignore_old | ignore_yaml
+${CTAGS} --quiet --options=NONE --list-roles='all.*' | ignore_xml | ignore_old | ignore_yaml | ignore_new
 
 title 'C.*'
 ${CTAGS} --quiet --options=NONE --list-roles='C.*'

--- a/Tmain/pretend-option.d/run.sh
+++ b/Tmain/pretend-option.d/run.sh
@@ -1,0 +1,6 @@
+# Copyright: 2018 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+"${CTAGS}" --quiet --options=NONE --with-list-header=no --_pretend-Lisp=C --list-kinds=C

--- a/Tmain/pretend-option.d/stdout-expected.txt
+++ b/Tmain/pretend-option.d/stdout-expected.txt
@@ -1,0 +1,1 @@
+f  functions

--- a/autogen.sh
+++ b/autogen.sh
@@ -5,6 +5,11 @@ set -xe
 type autoreconf || exit 1
 type pkg-config || exit 1
 
+if ! [ -f misc/packcc/packcc.c ]; then
+	git submodule init
+	git submodule update
+fi
+
 if [ -z "${MAKE}" ]; then
 	if type make > /dev/null; then
 		MAKE=make

--- a/autogen.sh
+++ b/autogen.sh
@@ -16,7 +16,7 @@ if [ -z "${MAKE}" ]; then
 	fi
 fi
 
-ctags_files=`${MAKE} -s -f makefiles/list-translator-input.mak`
+ctags_files=`${MAKE} -s -f makefiles/list-optlib2c-input.mak`
 misc/dist-test-cases && \
     if autoreconf -vfi; then
 	if type perl > /dev/null; then

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ jobs:
        - run:
            name: Test
            command: |
-             MAKE=bmake bmake validate-input check roundtrip CIRCLECI=1
+             MAKE=bmake bmake validate-input check roundtrip CIRCLECI=1 PMAP=NewJava/Java
    centos_make:
      working_directory: ~/universal-ctags
      docker:
@@ -49,7 +49,7 @@ jobs:
        - run:
            name: Test
            command: |
-             make check roundtrip CIRCLECI=1
+             make check roundtrip CIRCLECI=1 PMAP=NewJava/Java
 
 workflows:
   version: 2

--- a/configure.ac
+++ b/configure.ac
@@ -385,8 +385,8 @@ AC_EGREP_HEADER(clock_t, time.h, AC_MSG_RESULT(yes),
 
 AC_CHECK_HEADERS([stdbool.h],
 [
-	AH_TEMPLATE([USE_STDBOOL_H], [whether or not to use <stdbool.h>.])
-	AC_DEFINE([USE_STDBOOL_H])
+	AH_TEMPLATE([HAVE_STDBOOL_H], [whether or not to use <stdbool.h>.])
+	AC_DEFINE([HAVE_STDBOOL_H])
 ],
 [
 	AH_TEMPLATE([bool],  [type for 'bool' if <stdbool.h> is missing or broken.])

--- a/configure.ac
+++ b/configure.ac
@@ -363,8 +363,8 @@ CHECK_HEADER_DEFINE(INT_MAX, [limits.h],,
 		AC_DEFINE(INT_MAX, MAXINT), AC_DEFINE(INT_MAX, 32767)))
 
 
-# Checks for typedefs
-# -------------------
+# Checks for typedefs and types
+# -----------------------------
 
 AC_TYPE_SIZE_T
 AC_TYPE_OFF_T
@@ -400,6 +400,41 @@ AC_CHECK_HEADERS([stdbool.h],
 	AC_DEFINE([false], [0])
 ])
 
+AC_MSG_CHECKING(if "%zu" in printf works)
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <stdio.h>
+int main(void) {
+	static char buffer[10];
+	size_t i = 999;
+	sprintf(buffer, "%zu", i);
+	return !(buffer[0] == '9' && buffer[1] == '9' && buffer[2] == '9');
+}
+]])],[have_zu_formatter=yes],[have_zu_formatter=no])
+AC_MSG_RESULT($have_zu_formatter)
+
+if test x$have_zu_formatter != xyes; then
+	AC_CHECK_SIZEOF(size_t)
+	AC_CHECK_SIZEOF(unsigned int)
+	AC_CHECK_SIZEOF(unsigned long)
+	AC_CHECK_SIZEOF(unsigned long long)
+	AC_MSG_CHECKING(alternative for "%zu")
+	if test x"$ac_cv_sizeof_size_t" = x"$ac_cv_sizeof_unsigned_int"; then
+		use_no_formatter_for_size_t=yes
+		AC_MSG_RESULT("%u")
+	elif test x"$ac_cv_sizeof_size_t" = x"$ac_cv_sizeof_unsigned_long"; then
+		use_ulong_formatter_for_size_t=yes
+		AC_MSG_RESULT("%lu")
+	elif test x"$ac_cv_sizeof_size_t" = x"$ac_cv_sizeof_unsigned_long_long"; then
+		use_ulonglong_formatter_for_size_t=yes
+		AC_MSG_RESULT("%llu")
+	else
+		AC_MSG_ERROR(no alternative for "%zu" formatter)
+	fi
+fi
+
+AM_CONDITIONAL([USE_NO_FORMATTER_FOR_SIZE_T], [test "x${use_no_formatter_for_size_t}" = "xyes"])
+AM_CONDITIONAL([USE_ULONG_FORMATTER_FOR_SIZE_T], [test "x${use_ulong_formatter_for_size_t}" = "xyes"])
+AM_CONDITIONAL([USE_ULONGLONG_FORMATTER_FOR_SIZE_T], [test "x${use_ulonglong_formatter_for_size_t}" = "xyes"])
 
 # Checks for compiler characteristics
 # -----------------------------------
@@ -714,6 +749,10 @@ AC_CHECK_DECLS([__environ], [], [], [
 AC_CHECK_DECLS([_NSGetEnviron],[],[],[
 [#include <crt_externs.h>]
 ])
+AC_CHECK_DECLS([strnlen],[have_strnlen=yes],[],[
+[#include <string.h>]
+])
+AM_CONDITIONAL(HAVE_STRNLEN, test "x$have_strnlen" = xyes)
 
 if test "$CTAGS_NAME_EXECUTABLE" != ctags ; then
 	AC_MSG_NOTICE(Changing name of 'ctags' for $CTAGS_NAME_EXECUTABLE)

--- a/main/general.h
+++ b/main/general.h
@@ -47,7 +47,7 @@
 *   DATA DECLARATIONS
 */
 
-#ifdef USE_STDBOOL_H
+#ifdef HAVE_STDBOOL_H
 # include <stdbool.h>
 #endif
 

--- a/main/mio.c
+++ b/main/mio.c
@@ -29,7 +29,7 @@
 #include <config.h>
 #endif
 
-#ifdef USE_STDBOOL_H
+#ifdef HAVE_STDBOOL_H
 #include <stdbool.h>
 #endif
 #endif

--- a/main/options.c
+++ b/main/options.c
@@ -473,6 +473,8 @@ static optionDescription ExperimentalLongOptionDescription [] = {
  {1,"       Define multitable regular expression for locating tags in specific language."},
  {1,"  --_mtable-totals=[yes|no]"},
  {1,"       Print statistics about mtable usage [no]."},
+ {1,"  --_pretend-<NEWLANG>=<OLDLANG>"},
+ {1,"       Make NEWLANG parser pretend OLDLANG parser in lang: field."},
  {1,"  --_roledef-<LANG>=kind_letter.role_name,role_desc"},
  {1,"       Define new role for kind specified with <kind_letter> in <LANG>."},
  {1,"  --_scopesep-<LANG>=[parent_kind_letter]/child_kind_letter:separator"},
@@ -748,8 +750,9 @@ extern void checkOptions (void)
 	}
 }
 
-extern langType getLanguageComponentInOption (const char *const option,
-											  const char *const prefix)
+extern langType getLanguageComponentInOptionFull (const char *const option,
+												  const char *const prefix,
+												  bool noPretending)
 {
 	size_t prefix_len;
 	langType language;
@@ -774,11 +777,17 @@ extern langType getLanguageComponentInOption (const char *const option,
 	colon = strchr (lang, ':');
 	if (colon)
 		lang_len = colon - lang;
-	language = getNamedLanguage (lang, lang_len);
+	language = getNamedLanguageFull (lang, lang_len, noPretending);
 	if (language == LANG_IGNORE)
 		error (FATAL, "Unknown language \"%s\" in \"%s\" option", lang, option);
 
 	return language;
+}
+
+extern langType getLanguageComponentInOption (const char *const option,
+											  const char *const prefix)
+{
+	return getLanguageComponentInOptionFull (option, prefix, false);
 }
 
 static void setEtagsMode (void)
@@ -3188,6 +3197,8 @@ static void processLongOption (
 	else if (processRoledefOption (option, parameter))
 		;
 	else if (processScopesepOption (option, parameter))
+		;
+	else if (processPretendOption (option, parameter))
 		;
 	else
 		error (FATAL, "Unknown option: --%s", option);

--- a/main/options.c
+++ b/main/options.c
@@ -563,6 +563,10 @@ static struct Feature {
 #ifdef HAVE_ASPELL
 	{"aspell", "linked with code for spell checking (internal use)"},
 #endif
+#ifdef HAVE_PACKCC
+	/* The test harnesses use this as hints for skipping test cases */
+	{"packcc", "has peg based parser(s)"},
+#endif
 	{NULL,}
 };
 

--- a/main/options_p.h
+++ b/main/options_p.h
@@ -164,6 +164,8 @@ extern void freeOptionResources (void);
 
 extern langType getLanguageComponentInOption (const char *const option,
 					      const char *const prefix);
+extern langType getLanguageComponentInOptionFull (const char *const option,
+					      const char *const prefix, bool noPretending);
 
 extern void processLanguageDefineOption (const char *const option, const char *const parameter);
 extern bool processMapOption (const char *const option, const char *const parameter);
@@ -179,6 +181,7 @@ extern bool processLanguageEncodingOption (const char *const option, const char 
 #endif
 extern bool processRoledefOption (const char *const option, const char *const parameter);
 extern bool processScopesepOption (const char *const option, const char *const parameter);
+extern bool processPretendOption (const char *const option, const char *const parameter);
 
 extern void setMainLoop (mainLoopFunc func, void *data);
 

--- a/main/parse.c
+++ b/main/parse.c
@@ -129,6 +129,10 @@ static parserDefinitionFunc* BuiltInParsers[] = {
 #ifdef HAVE_LIBYAML
 	,
 #endif
+	PEG_PARSER_LIST
+#ifdef HAVE_PACKCC
+	,
+#endif
 };
 static parserObject* LanguageTable = NULL;
 static unsigned int LanguageCount = 0;

--- a/main/parse.c
+++ b/main/parse.c
@@ -91,6 +91,14 @@ typedef struct sParserObject {
 	struct slaveControlBlock *slaveControlBlock;
 	struct kindControlBlock  *kindControlBlock;
 	struct lregexControlBlock *lregexControlBlock;
+
+	langType pretendingAsLanguage; /* OLDLANG in --_pretend-<NEWLANG>=<OLDLANG>
+									  is set here if this parser is NEWLANG.
+									  LANG_IGNORE is set if no pretending. */
+	langType pretendedAsLanguage;  /* NEWLANG in --_pretend-<NEWLANG>=<OLDLANG>
+									  is set here if this parser is OLDLANG.
+									  LANG_IGNORE is set if no being pretended. */
+
 } parserObject;
 
 /*
@@ -224,17 +232,35 @@ extern bool doesLanguageRequestAutomaticFQTag (const langType language)
 	return LanguageTable [language].def->requestAutomaticFQTag;
 }
 
-extern const char *getLanguageName (const langType language)
+static const char *getLanguageNameFull (const langType language, bool noPretending)
 {
 	const char* result;
+
 	if (language == LANG_IGNORE)
 		result = "unknown";
 	else
 	{
 		Assert (0 <= language  &&  language < (int) LanguageCount);
-		result = LanguageTable [language].def->name;
+		if (noPretending)
+			result = LanguageTable [language].def->name;
+		else
+		{
+			langType real_language = LanguageTable [language].pretendingAsLanguage;
+			if (real_language == LANG_IGNORE)
+				result = LanguageTable [language].def->name;
+			else
+			{
+				Assert (0 <= real_language  &&  real_language < (int) LanguageCount);
+				result = LanguageTable [real_language].def->name;
+			}
+		}
 	}
 	return result;
+}
+
+extern const char *getLanguageName (const langType language)
+{
+	return getLanguageNameFull (language, false);
 }
 
 extern const char *getLanguageKindName (const langType language, const int kindIndex)
@@ -321,7 +347,7 @@ extern roleDefinition* getLanguageRoleForName (const langType language, int kind
 	return getRoleForName (LanguageTable [language].kindControlBlock, kindIndex, roleName);
 }
 
-extern langType getNamedLanguage (const char *const name, size_t len)
+extern langType getNamedLanguageFull (const char *const name, size_t len, bool noPretending)
 {
 	langType result = LANG_IGNORE;
 	unsigned int i;
@@ -345,7 +371,18 @@ extern langType getNamedLanguage (const char *const name, size_t len)
 				result = i;
 			vStringDelete (vstr);
 		}
+
+	if (result != LANG_IGNORE
+		&& (!noPretending)
+		&& LanguageTable [result].pretendedAsLanguage != LANG_IGNORE)
+		result = LanguageTable [result].pretendedAsLanguage;
+
 	return result;
+}
+
+extern langType getNamedLanguage (const char *const name, size_t len)
+{
+	return getNamedLanguageFull (name, len, false);
 }
 
 static langType getNameOrAliasesLanguageAndSpec (const char *const key, langType start_index,
@@ -1844,6 +1881,11 @@ extern void initializeParsing (void)
 	builtInCount = ARRAY_SIZE (BuiltInParsers);
 	LanguageTable = xMalloc (builtInCount, parserObject);
 	memset(LanguageTable, 0, builtInCount * sizeof (parserObject));
+	for (i = 0; i < builtInCount; ++i)
+	{
+		LanguageTable [i].pretendingAsLanguage = LANG_IGNORE;
+		LanguageTable [i].pretendedAsLanguage = LANG_IGNORE;
+	}
 
 	LanguageHTable = hashTableNew (127,
 								   hashCstrcasehash,
@@ -2118,6 +2160,8 @@ extern void processLanguageDefineOption (
 
 		LanguageTable [def->id].currentPatterns = stringListNew ();
 		LanguageTable [def->id].currentExtensions = stringListNew ();
+		LanguageTable [def->id].pretendingAsLanguage = LANG_IGNORE;
+		LanguageTable [def->id].pretendedAsLanguage = LANG_IGNORE;
 
 		eFree (name);
 	}
@@ -3386,7 +3430,9 @@ static void printGuessedParser (const char* const fileName, langType language)
 		parserName = RSV_NONE;
 	}
 	else
-		parserName = LanguageTable [language].def->name;
+	{
+		parserName = getLanguageName (language);
+	}
 
 	printf("%s: %s\n", fileName, parserName);
 }
@@ -4238,6 +4284,54 @@ extern void addLanguageTagMultiTableRegex(const langType language,
 	parserObject* const parser = LanguageTable + language;
 	addTagMultiTableRegex (parser->lregexControlBlock, table_name, regex,
 						   name, kinds, flags, disabled);
+}
+
+extern bool processPretendOption (const char *const option, const char *const parameter)
+{
+	langType new_language, old_language;
+
+#define pretendOptionPrefix "_pretend-"
+	new_language = getLanguageComponentInOptionFull (option, pretendOptionPrefix, true);
+	if (new_language == LANG_IGNORE)
+		return false;
+
+	if (parameter == NULL || parameter[0] == '\0')
+		error (FATAL, "A parameter is needed after \"%s\" option", option);
+
+	old_language = getNamedLanguageFull (parameter, 0, true);
+	if (old_language == LANG_IGNORE)
+		error (FATAL, "Unknown language \"%s\" in option \"--%s=%s\"",
+			   parameter, option, parameter);
+
+	if (LanguageTable [new_language].pretendingAsLanguage != LANG_IGNORE)
+	{
+		error (FATAL, "%s parser pretends as %s already\n",
+			   getLanguageNameFull (new_language, true),
+			   getLanguageNameFull (LanguageTable [new_language].pretendingAsLanguage, true));
+	}
+	if (LanguageTable [old_language].pretendedAsLanguage != LANG_IGNORE)
+	{
+		error (FATAL, "%s parser is pretended as %s already\n",
+			   getLanguageNameFull (old_language, true),
+			   getLanguageNameFull (LanguageTable [old_language].pretendedAsLanguage, true));
+	}
+
+	verbose ("%s pretends %s\n",
+			 getLanguageNameFull (new_language, true),
+			 getLanguageNameFull (old_language, true));
+
+	LanguageTable [new_language].pretendingAsLanguage = old_language;
+	LanguageTable [old_language].pretendedAsLanguage  = new_language;
+
+	verbose ("force enabling %s\n",
+			 getLanguageNameFull (new_language, true));
+	enableLanguage (new_language, true);
+
+	verbose ("force disbling %s\n",
+			 getLanguageNameFull (old_language, true));
+	enableLanguage (old_language, false);
+
+	return true;
 }
 
 /*

--- a/main/parse_p.h
+++ b/main/parse_p.h
@@ -52,6 +52,8 @@ extern parserDefinitionFunc YAML_PARSER_LIST;
 extern bool doesLanguageAllowNullTag (const langType language);
 extern bool doesLanguageRequestAutomaticFQTag (const langType language);
 
+extern langType getNamedLanguageFull (const char *const name, size_t len, bool noPretending);
+
 extern kindDefinition* getLanguageKind(const langType language, int kindIndex);
 extern kindDefinition* getLanguageKindForName (const langType language, const char *kindName);
 extern roleDefinition* getLanguageRole(const langType language, int kindIndex, int roleIndex);

--- a/main/parse_p.h
+++ b/main/parse_p.h
@@ -48,6 +48,9 @@ extern parserDefinitionFunc XML_PARSER_LIST;
 #ifdef HAVE_LIBYAML
 extern parserDefinitionFunc YAML_PARSER_LIST;
 #endif
+#ifdef HAVE_PACKCC
+extern parserDefinitionFunc PEG_PARSER_LIST;
+#endif
 
 extern bool doesLanguageAllowNullTag (const langType language);
 extern bool doesLanguageRequestAutomaticFQTag (const langType language);

--- a/main/parsers_p.h
+++ b/main/parsers_p.h
@@ -33,6 +33,13 @@
 #define YAML_PARSER_LIST
 #endif
 
+#ifdef HAVE_PACKCC
+#define PEG_PARSER_LIST						\
+	NewJavaParser
+#else
+#define PEG_PARSER_LIST
+#endif
+
 
 /* Add the name of any new parser definition function here */
 #define PARSER_LIST \

--- a/main/read.h
+++ b/main/read.h
@@ -55,6 +55,7 @@ enum eCharacters {
 
 /* InputFile: reading from fp in inputFile with updating fields in input fields */
 extern unsigned long getInputLineNumber (void);
+extern unsigned long getInputLineNumberForFileOffset(long offset);
 extern int getInputLineOffset (void);
 extern const char *getInputFileName (void);
 extern MIOPos getInputFilePosition (void);

--- a/main/read_p.h
+++ b/main/read_p.h
@@ -70,8 +70,6 @@ extern void   pushNarrowedInputStream (
 				       int promise);
 extern void   popNarrowedInputStream  (void);
 
-extern unsigned long getInputLineNumberForFileOffset(long offset);
-
 #define THIN_STREAM_SPEC 0, 0, 0, 0, 0
 extern bool isThinStreamSpec(unsigned long startLine, long startCharOffset,
 							 unsigned long endLine, long endCharOffset,

--- a/main/routines.c
+++ b/main/routines.c
@@ -259,6 +259,11 @@ extern void eFree (void *const ptr)
 	free (ptr);
 }
 
+extern void eFreeNoNullCheck (void *const ptr)
+{
+	free (ptr);
+}
+
 extern void eFreeIndirect(void **ptr)
 {
 	if (ptr && *ptr)

--- a/main/routines.h
+++ b/main/routines.h
@@ -50,6 +50,7 @@ extern void *eMalloc (const size_t size);
 extern void *eCalloc (const size_t count, const size_t size);
 extern void *eRealloc (void *const ptr, const size_t size);
 extern void eFree (void *const ptr);
+extern void eFreeNoNullCheck (void *const ptr);
 extern void eFreeIndirect(void **ptr);
 
 /* String manipulation functions */

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -130,6 +130,12 @@ extern void vStringNCatS (
 	stringCat (string, s, len);
 }
 
+extern void vStringNCatSUnsafe (
+		vString *const string, const char *const s, const size_t length)
+{
+	stringCat (string, s, length);
+}
+
 extern void vStringCat (vString *const string, const vString *const s)
 {
 	size_t len = vStringLength (s);

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -66,7 +66,15 @@ extern void vStringStripTrailing (vString *const string);
 extern void vStringCat (vString *const string, const vString *const s);
 extern void vStringCatS (vString *const string, const char *const s);
 extern void vStringNCat (vString *const string, const vString *const s, const size_t length);
+
+/* vStringNCatS calls strlen(S) thought it takes LENGTH because
+ * the handle the case that strlen(S) is smaller than LENGTH.
+ *
+ * In the case a caller knows strlen(S) equals to or is greater than LENGTH,
+ * calling strlen is just overhead. vStringNCatSUnsafe doesn't call strlen. */
 extern void vStringNCatS (vString *const string, const char *const s, const size_t length);
+extern void vStringNCatSUnsafe (vString *const string, const char *const s, const size_t length);
+
 extern vString *vStringNewCopy (const vString *const string);
 extern vString *vStringNewInit (const char *const s);
 extern vString *vStringNewNInit (const char *const s, const size_t length);

--- a/makefiles/help.mak
+++ b/makefiles/help.mak
@@ -24,6 +24,7 @@ help:
 	@echo "CATEGORIES=<category>             - Only run tests available under folder Units/<category>.r"
 	@echo "UNITS=<case>[,<case>]             - Only run tests named Units/[category.r/]/<case>.d in units target"
 	@echo "                                                         Tmain/<case>.d in tmain target"
+	@echo "PMAP=<newlang>/<oldlang>[,...]    - Make <newlang> parser pretend <oldlang> (units target only)"
 	@echo ""
 	@echo "Input validation target:"
 	@echo ""

--- a/makefiles/list-optlib2c-input.mak
+++ b/makefiles/list-optlib2c-input.mak
@@ -1,0 +1,5 @@
+# -*- makefile -*-
+include makefiles/optlib2c_input.mak
+.PHONY: list-optlib2c-input
+list-optlib2c-input:
+	@for x in $(OPTLIB2C_INPUT); do echo $$x; done

--- a/makefiles/list-translator-input.mak
+++ b/makefiles/list-translator-input.mak
@@ -1,5 +1,0 @@
-# -*- makefile -*-
-include makefiles/translator_input.mak
-.PHONY: list-translator-input
-list-translator-input:
-	@for x in $(TRANSLATOR_INPUT); do echo $$x; done

--- a/makefiles/optlib2c_input.mak
+++ b/makefiles/optlib2c_input.mak
@@ -1,5 +1,5 @@
 # -*- makefile -*-
-TRANSLATOR_INPUT = \
+OPTLIB2C_INPUT = \
 	optlib/RSpec.ctags			\
 	optlib/cmake.ctags			\
 	optlib/ctags-optlib.ctags		\

--- a/makefiles/peg_input.mak
+++ b/makefiles/peg_input.mak
@@ -1,0 +1,4 @@
+# -*- makefile -*-
+PEG_INPUT = \
+       \
+       $(NULL)

--- a/makefiles/peg_input.mak
+++ b/makefiles/peg_input.mak
@@ -1,4 +1,5 @@
 # -*- makefile -*-
 PEG_INPUT = \
+       peg/java.peg \
        \
        $(NULL)

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -20,6 +20,7 @@ endif
 LANGUAGES=
 CATEGORIES=
 UNITS=
+PMAP=
 
 SILENT = $(SILENT_@AM_V@)
 SILENT_ = $(SILENT_@AM_DEFAULT_V@)
@@ -111,6 +112,7 @@ units: $(CTAGS_TEST)
 		--languages=$(LANGUAGES) \
 		--categories=$(CATEGORIES) \
 		--units=$(UNITS) \
+		--with-pretense-map=$(PMAP) \
 		$${VALGRIND} --run-shrink \
 		--with-timeout=`expr $(TIMEOUT) '*' 10`\
 		$${SHOW_DIFF_OUTPUT}"; \

--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -41,7 +41,7 @@ if [ "$TARGET" = "Unix" ]; then
         echo 'List features'
         ./ctags --list-features
         echo 'Run "make check" with gcov'
-        make -j2 check roundtrip TRAVIS=1
+        make -j2 check roundtrip TRAVIS=1 PMAP=NewJava/Java
 
     else
 		${CONFIGURE_CMDLINE}
@@ -49,7 +49,7 @@ if [ "$TARGET" = "Unix" ]; then
         echo 'List features'
         ./ctags --list-features
         echo 'Run "make check" (without gcov)'
-        make -j2 check roundtrip TRAVIS=1
+        make -j2 check roundtrip TRAVIS=1 PMAP=NewJava/Java
     fi
 elif [ "$TARGET" = "Mingw32" ]; then
     make -j2 CC=i686-w64-mingw32-gcc CC_FOR_PACKCC=gcc -f mk_mingw.mak

--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -52,7 +52,7 @@ if [ "$TARGET" = "Unix" ]; then
         make -j2 check roundtrip TRAVIS=1
     fi
 elif [ "$TARGET" = "Mingw32" ]; then
-    make -j2 CC=i686-w64-mingw32-gcc -f mk_mingw.mak
+    make -j2 CC=i686-w64-mingw32-gcc CC_FOR_PACKCC=gcc -f mk_mingw.mak
     # Don't run test units in Mingw32 target
 else
     echo 'Invalid $TARGET value' 1>&2

--- a/misc/units
+++ b/misc/units
@@ -35,6 +35,7 @@ COLORIZED_OUTPUT=yes
 CATEGORIES=
 UNITS=
 LANGUAGES=
+PRETENSE_OPTS=
 RUN_SHRINK=
 QUIET=
 SHOW_DIFF_OUTPUT=
@@ -559,7 +560,7 @@ run_tcase ()
     #
     # Build _CMDLINE
     #
-    _CMDLINE="${CTAGS} --verbose --options=NONE --optlib-dir=+$t/optlib -o -"
+    _CMDLINE="${CTAGS} --verbose --options=NONE $PRETENSE_OPTS --optlib-dir=+$t/optlib -o -"
     [ -f "${fargs}" ] && _CMDLINE="${_CMDLINE} --options=${fargs}"
 
     if [ -f "${fargs}" ] && ! ${_CMDLINE} --_force-quit=0 > /dev/null 2>&1; then
@@ -900,6 +901,30 @@ run_summary ()
     fi
 }
 
+make_pretense_map ()
+{
+    local ifs=$IFS
+    local p
+    local r
+
+    IFS=,
+    for p in $1; do
+	newlang=${p%/*}
+	oldlang=${p#*/}
+
+	if [ -z "$newlang" ]; then
+	    ERROR 1 "newlang part of --pretend option arg is empty"
+	fi
+	if [ -z "$oldlang" ]; then
+	    ERROR 1 "oldlang part of --pretend option arg is empty"
+	fi
+
+	r="$r --_pretend-$newlang=$oldlang"
+    done
+    IFS=$ifs
+    echo $r
+}
+
 action_run ()
 {
     local action="$1"
@@ -983,6 +1008,15 @@ action_run ()
 		;;
 	    --show-diff-output)
 		SHOW_DIFF_OUTPUT=yes
+		shift
+		;;
+	    --with-pretense-map)
+		shift
+		PRETENSE_OPTS=$(make_pretense_map "$1")
+		shift
+		;;
+	    --with-pretense-map=*)
+		PRETENSE_OPTS=$(make_pretense_map "${1#--with-pretense-map=}")
 		shift
 		;;
 	    -*)
@@ -1088,6 +1122,8 @@ $0 run [OPTIONS] UNITS-DIR
 			       If this option given, DURATION is changed to
 			       DURATION := DURATION * ${_VG_TIMEOUT_FACTOR}
 		--show-diff-output: show diff output for failed test cases in the summary.
+		--with-pretense-map=NEWLANG0/OLDLANG0[,...]: make NEWLANG parser pretend
+							     OLDLANG.
 EOF
 }
 

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -53,7 +53,7 @@ V_OPTLIB2C_1 =
 .c.o:
 	$(V_CC) $(CC) -c $(OPT) $(CFLAGS) $(DEFINES) $(INCLUDES) -o $@ $<
 
-.ctags.c: $(OPTLIB2C)
+%.c: %.ctags $(OPTLIB2C)
 	$(V_OPTLIB2C) $(OPTLIB2C) $< > $@
 
 all: ctags.exe readtags.exe

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -5,14 +5,19 @@ include source.mak
 REGEX_DEFINES = -DHAVE_REGCOMP -D__USE_GNU -Dbool=int -Dfalse=0 -Dtrue=1 -Dstrcasecmp=stricmp
 
 CFLAGS = -Wall -std=gnu99
-DEFINES = -DWIN32 $(REGEX_DEFINES)
+# sizeof (size_t) == sizeof(unsigned long) == 4 on i686-w64-mingw32-gcc.
+SIZE_T_FMT_CHAR='""'
+COMMON_DEFINES=-DUSE_SYSTEM_STRNLEN
+DEFINES = -DWIN32 $(REGEX_DEFINES) -DHAVE_PACKCC $(COMMON_DEFINES)
 INCLUDES = -I. -Imain -Ignu_regex -Ifnmatch -Iparsers
 CC = gcc
 OPTLIB2C = ./misc/optlib2c
+PACKCC   = ./packcc.exe
 OBJEXT = o
 ALL_OBJS += $(REGEX_OBJS)
 ALL_OBJS += $(FNMATCH_OBJS)
 ALL_OBJS += $(WIN32_OBJS)
+ALL_OBJS += $(PEG_OBJS)
 VPATH = . ./main ./parsers ./optlib ./read ./win32
 
 ifeq (yes, $(WITH_ICONV))
@@ -28,7 +33,7 @@ OPT = -O4 -Os -fexpensive-optimizations
 LDFLAGS = -s
 endif
 
-.SUFFIXES: .c .o .ctags
+.SUFFIXES: .c .o .ctags .peg
 
 #
 # Silent/verbose commands
@@ -36,6 +41,7 @@ endif
 # when V is not set the output of commands is omitted or simplified
 #
 V	 ?= 0
+CC_FOR_PACKCC ?= $(CC)
 
 SILENT   = $(SILENT_$(V))
 SILENT_0 = @
@@ -49,6 +55,10 @@ V_OPTLIB2C   = $(V_OPTLIB2C_$(V))
 V_OPTLIB2C_0 = @echo [OPTLIB2C] $@;
 V_OPTLIB2C_1 =
 
+V_PACKCC   = $(V_PACKCC_$(V))
+V_PACKCC_0 = @echo [PACKCC] $@;
+V_PACKCC_1 =
+
 
 .c.o:
 	$(V_CC) $(CC) -c $(OPT) $(CFLAGS) $(DEFINES) $(INCLUDES) -o $@ $<
@@ -56,11 +66,24 @@ V_OPTLIB2C_1 =
 %.c: %.ctags $(OPTLIB2C)
 	$(V_OPTLIB2C) $(OPTLIB2C) $< > $@
 
-all: ctags.exe readtags.exe
+peg/%.c peg/%.h: peg/%.peg $(PACKCC)
+	$(V_PACKCC) $(PACKCC) $<
+
+all: $(PACKCC) ctags.exe readtags.exe
 
 ctags: ctags.exe
 
-ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS) $(WIN32_HEADS)
+$(PACKCC_SRCS):
+	git submodule init
+	git submodule update
+
+$(PACKCC_OBJS): $(PACKCC_SRCS)
+	$(V_CC) $(CC_FOR_PACKCC) -c $(OPT) $(CFLAGS) $(COMMON_DEFINES) -DSIZE_T_FMT_CHAR=$(SIZE_T_FMT_CHAR) -o $@ $<
+
+$(PACKCC): $(PACKCC_OBJS)
+	$(V_CC) $(CC_FOR_PACKCC) $(OPT) -o $@ $^
+
+ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(PEG_HEADS) $(PEG_EXTRA_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS) $(WIN32_HEADS)
 	$(V_CC) $(CC) $(OPT) $(CFLAGS) $(LDFLAGS) $(DEFINES) $(INCLUDES) -o $@ $(ALL_OBJS) $(LIBS)
 
 read/%.o: read/%.c

--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -10,8 +10,8 @@
 include source.mak
 
 OBJEXT = obj
-REGEX_DEFINES = -DHAVE_REGCOMP -D__USE_GNU -Dbool=int -Dfalse=0 -Dtrue=1 -Dstrcasecmp=stricmp -DHAVE_REPOINFO_H
-DEFINES = -DWIN32 $(REGEX_DEFINES)
+DEFINES = -DWIN32 -DHAVE_REGCOMP -D__USE_GNU -Dstrcasecmp=stricmp -DHAVE_REPOINFO_H
+REGEX_DEFINES = -Dbool=int -Dfalse=0 -Dtrue=1 $(DEFINES)
 INCLUDES = -I. -Imain -Ignu_regex -Ifnmatch -Iparsers
 OPT = /O2 /WX
 REGEX_OBJS = $(REGEX_SRCS:.c=.obj)
@@ -66,7 +66,7 @@ readtags.exe: $(READTAGS_OBJS) $(READTAGS_HEADS)
 	$(CC) $(OPT) /Fe$@ $(READTAGS_OBJS) /link setargv.obj $(PDBFLAG)
 
 $(REGEX_OBJS): $(REGEX_SRCS)
-	$(CC) /c $(OPT) /Fo$@ $(INCLUDES) $(DEFINES) $(REGEX_SRCS)
+	$(CC) /c $(OPT) /Fo$@ $(INCLUDES) $(REGEX_DEFINES) $(REGEX_SRCS)
 
 $(FNMATCH_OBJS): $(FNMATCH_SRCS)
 	$(CC) /c $(OPT) /Fo$@ $(INCLUDES) $(DEFINES) $(FNMATCH_SRCS)

--- a/peg/java.peg
+++ b/peg/java.peg
@@ -1,0 +1,1013 @@
+%prefix "pjava"
+
+%auxil	"struct parserCtx *"
+
+%header {
+	struct parserCtx;
+}
+
+%source {
+#include "java_pre.h"
+}
+
+#
+# The original code is taken from
+# https://github.com/pointlander/peg/blob/master/grammars/java/java_1_7.peg
+# https://raw.githubusercontent.com/pointlander/peg/master/grammars/java/java_1_7.peg
+#
+#===========================================================================
+#
+#  Parsing Expression Grammar for Java 1.7 for Mouse 1.1 - 1.5.
+#  Based on Chapters 3 and 18 of Java Language Specification, Third Edition,
+#  at http://java.sun.com/docs/books/jls/third_edition/html/j3TOC.html,
+#  and description of Java SE 7 enhancements in
+#  http://download.java.net/jdk7/docs/technotes/guides/language/enhancements.html.
+#
+#---------------------------------------------------------------------------
+#
+#  Copyright (C) 2006, 2009, 2010, 2011
+#  by Roman R Redziejowski(www.romanredz.se).
+#
+#  The author gives unlimited permission to copy and distribute
+#  this file, with or without modifications, as long as this notice
+#  is preserved, and any changes are properly documented.
+#
+#  This file is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+#---------------------------------------------------------------------------
+#
+#  Latest update 2011-07-21
+#
+#---------------------------------------------------------------------------
+#
+#  Change log
+#    2006-12-06 Posted on Internet.
+#    2009-04-04 Modified to conform to Mouse syntax:
+#		Underscore removed from names
+#		\f in Space replaced by Unicode for FormFeed.
+#    2009-07-10 Unused rule THREADSAFE removed.
+#    2009-07-10 Copying and distribution conditions relaxed by the author.
+#    2010-07-01 Updated Mouse version in the comment.
+#    2010-09-15 Updated comment on Java release.
+#    2010-09-18 Updated list of reserved words ("keywords") according to
+#		JLS 3.9: added "const" and "goto", removed "threadsafe".
+#    2010-09-18 Removed superfluous "?" everywhere after "Spacing".
+#    2010-10-05 Removed erroneous "TypeArguments?" from "EnumConstant".
+#		See JLS 8.9, JLS 18.1.
+#		NB. "Annotations" are optional, but not shown as such in JLS.
+#    2010-10-20 Corrected "FormalParameterList" according to JLS 8.4.1.
+#		NB. "VariableModifiers" in "FormalParameter" and "LastFormalParameter"
+#		are optional, but not shown as such in JLS.
+#    2010-10-20 Corrected "Annotation" according to JLS 9.7.
+#		Is incorrect in JLS 18.1 (does not allow list of value pairs).
+#    2010-10-20 Corrected "LocalVariableDeclarationStatement".
+#		Is incorrect in JLS 18.1: only FINAL allowed as "VariableModifier".
+#		Is incorrect in JLS 14.4: "VariableModifiers" not shown as optional.
+#    2010-10-20 Corrected "AnnotationTypeElementRest": added SEMI as last alternative.
+#		See JLS 9.6. NB. Missing in JLS 18.1.
+#    2010-10-20 Moved "Identifier" from "AnnotationTypeElementRest" to
+#		"AnnotationMethodRest". Was incorrect in JLS 18.1.
+#    2010-10-21 Inverted order of alternatives in "HexSignificand".
+#    2010-10-24 Corrected previous correction: moved SEMI from
+#		"AnnotationTypeElementRest" to "AnnotationTypeElementDeclaration".
+#    2010-10-25 Repeated "u" allowed in UnicodeEscape (JLS 3.3).
+#		Line terminators not allowed in StringLiteral (JLS 3.10.5).
+#		(Found thanks to Java PEG for Parboiled, which in turn credits
+#		Reinier Zwitserloot for finding it.)
+#    2011-07-19 Added SEMI after "VariableDeclarators" in "MemberDecl" (JLS 8.3).
+#    2011-07-21 Corrected "ArrayInitializer" to allow for "{,}" (JLS 10.6).
+#
+#---------------------------------------------------------------------------
+#
+#  Changes for Java 1.7
+#    2011-07-18 Implemented Binary Literals: added "BinaryNumeral".
+#    2011-07-19 Implemented Underscores in Numerical Literals:
+#		Added "Digits" and "HexDigits". Removed "Digit".
+#		Modified "DecimalNumeral", "HexNumeral", "BinaryNumeral",
+#		"OctalNumeral", "DecimalFloat", "Exponent",
+#		"HexSignificand", and "BinaryExponent".
+#    2011-07-20 Implemented Type Inference for Generic Instance Creation:
+#		Added "Diamond".
+#		Modified "ClassCreatorRest" by adding "Diamond?".
+#    2011-07-20 Implemented try-with-resources Statement:
+#		Added try-with-resources as an alternative of "Statement".
+#		Added "Resource". (Based on comments to JavacParser).
+#    2011-07-20 Implemented catching of multiple exceptions:
+#		Modified "Catch" to allow multiple exception types.
+#		Based on a pure guess.
+#
+#---------------------------------------------------------------------------
+#
+#    2013-02-16 Modified to work with github.com/pointlander/peg
+#
+#---------------------------------------------------------------------------
+#
+#    2018-08-17 s/SEM/SEMI/ in rule "InterfaceMethodDeclaratorRest"
+#
+#---------------------------------------------------------------------------
+#
+#    2018-08-17 Embed C code for Universal-ctags
+#
+#===========================================================================
+
+#-------------------------------------------------------------------------
+#  Compilation Unit
+#-------------------------------------------------------------------------
+
+# package main
+# type Java Peg {
+# }
+
+CompilationUnit <- Spacing PackageDeclaration? ImportDeclaration* TypeDeclaration* < EOT > {
+	leavePackageMaybe (auxil, $1e);
+    }
+PackageDeclaration <- Annotation* PACKAGE { activateSink(auxil, S_NAME); } QualifiedIdentifier {
+	enterPackage (auxil);
+    } SEMI
+ImportDeclaration <- IMPORT {
+	resetModifier (auxil);
+	activateSink(auxil, S_NAME);
+    } STATIC? QualifiedIdentifier (DOT STAR { eatString (auxil, ".*", 2); })? {
+	captureImportedPackage(auxil);
+    } SEMI
+TypeDeclaration <- { resetModifier (auxil); } Modifier* (ClassDeclaration
+			     / EnumDeclaration
+			     / InterfaceDeclaration
+			     / AnnotationTypeDeclaration)
+		 / SEMI
+
+#-------------------------------------------------------------------------
+#  Class Declaration
+#-------------------------------------------------------------------------
+
+ClassDeclaration <- CLASS { activateSink(auxil, S_NAME); } Identifier {
+	enterClass (auxil);
+} TypeParameters? (EXTENDS { activateSink(auxil, S_SUPER); } ClassType)? (IMPLEMENTS {
+	    eatChar (auxil, ',');
+	} ClassTypeList)? { attachInheritsMaybe (auxil); } ClassBody {
+	leaveClass (auxil);
+}
+
+ClassBody <- LWING { markAnonClassMaybe (auxil); } ClassBodyDeclaration* RWING
+
+ClassBodyDeclaration
+   <- SEMI
+    / { resetModifier (auxil); } STATIC? Block	       # Static or Instance Initializer
+    / { resetModifier (auxil); } Modifier* MemberDecl  # ClassMemberDeclaration
+
+MemberDecl
+   <- TypeParameters GenericMethodOrConstructorRest    # Generic Method or Constructor
+    / Type { activateSink(auxil, S_NAME); } Identifier {
+	enterMethod (auxil);
+    } MethodDeclaratorRest {
+	leaveMethod (auxil);
+    }						       # Method
+    / Type { pushModifier (auxil); pushVarKind(auxil, K_FIELD); } VariableDeclarators SEMI {
+	popVarKind(auxil);
+	popModifier (auxil);
+      }						       # Field
+    / VOID { activateSink(auxil, S_NAME); } Identifier {
+	enterMethod (auxil);
+    }  VoidMethodDeclaratorRest {
+	leaveMethod (auxil);
+    }						       # Void method
+    / { activateSink(auxil, S_NAME); } Identifier {
+	enterMethod (auxil);
+    } ConstructorDeclaratorRest {
+	leaveMethod (auxil);
+    }						       # Constructor
+    / InterfaceDeclaration			       # Interface
+    / ClassDeclaration				       # Class
+    / EnumDeclaration				       # Enum
+    / AnnotationTypeDeclaration			       # Annotation
+
+GenericMethodOrConstructorRest
+    <- (Type / VOID) { activateSink(auxil, S_NAME); } Identifier {
+	enterMethod (auxil);
+    } MethodDeclaratorRest {
+	leaveMethod (auxil);
+    }
+    / { activateSink(auxil, S_NAME); } Identifier {
+	enterMethod (auxil);
+    } ConstructorDeclaratorRest {
+	leaveMethod (auxil);
+    }
+
+MethodDeclaratorRest
+    <- FormalParameters Dim* (THROWS ClassTypeList)? (MethodBody / SEMI)
+
+VoidMethodDeclaratorRest
+    <- FormalParameters (THROWS ClassTypeList)? (MethodBody / SEMI)
+
+ConstructorDeclaratorRest
+    <- FormalParameters (THROWS ClassTypeList)? MethodBody
+
+MethodBody
+    <- Block
+
+#-------------------------------------------------------------------------
+#  Interface Declaration
+#-------------------------------------------------------------------------
+
+InterfaceDeclaration
+    <- INTERFACE { activateSink(auxil, S_NAME); } Identifier {
+	enterInterface (auxil);
+    } TypeParameters? (EXTENDS {
+				   activateSink(auxil, S_SUPER);
+			       } ClassTypeList {
+				   attachInheritsMaybe (auxil);
+			       })? InterfaceBody {
+	leaveInterface (auxil);
+    }
+
+InterfaceBody
+    <- LWING InterfaceBodyDeclaration* RWING
+
+InterfaceBodyDeclaration
+    <- { resetModifier (auxil); } Modifier* InterfaceMemberDecl
+    / SEMI
+
+InterfaceMemberDecl
+    <- InterfaceMethodOrFieldDecl
+    / InterfaceGenericMethodDecl
+    / VOID { activateSink(auxil, S_NAME); } Identifier {
+       enterMethod (auxil);
+    } VoidInterfaceMethodDeclaratorRest {
+       leaveMethod (auxil);
+    }
+    / InterfaceDeclaration
+    / AnnotationTypeDeclaration
+    / ClassDeclaration
+    / EnumDeclaration
+
+InterfaceMethodOrFieldDecl
+    <- Type { activateSink(auxil, S_NAME); } Identifier InterfaceMethodOrFieldRest
+
+InterfaceMethodOrFieldRest
+    <- { pushModifier (auxil); captureField(auxil); } ConstantDeclaratorsRest SEMI {
+	 popModifier (auxil);
+       }
+    /  { enterMethod (auxil); } InterfaceMethodDeclaratorRest {
+	 leaveMethod (auxil);
+    }
+
+InterfaceMethodDeclaratorRest
+    <- FormalParameters Dim* (THROWS ClassTypeList)? SEMI
+
+InterfaceGenericMethodDecl
+    <- TypeParameters (Type / VOID) { activateSink(auxil, S_NAME); } Identifier {
+	  enterMethod (auxil);
+    } InterfaceMethodDeclaratorRest {
+	  leaveMethod (auxil);
+    }
+
+VoidInterfaceMethodDeclaratorRest
+    <- FormalParameters (THROWS ClassTypeList)? SEMI
+
+ConstantDeclaratorsRest
+    <- ConstantDeclaratorRest (COMMA ConstantDeclarator)*
+
+ConstantDeclarator
+    <- { activateSink(auxil, S_NAME); } Identifier { captureField(auxil); } ConstantDeclaratorRest
+
+ConstantDeclaratorRest
+    <- Dim* EQU VariableInitializer
+
+#-------------------------------------------------------------------------
+#  Enum Declaration
+#-------------------------------------------------------------------------
+
+EnumDeclaration
+    <- ENUM { activateSink(auxil, S_NAME); } Identifier {
+	enterEnum (auxil);
+    } (IMPLEMENTS { activateSink(auxil, S_SUPER); } ClassTypeList {
+	attachInheritsMaybe (auxil);
+    })? EnumBody {
+	leaveEnum (auxil);
+    }
+
+EnumBody
+    <- LWING EnumConstants? COMMA? EnumBodyDeclarations? RWING
+
+EnumConstants
+    <- EnumConstant (COMMA { patchEndline (auxil); } EnumConstant)*
+
+EnumConstant
+    <- Annotation* { activateSink(auxil, S_NAME); } Identifier {
+	enterEnumConstant (auxil);
+    } Arguments? ClassBody? {
+	leaveEnumConstant (auxil);
+    }
+
+EnumBodyDeclarations
+    <- SEMI ClassBodyDeclaration*
+
+#-------------------------------------------------------------------------
+#  Variable Declarations
+#-------------------------------------------------------------------------
+
+LocalVariableDeclarationStatement
+    <- (FINAL / Annotation)* Type {
+	pushVarKind(auxil, K_LOCAL);
+    } VariableDeclarators SEMI {
+	popVarKind(auxil);
+    }
+
+VariableDeclarators
+    <- VariableDeclarator (COMMA VariableDeclarator)*
+
+VariableDeclarator
+    <- { activateSink(auxil, S_NAME); } Identifier {
+	captureVariable(auxil);
+    } Dim* (EQU VariableInitializer)?
+
+#-------------------------------------------------------------------------
+#  Formal Parameters
+#-------------------------------------------------------------------------
+
+FormalParameters
+    <- LPAR FormalParameterList? RPAR
+
+FormalParameter
+    <- (FINAL / Annotation)* Type VariableDeclaratorId
+
+LastFormalParameter
+    <- (FINAL / Annotation)* Type ELLIPSIS VariableDeclaratorId
+
+FormalParameterList
+    <- FormalParameter (COMMA FormalParameter)* (COMMA LastFormalParameter)?
+    / LastFormalParameter
+
+VariableDeclaratorId
+    <- Identifier Dim*
+
+#-------------------------------------------------------------------------
+#  Statements
+#-------------------------------------------------------------------------
+
+Block
+    <- LWING BlockStatements RWING
+
+BlockStatements
+    <- BlockStatement*
+
+BlockStatement
+    <- LocalVariableDeclarationStatement
+    / { resetModifier (auxil); } Modifier*
+      ( ClassDeclaration
+      / EnumDeclaration
+      )
+    / Statement
+
+Statement
+    <- Block
+    / ASSERT Expression (COLON Expression)? SEMI
+    / IF ParExpression Statement (ELSE Statement)?
+    / FOR LPAR ForInit? SEMI Expression? SEMI ForUpdate? RPAR Statement
+    / FOR LPAR FormalParameter COLON Expression RPAR Statement
+    / WHILE ParExpression Statement
+    / DO Statement WHILE ParExpression	 SEMI
+    / TRY LPAR Resource (SEMI Resource)* SEMI? RPAR Block Catch* Finally?
+    / TRY Block (Catch+ Finally? / Finally)
+    / SWITCH ParExpression LWING SwitchBlockStatementGroups RWING
+    / SYNCHRONIZED ParExpression Block
+    / RETURN Expression? SEMI
+    / THROW Expression	 SEMI
+    / BREAK Identifier? SEMI
+    / CONTINUE Identifier? SEMI
+    / SEMI
+    / StatementExpression SEMI
+    / Identifier COLON Statement
+
+Resource
+    <- Modifier* Type VariableDeclaratorId EQU Expression
+
+Catch
+    <- CATCH LPAR (FINAL / Annotation)* Type (OR Type)* VariableDeclaratorId RPAR Block
+
+Finally
+    <- FINALLY Block
+
+SwitchBlockStatementGroups
+    <- SwitchBlockStatementGroup*
+
+SwitchBlockStatementGroup
+    <- SwitchLabel BlockStatements
+
+SwitchLabel
+    <- CASE ConstantExpression COLON
+    / CASE EnumConstantName COLON
+    / DEFAULT COLON
+
+ForInit
+    <- (FINAL / Annotation)* Type VariableDeclarators
+    / StatementExpression (COMMA StatementExpression)*
+
+ForUpdate
+    <- StatementExpression (COMMA StatementExpression)*
+
+EnumConstantName
+    <- Identifier
+
+#-------------------------------------------------------------------------
+#  Expressions
+#-------------------------------------------------------------------------
+
+StatementExpression
+    <- Expression
+
+    # This is more generous than definition in section 14.8, which allows only
+    # specific forms of Expression.
+
+
+ConstantExpression
+    <- Expression
+
+Expression
+    <- ConditionalExpression (AssignmentOperator ConditionalExpression)*
+
+    # This definition is part of the modification in JLS Chapter 18
+    # to minimize look ahead. In JLS Chapter 15.27, Expression is defined
+    # as AssignmentExpression, which is effectively defined as
+    # (LeftHandSide AssignmentOperator)* ConditionalExpression.
+    # The above is obtained by allowing ANY ConditionalExpression
+    # as LeftHandSide, which results in accepting statements like 5 = a.
+
+
+AssignmentOperator
+    <- EQU
+    / PLUSEQU
+    / MINUSEQU
+    / STAREQU
+    / DIVEQU
+    / ANDEQU
+    / OREQU
+    / HATEQU
+    / MODEQU
+    / SLEQU
+    / SREQU
+    / BSREQU
+
+ConditionalExpression
+    <- ConditionalOrExpression (QUERY Expression COLON ConditionalOrExpression)*
+
+ConditionalOrExpression
+    <- ConditionalAndExpression (OROR ConditionalAndExpression)*
+
+ConditionalAndExpression
+    <- InclusiveOrExpression (ANDAND InclusiveOrExpression)*
+
+InclusiveOrExpression
+    <- ExclusiveOrExpression (OR ExclusiveOrExpression)*
+
+ExclusiveOrExpression
+    <- AndExpression (HAT AndExpression)*
+
+AndExpression
+    <- EqualityExpression (AND EqualityExpression)*
+
+EqualityExpression
+    <- RelationalExpression ((EQUAL /  NOTEQUAL) RelationalExpression)*
+
+RelationalExpression
+    <- ShiftExpression ((LE / GE / LT / GT) ShiftExpression / INSTANCEOF ReferenceType)*
+
+ShiftExpression
+    <- AdditiveExpression ((SL / SR / BSR) AdditiveExpression)*
+
+AdditiveExpression
+    <- MultiplicativeExpression ((PLUS / MINUS) MultiplicativeExpression)*
+
+MultiplicativeExpression
+    <- UnaryExpression ((STAR / DIV / MOD) UnaryExpression)*
+
+UnaryExpression
+    <- PrefixOp UnaryExpression
+    / LPAR Type RPAR UnaryExpression
+    / Primary (Selector)* (PostfixOp)*
+
+Primary
+    <- ParExpression
+    / NonWildcardTypeArguments (ExplicitGenericInvocationSuffix / THIS Arguments)
+    / THIS Arguments?
+    / SUPER SuperSuffix
+    / Literal
+    / NEW Creator
+    / QualifiedIdentifier IdentifierSuffix?
+    / BasicType Dim* DOT CLASS
+    / VOID DOT CLASS
+
+IdentifierSuffix
+    <- LBRK ( RBRK Dim* DOT CLASS / Expression RBRK)
+    / Arguments
+    / DOT
+      ( CLASS
+      / ExplicitGenericInvocation
+      / THIS
+      / SUPER Arguments
+      / NEW NonWildcardTypeArguments? InnerCreator
+      )
+
+ExplicitGenericInvocation
+    <- NonWildcardTypeArguments ExplicitGenericInvocationSuffix
+
+NonWildcardTypeArguments
+    <- LPOINT ReferenceType (COMMA ReferenceType)* RPOINT
+
+ExplicitGenericInvocationSuffix
+    <- SUPER SuperSuffix
+    / Identifier Arguments
+
+PrefixOp
+    <- INC
+    / DEC
+    / BANG
+    / TILDA
+    / PLUS
+    / MINUS
+
+PostfixOp
+    <- INC
+    / DEC
+
+Selector
+    <- DOT Identifier Arguments?
+    / DOT ExplicitGenericInvocation
+    / DOT THIS
+    / DOT SUPER SuperSuffix
+    / DOT NEW NonWildcardTypeArguments? InnerCreator
+    / DimExpr
+
+SuperSuffix
+    <- Arguments
+    / DOT Identifier Arguments?
+
+BasicType
+    <- < ( 'byte'
+      / 'short'
+      / 'char'
+      / 'int'
+      / 'long'
+      / 'float'
+      / 'double'
+      / 'boolean'
+      ) > { eatIdentifier (auxil, $1, $1s, $1e); } !LetterOrDigit Spacing
+
+Arguments
+    <- LPAR (Expression (COMMA Expression)*)? RPAR
+
+Creator
+    <- NonWildcardTypeArguments? { activateSink(auxil, S_NAME); } CreatedName {
+	enterAnonClassMaybe(auxil);
+    } ClassCreatorRest {
+	leaveAnonClass(auxil);
+    }
+    / NonWildcardTypeArguments? (ClassType / BasicType) ArrayCreatorRest
+
+CreatedName
+    <- Identifier NonWildcardTypeArguments? (DOT Identifier NonWildcardTypeArguments?)*
+
+InnerCreator
+    <- Identifier ClassCreatorRest
+
+ArrayCreatorRest
+    <- LBRK ( RBRK Dim* ArrayInitializer / Expression RBRK DimExpr* Dim* )
+
+    # This is more generous than JLS 15.10. According to that definition,
+    # BasicType must be followed by at least one DimExpr or by ArrayInitializer.
+
+
+ClassCreatorRest
+    <- Diamond? Arguments ClassBody?
+
+Diamond
+    <- LPOINT RPOINT
+
+ArrayInitializer
+    <- LWING (VariableInitializer (COMMA VariableInitializer)*)? COMMA?	 RWING
+
+VariableInitializer
+    <- ArrayInitializer
+    / Expression
+
+ParExpression
+    <- LPAR Expression RPAR
+
+QualifiedIdentifier
+    <- Identifier (DOT Identifier)*
+
+Dim
+    <- LBRK RBRK { eatString (auxil, "[]", 2); }
+
+DimExpr
+    <- LBRK Expression RBRK
+
+#-------------------------------------------------------------------------
+#  Types and Modifiers
+#-------------------------------------------------------------------------
+
+Type
+    <- (BasicType / ClassType) Dim*
+
+ReferenceType
+    <- BasicType Dim+
+    / ClassType Dim*
+
+ClassType
+    <- Identifier TypeArguments? (DOT {
+	   eatChar (auxil, '.');
+       } Identifier TypeArguments?)*
+
+ClassTypeList
+    <- ClassType (COMMA { eatChar (auxil, ','); } ClassType)*
+
+TypeArguments
+    <- LPOINT {
+	  enterTypeArguments (auxil);
+	  eatChar(auxil, '<');
+       } TypeArgument (COMMA {
+	  eatChar(auxil, ',');
+       } TypeArgument)* RPOINT {
+	  eatChar(auxil, '>');
+	  leaveTypeArguments (auxil);
+       }
+
+TypeArgument
+    <- ReferenceType
+    / QUERY { eatChar(auxil, '?'); } ((EXTENDS {
+	eatString (auxil, " extends ", 9);
+    } / SUPER {
+	eatString (auxil, " super ", 7);
+    } ) ReferenceType)?
+
+TypeParameters
+    <- LPOINT TypeParameter (COMMA TypeParameter)* RPOINT
+
+TypeParameter
+    <- Identifier (EXTENDS Bound)?
+
+Bound
+    <- ClassType (AND ClassType)*
+
+Modifier
+    <- Annotation
+    / ( 'public'       { markModifier (auxil, JMOD_PUBLIC); }
+      / 'protected'    { markModifier (auxil, JMOD_PROTECTED); }
+      / 'private'      { markModifier (auxil, JMOD_PRIVATE); }
+      / 'static'       { markModifier (auxil, JMOD_STATIC); }
+      / 'abstract'     { markModifier (auxil, JMOD_ABSTRACT); }
+      / 'final'	       { markModifier (auxil, JMOD_FINAL); }
+      / 'native'       { markModifier (auxil, JMOD_NATIVE); }
+      / 'synchronized' { markModifier (auxil, JMOD_SYNCHRONIZED); }
+      / 'transient'    { markModifier (auxil, JMOD_TRANSIENT); }
+      / 'volatile'     { markModifier (auxil, JMOD_VOLATILE); }
+      / 'strictfp'     { markModifier (auxil, JMOD_STRICTFP); }
+      ) !LetterOrDigit Spacing
+
+    # This common definition of Modifier is part of the modification
+    # in JLS Chapter 18 to minimize look ahead. The main body of JLS has
+    # different lists of modifiers for different language elements.
+
+#-------------------------------------------------------------------------
+#  Annotations
+#-------------------------------------------------------------------------
+
+AnnotationTypeDeclaration
+    <- AT INTERFACE { activateSink(auxil, S_NAME); } Identifier {
+	enterAnnotationDecl (auxil);
+    } AnnotationTypeBody {
+	leaveAnnotationDecl (auxil);
+    }
+
+AnnotationTypeBody
+    <- LWING AnnotationTypeElementDeclaration* RWING
+
+AnnotationTypeElementDeclaration
+    <- { resetModifier (auxil); } Modifier* AnnotationTypeElementRest
+    / SEMI
+
+AnnotationTypeElementRest
+    <- Type AnnotationMethodOrConstantRest SEMI
+    / ClassDeclaration
+    / EnumDeclaration
+    / InterfaceDeclaration
+    / AnnotationTypeDeclaration
+
+AnnotationMethodOrConstantRest
+    <- AnnotationMethodRest
+    / AnnotationConstantRest
+
+AnnotationMethodRest
+    <- {
+	activateSink(auxil, S_NAME);
+    } Identifier {
+	enterMethod (auxil);
+    } LPAR RPAR DefaultValue? {
+	leaveMethod (auxil);
+    }
+
+AnnotationConstantRest
+    <- {
+	pushModifier (auxil);
+	pushVarKind(auxil, K_FIELD);
+    } VariableDeclarators {
+	popVarKind(auxil);
+	popModifier (auxil);
+    }
+
+DefaultValue
+    <- DEFAULT ElementValue
+
+Annotation
+    <- NormalAnnotation
+    / SingleElementAnnotation
+    / MarkerAnnotation
+
+NormalAnnotation
+    <- AT QualifiedIdentifier LPAR ElementValuePairs? RPAR
+
+SingleElementAnnotation
+    <- AT QualifiedIdentifier LPAR ElementValue RPAR
+
+MarkerAnnotation
+    <- AT QualifiedIdentifier
+
+ElementValuePairs
+    <- ElementValuePair (COMMA ElementValuePair)*
+
+ElementValuePair
+    <- Identifier EQU ElementValue
+
+ElementValue
+    <- ConditionalExpression
+    / Annotation
+    / ElementValueArrayInitializer
+
+ElementValueArrayInitializer
+    <- LWING ElementValues? COMMA? RWING
+
+ElementValues
+    <- ElementValue (COMMA ElementValue)*
+
+
+#=========================================================================
+#  Lexical Structure
+#=========================================================================
+#-------------------------------------------------------------------------
+#  JLS 3.6-7  Spacing
+#-------------------------------------------------------------------------
+
+Spacing
+     <- ( [ \t\r\n]+		  # WhiteSpace [ \t\r\n\u000C]+
+      / '/*' (!'*/' .)* '*/'	  # TraditionalComment
+      / '//' (![\r\n] .)* [\r\n]  # EndOfLineComment
+      )*
+
+#-------------------------------------------------------------------------
+#  JLS 3.8  Identifiers
+#-------------------------------------------------------------------------
+
+Identifier <- < !Keyword Letter LetterOrDigit* > Spacing {
+	       eatIdentifier(auxil, $1, $1s, $1e);
+	   }
+
+Letter <- [a-z] / [A-Z] / [_$]
+
+LetterOrDigit <- [a-z] / [A-Z] / [0-9] / [_$]
+
+    # These are traditional definitions of letters and digits.
+    # JLS defines letters and digits as Unicode characters recognized
+    # as such by special Java procedures, which is difficult
+    # to express in terms of Parsing Expressions.
+
+#-------------------------------------------------------------------------
+#  JLS 3.9  Keywords
+#  More precisely: reserved words. According to JLS, "true", "false",
+#  and "null" are technically not keywords - but still must not appear
+#  as identifiers. Keywords "const" and "goto" are not used; JLS explains
+#  the reason.
+#-------------------------------------------------------------------------
+
+Keyword
+   <- ( 'abstract'
+      / 'assert'
+      / 'boolean'
+      / 'break'
+      / 'byte'
+      / 'case'
+      / 'catch'
+      / 'char'
+      / 'class'
+      / 'const'
+      / 'continue'
+      / 'default'
+      / 'double'
+      / 'do'
+      / 'else'
+      / 'enum'
+      / 'extends'
+      / 'false'
+      / 'finally'
+      / 'final'
+      / 'float'
+      / 'for'
+      / 'goto'
+      / 'if'
+      / 'implements'
+      / 'import'
+      / 'interface'
+      / 'int'
+      / 'instanceof'
+      / 'long'
+      / 'native'
+      / 'new'
+      / 'null'
+      / 'package'
+      / 'private'
+      / 'protected'
+      / 'public'
+      / 'return'
+      / 'short'
+      / 'static'
+      / 'strictfp'
+      / 'super'
+      / 'switch'
+      / 'synchronized'
+      / 'this'
+      / 'throws'
+      / 'throw'
+      / 'transient'
+      / 'true'
+      / 'try'
+      / 'void'
+      / 'volatile'
+      / 'while'
+      ) !LetterOrDigit
+
+ASSERT	     <- 'assert'       !LetterOrDigit Spacing
+BREAK	     <- 'break'	       !LetterOrDigit Spacing
+CASE	     <- 'case'	       !LetterOrDigit Spacing
+CATCH	     <- 'catch'	       !LetterOrDigit Spacing
+CLASS	     <- 'class'	       !LetterOrDigit Spacing
+CONTINUE     <- 'continue'     !LetterOrDigit Spacing
+DEFAULT	     <- 'default'      !LetterOrDigit Spacing
+DO	     <- 'do'	       !LetterOrDigit Spacing
+ELSE	     <- 'else'	       !LetterOrDigit Spacing
+ENUM	     <- 'enum'	       !LetterOrDigit Spacing
+EXTENDS	     <- 'extends'      !LetterOrDigit Spacing
+FINALLY	     <- 'finally'      !LetterOrDigit Spacing
+FINAL	     <- 'final'	       !LetterOrDigit Spacing
+FOR	     <- 'for'	       !LetterOrDigit Spacing
+IF	     <- 'if'	       !LetterOrDigit Spacing
+IMPLEMENTS   <- 'implements'   !LetterOrDigit Spacing
+IMPORT	     <- 'import'       !LetterOrDigit Spacing
+INTERFACE    <- 'interface'    !LetterOrDigit Spacing
+INSTANCEOF   <- 'instanceof'   !LetterOrDigit Spacing
+NEW	     <- 'new'	       !LetterOrDigit Spacing
+PACKAGE	     <- 'package'      !LetterOrDigit Spacing
+RETURN	     <- 'return'       !LetterOrDigit Spacing
+STATIC	     <- 'static' {
+		 markModifier (auxil, JMOD_STATIC);
+	     } !LetterOrDigit Spacing
+SUPER	     <- 'super'	       !LetterOrDigit Spacing
+SWITCH	     <- 'switch'       !LetterOrDigit Spacing
+SYNCHRONIZED <- 'synchronized' !LetterOrDigit Spacing
+THIS	     <- 'this'	       !LetterOrDigit Spacing
+THROWS	     <- 'throws'       !LetterOrDigit Spacing
+THROW	     <- 'throw'	       !LetterOrDigit Spacing
+TRY	     <- 'try'	       !LetterOrDigit Spacing
+VOID	     <- 'void'	       !LetterOrDigit Spacing
+WHILE	     <- 'while'	       !LetterOrDigit Spacing
+
+#-------------------------------------------------------------------------
+#  JLS 3.10  Literals
+#-------------------------------------------------------------------------
+
+Literal
+   <- ( FloatLiteral
+      / IntegerLiteral		# May be a prefix of FloatLiteral
+      / CharLiteral
+      / StringLiteral
+      / 'true'	!LetterOrDigit
+      / 'false' !LetterOrDigit
+      / 'null'	!LetterOrDigit
+      ) Spacing
+
+IntegerLiteral
+   <- ( HexNumeral
+      / BinaryNumeral
+      / OctalNumeral		# May be a prefix of HexNumeral or BinaryNumeral
+      / DecimalNumeral		# May be a prefix of OctalNumeral
+      ) [lL]?
+
+DecimalNumeral <- '0' / [1-9] ([_]* [0-9])*
+
+HexNumeral     <- ('0x' / '0X') HexDigits
+
+BinaryNumeral  <- ('0b' / '0B') [01] ([_]* [01])*
+
+OctalNumeral   <- '0' ([_]* [0-7])+
+
+FloatLiteral   <- HexFloat / DecimalFloat
+
+DecimalFloat
+   <- Digits '.' Digits?  Exponent? [fFdD]?
+    / '.' Digits Exponent? [fFdD]?
+    / Digits Exponent [fFdD]?
+    / Digits Exponent? [fFdD]
+
+Exponent <- [eE] [+\-]? Digits
+
+HexFloat <- HexSignificand BinaryExponent [fFdD]?
+
+HexSignificand
+   <- ('0x' / '0X') HexDigits? '.' HexDigits
+    / HexNumeral '.'?				# May be a prefix of above
+
+BinaryExponent <- [pP] [+\-]? Digits
+
+Digits <- [0-9]([_]*[0-9])*
+
+HexDigits <- HexDigit ([_]*HexDigit)*
+
+HexDigit <- [a-f] / [A-F] / [0-9]
+
+CharLiteral <- ['] (Escape / !['\\] .) [']
+
+StringLiteral <- '\"' (Escape / !["\\\n\r] .)* '\"'
+
+Escape <- '\\' ([btnfr"'\\] / OctalEscape / UnicodeEscape)
+
+OctalEscape
+   <- [0-3][0-7][0-7]
+    / [0-7][0-7]
+    / [0-7]
+
+UnicodeEscape
+   <- 'u'+ HexDigit HexDigit HexDigit HexDigit
+
+#-------------------------------------------------------------------------
+#  JLS 3.11-12	Separators, Operators
+#-------------------------------------------------------------------------
+
+AT		<-   '@'       Spacing
+AND		<-   '&'![=&]  Spacing
+ANDAND		<-   '&&'      Spacing
+ANDEQU		<-   '&='      Spacing
+BANG		<-   '!' !'='  Spacing
+BSR		<-   '>>>' !'=' Spacing
+BSREQU		<-   '>>>='    Spacing
+COLON		<-   ':'       Spacing
+COMMA		<-   ',' {
+		    eatComma(auxil, $0s);
+		}	       Spacing
+DEC		<-   '--'      Spacing
+DIV		<-   '/' !'='  Spacing
+DIVEQU		<-   '/='      Spacing
+DOT		<-   '.'       Spacing
+ELLIPSIS	<-   '...'     Spacing
+EQU		<-   '=' !'='  Spacing
+EQUAL		<-   '=='      Spacing
+GE		<-   '>='      Spacing
+GT		<-   '>'![=>]  Spacing
+HAT		<-   '^' !'='	Spacing
+HATEQU		<-   '^='      Spacing
+INC		<-   '++'      Spacing
+LBRK		<-   '['       Spacing
+LE		<-   '<='      Spacing
+LPAR		<-   '('       Spacing
+LPOINT		<-   '<'       Spacing
+LT		<-   '<' ![=<]	Spacing
+LWING		<-   '{'       Spacing
+MINUS		<-   '-' ![=\-] Spacing
+MINUSEQU	<-   '-='      Spacing
+MOD		<-   '%' !'='	Spacing
+MODEQU		<-   '%='      Spacing
+NOTEQUAL	<-   '!='      Spacing
+OR		<-   '|' ![=|]	Spacing
+OREQU		<-   '|='      Spacing
+OROR		<-   '||'      Spacing
+PLUS		<-   '+' ![=+]	Spacing
+PLUSEQU		<-   '+='      Spacing
+QUERY		<-   '?'       Spacing
+RBRK		<-   ']'       Spacing
+RPAR		<-   ')'       Spacing
+RPOINT		<-   '>'       Spacing
+RWING		<-   '}' {
+		    eatRightwing(auxil, $0s);
+		}	       Spacing
+SEMI		<-   ';'       Spacing
+SL		<-   '<<' !'='	Spacing
+SLEQU		<-   '<<='     Spacing
+SR		<-   '>>' ![=>] Spacing
+SREQU		<-   '>>='     Spacing
+STAR		<-   '*' !'='	Spacing
+STAREQU		<-   '*='      Spacing
+TILDA		<-   '~'       Spacing
+
+EOT <- !.
+
+%%
+#include "java_post.h"

--- a/peg/java_post.h
+++ b/peg/java_post.h
@@ -1,0 +1,535 @@
+/*
+ *   Copyright (c) 2018 Masatake YAMATO
+ *   Copyright (c) 2018 Red Hat, Inc.
+ *
+ *   This source code is released for free distribution under the terms of the
+ *   GNU General Public License version 2 or (at your option) any later version.
+ *
+ *   This module contains functions to generate tags for Java 1.7.
+ */
+
+#include "trace.h"
+
+static bool includeTypeArgument;
+
+static void leaveBlock (struct parserCtx *auxil);
+
+static void ctxInit (struct parserCtx *auxil)
+{
+	auxil->currentSink = NULL;
+	auxil->offset = -1;
+
+	for (int i = 0; i < MAX_SINK_TYPE; i++)
+		auxil->sinks[i] = vStringNew();
+	auxil->sinkBlockDepth = 0;
+
+	auxil->nlevels = nestingLevelsNew (0);
+	auxil->inPackage = false;
+	auxil->modifiersTracker = ulongArrayNew ();
+	auxil->varKindsTracker = intArrayNew ();
+
+	auxil->modifier = 0UL;
+	auxil->found_syntax_error = false;
+	auxil->lastPoppedCorkIndex = CORK_NIL;
+	auxil->looking_for_anon_class = false;
+}
+
+static void ctxFini (struct parserCtx *auxil)
+{
+	auxil->currentSink = NULL;
+	auxil->offset = -1;
+
+	for (int i = 0; i < MAX_SINK_TYPE; i++)
+	{
+		vStringDelete (auxil->sinks[i]);
+		auxil->sinks[i] = NULL;
+	}
+	auxil->currentSink = NULL;
+
+	nestingLevelsFree(auxil->nlevels);
+	auxil->nlevels = NULL;
+	auxil->inPackage = false;
+	ulongArrayDelete (auxil->modifiersTracker);
+	auxil->modifiersTracker = NULL;
+	intArrayDelete (auxil->varKindsTracker);
+	auxil->varKindsTracker = NULL;
+}
+
+static void enterTypeArguments(struct parserCtx *auxil)
+{
+	if (includeTypeArgument == 0)
+		auxil->sinkBlockDepth++;
+}
+
+static void leaveTypeArguments(struct parserCtx *auxil)
+{
+	if (includeTypeArgument == 0)
+		auxil->sinkBlockDepth--;
+}
+
+static void activateSink (struct parserCtx *auxil, sinkType stype)
+{
+	auxil->currentSink = auxil->sinks [stype];
+	auxil->offset = -1;
+}
+
+static void deactivateSink (struct parserCtx *auxil)
+{
+	if (auxil->currentSink)
+		vStringClear (auxil->currentSink);
+	auxil->currentSink = NULL;
+	auxil->offset = -1;
+}
+
+static const vString* fossick (struct parserCtx *auxil)
+{
+	return auxil->currentSink;
+}
+
+static void eatIdentifier (struct parserCtx *auxil, const char *id,
+						   int idOffset, int endCandidateOffset)
+{
+	if (auxil->currentSink)
+	{
+		if (auxil->offset == -1)
+			auxil->offset = idOffset;
+		else
+		{
+			if (auxil->currentSink == auxil->sinks[S_NAME])
+				eatChar (auxil, '.');
+		}
+		eatString(auxil, id, endCandidateOffset - idOffset);
+		auxil->endCandidateOffset = endCandidateOffset;
+	}
+}
+
+static void eatRightwing (struct parserCtx *auxil, int wingOffset)
+{
+	auxil->endCandidateOffset = wingOffset;
+}
+
+static void eatComma (struct parserCtx *auxil, int commaOffset)
+{
+	auxil->endCandidateOffset = commaOffset;
+}
+
+static void eatChar (struct parserCtx *auxil, char c)
+{
+	if (auxil->currentSink && auxil->sinkBlockDepth == 0)
+		vStringPut (auxil->currentSink, c);
+}
+
+static void eatString (struct parserCtx *auxil, const char *s, size_t len)
+{
+	if (auxil->currentSink && auxil->sinkBlockDepth == 0)
+		vStringNCatSUnsafe (auxil->currentSink, s, len);
+}
+
+static void patchEndline (struct parserCtx *auxil)
+{
+	if (auxil->lastPoppedCorkIndex != CORK_NIL)
+	{
+		tagEntryInfo *e = getEntryInCorkQueue (auxil->lastPoppedCorkIndex);
+		e->extensionFields.endLine = getInputLineNumberForFileOffset (auxil->endCandidateOffset);
+	}
+}
+
+static const char* chooseAccessString (unsigned long modifier, int kind, int kind_parent)
+{
+	if (modifier & (1UL << JMOD_PUBLIC))
+		return "public";
+	else if (modifier & (1UL << JMOD_PROTECTED))
+		return "protected";
+	else if (modifier & (1UL << JMOD_PRIVATE))
+		return "private";
+	else
+	{
+		switch (kind_parent)
+		{
+		case K_CLASS:
+			return "default";
+		case K_INTERFACE:
+		case K_ENUM:
+		case K_ANNOTATION:
+			return "public";
+		default:
+			return "default";
+			return NULL;
+		}
+	}
+}
+
+static int makeJavaRefTag (struct parserCtx *auxil, const char* name, int kind, int role)
+{
+	tagEntryInfo e, *e_parent = NULL;
+	NestingLevel *n;
+	vString *anon = NULL;
+
+	if (name)
+		initRefTagEntry(&e, name, kind, role);
+	else
+	{
+		anon = vStringNew ();
+
+		if (kind == K_CLASS)
+			anonGenerate (anon, "__anon", K_CLASS);
+		else
+			anonGenerate (anon, "__anon???", kind);
+
+		initTagEntry(&e, vStringValue(anon), kind);
+		markTagExtraBit (&e, XTAG_ANONYMOUS);
+	}
+
+	if (kind != K_PACKAGE
+		&& (n = nestingLevelsGetCurrent (auxil->nlevels)))
+	{
+		e.extensionFields.scopeIndex = n->corkIndex;
+		e_parent = getEntryInCorkQueue (n->corkIndex);
+	}
+
+	if (auxil->offset != -1)
+	{
+		e.lineNumber = getInputLineNumberForFileOffset (auxil->offset);
+		e.filePosition = getInputFilePositionForLine (e.lineNumber);
+	}
+
+	e.isFileScope = (auxil->modifier & (1UL << JMOD_PRIVATE))? 1: 0;
+
+	{
+		int kind_parent = e_parent? e_parent->kindIndex: K_UNDEFINED;
+		e.extensionFields.access = chooseAccessString(auxil->modifier, kind,
+													  kind_parent);
+	}
+	e.extensionFields.implementation = (auxil->modifier & (1UL << JMOD_ABSTRACT))
+		? "abstract": NULL;
+
+	/* TODO: signature, typeRef */
+
+	unsigned int cork_Id = makeTagEntry(&e);
+
+	switch (kind)
+	{
+	case K_ANNOTATION:
+	case K_CLASS:
+	case K_INTERFACE:
+	case K_METHOD:
+	case K_ENUM:
+	case K_ENUM_CONSTANT:
+		nestingLevelsPush(auxil->nlevels, cork_Id);
+		break;
+	case K_PACKAGE:
+		if (role == ROLE_INDEX_DEFINITION)
+			nestingLevelsPush(auxil->nlevels, cork_Id);
+		break;
+	}
+
+	if (anon)
+		vStringDelete (anon);
+
+	return cork_Id;
+}
+
+static int makeJavaTag (struct parserCtx *auxil, const char* name, int kind)
+{
+	return makeJavaRefTag (auxil, name, kind, ROLE_INDEX_DEFINITION);
+}
+
+static void enterPackage (struct parserCtx *auxil)
+{
+	const vString *package = fossick (auxil);
+
+	makeJavaTag (auxil, vStringValue(package), K_PACKAGE);
+	auxil->inPackage = true;
+
+	deactivateSink (auxil);
+}
+
+static void leavePackageMaybe (struct parserCtx *auxil, int endOffset)
+{
+	if (auxil->inPackage)
+	{
+		auxil->endCandidateOffset = endOffset;
+		leaveBlock(auxil);
+		auxil->inPackage = false;
+	}
+}
+
+static int enterBlock (struct parserCtx *auxil, const vString *const name, int kind)
+{
+	int corkIndex;
+
+	auxil->lastPoppedCorkIndex = CORK_NIL;
+	corkIndex = makeJavaTag (auxil, name? vStringValue(name): NULL, kind);
+	resetModifier (auxil);
+	return corkIndex;
+}
+
+static void leaveBlock (struct parserCtx *auxil)
+{
+	NestingLevel *n = nestingLevelsGetCurrent (auxil->nlevels);
+
+	if (n)
+	{
+		int corkIndex = n->corkIndex;
+
+		tagEntryInfo *e;
+		e = getEntryInCorkQueue (corkIndex);
+		if (e)
+		{
+			switch (e->kindIndex)
+			{
+			case K_ANNOTATION:
+			case K_CLASS:
+			case K_INTERFACE:
+			case K_METHOD:
+			case K_ENUM:
+			case K_ENUM_CONSTANT:
+			case K_PACKAGE:
+				e->extensionFields.endLine = getInputLineNumberForFileOffset (auxil->endCandidateOffset);
+				nestingLevelsPop(auxil->nlevels);
+				auxil->lastPoppedCorkIndex = corkIndex;
+			}
+		}
+	}
+}
+
+static void enterClass (struct parserCtx *auxil)
+{
+	const vString *klass = fossick (auxil);
+	enterBlock (auxil, klass, K_CLASS);
+	deactivateSink (auxil);
+}
+
+static void leaveClass (struct parserCtx *auxil)
+{
+	leaveBlock (auxil);
+}
+
+static void enterAnonClassMaybe (struct parserCtx *auxil)
+{
+	int corkIndex = enterBlock (auxil, NULL, K_CLASS);
+	tagEntryInfo *e = getEntryInCorkQueue (corkIndex);
+	const vString *inheritance = fossick (auxil);
+	e->extensionFields.inheritance = vStringStrdup (inheritance);
+	deactivateSink (auxil);
+
+	e->placeholder = true;
+	auxil->looking_for_anon_class = true;
+}
+
+static void markAnonClassMaybe (struct parserCtx *auxil)
+{
+	if (auxil->looking_for_anon_class)
+	{
+		NestingLevel *n = nestingLevelsGetCurrent (auxil->nlevels);
+
+		if (n && (n->corkIndex != CORK_NIL))
+		{
+			tagEntryInfo *e = getEntryInCorkQueue (n->corkIndex);
+			e->placeholder = false;
+		}
+		auxil->looking_for_anon_class = false;
+	}
+}
+
+static void leaveAnonClass (struct parserCtx *auxil)
+{
+	auxil->looking_for_anon_class = false;
+	leaveBlock(auxil);
+}
+
+static void enterInterface (struct parserCtx *auxil)
+{
+	const vString *iface = fossick (auxil);
+	enterBlock (auxil, iface, K_INTERFACE);
+	deactivateSink (auxil);
+}
+
+static void leaveInterface (struct parserCtx *auxil)
+{
+	leaveBlock (auxil);
+}
+
+static void enterMethod (struct parserCtx *auxil)
+{
+	const vString *method = fossick (auxil);
+	enterBlock (auxil, method, K_METHOD);
+	deactivateSink (auxil);
+}
+
+static void leaveMethod (struct parserCtx *auxil)
+{
+	leaveBlock (auxil);
+}
+
+static void enterAnnotationDecl (struct parserCtx *auxil)
+{
+	const vString *anot = fossick (auxil);
+	enterBlock (auxil, anot, K_ANNOTATION);
+	deactivateSink (auxil);
+}
+
+static void leaveAnnotationDecl (struct parserCtx *auxil)
+{
+	leaveBlock (auxil);
+}
+
+static void resetModifier(struct parserCtx *auxil)
+{
+	auxil->modifier = 0UL;
+}
+
+static void markModifier(struct parserCtx *auxil, javaModifier jmod)
+{
+	auxil->modifier |= (1UL << jmod);
+}
+
+static void pushModifier(struct parserCtx *auxil)
+{
+	TRACE_PRINT("modifier: %x", auxil->modifier);
+	ulongArrayAdd (auxil->modifiersTracker, auxil->modifier);
+	resetModifier (auxil);
+}
+
+static void popModifier(struct parserCtx *auxil)
+{
+	ulongArrayRemoveLast (auxil->modifiersTracker);
+	resetModifier (auxil);
+}
+
+static unsigned long peekModifier(struct parserCtx *auxil)
+{
+	return ulongArrayLast (auxil->modifiersTracker);
+}
+
+static void pushVarKind(struct parserCtx *auxil, javaKind kind)
+{
+	intArrayAdd(auxil->varKindsTracker, kind);
+}
+
+static void popVarKind(struct parserCtx *auxil)
+{
+	intArrayRemoveLast(auxil->varKindsTracker);
+}
+
+static void captureField(struct parserCtx *auxil)
+{
+	const vString *field = fossick (auxil);
+	auxil->modifier = peekModifier (auxil);
+	makeJavaTag (auxil, vStringValue (field), K_FIELD);
+	resetModifier (auxil);
+	deactivateSink (auxil);
+}
+
+static void captureVariable(struct parserCtx *auxil)
+{
+	if (intArrayCount (auxil->varKindsTracker) == 0)
+		return;
+
+	const vString *var = fossick(auxil);
+	javaKind var_kind = intArrayLast (auxil->varKindsTracker);
+	if (var_kind == K_FIELD)
+		auxil->modifier = peekModifier (auxil);
+	makeJavaTag (auxil, vStringValue (var), var_kind);
+	resetModifier (auxil);
+	deactivateSink (auxil);
+}
+
+static void enterEnum (struct parserCtx *auxil)
+{
+	const vString *enumClass = fossick (auxil);
+	enterBlock (auxil, enumClass, K_ENUM);
+	deactivateSink (auxil);
+}
+
+static void leaveEnum (struct parserCtx *auxil)
+{
+	leaveBlock (auxil);
+}
+
+static void enterEnumConstant (struct parserCtx *auxil)
+{
+	const vString *enumConstant = fossick (auxil);
+	enterBlock (auxil, enumConstant, K_ENUM_CONSTANT);
+	deactivateSink (auxil);
+}
+
+static void leaveEnumConstant (struct parserCtx *auxil)
+{
+	leaveBlock (auxil);
+}
+
+static void attachInheritsMaybe (struct parserCtx *auxil)
+{
+	const vString *superList = fossick (auxil);
+	if (superList && vStringLength (superList) > 0)
+	{
+		NestingLevel *n = nestingLevelsGetCurrent (auxil->nlevels);
+		if (n)
+		{
+			int corkIndex = n->corkIndex;
+
+			tagEntryInfo *e;
+			e = getEntryInCorkQueue (corkIndex);
+			if (e)
+			{
+				Assert(!e->extensionFields.inheritance);
+				e->extensionFields.inheritance = vStringStrdup (superList);
+			}
+		}
+	}
+	deactivateSink (auxil);
+}
+
+static void captureImportedPackage(struct parserCtx *auxil)
+{
+	const vString *imported = fossick (auxil);
+	makeJavaRefTag (auxil, vStringValue (imported),
+					K_PACKAGE, JAVAR_PACKAGE_IMPORTED);
+	resetModifier (auxil);
+	deactivateSink (auxil);
+}
+
+static void findJavaTags (void)
+{
+	struct parserCtx auxil;
+
+	ctxInit (&auxil);
+	pjava_context_t *pctx = pjava_create(&auxil);
+
+	while (pjava_parse(pctx, NULL) && (!auxil.found_syntax_error) );
+
+	pjava_destroy(pctx);
+	ctxFini (&auxil);
+}
+
+static void java_include_type_argument_handler (const langType language CTAGS_ATTR_UNUSED,
+												const char *optname,
+												const char *arg)
+{
+	includeTypeArgument = paramParserBool (arg, includeTypeArgument,
+										   optname, "parameter");
+}
+
+static parameterHandlerTable JavaParameterHandlerTable [] = {
+	{ .name = "includeTypeArgument",
+	  .desc = "include type arguments to inheritance field: true or [false]",
+	  .handleParameter = java_include_type_argument_handler,
+	},
+};
+
+extern parserDefinition* NewJavaParser (void)
+{
+	static const char *const extensions [] = { "java", NULL };
+	parserDefinition* def = parserNew ("NewJava");
+	def->kindTable  = JavaKinds;
+	def->kindCount  = ARRAY_SIZE (JavaKinds);
+	def->extensions = extensions;
+	def->parser     = findJavaTags;
+	def->useCork    = true;
+	def->enabled    = 0;
+	def->parameterHandlerTable = JavaParameterHandlerTable;
+	def->parameterHandlerCount = ARRAY_SIZE(JavaParameterHandlerTable);
+
+	return def;
+}

--- a/peg/java_pre.h
+++ b/peg/java_pre.h
@@ -1,0 +1,152 @@
+/*
+ *   Copyright (c) 2018 Masatake YAMATO
+ *   Copyright (c) 2018 Red Hat, Inc.
+ *
+ *   This source code is released for free distribution under the terms of the
+ *   GNU General Public License version 2 or (at your option) any later version.
+ *
+ *   This module contains functions to generate tags for Java 1.7.
+ */
+
+#include "general.h"  /* must always come first */
+
+#include "options.h"
+#include "entry.h"
+#include "kind.h"
+#include "nestlevel.h"
+#include "numarray.h"
+#include "parse.h"
+#include "param.h"
+#include "read.h"
+#include "routines.h"
+#include "strlist.h"
+#include "vstring.h"
+
+#define PCC_GETCHAR(auxil) getcFromInputFile()
+#define PCC_MALLCO(auxil,size) eMalloc(size)
+#define PCC_REALLOC(auxil,ptr,size) eRealloc(ptr,size)
+#define PCC_FREE(auxil,ptr) eFreeNoNullCheck(ptr)
+#define PCC_ERROR(auxil) reportError(auxil)
+
+/* Used to index into the JavaKinds table. */
+typedef enum {
+	JAVAR_PACKAGE_IMPORTED,
+} javaPackageRole;
+
+static roleDefinition JavaPackageRoles [] = {
+	{ true, "imported", "imported package"},
+};
+
+typedef enum {
+	K_UNDEFINED = -1,
+	K_ANNOTATION, K_CLASS, K_ENUM_CONSTANT, K_FIELD, K_ENUM, K_INTERFACE,
+	K_LOCAL, K_METHOD, K_PACKAGE,
+} javaKind;
+
+static kindDefinition JavaKinds [] = {
+	{ true,  'a', "annotation",    "annotation declarations" },
+	{ true,  'c', "class",         "classes"},
+	{ true,  'e', "enumConstant",  "enum constants"},
+	{ true,  'f', "field",         "fields"},
+	{ true,  'g', "enum",          "enum types"},
+	{ true,  'i', "interface",     "interfaces"},
+	{ false, 'l', "local",         "local variables"},
+	{ true,  'm', "method",        "methods"},
+	{ true,  'p', "package",       "packages",
+	  .referenceOnly = false, ATTACH_ROLES(JavaPackageRoles)},
+};
+
+typedef enum {
+	JMOD_PUBLIC,
+	JMOD_PROTECTED,
+	JMOD_PRIVATE,
+	JMOD_STATIC,
+	JMOD_ABSTRACT,
+	JMOD_FINAL,
+	JMOD_NATIVE,
+	JMOD_SYNCHRONIZED,
+	JMOD_TRANSIENT,
+	JMOD_VOLATILE,
+	JMOD_STRICTFP,
+} javaModifier;
+
+typedef enum  {
+	S_NAME,
+	S_SUPER,
+	MAX_SINK_TYPE
+} sinkType;
+
+struct parserCtx {
+	vString *currentSink;
+	vString *sinks[MAX_SINK_TYPE];
+	int sinkBlockDepth;
+	int offset;
+	int endCandidateOffset;
+	NestingLevels *nlevels;
+	bool inPackage;
+	ulongArray *modifiersTracker;
+	intArray *varKindsTracker;
+
+	unsigned long modifier;
+	bool found_syntax_error;
+	int lastPoppedCorkIndex;
+	bool looking_for_anon_class;
+};
+
+static void enterTypeArguments(struct parserCtx *auxil);
+static void leaveTypeArguments(struct parserCtx *auxil);
+
+static void activateSink (struct parserCtx *auxil, sinkType stype);
+static void eatIdentifier(struct parserCtx *auxil, const char *const id, int idOffset, int endCandidateOffset);
+static void eatRightwing (struct parserCtx *auxil, int wingOffset);
+static void eatComma (struct parserCtx *auxil, int commaOffset);
+static void eatChar (struct parserCtx *auxil, char c);
+static void eatString (struct parserCtx *auxil, const char *const s, size_t len);
+
+static void patchEndline (struct parserCtx *auxil);
+
+static void enterPackage (struct parserCtx *auxil);
+static void leavePackageMaybe (struct parserCtx *auxil, int endOffset);
+
+static void enterClass (struct parserCtx *auxil);
+static void leaveClass (struct parserCtx *auxil);
+
+static void enterAnonClassMaybe (struct parserCtx *auxil);
+static void markAnonClassMaybe (struct parserCtx *auxil);
+static void leaveAnonClass (struct parserCtx *auxil);
+
+static void enterInterface (struct parserCtx *auxil);
+static void leaveInterface (struct parserCtx *auxil);
+
+static void enterAnnotationDecl (struct parserCtx *auxil);
+static void leaveAnnotationDecl (struct parserCtx *auxil);
+
+static void enterMethod (struct parserCtx *auxil);
+static void leaveMethod (struct parserCtx *auxil);
+
+static void resetModifier(struct parserCtx *auxil);
+static void markModifier(struct parserCtx *auxil, javaModifier jmod);
+static void pushModifier(struct parserCtx *auxil);
+static void popModifier(struct parserCtx *auxil);
+
+static void captureField(struct parserCtx *auxil);
+
+static void pushVarKind(struct parserCtx *auxil, javaKind kind);
+static void popVarKind(struct parserCtx *auxil);
+static void captureVariable(struct parserCtx *auxil);
+
+static void enterEnum (struct parserCtx *auxil);
+static void leaveEnum (struct parserCtx *auxil);
+
+static void enterEnumConstant (struct parserCtx *auxil);
+static void leaveEnumConstant (struct parserCtx *auxil);
+
+static void attachInheritsMaybe (struct parserCtx *auxil);
+
+static void captureImportedPackage (struct parserCtx *auxil);
+
+static void reportError (struct parserCtx *auxil)
+{
+	auxil->found_syntax_error = true;
+	verbose ("NewJava: syntax error\n");
+}

--- a/source.mak
+++ b/source.mak
@@ -137,8 +137,8 @@ MAIN_SRCS =				\
 	\
 	$(NULL)
 
-include makefiles/translator_input.mak
-TRANSLATED_SRCS = $(TRANSLATOR_INPUT:.ctags=.c)
+include makefiles/optlib2c_input.mak
+OPTLIB2C_SRCS = $(OPTLIB2C_INPUT:.ctags=.c)
 
 PARSER_HEADS = \
 	parsers/cxx/cxx_debug.h \
@@ -255,7 +255,7 @@ PARSER_SRCS =				\
 	parsers/yacc.c			\
 	parsers/yumrepo.c		\
 	\
-	$(TRANSLATED_SRCS)		\
+	$(OPTLIB2C_SRCS)		\
 	\
 	$(NULL)
 

--- a/source.mak
+++ b/source.mak
@@ -140,6 +140,12 @@ MAIN_SRCS =				\
 include makefiles/optlib2c_input.mak
 OPTLIB2C_SRCS = $(OPTLIB2C_INPUT:.ctags=.c)
 
+include makefiles/peg_input.mak
+PEG_SRCS = $(PEG_INPUT:.peg=.c)
+PEG_HEADS = $(PEG_INPUT:.peg=.h)
+PEG_EXTRA_HEADS = $(PEG_INPUT:.peg=_pre.h) $(PEG_INPUT:.peg=_post.h)
+PEG_OBJS = $(PEG_SRCS:.c=.$(OBJEXT))
+
 PARSER_HEADS = \
 	parsers/cxx/cxx_debug.h \
 	parsers/cxx/cxx_keyword.h \
@@ -328,5 +334,12 @@ READTAGS_SRCS  = \
 	       $(NULL)
 READTAGS_HEADS = read/readtags.h
 READTAGS_OBJS  = $(READTAGS_SRCS:.c=.$(OBJEXT))
+
+PACKCC_SRCS = \
+	    misc/packcc/packcc.c \
+	    \
+	    $(NULL)
+
+PACKCC_OBJS = $(PACKCC_SRCS:.c=.$(OBJEXT))
 
 # vim: ts=8

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -115,7 +115,7 @@ c:\cygwin64\bin\file readtags.exe
 .\ctags --version || exit 1
 
 :: Run tests on msys2
-bash -lc "make check APPVEYOR=1"
+bash -lc "make check APPVEYOR=1 PMAP=NewJava/Java"
 
 @echo off
 goto :eof
@@ -171,7 +171,7 @@ if "%normalbuild%-%ARCH%"=="yes-x64" (
   @echo Tests for msys2 x64 are skipped.
   exit 0
 )
-bash -lc "make check APPVEYOR=1"
+bash -lc "make check APPVEYOR=1 PMAP=NewJava/Java"
 
 @echo off
 goto :eof
@@ -258,7 +258,7 @@ c:\cygwin64\bin\file readtags.exe
 :: Check if it works
 .\ctags --version || exit 1
 :: Run tests
-bash -lc "make check APPVEYOR=1"
+bash -lc "make check APPVEYOR=1 PMAP=NewJava/Java"
 
 @echo off
 goto :eof


### PR DESCRIPTION
This will be the biggest change in the history of fishman/ctags and Universal-ctags.

This is an experimental branch for testing "packcc" parser generator
and peg based "NewJava" parser.  Only building with Autotools is
supported. Volunteers for the other build-system are welcome.

packcc is registred as a git submodule. It is taken from https://github.com/enechaev/packcc.
The peg definition for Java 1.7 is taken from https://github.com/pointlander/peg/blob/master/grammars/java/java_1_7.peg.

git submodule handling is done in ./autogen.sh.

How to switch the branch:

```
[yamato@master]/tmp% git clone https://github.com/masatake/ctags.git
Cloning into 'ctags'...
remote: Counting objects: 38867, done.
remote: Compressing objects: 100% (48/48), done.
remote: Total 38867 (delta 18), reused 43 (delta 16), pack-reused 38802
Receiving objects: 100% (38867/38867), 11.80 MiB | 4.41 MiB/s, done.
Resolving deltas: 100% (24486/24486), done.
[yamato@master]/tmp% cd ctags
[yamato@master]/tmp/ctags% git checkout peg-based-java-parser
Branch 'peg-based-java-parser' set up to track remote branch 'peg-based-java-parser' from 'origin'.
Switched to a new branch 'peg-based-java-parser'
```

How to try the new java parser:
```
[yamato@master]~/var/ctags-peg% ./ctags --fields=+l -o - --languages=+NewJava --language-force=NewJava foo.java
A	foo.java	/^    A;$/;"	e	language:NewJava	enum:e
e	foo.java	/^public enum e {$/;"	g	language:NewJava
getString	foo.java	/^    public String getString() {$/;"	m	language:NewJava	enum:e
```

TODO:

* Improve or modify packcc to make ctags pass the test case parser-java.r/accented-latin1-identifiers.java.d,
* Build a ctags executable on non-Autotools platform,
* Support Java-1.9 (See http://www.romanredz.se/Mouse/index.htm#parsing), and
* Add a parser for peg itself.
```