### PR TITLE
PuppetManifest: allow to use a underscore char and a hyphen char in a…

### DIFF
--- a/Units/parser-puppetManifest.r/fix-1901.d/expected.tags
+++ b/Units/parser-puppetManifest.r/fix-1901.d/expected.tags
@@ -1,0 +1,4 @@
+/tmp/12	input.pp	/^    file { "\/tmp\/12": ensure => $ensure }$/;"	r	definition:one_one::two
+/tmp/34	input.pp	/^    file { "\/tmp\/34": ensure => $ensure }$/;"	r	definition:three::four_four
+one_one::two	input.pp	/^define one_one::two($ensure) {$/;"	d
+three::four_four	input.pp	/^define three::four_four($ensure) {$/;"	d

--- a/Units/parser-puppetManifest.r/fix-1901.d/input.pp
+++ b/Units/parser-puppetManifest.r/fix-1901.d/input.pp
@@ -1,0 +1,8 @@
+define one_one::two($ensure) {
+    file { "/tmp/12": ensure => $ensure }
+}
+
+define three::four_four($ensure) {
+    file { "/tmp/34": ensure => $ensure }
+}
+

--- a/optlib/puppetManifest.c
+++ b/optlib/puppetManifest.c
@@ -366,10 +366,10 @@ static void initializePuppetManifestParser (const langType language CTAGS_ATTR_U
 	                               "^\\#",
 	                               "", "", "{tenter=comment_oneline}", NULL);
 	addLanguageTagMultiTableRegex (language, "defineStart",
-	                               "^([a-zA-Z:][a-zA-Z0-9:]*)[ \n\t]*\\(",
+	                               "^([a-z:][-_a-zA-Z0-9:]*)[ \n\t]*\\(",
 	                               "\\1", "d", "{tenter=skipArgs,blockHeadPopAtLast}{scope=push}", NULL);
 	addLanguageTagMultiTableRegex (language, "defineStart",
-	                               "^([a-zA-Z:][a-zA-Z0-9:]*)[ \n\t]*\\{",
+	                               "^([a-z:][-_a-zA-Z0-9:]*)[ \n\t]*\\{",
 	                               "\\1", "d", "{tenter=block,endWithPop}{scope=push}", NULL);
 	addLanguageTagMultiTableRegex (language, "caseStart",
 	                               "^/\\*",

--- a/optlib/puppetManifest.ctags
+++ b/optlib/puppetManifest.ctags
@@ -277,8 +277,8 @@
 # define
 #
 --_mtable-extend-PuppetManifest=defineStart+comment
---_mtable-regex-PuppetManifest=defineStart/([a-zA-Z:][a-zA-Z0-9:]*)[ \n\t]*\(/\1/d/{tenter=skipArgs,blockHeadPopAtLast}{scope=push}
---_mtable-regex-PuppetManifest=defineStart/([a-zA-Z:][a-zA-Z0-9:]*)[ \n\t]*\{/\1/d/{tenter=block,endWithPop}{scope=push}
+--_mtable-regex-PuppetManifest=defineStart/([a-z:][-_a-zA-Z0-9:]*)[ \n\t]*\(/\1/d/{tenter=skipArgs,blockHeadPopAtLast}{scope=push}
+--_mtable-regex-PuppetManifest=defineStart/([a-z:][-_a-zA-Z0-9:]*)[ \n\t]*\{/\1/d/{tenter=block,endWithPop}{scope=push}
 
 #
 # case


### PR DESCRIPTION
… name

Close #1901.

I refereed https://puppet.com/docs/puppet/6.0/lang_data_string.html#bare-words for fixing this.
I also add a hyphen char to the list of acceptable chars.