### PR TITLE
Verilog,refactor: don't use Cpreprocessor code

### DIFF
--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -914,7 +914,7 @@ static Comment isComment (void)
 /*  Skips over a C style comment. According to ANSI specification a comment
  *  is treated as white space, so we perform this substitution.
  */
-int cppSkipOverCComment (void)
+static int cppSkipOverCComment (void)
 {
 	int c = cppGetcFromUngetBufferOrFile ();
 

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -76,7 +76,6 @@ extern void cppEndStatement (void);
 extern void cppUngetc (const int c);
 extern void cppUngetString(const char * string,int len);
 extern int cppGetc (void);
-extern int cppSkipOverCComment (void);
 
 /* notify the external parser state for the purpose of conditional
    branch choice. The CXX parser stores the block level here. */

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -22,7 +22,6 @@
 #include <string.h>
 
 #include "debug.h"
-#include "cpreprocessor.h"
 #include "keyword.h"
 #include "options.h"
 #include "parse.h"
@@ -379,6 +378,37 @@ static void vUngetc (int c)
 	Ungetc = c;
 }
 
+/* Mostly copyed from cppSkipOverCComment() in cpreprocessor.c.
+ *
+ * cppSkipOverCComment() uses the internal ungetc buffer of
+ * CPreProcessor.  On the other hand, the Verilog parser uses
+ * getcFromInputFile() directly. getcFromInputFile() uses just
+ * another internal ungetc buffer. Using them mixed way will
+ * cause a trouble. */
+static int verilogSkipOverCComment (void)
+{
+	int c =  getcFromInputFile();
+
+	while (c != EOF)
+	{
+		if (c != '*')
+			c = getcFromInputFile ();
+		else
+		{
+			const int next = getcFromInputFile ();
+
+			if (next != '/')
+				c = next;
+			else
+			{
+				c = SPACE;  /* replace comment with space */
+				break;
+			}
+		}
+	}
+	return c;
+}
+
 static int vGetc (void)
 {
 	int c;
@@ -402,7 +432,7 @@ static int vGetc (void)
 		}
 		else if (c2 == '*')  /* strip block comment */
 		{
-			c = cppSkipOverCComment();
+			c = verilogSkipOverCComment();
 		}
 		else
 		{


### PR DESCRIPTION
Verilog uses getcFromInputFile() in the most of all areas.  The
exception is when handling C style comments.  When handling the
comments, the parser uses cppSkipOverCComment().

Using them mixed way can cause a trouble in the future.  If using them
mixed way, the layers of ungetc buffesrs will corrupt.

getcFromInputFile maintains its internal ungetc buffer.
cppGetcFromUngetBufferOrFile called from cppSkipOverCComment maintains
just another internal ungetc buffer.

cppGetcFromUngetBufferOrFile assumes the clinet parser never uses
getcFromInputFile directly.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>