### PR TITLE
Fix xMalloc usage

### DIFF
--- a/parsers/cxx/cxx_token.c
+++ b/parsers/cxx/cxx_token.c
@@ -27,7 +27,7 @@ void cxxTokenForceDestroy(CXXToken * t);
 
 static CXXToken *createToken(void *createArg CTAGS_ATTR_UNUSED)
 {
-	CXXToken *t = xMalloc(sizeof(CXXToken),CXXToken);
+	CXXToken *t = xMalloc(1, CXXToken);
 	// we almost always want a string, and since this token
 	// is being reused..well.. we always want it
 	t->pszWord = vStringNew();

--- a/parsers/cxx/cxx_token_chain.c
+++ b/parsers/cxx/cxx_token_chain.c
@@ -27,7 +27,7 @@ void cxxTokenChainInit(CXXTokenChain * tc)
 
 CXXTokenChain * cxxTokenChainCreate(void)
 {
-	CXXTokenChain * tc = xMalloc(sizeof(CXXTokenChain),CXXTokenChain);
+	CXXTokenChain * tc = xMalloc(1, CXXTokenChain);
 	cxxTokenChainInit(tc);
 	return tc;
 }


### PR DESCRIPTION
No need to allocate `sizeof(CXXToken) * sizeof(CXXToken)` bytes for a single token structure when `1 * sizeof(CXXToken)` bytes is enough.

This fixes ctags memory usage issue mentioned here: https://github.com/oracle/opengrok/issues/2364