### PR TITLE
Use vStringCat() instead of vStringCatS() when possible

### DIFF
--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -268,7 +268,7 @@ static void makeFlexTag (tokenInfo *const token, flexKind kind)
 			fulltag = vStringNew ();
 			vStringCopy(fulltag, token->scope);
 			vStringPut (fulltag, '.');
-			vStringCatS (fulltag, vStringValue(token->string));
+			vStringCat (fulltag, token->string);
 			vStringCopy(token->string, fulltag);
 			vStringDelete (fulltag);
 		}
@@ -287,7 +287,7 @@ static void makeClassTag (tokenInfo *const token)
 		{
 			vStringCopy(fulltag, token->scope);
 			vStringPut (fulltag, '.');
-			vStringCatS (fulltag, vStringValue(token->string));
+			vStringCat (fulltag, token->string);
 		}
 		else
 		{
@@ -313,7 +313,7 @@ static void makeMXTag (tokenInfo *const token)
 		{
 			vStringCopy(fulltag, token->scope);
 			vStringPut (fulltag, '.');
-			vStringCatS (fulltag, vStringValue(token->string));
+			vStringCat (fulltag, token->string);
 		}
 		else
 		{
@@ -335,7 +335,7 @@ static void makeFunctionTag (tokenInfo *const token)
 		{
 			vStringCopy(fulltag, token->scope);
 			vStringPut (fulltag, '.');
-			vStringCatS (fulltag, vStringValue(token->string));
+			vStringCat (fulltag, token->string);
 		}
 		else
 		{
@@ -800,7 +800,7 @@ static void addContext (tokenInfo* const parent, const tokenInfo* const child)
 	{
 		vStringPut (parent->string, '.');
 	}
-	vStringCatS (parent->string, vStringValue(child->string));
+	vStringCat (parent->string, child->string);
 }
 
 static void addToScope (tokenInfo* const token, vString* const extra)
@@ -809,7 +809,7 @@ static void addToScope (tokenInfo* const token, vString* const extra)
 	{
 		vStringPut (token->scope, '.');
 	}
-	vStringCatS (token->scope, vStringValue(extra));
+	vStringCat (token->scope, extra);
 }
 
 /*
@@ -1857,7 +1857,7 @@ static bool parseStatement (tokenInfo *const token)
 				{
 					vStringCopy(fulltag, token->scope);
 					vStringPut (fulltag, '.');
-					vStringCatS (fulltag, vStringValue(token->string));
+					vStringCat (fulltag, token->string);
 				}
 				else
 				{

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -399,7 +399,7 @@ static void makeClassTagCommon (tokenInfo *const token, vString *const signature
 		{
 			vStringCopy(fulltag, token->scope);
 			vStringPut (fulltag, '.');
-			vStringCatS (fulltag, vStringValue(token->string));
+			vStringCat (fulltag, token->string);
 		}
 		else
 		{
@@ -433,7 +433,7 @@ static void makeFunctionTagCommon (tokenInfo *const token, vString *const signat
 		{
 			vStringCopy(fulltag, token->scope);
 			vStringPut (fulltag, '.');
-			vStringCatS (fulltag, vStringValue(token->string));
+			vStringCat (fulltag, token->string);
 		}
 		else
 		{
@@ -1155,7 +1155,7 @@ static void addContext (tokenInfo* const parent, const tokenInfo* const child)
 	{
 		vStringPut (parent->string, '.');
 	}
-	vStringCatS (parent->string, vStringValue(child->string));
+	vStringCat (parent->string, child->string);
 }
 
 static void addToScope (tokenInfo* const token, const vString* const extra)
@@ -1164,7 +1164,7 @@ static void addToScope (tokenInfo* const token, const vString* const extra)
 	{
 		vStringPut (token->scope, '.');
 	}
-	vStringCatS (token->scope, vStringValue(extra));
+	vStringCat (token->scope, extra);
 }
 
 /*
@@ -2193,7 +2193,7 @@ nextVar:
 					{
 						vStringCopy(fulltag, token->scope);
 						vStringPut (fulltag, '.');
-						vStringCatS (fulltag, vStringValue(token->string));
+						vStringCat (fulltag, token->string);
 					}
 					else
 					{
@@ -2283,7 +2283,7 @@ nextVar:
 				{
 					vStringCopy(fulltag, token->scope);
 					vStringPut (fulltag, '.');
-					vStringCatS (fulltag, vStringValue(token->string));
+					vStringCat (fulltag, token->string);
 				}
 				else
 				{

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -740,7 +740,7 @@ static void readIdentifier (tokenInfo *const token)
  *	   {
  *		   vStringPut (parent->string, '.');
  *	   }
- *	   vStringCatS (parent->string, vStringValue(child->string));
+ *	   vStringCat (parent->string, child->string);
  * }
  */
 
@@ -750,7 +750,7 @@ static void addToScope (tokenInfo* const token, vString* const extra, sqlKind ki
 	{
 		vStringPut (token->scope, '.');
 	}
-	vStringCatS (token->scope, vStringValue(extra));
+	vStringCat (token->scope, extra);
 	token->scopeKind = kind;
 }
 

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -622,7 +622,7 @@ static void createTag (tokenInfo *const token)
 
 		vStringCopy (scopedName, currentContext->name);
 		vStringPut (scopedName, '.');
-		vStringCatS (scopedName, vStringValue (token->name));
+		vStringCat (scopedName, token->name);
 		tag.name = vStringValue (scopedName);
 
 		markTagExtraBit (&tag, XTAG_QUALIFIED_TAGS);

--- a/parsers/vhdl.c
+++ b/parsers/vhdl.c
@@ -535,7 +535,7 @@ static void makeVhdlTag (tokenInfo * const token, const vhdlKind kind)
 			vString *fulltag = vStringNew ();
 			vStringCopy (fulltag, token->scope);
 			vStringPut (fulltag, '.');
-			vStringCatS (fulltag, vStringValue (token->string));
+			vStringCat (fulltag, token->string);
 			vStringCopy (token->string, fulltag);
 			vStringDelete (fulltag);
 		}


### PR DESCRIPTION
This avoids computing the length that is already known.