### PR TITLE
Cxx: don't use the size of array when checking the argument in debug code

### DIFF
--- a/parsers/cxx/cxx_debug.c
+++ b/parsers/cxx/cxx_debug.c
@@ -170,7 +170,7 @@ const char* cxxDebugScopeDecode(enum CXXScopeType scope)
 		[CXXScopeTypeUnion] = "union",
 		[CXXScopeTypeStruct] = "structg",
 	};
-	if (sizeof(table) > scope)
+	if (CXXScopeTypeLAST > scope)
 		return table[scope];
 	else
 		return NULL;

--- a/parsers/cxx/cxx_scope.h
+++ b/parsers/cxx/cxx_scope.h
@@ -28,7 +28,8 @@ enum CXXScopeType
 	CXXScopeTypeClass,
 	CXXScopeTypeEnum,
 	CXXScopeTypeUnion,
-	CXXScopeTypeStruct
+	CXXScopeTypeStruct,
+	CXXScopeTypeLAST
 };
 
 void cxxScopeInit(void);


### PR DESCRIPTION
To checkout the argument of cxxDebugScopeDecode() whether it has an
acceptable value, sizeof operator is used. It is wrong. clang reports
this. In stead, I should use the count of enum elements.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>