### PR TITLE
Add the common ".ada" as an accepted file extension.

### DIFF
--- a/Tmain/map-removing.d/stdout-expected.txt
+++ b/Tmain/map-removing.d/stdout-expected.txt
@@ -9,13 +9,13 @@ MatLab   *.m
 
 [--map-<LANG>] adding *.m to Ada
 =======================================
-Ada      *.adb *.ads *.Ada *.m
+Ada      *.adb *.ads *.Ada *.ada *.m
 MatLab   *.m
 ObjectiveC *.mm *.m *.h
 
 [--map-<LANG>] removing from *.m from ObjectiveC, and adding *.m to Ada
 =======================================
-Ada      *.adb *.ads *.Ada *.m
+Ada      *.adb *.ads *.Ada *.ada *.m
 MatLab   *.m
 
 [--map-<LANG>] guessing parser with adding *.m to Ada

--- a/parsers/ada.c
+++ b/parsers/ada.c
@@ -2218,7 +2218,7 @@ static void findAdaTags(void)
 /* parser definition function */
 extern parserDefinition* AdaParser(void)
 {
-  static const char *const extensions[] = { "adb", "ads", "Ada", NULL };
+  static const char *const extensions[] = { "adb", "ads", "Ada", "ada", NULL };
   parserDefinition* def = parserNew("Ada");
   def->kindTable = AdaKinds;
   def->kindCount = ADA_KIND_COUNT;


### PR DESCRIPTION
This extension is used in a lot of old Ada source files which contain multiple compilation units.