### PR TITLE
Robot: remove empty expression .{0} in parsers/robots.c to fix unit test tmain and units on FreeBSD

### DIFF
--- a/parsers/robot.c
+++ b/parsers/robot.c
@@ -144,7 +144,7 @@ static void initialize (const langType language)
 
     addLanguageCallbackRegex (
 		language,
-		"(^([A-Za-z0-9]+|\\$\\{[_A-Za-z0-9][' _A-Za-z0-9]*(:([^}]|\\\\|.{0})+)*\\})([${}' _]([-_$A-Za-z0-9]+|\\{[_A-Za-z0-9][' _A-Za-z0-9]*(:([^}]|\\\\|.{0})+)*\\})+)*)",
+		"(^([A-Za-z0-9]+|\\$\\{[_A-Za-z0-9][' _A-Za-z0-9]*(:([^}]|\\\\)+)*\\})([${}' _]([-_$A-Za-z0-9]+|\\{[_A-Za-z0-9][' _A-Za-z0-9]*(:([^}]|\\\\)+)*\\})+)*)",
 		"{exclusive}", tagKeywordsAndTestCases, NULL, NULL);
 
     addLanguageCallbackRegex (language, "^[$@]\\{([_A-Za-z0-9][' _A-Za-z0-9]+)\\}  [ ]*.+",


### PR DESCRIPTION
Removing empty expression .{0} fixes unit test on FreeBSD due to FreeBSD libc regcomp not liking the following (a|b|.{0}).   Even though .{0} is valid removing it shouldn't create any issues.