### PR TITLE
Go:  fill the typeref field for struct "memeber" kind

### DIFF
--- a/Units/parser-go.r/go-anonmember.d/expected.tags
+++ b/Units/parser-go.r/go-anonmember.d/expected.tags
@@ -3,27 +3,27 @@ T1	input.go	/^	T1$/;"	M	struct:X	typeref:typename:T1
 T2	input.go	/^	*T2$/;"	M	struct:X	typeref:typename:*T2
 T3	input.go	/^	P.T3$/;"	M	struct:X	typeref:typename:P.T3
 T4	input.go	/^	*P.T4$/;"	M	struct:X	typeref:typename:*P.T4
-age	input.go	/^	age T5$/;"	m	struct:X
-skill	input.go	/^	skill *T6$/;"	m	struct:X
-address	input.go	/^	address, hometown T7$/;"	m	struct:X
-hometown	input.go	/^	address, hometown T7$/;"	m	struct:X
-natualLang	input.go	/^	natualLang,programmingLang *T8$/;"	m	struct:X
-programmingLang	input.go	/^	natualLang,programmingLang *T8$/;"	m	struct:X
-person	input.go	/^	person P.T9$/;"	m	struct:X
-parent	input.go	/^	parent *P.T10$/;"	m	struct:X
-lang1	input.go	/^	lang1, lang2 P.LANG$/;"	m	struct:X
-lang2	input.go	/^	lang1, lang2 P.LANG$/;"	m	struct:X
-lang3	input.go	/^	lang3, lang4 *P.LANG$/;"	m	struct:X
-lang4	input.go	/^	lang3, lang4 *P.LANG$/;"	m	struct:X
+age	input.go	/^	age T5$/;"	m	struct:X	typeref:typename:T5
+skill	input.go	/^	skill *T6$/;"	m	struct:X	typeref:typename:*T6
+address	input.go	/^	address, hometown T7$/;"	m	struct:X	typeref:typename:T7
+hometown	input.go	/^	address, hometown T7$/;"	m	struct:X	typeref:typename:T7
+natualLang	input.go	/^	natualLang,programmingLang *T8$/;"	m	struct:X	typeref:typename:*T8
+programmingLang	input.go	/^	natualLang,programmingLang *T8$/;"	m	struct:X	typeref:typename:*T8
+person	input.go	/^	person P.T9$/;"	m	struct:X	typeref:typename:P.T9
+parent	input.go	/^	parent *P.T10$/;"	m	struct:X	typeref:typename:*P.T10
+lang1	input.go	/^	lang1, lang2 P.LANG$/;"	m	struct:X	typeref:typename:P.LANG
+lang2	input.go	/^	lang1, lang2 P.LANG$/;"	m	struct:X	typeref:typename:P.LANG
+lang3	input.go	/^	lang3, lang4 *P.LANG$/;"	m	struct:X	typeref:typename:*P.LANG
+lang4	input.go	/^	lang3, lang4 *P.LANG$/;"	m	struct:X	typeref:typename:*P.LANG
 Q	input.go	/^	P.Q$/;"	M	struct:X	typeref:typename:P.Q
 Q	input.go	/^	*P.Q$/;"	M	struct:X	typeref:typename:*P.Q
 Y	input.go	/^type Y struct {$/;"	s
 byte	input.go	/^	byte$/;"	M	struct:Y	typeref:typename:byte
-b	input.go	/^	b byte$/;"	m	struct:Y
-ss	input.go	/^	ss []string$/;"	m	struct:Y
-bss	input.go	/^	bss [][]byte$/;"	m	struct:Y
-f	input.go	/^	f func() error$/;"	m	struct:Y
-ifaces	input.go	/^	ifaces []interface{}$/;"	m	struct:Y
-tags	input.go	/^	tags  map[string]struct{}$/;"	m	struct:Y
-notify	input.go	/^	notify chan<- struct{}$/;"	m	struct:Y
-p	input.go	/^	p *struct {$/;"	m	struct:Y
+b	input.go	/^	b byte$/;"	m	struct:Y	typeref:typename:byte
+ss	input.go	/^	ss []string$/;"	m	struct:Y	typeref:typename:[]string
+bss	input.go	/^	bss [][]byte$/;"	m	struct:Y	typeref:typename:[][]byte
+f	input.go	/^	f func() error$/;"	m	struct:Y	typeref:typename:func() error
+ifaces	input.go	/^	ifaces []interface{}$/;"	m	struct:Y	typeref:typename:[]interface{}
+tags	input.go	/^	tags  map[string]struct{}$/;"	m	struct:Y	typeref:typename:map[string]struct{}
+notify	input.go	/^	notify chan<- struct{}$/;"	m	struct:Y	typeref:typename:chan<- struct{}
+p	input.go	/^	p *struct {$/;"	m	struct:Y	typeref:typename:*struct { x int; y int; z int; }

--- a/Units/parser-go.r/go-anonmember.d/expected.tags
+++ b/Units/parser-go.r/go-anonmember.d/expected.tags
@@ -13,10 +13,10 @@ person	input.go	/^	person P.T9$/;"	m	struct:X
 parent	input.go	/^	parent *P.T10$/;"	m	struct:X
 lang1	input.go	/^	lang1, lang2 P.LANG$/;"	m	struct:X
 lang2	input.go	/^	lang1, lang2 P.LANG$/;"	m	struct:X
-lang3	input.go	/^	lang3, lang4 *P.Q.LANG$/;"	m	struct:X
-lang4	input.go	/^	lang3, lang4 *P.Q.LANG$/;"	m	struct:X
-T11	input.go	/^	P.Q.T11$/;"	M	struct:X	typeref:typename:P.Q.T11
-T12	input.go	/^	*P.Q.T12$/;"	M	struct:X	typeref:typename:*P.Q.T12
+lang3	input.go	/^	lang3, lang4 *P.LANG$/;"	m	struct:X
+lang4	input.go	/^	lang3, lang4 *P.LANG$/;"	m	struct:X
+Q	input.go	/^	P.Q$/;"	M	struct:X	typeref:typename:P.Q
+Q	input.go	/^	*P.Q$/;"	M	struct:X	typeref:typename:*P.Q
 Y	input.go	/^type Y struct {$/;"	s
 byte	input.go	/^	byte$/;"	M	struct:Y	typeref:typename:byte
 b	input.go	/^	b byte$/;"	m	struct:Y

--- a/Units/parser-go.r/go-anonmember.d/input.go
+++ b/Units/parser-go.r/go-anonmember.d/input.go
@@ -10,9 +10,9 @@ type X struct {
 	person P.T9
 	parent *P.T10
 	lang1, lang2 P.LANG
-	lang3, lang4 *P.Q.LANG
-	P.Q.T11
-	*P.Q.T12
+	lang3, lang4 *P.LANG
+	P.Q
+	*P.Q
 }
 
 type Y struct {

--- a/Units/parser-go.r/go-scope.d/expected.tags
+++ b/Units/parser-go.r/go-scope.d/expected.tags
@@ -1,10 +1,10 @@
 main	input.go	/^package main$/;"	p
 Point	input.go	/^type Point struct { X, Y int }$/;"	s	package:main
 main.Point	input.go	/^type Point struct { X, Y int }$/;"	s	package:main
-X	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point
-main.Point.X	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point
-Y	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point
-main.Point.Y	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point
+X	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point	typeref:typename:int
+main.Point.X	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point	typeref:typename:int
+Y	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point	typeref:typename:int
+main.Point.Y	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point	typeref:typename:int
 Render	input.go	/^func (p *Point) Render() {$/;"	f	unknown:main.Point
 main.Point.Render	input.go	/^func (p *Point) Render() {$/;"	f	unknown:main.Point
 main	input.go	/^func main() {$/;"	f	package:main

--- a/Units/parser-go.r/go-torture.d/expected.tags
+++ b/Units/parser-go.r/go-torture.d/expected.tags
@@ -18,11 +18,11 @@ T6	input.go	/^type T6 struct {$/;"	s	package:main
 T7	input.go	/^type (T7 func (a struct{_ int; _ float32}, b int) (int, map[string]int);T8 float32)$/;"	t	package:main
 T8	input.go	/^type (T7 func (a struct{_ int; _ float32}, b int) (int, map[string]int);T8 float32)$/;"	t	package:main
 T9	input.go	/^func f1() {};func f2() {};type\/*no newline here*\/T9 int\/*var ignored int$/;"	t	package:main
-_a	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6
-_b	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6
-_c	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6
-_d	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6
-_e	input.go	/^	_e float32$/;"	m	struct:main.T6
+_a	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6	typeref:typename:int
+_b	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6	typeref:typename:int
+_c	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6	typeref:typename:int
+_d	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6	typeref:typename:int
+_e	input.go	/^	_e float32$/;"	m	struct:main.T6	typeref:typename:float32
 a	input.go	/^var (a, b, c int$/;"	v	package:main
 b	input.go	/^var (a, b, c int$/;"	v	package:main
 c	input.go	/^var (a, b, c int$/;"	v	package:main


### PR DESCRIPTION
An example output:
    
      $ cat foo.go
      type P struct  {
           x, y int
      }
    
      $ u-ctags -o - foo.go
      P     foo.go  /^type P struct  {$/;"  s
      x     foo.go  /^     x, y int$/;"     m       struct:P        typeref:typename:int
      y     foo.go  /^     x, y int$/;"     m       struct:P        typeref:typename:int
