### PR TITLE
optlib: Add option/flags to help users develop multi-table regex parsers

### DIFF
--- a/Tmain/list-mline-regex-flags.d/stdout-expected.txt
+++ b/Tmain/list-mline-regex-flags.d/stdout-expected.txt
@@ -8,4 +8,4 @@ i       icase                   applied in a case-insensitive manner
 -       _advanceTo=N[start|end] a group in pattern from where the next scan starts [0end]
 -       _extra=EXTRA            record the tag only when the extra is enabled
 -       _field=FIELD:VALUE      record the matched string(VALUE) to parser own FIELD of the tag
--       _role=ROLE              Set given ROLE to roles field
+-       _role=ROLE              set the given ROLE to the roles field

--- a/Tmain/list-mtable-regex-flags.d/run.sh
+++ b/Tmain/list-mtable-regex-flags.d/run.sh
@@ -1,0 +1,6 @@
+# Copyright: 2017 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+${CTAGS} --quiet --options=NONE --_list-mtable-regex-flags

--- a/Tmain/list-mtable-regex-flags.d/stdout-expected.txt
+++ b/Tmain/list-mtable-regex-flags.d/stdout-expected.txt
@@ -15,4 +15,4 @@ i       icase                   applied in a case-insensitive manner
 -       _advanceTo=N[start|end] a group in pattern from where the next scan starts [0end]
 -       _extra=EXTRA            record the tag only when the extra is enabled
 -       _field=FIELD:VALUE      record the matched string(VALUE) to parser own FIELD of the tag
--       _role=ROLE              Set given ROLE to roles field
+-       _role=ROLE              set the given ROLE to the roles field

--- a/Tmain/list-mtable-regex-flags.d/stdout-expected.txt
+++ b/Tmain/list-mtable-regex-flags.d/stdout-expected.txt
@@ -4,6 +4,13 @@ e       extend                  interpreted as a Posix extended regular expressi
 i       icase                   applied in a case-insensitive manner
 -       fatal="MESSAGE"         print the given MESSAGE and exit
 -       mgroup=N                a group in pattern determining the line number of tag
+-       placeholder             don't put this tag to tags file.
+-       scope=ACTION            use scope stack: ACTION = ref|push|pop|clear|set
+-       tenter=TABLE[,CONT]     enter to given regext table (with specifying continuation)
+-       tjump=TABLE             jump to another regext table(don't push the current table to state stack)
+-       tleave                  leave from the current regext table
+-       tquit                   stop the parsing with this parser
+-       treset=TABLE            clear the state stack and jump to given regex table
 -       warning="MESSAGE"       print the given MESSAGE at WARNING level
 -       _advanceTo=N[start|end] a group in pattern from where the next scan starts [0end]
 -       _extra=EXTRA            record the tag only when the extra is enabled

--- a/Tmain/list-regex-flags.d/stdout-expected.txt
+++ b/Tmain/list-regex-flags.d/stdout-expected.txt
@@ -3,8 +3,10 @@ b       basic              interpreted as a Posix basic regular expression.
 e       extend             interpreted as a Posix extended regular expression (default)
 i       icase              applied in a case-insensitive manner
 x       exclusive          skip testing the other patterns if a line is matched to this pattern
+-       fatal="MESSAGE"    print the given MESSAGE and exit
 -       placeholder        don't put this tag to tags file.
 -       scope=ACTION       use scope stack: ACTION = ref|push|pop|clear|set
+-       warning="MESSAGE"  print the given MESSAGE at WARNING level
 -       _extra=EXTRA       record the tag only when the extra is enabled
 -       _field=FIELD:VALUE record the matched string(VALUE) to parser own FIELD of the tag
 -       _role=ROLE         Set given ROLE to roles field

--- a/Tmain/list-regex-flags.d/stdout-expected.txt
+++ b/Tmain/list-regex-flags.d/stdout-expected.txt
@@ -9,4 +9,4 @@ x       exclusive          skip testing the other patterns if a line is matched 
 -       warning="MESSAGE"  print the given MESSAGE at WARNING level
 -       _extra=EXTRA       record the tag only when the extra is enabled
 -       _field=FIELD:VALUE record the matched string(VALUE) to parser own FIELD of the tag
--       _role=ROLE         Set given ROLE to roles field
+-       _role=ROLE         set the given ROLE to the roles field

--- a/Tmain/mtable-stats.d/args.ctags
+++ b/Tmain/mtable-stats.d/args.ctags
@@ -1,0 +1,24 @@
+--langdef=FOO
+--map-FOO=+.foo
+
+--kinddef-FOO=n,namespace,namespaces
+--kinddef-FOO=c,class,classes
+--kinddef-FOO=v,variable,variables
+
+--_tabledef-FOO=main
+--_tabledef-FOO=block
+--_tabledef-FOO=blockEnd
+--_tabledef-FOO=skipWhitespace
+
+--_mtable-regex-FOO=skipWhitespace/[ \t\n]+//
+
+--_mtable-regex-FOO=main/namespace ([a-zA-Z]+) \{/\1/n/{tenter=block,blockEnd}{scope=push}
+--_mtable-extend-FOO=main+skipWhitespace
+--_mtable-regex-FOO=main///
+
+--_mtable-regex-FOO=blockEnd/\};?//{scope=pop}
+--_mtable-extend-FOO=blockEnd+skipWhitespace
+
+--_mtable-regex-FOO=block/class ([a-zA-Z]+) \{/\1/c/{tenter=block,blockEnd}{scope=ref}{scope=push}
+--_mtable-regex-FOO=block/var ([a-zA-Z]+) ([a-zA-Z]+);/\2/v/{scope=ref}
+--_mtable-extend-FOO=block+skipWhitespace

--- a/Tmain/mtable-stats.d/input.foo
+++ b/Tmain/mtable-stats.d/input.foo
@@ -1,0 +1,5 @@
+namespace A {
+	class B {
+		var bool C;
+	};
+}

--- a/Tmain/mtable-stats.d/run.sh
+++ b/Tmain/mtable-stats.d/run.sh
@@ -1,0 +1,8 @@
+# Copyright: 2018 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+. ../utils.sh
+
+${CTAGS} --options=NONE --options=./args.ctags --_mtable-totals=yes -o - ./input.foo

--- a/Tmain/mtable-stats.d/stderr-expected.txt
+++ b/Tmain/mtable-stats.d/stderr-expected.txt
@@ -1,0 +1,24 @@
+ctags: Notice: No options will be read from files or environment
+MTABLE REGEX STATISTICS of FOO
+==============================================
+main
+-----------------------
+         1/1         ^namespace ([a-zA-Z]+) \\{               ref: 1
+         0/0         ^[ \t\n]+                                ref: 4
+         0/0         ^                                        ref: 1
+
+block
+-----------------------
+         1/6         ^class ([a-zA-Z]+) \\{                   ref: 1
+         1/5         ^var ([a-zA-Z]+) ([a-zA-Z]+);            ref: 1
+         3/4         ^[ \t\n]+                                ref: 4
+
+blockEnd
+-----------------------
+         2/6         ^\\};?                                   ref: 1
+         2/4         ^[ \t\n]+                                ref: 4
+
+skipWhitespace
+-----------------------
+         0/0         ^[ \t\n]+                                ref: 4
+

--- a/Tmain/mtable-stats.d/stdout-expected.txt
+++ b/Tmain/mtable-stats.d/stdout-expected.txt
@@ -1,0 +1,3 @@
+A	./input.foo	/^namespace A {$/;"	n
+B	./input.foo	/^	class B {$/;"	c	namespace:A
+C	./input.foo	/^		var bool C;$/;"	v	class:A.B

--- a/Tmain/optlib-message-flag.d/args.ctags
+++ b/Tmain/optlib-message-flag.d/args.ctags
@@ -1,0 +1,36 @@
+--langdef=FOO
+--map-FOO=+.foo
+
+--kinddef-FOO=n,namespace,namespaces
+--kinddef-FOO=c,class,classes
+--kinddef-FOO=v,variable,variables
+
+--regex-FOO=/namespace ([a-zA-Z]+) /\1/N,another_namespace/{warning="found namespace '\1'"}{exclusive}
+--regex-FOO=/namespace ([a-zA-Z]+) /\1/x,bad/{fatal="should not get this"}
+--regex-FOO=/bad regex ([a-zA-Z-]+)/\1/x,bad/{fatal="bad='\1'"}
+
+
+--mline-regex-FOO=/namespace ([a-zA-Z]+) /\1/m,mline_namespace/{mgroup=1}{warning="got namespace"}
+--mline-regex-FOO=/var ([a-zA-Z]+) ([a-zA-Z]+);/\2/V,mline_variable/{warning="got variable '\2' of type \1"}{mgroup=2}
+--mline-regex-FOO=/bad multi-line ([a-zA-Z-]+)/\1/x,bad/{fatal="bad='\1'"}
+
+
+--_tabledef-FOO=main
+--_tabledef-FOO=block
+--_tabledef-FOO=blockEnd
+--_tabledef-FOO=skipWhitespace
+
+--_mtable-regex-FOO=skipWhitespace/[ \t\n]+//
+
+--_mtable-regex-FOO=main/namespace ([a-zA-Z]+) \{/\1/n/{tenter=block,blockEnd}{warning="found namespace"}{scope=push}
+--_mtable-extend-FOO=main+skipWhitespace
+--_mtable-regex-FOO=main///
+
+--_mtable-regex-FOO=blockEnd/\};?//{scope=pop}{warning="end of block"}
+--_mtable-extend-FOO=blockEnd+skipWhitespace
+--_mtable-regex-FOO=blockEnd/bad multi-table ([a-zA-Z-]+)//{fatal="bad='\1'"}
+--_mtable-regex-FOO=blockEnd/bad [^\n]+\n//
+
+--_mtable-regex-FOO=block/class ([a-zA-Z]+) \{/\1/c/{tenter=block,blockEnd}{warning="got class"}{scope=ref}{scope=push}
+--_mtable-regex-FOO=block/var ([a-zA-Z]+) ([a-zA-Z]+);/\2/v/{scope=ref}{warning="got variable '\2' of type \1"}
+--_mtable-extend-FOO=block+skipWhitespace

--- a/Tmain/optlib-message-flag.d/input0.foo
+++ b/Tmain/optlib-message-flag.d/input0.foo
@@ -1,0 +1,5 @@
+namespace A {
+	class B {
+		var bool C;
+	};
+}

--- a/Tmain/optlib-message-flag.d/input1.foo
+++ b/Tmain/optlib-message-flag.d/input1.foo
@@ -1,0 +1,9 @@
+namespace X {
+	class Y {
+		var bool Z;
+	};
+}
+
+bad regex found-it
+bad multi-line found-mline
+bad multi-table found-mtable

--- a/Tmain/optlib-message-flag.d/input2.foo
+++ b/Tmain/optlib-message-flag.d/input2.foo
@@ -1,0 +1,8 @@
+namespace XX {
+	class YY {
+		var bool ZZ;
+	};
+}
+
+bad multi-line found-mline
+bad multi-table found-mtable

--- a/Tmain/optlib-message-flag.d/input3.foo
+++ b/Tmain/optlib-message-flag.d/input3.foo
@@ -1,0 +1,7 @@
+namespace XXX {
+	class YYY {
+		var bool ZZZ;
+	};
+}
+
+bad multi-table found-mtable

--- a/Tmain/optlib-message-flag.d/run.sh
+++ b/Tmain/optlib-message-flag.d/run.sh
@@ -1,0 +1,26 @@
+# Copyright: 2018 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+. ../utils.sh
+
+echo '#' warning messages 1>&2
+(
+	${CTAGS} --options=NONE --options=./args.ctags -o - ./input0.foo
+)
+
+echo '#' fatal regex message 1>&2
+(
+	${CTAGS} --options=NONE --options=./args.ctags -o - ./input1.foo
+)
+
+echo '#' fatal mline-regex message 1>&2
+(
+	${CTAGS} --options=NONE --options=./args.ctags -o - ./input2.foo
+)
+
+echo '#' fatal mtable-regex message 1>&2
+(
+	${CTAGS} --options=NONE --options=./args.ctags -o - ./input3.foo
+)

--- a/Tmain/optlib-message-flag.d/stderr-expected.txt
+++ b/Tmain/optlib-message-flag.d/stderr-expected.txt
@@ -1,0 +1,31 @@
+# warning messages
+ctags: Notice: No options will be read from files or environment
+ctags: Warning: Message from regex<FOO>: found namespace 'A' (./input0.foo:1)
+ctags: Warning: Message from regex<FOO>: got namespace (./input0.foo:1)
+ctags: Warning: Message from regex<FOO>: got variable 'C' of type bool (./input0.foo:3)
+ctags: Warning: Message from mtable<FOO/main[ 0]>: found namespace (./input0.foo:1)
+ctags: Warning: Message from mtable<FOO/block[ 0]>: got class (./input0.foo:2)
+ctags: Warning: Message from mtable<FOO/block[ 1]>: got variable 'C' of type bool (./input0.foo:3)
+ctags: Warning: Message from mtable<FOO/blockEnd[ 0]>: end of block (./input0.foo:4)
+ctags: Warning: Message from mtable<FOO/blockEnd[ 0]>: end of block (./input0.foo:5)
+# fatal regex message
+ctags: Notice: No options will be read from files or environment
+ctags: Warning: Message from regex<FOO>: found namespace 'X' (./input1.foo:1)
+ctags: Fatal: Message from regex<FOO>: bad='found-it' (./input1.foo:7)
+# fatal mline-regex message
+ctags: Notice: No options will be read from files or environment
+ctags: Warning: Message from regex<FOO>: found namespace 'XX' (./input2.foo:1)
+ctags: Warning: Message from regex<FOO>: got namespace (./input2.foo:1)
+ctags: Warning: Message from regex<FOO>: got variable 'ZZ' of type bool (./input2.foo:3)
+ctags: Fatal: Message from regex<FOO>: bad='found-mline' (./input2.foo:7)
+# fatal mtable-regex message
+ctags: Notice: No options will be read from files or environment
+ctags: Warning: Message from regex<FOO>: found namespace 'XXX' (./input3.foo:1)
+ctags: Warning: Message from regex<FOO>: got namespace (./input3.foo:1)
+ctags: Warning: Message from regex<FOO>: got variable 'ZZZ' of type bool (./input3.foo:3)
+ctags: Warning: Message from mtable<FOO/main[ 0]>: found namespace (./input3.foo:1)
+ctags: Warning: Message from mtable<FOO/block[ 0]>: got class (./input3.foo:2)
+ctags: Warning: Message from mtable<FOO/block[ 1]>: got variable 'ZZZ' of type bool (./input3.foo:3)
+ctags: Warning: Message from mtable<FOO/blockEnd[ 0]>: end of block (./input3.foo:4)
+ctags: Warning: Message from mtable<FOO/blockEnd[ 0]>: end of block (./input3.foo:5)
+ctags: Fatal: Message from mtable<FOO/blockEnd[ 2]>: bad='found-mtable' (./input3.foo:7)

--- a/Tmain/optlib-message-flag.d/stdout-expected.txt
+++ b/Tmain/optlib-message-flag.d/stdout-expected.txt
@@ -1,0 +1,6 @@
+A	./input0.foo	/^namespace A {$/;"	N
+A	./input0.foo	/^namespace A {$/;"	m
+A	./input0.foo	/^namespace A {$/;"	n
+B	./input0.foo	/^	class B {$/;"	c	namespace:A
+C	./input0.foo	/^		var bool C;$/;"	V
+C	./input0.foo	/^		var bool C;$/;"	v	class:A.B

--- a/main/main.c
+++ b/main/main.c
@@ -673,12 +673,11 @@ extern int main (int argc CTAGS_ATTR_UNUSED, char **argv)
 	runMainLoop (args);
 
 
-	BEGIN_VERBOSE(vfp);
+	if (Option.verbose || Option.mtablePrintTotals)
 	{
 		for (unsigned int i = 0; i < countParsers(); i++)
-			printLanguageMultitableStatistics (i, vfp);
+			printLanguageMultitableStatistics (i, stderr);
 	}
-	END_VERBOSE();
 
 	/*  Clean up.
 	 */

--- a/main/main.c
+++ b/main/main.c
@@ -673,11 +673,12 @@ extern int main (int argc CTAGS_ATTR_UNUSED, char **argv)
 	runMainLoop (args);
 
 
-	if (Option.verbose || Option.mtablePrintTotals)
+	BEGIN_VERBOSE_IF(Option.mtablePrintTotals, vfp);
 	{
 		for (unsigned int i = 0; i < countParsers(); i++)
-			printLanguageMultitableStatistics (i, stderr);
+			printLanguageMultitableStatistics (i, vfp);
 	}
+	END_VERBOSE();
 
 	/*  Clean up.
 	 */

--- a/main/options.c
+++ b/main/options.c
@@ -169,6 +169,7 @@ optionValues Option = {
 	.putFieldPrefix = false,
 	.maxRecursionDepth = 0xffffffff,
 	.interactive = false,
+	.mtablePrintTotals = false,
 #ifdef DEBUG
 	.debugLevel = 0,
 	.breakLine = 0,
@@ -467,6 +468,8 @@ static optionDescription ExperimentalLongOptionDescription [] = {
  {1,"       Copy patterns of a regex table to another regex table."},
  {1,"  --_mtable-regex-<LANG>=table/line_pattern/name_pattern/[flags]"},
  {1,"       Define multitable regular expression for locating tags in specific language."},
+ {1,"  --_mtable-totals=[yes|no]"},
+ {1,"       Print statistics about mtable usage [no]."},
  {1,"  --_roledef-<LANG>=kind_letter.role_name,role_desc"},
  {1,"       Define new role for kind specified with <kind_letter> in <LANG>."},
  {1,"  --_tabledef-<LANG>=name"},
@@ -2757,6 +2760,7 @@ static booleanOption BooleanOptions [] = {
 	{ "verbose",        &Option.verbose,                false, STAGE_ANY },
 	{ "with-list-header", &localOption.withListHeader,       true,  STAGE_ANY },
 	{ "_fatal-warnings",&Option.fatalWarnings,          false, STAGE_ANY },
+	{ "_mtable-totals", &Option.mtablePrintTotals,      false, STAGE_ANY },
 };
 
 /*

--- a/main/options.h
+++ b/main/options.h
@@ -134,9 +134,14 @@ extern CONST_OPTION optionValues		Option;
 */
 extern void notice (const char *const format, ...) CTAGS_ATTR_PRINTF (1, 2);
 extern void verbose (const char *const format, ...) CTAGS_ATTR_PRINTF (1, 2);
+
 #define BEGIN_VERBOSE(VFP) do { if (Option.verbose) { \
                                 FILE* VFP = stderr
 #define END_VERBOSE()      } } while (0)
+
+#define BEGIN_VERBOSE_IF(COND,VFP) do { if (Option.verbose || (COND)) { \
+                                FILE* VFP = stderr
+
 
 extern void freeList (stringList** const pString);
 extern void setDefaultTagFileName (void);

--- a/main/options.h
+++ b/main/options.h
@@ -104,6 +104,7 @@ typedef struct sOptionValues {
 	enum interactiveMode { INTERACTIVE_NONE = 0,
 						   INTERACTIVE_DEFAULT,
 						   INTERACTIVE_SANDBOX, } interactive; /* --interactive */
+	bool mtablePrintTotals;  /* display mtable statistics */
 #ifdef DEBUG
 	long debugLevel;        /* -d  debugging output */
 	unsigned long breakLine;/* -b  input line at which to call lineBreak() */


### PR DESCRIPTION
This PR adds a new option and a couple new flags to help users debug and optimize optlib multi-table regex parsers. It also does some code cleanup along the way.

Documentation for the new option and flags will be added to `optlib.rst` after PR #1826 is merged into master. (otherwise I'll get conflicts with that one)