### PR TITLE
Check again if we need to use cork after initializing parsers

### DIFF
--- a/Units/mtable-simple-with-table-extending.d/args.ctags
+++ b/Units/mtable-simple-with-table-extending.d/args.ctags
@@ -6,6 +6,8 @@
 --kinddef-X=v,var,variables
 --kinddef-X=f,fun,functions
 
+--kinds-X=+{var}
+
 --_tabledef-X=main
 --_tabledef-X=comment_sharp_sa
 --_tabledef-X=comment_sharp_sharp

--- a/main/parse.c
+++ b/main/parse.c
@@ -1804,6 +1804,11 @@ static void lazyInitialize (langType language)
 			def->parser = optlibRunBaseParser;
 		else
 			def->parser = findRegexTags;
+
+		if (!def->useCork &&
+			(hasLanguageScopeActionInRegex (language)
+			 || def->requestAutomaticFQTag))
+			def->useCork = true;
 	}
 }
 


### PR DESCRIPTION
Fix for issue #1851.