### PR TITLE
vstring: Use memcpy() instead of strncpy()

### DIFF
--- a/main/vstring.c
+++ b/main/vstring.c
@@ -107,7 +107,7 @@ static void stringCat (
 	if (string->length + length + 1 > string->size)
 		vStringResize (string, string->length + length + 1);
 
-	strncpy (string->buffer + string->length, s, length);
+	memcpy (string->buffer + string->length, s, length);
 	string->length += length;
 	vStringPut (string, '\0');
 }


### PR DESCRIPTION
We don't need the extra strncpy() semantic in stringCat() as we always
know the length we want, so it's slightly faster to use memcpy(), about
2% in some cases.

Additionally, this would improve support for NUL bytes embedded in a
vString, avoiding an extra truncation.  However, no consumer currently
rely on NUL byte support so it currently has no impact on this end.