### PR TITLE
SQL: remove unexpected introduced debug-print code

### DIFF
--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -1932,10 +1932,6 @@ static void parseTable (tokenInfo *const token)
 			vStringClear (token->scope);
 			token->scopeKind = SQLTAG_COUNT;
 			readToken (token);
-			fprintf(stderr, "=> %s, t: %d, k: %d\n", vStringValue(token->string),
-					token->type,
-					token->keyword
-				);
 		}
 		else
 			skipToMatched(token);


### PR DESCRIPTION
In 6e74a9bbb, I added a fprintf call to our source tree unexpected.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>