### PR TITLE
Unit test input files are verified during `make verify-units-inputs` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 *.ssexwsp.user
 *.TMP
 *.tmp
+# Makefile empty target files of verify-units-inputs target
+Units/**/.input.*.verified
 *~
 .deps
 .dirstamp

--- a/Units/parser-puppetManifest.r/node.d/expected.tags
+++ b/Units/parser-puppetManifest.r/node.d/expected.tags
@@ -1,3 +1,4 @@
-www1.example.com	input.pp	/^node 'www1.example.com' {$/;"	node	line:2	language:PuppetManifest
-www2.example.com	input.pp	/^node 'www2.example.com', 'www3.example.com' {$/;"	node	line:12	language:PuppetManifest
-www3.example.com	input.pp	/^node 'www2.example.com', 'www3.example.com' {$/;"	node	line:12	language:PuppetManifest
+default	input.pp	/^node 'default' {}$/;"	node	line:2	language:PuppetManifest
+www1.example.com	input.pp	/^node 'www1.example.com' {$/;"	node	line:3	language:PuppetManifest
+www2.example.com	input.pp	/^node 'www2.example.com', 'www3.example.com' {$/;"	node	line:13	language:PuppetManifest
+www3.example.com	input.pp	/^node 'www2.example.com', 'www3.example.com' {$/;"	node	line:13	language:PuppetManifest

--- a/Units/parser-puppetManifest.r/node.d/input.pp
+++ b/Units/parser-puppetManifest.r/node.d/input.pp
@@ -1,4 +1,5 @@
 /* Taken from https://docs.puppet.com/puppet/5.1/lang_node_definitions.html */
+node 'default' {}
 node 'www1.example.com' {
   include common
   include apache

--- a/Units/parser-puppetManifest.r/puppet-append.d/expected.tags
+++ b/Units/parser-puppetManifest.r/puppet-append.d/expected.tags
@@ -1,2 +1,3 @@
 var	input.pp	/^$var=['\/tmp\/file1','\/tmp\/file2']$/;"	variable	line:1	language:PuppetManifest
 arraytest	input.pp	/^class arraytest {$/;"	class	line:3	language:PuppetManifest	end:9
+var	input.pp	/^    $var = $var + ['\/tmp\/file3', '\/tmp\/file4']$/;"	variable	line:4	language:PuppetManifest	scope:class:arraytest

--- a/Units/parser-puppetManifest.r/puppet-append.d/input.pp
+++ b/Units/parser-puppetManifest.r/puppet-append.d/input.pp
@@ -1,7 +1,7 @@
 $var=['/tmp/file1','/tmp/file2']
 
 class arraytest {
-    $var += ['/tmp/file3', '/tmp/file4']
+    $var = $var + ['/tmp/file3', '/tmp/file4']
     file {
         $var:
             content => "test"

--- a/Units/parser-puppetManifest.r/puppet-collection_within_virtual_definitions.d/expected.tags
+++ b/Units/parser-puppetManifest.r/puppet-collection_within_virtual_definitions.d/expected.tags
@@ -1,5 +1,5 @@
-test	input.pp	/^define test($name) {$/;"	definition	line:1	language:PuppetManifest	end:6
-/tmp/collection_within_virtual_definitions1_$name.txt	input.pp	/^    file {"\/tmp\/collection_within_virtual_definitions1_$name.txt":$/;"	resource	line:2	language:PuppetManifest	scope:definition:test	end:4
+test	input.pp	/^define test($my_name) {$/;"	definition	line:1	language:PuppetManifest	end:6
+/tmp/collection_within_virtual_definitions1_$my_name.txt	input.pp	/^    file {"\/tmp\/collection_within_virtual_definitions1_$my_name.txt":$/;"	resource	line:2	language:PuppetManifest	scope:definition:test	end:4
 test2	input.pp	/^define test2() {$/;"	definition	line:8	language:PuppetManifest	end:12
 /tmp/collection_within_virtual_definitions2_$name.txt	input.pp	/^    file {"\/tmp\/collection_within_virtual_definitions2_$name.txt":$/;"	resource	line:9	language:PuppetManifest	scope:definition:test2	end:11
 foo	input.pp	/^    @test {"foo":$/;"	resource	line:15	language:PuppetManifest	end:17

--- a/Units/parser-puppetManifest.r/puppet-collection_within_virtual_definitions.d/input.pp
+++ b/Units/parser-puppetManifest.r/puppet-collection_within_virtual_definitions.d/input.pp
@@ -1,6 +1,6 @@
-define test($name) {
-    file {"/tmp/collection_within_virtual_definitions1_$name.txt":
-        content => "File name $name\n"
+define test($my_name) {
+    file {"/tmp/collection_within_virtual_definitions1_$my_name.txt":
+        content => "File name $my_name\n"
     }
     Test2 <||>
 }
@@ -13,7 +13,7 @@ define test2() {
 
 node default {
     @test {"foo":
-        name => "foo"
+        my_name => "foo"
     }
     @test2 {"foo2": }
     Test <||>

--- a/Units/parser-puppetManifest.r/puppet-emptyif.d/args.ctags
+++ b/Units/parser-puppetManifest.r/puppet-emptyif.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--fields=+KZlne

--- a/Units/parser-puppetManifest.r/puppet-emptyif.d/input.pp
+++ b/Units/parser-puppetManifest.r/puppet-emptyif.d/input.pp
@@ -1,0 +1,4 @@
+
+if true {
+  # still nothing
+}

--- a/Units/parser-puppetManifest.r/puppet-emptyifelse.d/input.pp
+++ b/Units/parser-puppetManifest.r/puppet-emptyifelse.d/input.pp
@@ -4,6 +4,3 @@ if false {
   # nothing here
 }
 
-if true {
-  # still nothing
-}

--- a/Units/parser-puppetManifest.r/puppet-multipleclass.d/expected.tags
+++ b/Units/parser-puppetManifest.r/puppet-multipleclass.d/expected.tags
@@ -1,4 +1,4 @@
 one	input.pp	/^class one {$/;"	class	line:1	language:PuppetManifest	end:3
 /tmp/multipleclassone	input.pp	/^    file { "\/tmp\/multipleclassone": content => "one" }$/;"	resource	line:2	language:PuppetManifest	scope:class:one	end:2
-one	input.pp	/^class one {$/;"	class	line:5	language:PuppetManifest	end:7
-/tmp/multipleclasstwo	input.pp	/^    file { "\/tmp\/multipleclasstwo": content => "two" }$/;"	resource	line:6	language:PuppetManifest	scope:class:one	end:6
+two	input.pp	/^class two {$/;"	class	line:5	language:PuppetManifest	end:7
+/tmp/multipleclasstwo	input.pp	/^    file { "\/tmp\/multipleclasstwo": content => "two" }$/;"	resource	line:6	language:PuppetManifest	scope:class:two	end:6

--- a/Units/parser-puppetManifest.r/puppet-multipleclass.d/input.pp
+++ b/Units/parser-puppetManifest.r/puppet-multipleclass.d/input.pp
@@ -2,7 +2,7 @@ class one {
     file { "/tmp/multipleclassone": content => "one" }
 }
 
-class one {
+class two {
     file { "/tmp/multipleclasstwo": content => "two" }
 }
 

--- a/Units/parser-puppetManifest.r/puppet-scopetest.d/expected.tags
+++ b/Units/parser-puppetManifest.r/puppet-scopetest.d/expected.tags
@@ -1,5 +1,5 @@
-mode	input.pp	/^$mode = 640$/;"	variable	line:2	language:PuppetManifest
+mode	input.pp	/^$mode = "640"$/;"	variable	line:2	language:PuppetManifest
 thing	input.pp	/^define thing {$/;"	definition	line:4	language:PuppetManifest	end:6
 /tmp/$name	input.pp	/^    file { "\/tmp\/$name": ensure => file, mode => $mode }$/;"	resource	line:5	language:PuppetManifest	scope:definition:thing	end:5
 testing	input.pp	/^class testing {$/;"	class	line:8	language:PuppetManifest	end:11
-mode	input.pp	/^    $mode = 755$/;"	variable	line:9	language:PuppetManifest	scope:class:testing
+mode	input.pp	/^    $mode = "755"$/;"	variable	line:9	language:PuppetManifest	scope:class:testing

--- a/Units/parser-puppetManifest.r/puppet-scopetest.d/input.pp
+++ b/Units/parser-puppetManifest.r/puppet-scopetest.d/input.pp
@@ -1,12 +1,12 @@
 
-$mode = 640
+$mode = "640"
 
 define thing {
     file { "/tmp/$name": ensure => file, mode => $mode }
 }
 
 class testing {
-    $mode = 755
+    $mode = "755"
     thing {scopetest: }
 }
 

--- a/Units/parser-puppetManifest.r/puppet-selectorvalues.d/input.pp
+++ b/Units/parser-puppetManifest.r/puppet-selectorvalues.d/input.pp
@@ -6,37 +6,37 @@ $value4 = yay
 $test = "yay"
 
 $mode1 = $value1 ? {
-    "" => 755,
-    default => 644
+    "" => "755",
+    default => "644"
 }
 
 $mode2 = $value2 ? {
-    true => 755,
-    default => 644
+    true => "755",
+    default => "644"
 }
 
 $mode3 = $value3 ? {
-    false => 755,
-    default => 644
+    false => "755",
+    default => "644"
 }
 
 $mode4 = $value4 ? {
-    $test => 755,
-    default => 644
+    $test => "755",
+    default => "644"
 }
 
 $mode5 = yay ? {
-    $test => 755,
-    default => 644
+    $test => "755",
+    default => "644"
 }
 
 $mode6 = $mode5 ? {
-    755 => 755
+    "755" => "755"
 }
 
 $mode7 = "test regex" ? {
-    /regex$/ => 755,
-    default => 644
+    /regex$/ => "755",
+    default => "644"
 }
 
 

--- a/Units/parser-puppetManifest.r/puppet-simpleselector.d/expected.tags
+++ b/Units/parser-puppetManifest.r/puppet-simpleselector.d/expected.tags
@@ -3,5 +3,5 @@ var	input.pp	/^$var = "value"$/;"	variable	line:3	language:PuppetManifest
 /tmp/snippetselectbtest	input.pp	/^file { "\/tmp\/snippetselectbtest":$/;"	resource	line:13	language:PuppetManifest	end:19
 othervar	input.pp	/^$othervar = "complex value"$/;"	variable	line:21	language:PuppetManifest
 /tmp/snippetselectctest	input.pp	/^file { "\/tmp\/snippetselectctest":$/;"	resource	line:23	language:PuppetManifest	end:29
-anothervar	input.pp	/^$anothervar = Yayness$/;"	variable	line:30	language:PuppetManifest
+anothervar	input.pp	/^$anothervar = "Yayness"$/;"	variable	line:30	language:PuppetManifest
 /tmp/snippetselectdtest	input.pp	/^file { "\/tmp\/snippetselectdtest":$/;"	resource	line:32	language:PuppetManifest	end:38

--- a/Units/parser-puppetManifest.r/puppet-simpleselector.d/input.pp
+++ b/Units/parser-puppetManifest.r/puppet-simpleselector.d/input.pp
@@ -5,16 +5,16 @@ $var = "value"
 file { "/tmp/snippetselectatest":
     ensure => file,
     mode => $var ? {
-        nottrue => 641,
-        value => 755
+        nottrue => "641",
+        value => "755"
     }
 }
 
 file { "/tmp/snippetselectbtest":
     ensure => file,
     mode => $var ? {
-        nottrue => 644,
-        default => 755
+        nottrue => "644",
+        default => "755"
     }
 }
 
@@ -23,16 +23,16 @@ $othervar = "complex value"
 file { "/tmp/snippetselectctest":
     ensure => file,
     mode => $othervar ? {
-        "complex value" => 755,
-        default => 644
+        "complex value" => "755",
+        default => "644"
     }
 }
-$anothervar = Yayness
+$anothervar = "Yayness"
 
 file { "/tmp/snippetselectdtest":
     ensure => file,
     mode => $anothervar ? {
-        Yayness => 755,
-        default => 644
+        "Yayness" => "755",
+        default => "644"
     }
 }

--- a/Units/parser-puppetManifest.r/puppet-singleselector.d/input.pp
+++ b/Units/parser-puppetManifest.r/puppet-singleselector.d/input.pp
@@ -6,15 +6,15 @@ $value4 = yay
 $test = "yay"
 
 $mode1 = $value1 ? {
-    "" => 755
+    "" => "755"
 }
 
 $mode2 = $value2 ? {
-    true => 755
+    true => "755"
 }
 
 $mode3 = $value3 ? {
-    default => 755
+    default => "755"
 }
 
 file { "/tmp/singleselector1": ensure => file, mode => $mode1 }

--- a/Units/parser-puppetManifest.r/unless.d/expected.tags
+++ b/Units/parser-puppetManifest.r/unless.d/expected.tags
@@ -1,1 +1,2 @@
-/tmp/x	input.pp	/^       file { "\/tmp\/x": }$/;"	resource	line:2	language:PuppetManifest	end:2
+array	input.pp	/^$array = [ 3, 5, 7 ]$/;"	variable	line:1	language:PuppetManifest
+/tmp/x	input.pp	/^       file { "\/tmp\/x": }$/;"	resource	line:3	language:PuppetManifest	end:3

--- a/Units/parser-puppetManifest.r/unless.d/input.pp
+++ b/Units/parser-puppetManifest.r/unless.d/input.pp
@@ -1,3 +1,4 @@
+$array = [ 3, 5, 7 ]
 unless $array[0] > 5 {
        file { "/tmp/x": }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -39,7 +39,8 @@ jobs:
            # TODO: enable spell checker
            command: |
               rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm \
-              && yum -y install epel-release gcc automake autoconf pkgconfig make \
+              && yum -y install epel-release \
+              && yum -y install gcc automake autoconf pkgconfig make \
                  libxml2-devel jansson-devel libyaml-devel findutils \
                  puppet-agent-5.5.6-1.el7 jq || :
        - run:

--- a/circle.yml
+++ b/circle.yml
@@ -39,8 +39,9 @@ jobs:
            # TODO: enable spell checker
            command: |
               rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm \
-              && yum -y install gcc automake autoconf pkgconfig make libxml2-devel \
-                  jansson-devel libyaml-devel findutils puppet-agent-5.5.6-1.el7 || :
+              && yum -y install epel-release gcc automake autoconf pkgconfig make \
+                 libxml2-devel jansson-devel libyaml-devel findutils \
+                 puppet-agent-5.5.6-1.el7 jq || :
        - run:
            name: Build
            command: |

--- a/circle.yml
+++ b/circle.yml
@@ -38,7 +38,9 @@ jobs:
            name: Install build tools
            # TODO: enable spell checker
            command: |
-              yum -y install gcc automake autoconf pkgconfig make libxml2-devel jansson-devel libyaml-devel findutils || :
+              rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm \
+              && yum -y install gcc automake autoconf pkgconfig make libxml2-devel \
+                  jansson-devel libyaml-devel findutils puppet-agent-5.5.6-1.el7 || :
        - run:
            name: Build
            command: |

--- a/circle.yml
+++ b/circle.yml
@@ -40,8 +40,7 @@ jobs:
            command: |
               rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm \
               && yum -y install gcc automake autoconf pkgconfig make libxml2-devel \
-                  jansson-devel libyaml-devel findutils puppet-agent-5.5.6-1.el7 \
-              && export PATH=/opt/puppetlabs/bin:$PATH || :
+                  jansson-devel libyaml-devel findutils puppet-agent-5.5.6-1.el7 || :
        - run:
            name: Build
            command: |
@@ -51,7 +50,7 @@ jobs:
        - run:
            name: Test
            command: |
-             make verify-units-inputs check roundtrip CIRCLECI=1
+             make verify-units-inputs check roundtrip CIRCLECI=1 PATH=/opt/puppetlabs/bin:$PATH
 
 workflows:
   version: 2

--- a/circle.yml
+++ b/circle.yml
@@ -35,12 +35,13 @@ jobs:
              yum -y install git || :
        - checkout
        - run:
-           name: Install build tools
+           name: Install build and test tools
            # TODO: enable spell checker
            command: |
               rpm -Uvh https://yum.puppet.com/puppet5/puppet5-release-el-7.noarch.rpm \
               && yum -y install gcc automake autoconf pkgconfig make libxml2-devel \
-                  jansson-devel libyaml-devel findutils puppet-agent-5.5.6-1.el7 || :
+                  jansson-devel libyaml-devel findutils puppet-agent-5.5.6-1.el7 \
+              && export PATH=/opt/puppetlabs/bin:$PATH || :
        - run:
            name: Build
            command: |
@@ -50,7 +51,7 @@ jobs:
        - run:
            name: Test
            command: |
-             make check roundtrip CIRCLECI=1
+             make verify-units-inputs check roundtrip CIRCLECI=1
 
 workflows:
   version: 2

--- a/configure.ac
+++ b/configure.ac
@@ -204,6 +204,7 @@ AC_ARG_PROGRAM
 AM_CONDITIONAL(INSTALL_LIB, [test "x$enable_readlib" = "xyes"])
 AM_CONDITIONAL(INSTALL_ETAGS, [test "x$enable_etags" = "xyes"])
 AM_CONDITIONAL(USE_READCMD, [test "x$enable_readcmd" = "xyes"])
+AM_CONDITIONAL(USING_BMAKE, [test "x$MAKE" = "xbmake"])
 
 dnl AC_MSG_NOTICE(Change with $program_transform_name)
 CTAGS_NAME_EXECUTABLE=`echo ctags | sed "$program_transform_name"`

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -112,7 +112,7 @@ verify-units-inputs: $(VERIFY_PUPPET_TEST_DIRS_TARGETS)
 #
 # UNITS Target
 #
-units: $(CTAGS_TEST) verify-units-inputs
+units: $(CTAGS_TEST)
 	$(V_RUN) \
 	if test -n "$${ZSH_VERSION+set}"; then set -o SH_WORD_SPLIT; fi; \
 	if test x$(VG) = x1; then		\

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -89,7 +89,7 @@ slap: $(CTAGS_TEST)
 	$(SHELL) $${c} $(srcdir)/Units
 
 # TODO: Possibly the bmake does not support the metaprogramming similar to gnu make.
-ifneq ($(MAKE),bmake)
+if !USING_BMAKE
 # Find the test directories where ctags is expected to succeed. Only tests with
 # an expected.tags file present are required to have valid input.
 PUPPET_TEST_DIRS = $(foreach path, \
@@ -110,7 +110,8 @@ $(foreach puppet_test_dir,$(PUPPET_TEST_DIRS),$(eval $(call VERIFY_ONE_PUPPET_TE
 # verify-units-inputs Target
 #
 verify-units-inputs: $(VERIFY_PUPPET_TEST_DIRS_TARGETS)
-endif  # ifneq ($(MAKE),bmake)
+
+endif  # if !USING_BMAKE
 
 #
 # UNITS Target

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -88,7 +88,8 @@ slap: $(CTAGS_TEST)
 		--with-timeout=$(TIMEOUT)"; \
 	$(SHELL) $${c} $(srcdir)/Units
 
-
+# TODO: Possibly the bmake does not support the metaprogramming similar to gnu make.
+ifneq ($(MAKE),bmake)
 # Find the test directories where ctags is expected to succeed. Only tests with
 # an expected.tags file present are required to have valid input.
 PUPPET_TEST_DIRS = $(foreach path, \
@@ -109,6 +110,7 @@ $(foreach puppet_test_dir,$(PUPPET_TEST_DIRS),$(eval $(call VERIFY_ONE_PUPPET_TE
 # verify-units-inputs Target
 #
 verify-units-inputs: $(VERIFY_PUPPET_TEST_DIRS_TARGETS)
+endif  # ifneq ($(MAKE),bmake)
 
 #
 # UNITS Target

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -89,7 +89,11 @@ slap: $(CTAGS_TEST)
 	$(SHELL) $${c} $(srcdir)/Units
 
 
-PUPPET_TEST_DIRS = $(shell find $(srcdir)/Units/parser-puppetManifest.r -maxdepth 1 -mindepth 1 -type d)
+# Find the test directories where ctags is expected to succeed. Only tests with
+# an expected.tags file present are required to have valid input.
+PUPPET_TEST_DIRS = $(foreach path, \
+    $(shell find $(srcdir)/Units/parser-puppetManifest.r -name expected.tags), \
+    $(shell dirname $(path)))
 VERIFY_PUPPET_TEST_DIRS_TARGETS := $(PUPPET_TEST_DIRS:%=TARGET_FOR_VERIFY_%)
 
 define VERIFY_ONE_PUPPET_TEST_DIR

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -114,7 +114,7 @@ verify-units-inputs: $$(VERIFY_$(1)_TEST_DIRS_TARGETS)
 
 define VERIFY_ONE_$(1)_TEST_DIR
 $$(1)/.input.pp.verified: $$(1)/input.pp
-	puppet apply --noop $$$$<  1>/dev/null && \
+	$(4) && \
 	touch $$$$@
 endef
 
@@ -122,7 +122,7 @@ $$(foreach $(1)_test_dir,$$($(1)_TEST_DIRS),$$(eval $$(call VERIFY_ONE_$(1)_TEST
 
 endef # define VERIFY_GIVEN_UNITS_TEST_DIR
 
-$(eval $(call VERIFY_GIVEN_UNITS_TEST_DIR,PUPPET,pp,parser-puppetManifest.r))
+$(eval $(call VERIFY_GIVEN_UNITS_TEST_DIR,PUPPET,pp,parser-puppetManifest.r,puppet apply --noop $$$$< 1>/dev/null))
 
 
 #

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -96,6 +96,7 @@ PUPPET_TEST_DIRS = $(foreach path, \
     $(shell dirname $(path)))
 VERIFY_PUPPET_TEST_DIRS_TARGETS := $(PUPPET_TEST_DIRS:%=TARGET_FOR_VERIFY_%)
 
+#TODO: We shuold make this an empty target rather than a phony target
 define VERIFY_ONE_PUPPET_TEST_DIR
 TARGET_FOR_VERIFY_$(1): $(1)/input.pp
 	puppet apply --noop $$<

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -1,5 +1,5 @@
 # -*- makefile -*-
-.PHONY: check units fuzz noise tmain tinst clean-units clean-tmain clean-gcov run-gcov codecheck cppcheck dicts cspell $(VERIFY_PUPPET_TEST_DIRS_TARGETS) verify-units-inputs
+.PHONY: check units fuzz noise tmain tinst clean-units clean-tmain clean-gcov run-gcov codecheck cppcheck dicts cspell verify-units-inputs
 
 check: tmain units
 
@@ -94,12 +94,13 @@ slap: $(CTAGS_TEST)
 PUPPET_TEST_DIRS = $(foreach path, \
     $(shell find $(srcdir)/Units/parser-puppetManifest.r -name expected.tags), \
     $(shell dirname $(path)))
-VERIFY_PUPPET_TEST_DIRS_TARGETS := $(PUPPET_TEST_DIRS:%=TARGET_FOR_VERIFY_%)
+VERIFY_PUPPET_TEST_DIRS_TARGETS := $(PUPPET_TEST_DIRS:%=%/.input.pp.verified)
 
 #TODO: We shuold make this an empty target rather than a phony target
 define VERIFY_ONE_PUPPET_TEST_DIR
-TARGET_FOR_VERIFY_$(1): $(1)/input.pp
-	puppet apply --noop $$<
+$(1)/.input.pp.verified: $(1)/input.pp
+	puppet apply --noop $$< && \
+	touch $$@
 endef
 
 $(foreach puppet_test_dir,$(PUPPET_TEST_DIRS),$(eval $(call VERIFY_ONE_PUPPET_TEST_DIR,$(puppet_test_dir))))

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -100,6 +100,7 @@ set = $(eval $(1) = $(2))
 # $(1): Language Name. For example: PUPPET
 # $(2): Extension. For example: pp
 # $(3): Directory Name. For example: parser-puppetManifest.r
+# $(4): Command: For example: puppet apply --noop $<
 define VERIFY_GIVEN_UNITS_TEST_DIR
 
 # Find the test directories where ctags is expected to succeed. Only tests with
@@ -113,7 +114,7 @@ verify-units-inputs: $$(VERIFY_$(1)_TEST_DIRS_TARGETS)
 
 define VERIFY_ONE_$(1)_TEST_DIR
 $$(1)/.input.pp.verified: $$(1)/input.pp
-	puppet apply --noop $$$$< && \
+	puppet apply --noop $$$$<  1>/dev/null && \
 	touch $$$$@
 endef
 
@@ -122,6 +123,13 @@ $$(foreach $(1)_test_dir,$$($(1)_TEST_DIRS),$$(eval $$(call VERIFY_ONE_$(1)_TEST
 endef # define VERIFY_GIVEN_UNITS_TEST_DIR
 
 $(eval $(call VERIFY_GIVEN_UNITS_TEST_DIR,PUPPET,pp,parser-puppetManifest.r))
+
+
+#
+#  Removes the empty target files of the verify-units-inputs target
+#
+clean-verify-units-inputs:
+	find Units -path "*/.input.*.verified" | xargs rm
 
 
 endif  # if !USING_BMAKE

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -135,7 +135,7 @@ $(eval $(call VERIFY_GIVEN_UNITS_TEST_DIR,JSON,.json,simple-json.d,jq '.' $$$$< 
 #  Removes the empty target files of the verify-units-inputs target
 #
 clean-verify-units-inputs:
-	find Units -path "*/.input.*.verified" | xargs rm
+	find Units -path "*/.input.*.verified" | xargs rm -f
 
 
 endif  # if !USING_BMAKE


### PR DESCRIPTION
This is an early work in progress. 

I am sending this PR out to discuss the implementation approach for incorporating the verification of the unit test input files to make check. 

I have used some makefile metaprogramming. http://make.mad-scientist.net/the-eval-function/ I am by no means a makefile expert. So let me know please if there is a better approach to this. 

Some missing pieces: 

1. The CATEGORIES and UNITS env vars are not taken into consideration. So every time all puppet files are verified regardless. 
2. The circileci config file needs to be updated to install puppet dependencies. The puppet command will fail in the containers. 
3. The input.pp files have not been fixed to pass the puppet syntax checking. 
4. If we want to go into this direction, the testing.mak should possibly be further parameterized or more meta-programming should be used. Right now the implementation is specific to the puppetManifest files. 
5. Better variable names can be used in testing.mak 
