### PR TITLE
tex: Fix infinite loop parsing an identifier at EOF

### DIFF
--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -35,7 +35,7 @@
 #define isType(token,t)		(bool) ((token)->type == (t))
 #define isKeyword(token,k)	(bool) ((token)->keyword == (k))
 #define isIdentChar(c) \
-	(isalpha (c) || isdigit (c) || (((unsigned char) c) >= 0x80) || (c) == '$' || \
+	(isalpha (c) || isdigit (c) || (c) >= 0x80 || (c) == '$' || \
 		(c) == '_' || (c) == '#' || (c) == '-' || (c) == '.' || (c) == ':')
 
 /*
@@ -264,7 +264,7 @@ static void parseIdentifier (vString *const string, const int firstChar)
 	{
 		vStringPut (string, c);
 		c = getcFromInputFile ();
-	} while (isIdentChar (c));
+	} while (c != EOF && isIdentChar (c));
 
 	if (c != EOF)
 		ungetcToInputFile (c);		/* unget non-identifier character */


### PR DESCRIPTION
This was introduced in 5d5afe64ca5517c50897164f72db174428961e9f which started accepting as an identifier character any byte with a value that cast as unsigned char is greater than or equal to 0x80.  The common value for the EOF constant being -1, which cast to unsigned char gives a value of 0xff, hence leading to accepting EOF as an identifier character.

Fix the loop accordingly to explicitly guard against EOF.

Fixes #1896.