### PR TITLE
Disabled kinds for builtin parsers should still enqueue tags

### DIFF
--- a/Units/parser-tcl.r/namespace-disabled.d/args.ctags
+++ b/Units/parser-tcl.r/namespace-disabled.d/args.ctags
@@ -1,0 +1,4 @@
+--sort=no
+--extras=+q
+--fields=+eE
+--kinds-Tcl=-n

--- a/Units/parser-tcl.r/namespace-disabled.d/expected.tags
+++ b/Units/parser-tcl.r/namespace-disabled.d/expected.tags
@@ -1,0 +1,11 @@
+pr1	input.tcl	/^    proc pr1 {s} {$/;"	p	namespace:A	end:7
+A::pr1	input.tcl	/^    proc pr1 {s} {$/;"	p	namespace:A	extras:qualified	end:7
+pr2	input.tcl	/^    proc B::pr2 {s} {$/;"	p	namespace:B	end:11
+B::pr2	input.tcl	/^    proc B::pr2 {s} {$/;"	p	extras:qualified	end:11
+pr3	input.tcl	/^	proc pr3 {s} {$/;"	p	namespace:A::C	end:15
+A::C::pr3	input.tcl	/^	proc pr3 {s} {$/;"	p	namespace:A::C	extras:qualified	end:15
+pr4	input.tcl	/^    proc ::pr4 {s} {$/;"	p	end:19
+::pr4	input.tcl	/^    proc ::pr4 {s} {$/;"	p	extras:qualified	end:19
+pr5	input.tcl	/^proc ::pr5 {s} {$/;"	p	end:25
+::pr5	input.tcl	/^proc ::pr5 {s} {$/;"	p	extras:qualified	end:25
+pr6	input.tcl	/^proc pr6 {s} {$/;"	p	end:29

--- a/Units/parser-tcl.r/namespace-disabled.d/input.tcl
+++ b/Units/parser-tcl.r/namespace-disabled.d/input.tcl
@@ -1,0 +1,41 @@
+namespace eval A::B {
+}
+
+namespace eval A {
+    proc pr1 {s} {
+	puts $s
+    }
+    pr1 "a"
+    proc B::pr2 {s} {
+	puts "$s"
+    }
+    namespace eval C {
+	proc pr3 {s} {
+	    puts $s
+	}
+    }
+    proc ::pr4 {s} {
+	puts "$s"
+    }
+
+}
+
+proc ::pr5 {s} {
+    puts "$s"
+}
+
+proc pr6 {s} {
+    puts "$s"
+}
+
+A::pr1 "b"
+
+A::B::pr2 "c"
+
+A::C::pr3 "d"
+
+pr4 "e"
+
+pr5 "f"
+
+pr6 "g"

--- a/main/parse.c
+++ b/main/parse.c
@@ -146,7 +146,8 @@ extern int makeSimpleTag (
 {
 	int r = CORK_NIL;
 
-	if (isInputLanguageKindEnabled(kindIndex) &&  name != NULL  &&  vStringLength (name) > 0)
+	/* do not check for kind being disabled - that happens later in makeTagEntry() */
+	if (name != NULL  &&  vStringLength (name) > 0)
 	{
 		tagEntryInfo e;
 		initTagEntry (&e, vStringValue (name), kindIndex);


### PR DESCRIPTION
See issue #1852.
The `makeSimpleTag()` function shouldn't be filtering out tags, because
that can screw up scoping. Note the tags still won't be written to the
file - they will be filtered out later, by `isTagWritable()`.