### PR TITLE
Allow fullqualified function definition

### DIFF
--- a/Units/parser-clojure.r/simple-clojure.d/expected.tags
+++ b/Units/parser-clojure.r/simple-clojure.d/expected.tags
@@ -1,5 +1,6 @@
 another.name	input.clj	/^(ns another.name)$/;"	n
 app.controller	input.clj	/^(ns app.controller)$/;"	n
+core-function-with-body	input.clj	/^(clojure.core\/defn core-function-with-body []$/;"	f	namespace:app.controller
 empty-fn	input.clj	/^ (defn empty-fn [])$/;"	f	namespace:app.controller
 function-with-body	input.clj	/^(defn function-with-body []$/;"	f	namespace:app.controller
 x	input.clj	/^(defn x [])$/;"	f	namespace:another.name

--- a/Units/parser-clojure.r/simple-clojure.d/input.clj
+++ b/Units/parser-clojure.r/simple-clojure.d/input.clj
@@ -5,6 +5,9 @@
 (defn function-with-body []
     (println "body"))
 
+(clojure.core/defn core-function-with-body []
+    (println "core"))
+
 '(defn quoted-function [])
 (quote quoted-function2 [])
 

--- a/parsers/clojure.c
+++ b/parsers/clojure.c
@@ -34,7 +34,12 @@ static int isNamespace (const char *strp)
 
 static int isFunction (const char *strp)
 {
-	return strncmp (++strp, "defn", 4) == 0 && isspace (strp[4]);
+	return (strncmp (++strp, "defn", 4) == 0 && isspace (strp[4])); // || (strncmp (++strp, "clojure.core/defn", 17) == 0 && isspace (strp[17]));
+}
+
+static int isCoreFunction (const char *strp)
+{
+	return (strncmp (++strp, "clojure.core/defn", 17) == 0 && isspace (strp[17]));
 }
 
 static int isQuote (const char *strp)
@@ -154,7 +159,7 @@ static void findClojureTags (void)
 				skipToSymbol (&p);
 				scope_index = makeNamespaceTag (name, p);
 			}
-			else if (isFunction (p))
+			else if (isFunction (p) || isCoreFunction (p))
 			{
 				skipToSymbol (&p);
 				makeFunctionTag (name, p, scope_index);


### PR DESCRIPTION
in clojure `clojure.core/defn` is also a valid way to define a function. 

p.s. the reason why I'm not using short `defn` - I have sources, which are generated, but need to be indexed. I those files all functions are full qualified including all clojure.core functions