### PR TITLE
fix-bug, both branch should visited, now don't processs

### DIFF
--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -551,6 +551,9 @@ static bool isIgnoreBranch (void)
 	{
 		CXX_DEBUG_PRINT("Choosing single branch");
 		ifdef->singleBranch = true;
+	} else {
+		CXX_DEBUG_PRINT("Choosing all branch");
+		ifdef->singleBranch = false;
 	}
 
 	/*  We will ignore this branch in the following cases:


### PR DESCRIPTION
struct sType
{
    union
    {
#ifdef Condition
        struct
        {
			int  usMember1;
        };
#else
        struct
        {
			int  usMember2;            
        };
#endif
    };
};
before change:
sType	D:\\CodeStyle\\refactorctags\\ifdef2.c	1;"	struct	file:
__anonf8dce96c010a	D:\\CodeStyle\\refactorctags\\ifdef2.c	4;"	union	struct:sType	file:
__anonf8dce96c0208	D:\\CodeStyle\\refactorctags\\ifdef2.c	7;"	struct	union:sType::__anonf8dce96c010a	file:
usMember1	D:\\CodeStyle\\refactorctags\\ifdef2.c	8;"	member	struct:sType::__anonf8dce96c010a::__anonf8dce96c0208	typeref:typename:int	file:

change after:
sType	D:\\CodeStyle\\refactorctags\\ifdef2.c	1;"	struct	file:
__anonf8dce96c010a	D:\\CodeStyle\\refactorctags\\ifdef2.c	4;"	union	struct:sType	file:
__anonf8dce96c0208	D:\\CodeStyle\\refactorctags\\ifdef2.c	7;"	struct	union:sType::__anonf8dce96c010a	file:
usMember1	D:\\CodeStyle\\refactorctags\\ifdef2.c	8;"	member	struct:sType::__anonf8dce96c010a::__anonf8dce96c0208	typeref:typename:int	file:
__anonf8dce96c0308	D:\\CodeStyle\\refactorctags\\ifdef2.c	12;"	struct	union:sType::__anonf8dce96c010a	file:
usMember2	D:\\CodeStyle\\refactorctags\\ifdef2.c	13;"	member	struct:sType::__anonf8dce96c010a::__anonf8dce96c0308	typeref:typename:int	file: