### PR TITLE
Go: introduce "imported" role to "package" kind

### DIFF
--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -11,6 +11,9 @@ x       UCTAGSxpath         no      NONE             s--    no    xpath for the 
 -       UCTAGSproperties    no      C++              s--    no    properties (static, inline, mutable,...)
 -       UCTAGStemplate      no      C++              s--    no    template parameters
 -       UCTAGSproperties    no      CUDA             s--    no    properties (static, inline, mutable,...)
+-       UCTAGShowImported   no      Go               s--    no    how the package is imported ("inline" for `.' or "init" for `_')
+-       UCTAGSpackage       yes     Go               s--    no    the real package specified by the package name
+-       UCTAGSpackageName   yes     Go               s--    no    the name for referring the package
 -       UCTAGSassignment    yes     LdScript         s--    no    how a value is assigned to the symbol
 -       UCTAGSsectionMarker no      Markdown         s--    no    character used for declaring section(#, ##, =, or -)
 -       UCTAGShome          yes     Passwd           s--    no    home directory

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -29,6 +29,9 @@ z	kind	no	NONE	s--	no	Include the "kind:" key in kind field (use k or K) in tags
 -	properties	no	C++	s--	no	properties (static, inline, mutable,...)
 -	template	no	C++	s--	no	template parameters
 -	properties	no	CUDA	s--	no	properties (static, inline, mutable,...)
+-	howImported	no	Go	s--	no	how the package is imported ("inline" for `.' or "init" for `_')
+-	package	yes	Go	s--	no	the real package specified by the package name
+-	packageName	yes	Go	s--	no	the name for referring the package
 -	assignment	yes	LdScript	s--	no	how a value is assigned to the symbol
 -	sectionMarker	no	Markdown	s--	no	character used for declaring section(#, ##, =, or -)
 -	home	yes	Passwd	s--	no	home directory

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -31,6 +31,7 @@ DTD            p/parameterEntity condition           on      conditions
 DTD            p/parameterEntity elementName         on      element names
 DTD            p/parameterEntity partOfAttDef        on      part of attribute definition
 Elm            m/module          imported            on      imported module
+Go             p/package         imported            on      imported package
 Go             u/unknown         receiverType        on      receiver type
 Java           p/package         imported            on      imported package
 LdScript       i/inputSection    discarded           on      discarded when linking
@@ -91,6 +92,7 @@ DTD            p/parameterEntity condition           on      conditions
 DTD            p/parameterEntity elementName         on      element names
 DTD            p/parameterEntity partOfAttDef        on      part of attribute definition
 Elm            m/module          imported            on      imported module
+Go             p/package         imported            on      imported package
 Go             u/unknown         receiverType        on      receiver type
 Java           p/package         imported            on      imported package
 LdScript       i/inputSection    discarded           on      discarded when linking

--- a/Units/parser-go.r/go-import.d/args.ctags
+++ b/Units/parser-go.r/go-import.d/args.ctags
@@ -1,0 +1,5 @@
+--fields=+rK
+--extras=+r
+--fields-Go=+{howImported}
+--sort=no
+

--- a/Units/parser-go.r/go-import.d/expected.tags
+++ b/Units/parser-go.r/go-import.d/expected.tags
@@ -1,0 +1,38 @@
+main	input.go	/^package main$/;"	package	roles:def
+fmt	input.go	/^import "fmt"$/;"	package	roles:imported
+main	input.go	/^func main() {$/;"	func	package:main	roles:def
+main	input-0.go	/^package main$/;"	package	roles:def
+f	input-0.go	/^import f "fmt"$/;"	packageName	roles:def	package:fmt
+fmt	input-0.go	/^import f "fmt"$/;"	package	roles:imported	packageName:f
+main	input-0.go	/^func main() {$/;"	func	package:main	roles:def
+main	input-1.go	/^package main$/;"	package	roles:def
+fmt	input-1.go	/^	"fmt"$/;"	package	roles:imported
+main	input-1.go	/^func main() {$/;"	func	package:main	roles:def
+main	input-2.go	/^package main$/;"	package	roles:def
+f	input-2.go	/^	f "fmt"$/;"	packageName	roles:def	package:fmt
+fmt	input-2.go	/^	f "fmt"$/;"	package	roles:imported	packageName:f
+main	input-2.go	/^func main() {$/;"	func	package:main	roles:def
+main	input-3.go	/^package main$/;"	package	roles:def
+time	input-3.go	/^	"time"$/;"	package	roles:imported
+fmt	input-3.go	/^	"fmt"$/;"	package	roles:imported
+main	input-3.go	/^func main() {$/;"	func	package:main	roles:def
+main	input-4.go	/^package main$/;"	package	roles:def
+t	input-4.go	/^	t "time"$/;"	packageName	roles:def	package:time
+time	input-4.go	/^	t "time"$/;"	package	roles:imported	packageName:t
+fmt	input-4.go	/^	"fmt"$/;"	package	roles:imported
+main	input-4.go	/^func main() {$/;"	func	package:main	roles:def
+main	input-5.go	/^package main$/;"	package	roles:def
+time	input-5.go	/^	"time"$/;"	package	roles:imported
+f	input-5.go	/^	f "fmt"$/;"	packageName	roles:def	package:fmt
+fmt	input-5.go	/^	f "fmt"$/;"	package	roles:imported	packageName:f
+main	input-5.go	/^func main() {$/;"	func	package:main	roles:def
+main	input-6.go	/^package main$/;"	package	roles:def
+t	input-6.go	/^	t "time"$/;"	packageName	roles:def	package:time
+time	input-6.go	/^	t "time"$/;"	package	roles:imported	packageName:t
+f	input-6.go	/^	f "fmt"$/;"	packageName	roles:def	package:fmt
+fmt	input-6.go	/^	f "fmt"$/;"	package	roles:imported	packageName:f
+main	input-6.go	/^func main() {$/;"	func	package:main	roles:def
+main	input-7.go	/^package main$/;"	package	roles:def
+fmt	input-7.go	/^	. "fmt"$/;"	package	roles:imported	howImported:inline
+time	input-7.go	/^	_ "time"$/;"	package	roles:imported	howImported:init
+main	input-7.go	/^func main() {$/;"	func	package:main	roles:def

--- a/Units/parser-go.r/go-import.d/input-0.go
+++ b/Units/parser-go.r/go-import.d/input-0.go
@@ -1,0 +1,6 @@
+package main
+import f "fmt"
+func main() {
+	f.Println("Hello, World!")
+}
+

--- a/Units/parser-go.r/go-import.d/input-1.go
+++ b/Units/parser-go.r/go-import.d/input-1.go
@@ -1,0 +1,9 @@
+package main
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("Hello, World!")
+}
+

--- a/Units/parser-go.r/go-import.d/input-2.go
+++ b/Units/parser-go.r/go-import.d/input-2.go
@@ -1,0 +1,9 @@
+package main
+import (
+	f "fmt"
+)
+
+func main() {
+	f.Println("Hello, World!")
+}
+

--- a/Units/parser-go.r/go-import.d/input-3.go
+++ b/Units/parser-go.r/go-import.d/input-3.go
@@ -1,0 +1,9 @@
+package main
+import (
+	"time"
+	"fmt"
+)
+func main() {
+	fmt.Println("<%s> Hello, World!", t.Now(()
+}
+

--- a/Units/parser-go.r/go-import.d/input-4.go
+++ b/Units/parser-go.r/go-import.d/input-4.go
@@ -1,0 +1,9 @@
+package main
+import (
+	t "time"
+	"fmt"
+)
+func main() {
+	fmt.Println("<%s> Hello, World!", t.Now(()
+}
+

--- a/Units/parser-go.r/go-import.d/input-5.go
+++ b/Units/parser-go.r/go-import.d/input-5.go
@@ -1,0 +1,9 @@
+package main
+import (
+	"time"
+	f "fmt"
+)
+func main() {
+	f.Println("<%s> Hello, World!", time.Now(()
+}
+

--- a/Units/parser-go.r/go-import.d/input-6.go
+++ b/Units/parser-go.r/go-import.d/input-6.go
@@ -1,0 +1,9 @@
+package main
+import (
+	t "time"
+	f "fmt"
+)
+func main() {
+	f.Println("<%s> Hello, World!", t.Now(()
+}
+

--- a/Units/parser-go.r/go-import.d/input-7.go
+++ b/Units/parser-go.r/go-import.d/input-7.go
@@ -1,0 +1,10 @@
+package main
+import (
+	. "fmt"
+	_ "time"
+)
+
+func main() {
+	Println("Hello, World!")
+}
+

--- a/Units/parser-go.r/go-import.d/input.go
+++ b/Units/parser-go.r/go-import.d/input.go
@@ -1,0 +1,6 @@
+package main
+import "fmt"
+func main() {
+	fmt.Println("Hello, World!")
+}
+


### PR DESCRIPTION
In addition, add following items:

* "packageName" kind representing 'f' in 'import f "aPackage"'
* "package" field for "packageName" kind
* "packageName" field for "package" kind
* "howImported" field for "imported" role of "package" kind

The "howImported" field takes "init" or "inline".

Signed-off-by: Masatake YAMATO <yamato@redhat.com>