### PR TITLE
unit: accept input_[0-9].* and input_[0-9]_*.* as input file names

### DIFF
--- a/docs/units.rst
+++ b/docs/units.rst
@@ -46,7 +46,7 @@ have its own directory under Units directory.
 	Input file name must have a *input* as basename. *TEST*
 	part should explain the test case well.
 
-*Units/TEST/input-[0-9].\** *Units/TEST/input-[0-9]-\*.\** **optional**
+*Units/TEST/input[-_][0-9].\** *Units/TEST/input[-_][0-9][-_]\*.\** **optional**
 
 	Optional input file names. They are put next to *input.\** in
 	testing command line.

--- a/misc/units
+++ b/misc/units
@@ -752,8 +752,8 @@ run_dir ()
 	    continue
 	fi
 
-	extra_inputs=$(for extra_tmp in $(dirname $input)/input-[0-9].* \
-					$(dirname $input)/input-[0-9]-*.* ; do
+	extra_inputs=$(for extra_tmp in $(dirname $input)/input[-_][0-9].* \
+					$(dirname $input)/input[-_][0-9][-_]*.* ; do
 	    if unwanted_file "$extra_tmp"; then
 		continue
 	    fi


### PR DESCRIPTION
Java language expects a class and the file where the class is defined
have a same name. On the othre hand, the language doesn't allow to use
`-` in a class name.

This means that we cannot write a test input file as a valid Java program.
This change solves this situation.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>