### PR TITLE
Add options/flags to help users develop multi-table regex parsers

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -673,12 +673,11 @@ extern int main (int argc CTAGS_ATTR_UNUSED, char **argv)
 	runMainLoop (args);
 
 
-	BEGIN_VERBOSE(vfp);
+	if (Option.verbose || Option.mtablePrintTotals)
 	{
 		for (unsigned int i = 0; i < countParsers(); i++)
-			printLanguageMultitableStatistics (i, vfp);
+			printLanguageMultitableStatistics (i, stderr);
 	}
-	END_VERBOSE();
 
 	/*  Clean up.
 	 */

--- a/main/options.c
+++ b/main/options.c
@@ -169,6 +169,7 @@ optionValues Option = {
 	.putFieldPrefix = false,
 	.maxRecursionDepth = 0xffffffff,
 	.interactive = false,
+	.mtablePrintTotals = false,
 	.mtableCopyExtended = false,
 #ifdef DEBUG
 	.debugLevel = 0,
@@ -470,6 +471,8 @@ static optionDescription ExperimentalLongOptionDescription [] = {
  {1,"       Copy patterns of a regex table to another regex table."},
  {1,"  --_mtable-regex-<LANG>=table/line_pattern/name_pattern/[flags]"},
  {1,"       Define multitable regular expression for locating tags in specific language."},
+ {1,"  --_mtable-totals=[yes|no]"},
+ {1,"       Print statistics about mtable usage [no]."},
  {1,"  --_roledef-<LANG>=kind_letter.role_name,role_desc"},
  {1,"       Define new role for kind specified with <kind_letter> in <LANG>."},
  {1,"  --_tabledef-<LANG>=name"},
@@ -2760,6 +2763,7 @@ static booleanOption BooleanOptions [] = {
 	{ "verbose",        &Option.verbose,                false, STAGE_ANY },
 	{ "with-list-header", &localOption.withListHeader,       true,  STAGE_ANY },
 	{ "_fatal-warnings",&Option.fatalWarnings,          false, STAGE_ANY },
+	{ "_mtable-totals", &Option.mtablePrintTotals,      false, STAGE_ANY },
 	{ "_mtable-copy-extended",&Option.mtableCopyExtended,false, STAGE_ANY },
 };
 

--- a/main/options.c
+++ b/main/options.c
@@ -169,6 +169,7 @@ optionValues Option = {
 	.putFieldPrefix = false,
 	.maxRecursionDepth = 0xffffffff,
 	.interactive = false,
+	.mtableCopyExtended = false,
 #ifdef DEBUG
 	.debugLevel = 0,
 	.breakLine = 0,
@@ -463,6 +464,8 @@ static optionDescription ExperimentalLongOptionDescription [] = {
  {1,"       Output list of flags which can be used with --langdef option."},
  {1,"  --_list-mtable-regex-flags"},
  {1,"       Output list of flags which can be used in a multitable regex parser definition."},
+ {1,"  --_mtable-copy-extended=[yes|no]"},
+ {1,"       Perform deep copying instead of just referencing, when extending tables using --_mtable-extend [no]."},
  {1,"  --_mtable-extend-<LANG>=disttable+srctable."},
  {1,"       Copy patterns of a regex table to another regex table."},
  {1,"  --_mtable-regex-<LANG>=table/line_pattern/name_pattern/[flags]"},
@@ -2757,6 +2760,7 @@ static booleanOption BooleanOptions [] = {
 	{ "verbose",        &Option.verbose,                false, STAGE_ANY },
 	{ "with-list-header", &localOption.withListHeader,       true,  STAGE_ANY },
 	{ "_fatal-warnings",&Option.fatalWarnings,          false, STAGE_ANY },
+	{ "_mtable-copy-extended",&Option.mtableCopyExtended,false, STAGE_ANY },
 };
 
 /*

--- a/main/options.h
+++ b/main/options.h
@@ -104,6 +104,7 @@ typedef struct sOptionValues {
 	enum interactiveMode { INTERACTIVE_NONE = 0,
 						   INTERACTIVE_DEFAULT,
 						   INTERACTIVE_SANDBOX, } interactive; /* --interactive */
+	bool mtableCopyExtended; /* perform copying instead of reference, for mtable extended */
 #ifdef DEBUG
 	long debugLevel;        /* -d  debugging output */
 	unsigned long breakLine;/* -b  input line at which to call lineBreak() */

--- a/main/options.h
+++ b/main/options.h
@@ -104,6 +104,7 @@ typedef struct sOptionValues {
 	enum interactiveMode { INTERACTIVE_NONE = 0,
 						   INTERACTIVE_DEFAULT,
 						   INTERACTIVE_SANDBOX, } interactive; /* --interactive */
+	bool mtablePrintTotals;  /* display mtable statistics */
 	bool mtableCopyExtended; /* perform copying instead of reference, for mtable extended */
 #ifdef DEBUG
 	long debugLevel;        /* -d  debugging output */


### PR DESCRIPTION
This PR adds a couple new options and flags to help users debug and optimize optlib multi-table regex parsers.

Documentation for them will be added to `optlib.rst` after PR #1826 is merged into master. (otherwise I'll get conflicts with that one)