### PR TITLE
asciidoc: check for invalid trailing inline anchors before recording tag

### DIFF
--- a/Units/parser-asciidoc.r/anchor-invalid-asciidoc.d/expected.tags
+++ b/Units/parser-asciidoc.r/anchor-invalid-asciidoc.d/expected.tags
@@ -1,0 +1,9 @@
+L1	input.adoc	/^== L1$/;"	s	chapter:[A B]
+L1_b	input.adoc	/^== L1_b$/;"	s	chapter:[A B]
+L2	input.adoc	/^=== L2$/;"	S	section:L1
+L3 Title	input.adoc	/^==== L3 Title$/;"	t	subsection:L2
+L4 Title [ ]	input.adoc	/^===== L4 Title [ ]$/;"	T	subsubsection:L3 Title
+[ #bad] L2_b Title [,]	input.adoc	/^=== [ #bad] L2_b Title [,]$/;"	S	section:L1_b
+[A B]	input.adoc	/^= [A B]$/;"	c
+[foo][bar] L2_c Title [[]	input.adoc	/^=== [foo][bar] L2_c Title [[] ===$/;"	S	section:L1_b
+good_anchor	input.adoc	/^[[good_anchor, ]]$/;"	a	section:L1

--- a/Units/parser-asciidoc.r/anchor-invalid-asciidoc.d/input.adoc
+++ b/Units/parser-asciidoc.r/anchor-invalid-asciidoc.d/input.adoc
@@ -1,0 +1,35 @@
+= [A B]
+
+Intro text of chapter 1
+
+[c]
+== L1
+
+Text of section 1.1
+
+[[good_anchor, ]]
+=== L2
+
+Text of subsection 1.1.1
+
+[#]
+==== L3 Title
+
+Text of subsection 1.1.1.1
+
+===== L4 Title [ ]
+
+Text of subsection 1.1.1.1
+
+[, bad]
+== L1_b
+
+[#invalid anchor for Text of section 1.2
+
+=== [ #bad] L2_b Title [,]
+
+Text of subsection 1.2.1
+
+=== [foo][bar] L2_c Title [[] ===
+
+Text of subsection 1.2.2

--- a/parsers/asciidoc.c
+++ b/parsers/asciidoc.c
@@ -239,7 +239,8 @@ static int process_trailing_anchor(const unsigned char *const begin,
 			if (end[-1] == ']' && found > begin && found[-1] == '[')
 				--found;
 
-			capture_anchor(found, &captured_len);
+			if (is_anchor (found))
+				capture_anchor(found, &captured_len);
 		}
 	}
 


### PR DESCRIPTION
This fixes issue #1859.