### PR TITLE
 Allow mio_new_mio() to have size 0

### DIFF
--- a/Units/parser-yacc.r/bom.d/expected.tags
+++ b/Units/parser-yacc.r/bom.d/expected.tags
@@ -1,2 +1,2 @@
 x	input.y	/^int x;$/;"	v	line:2	typeref:typename:int
-y	input.y	/^int y;$/;"	v	line:8	typeref:typename:int
+y	input.y	/^int y;/;"	v	line:8	typeref:typename:int

--- a/main/mio.c
+++ b/main/mio.c
@@ -361,12 +361,12 @@ MIO *mio_new_memory (unsigned char *data,
  * @size: the length of the data copied from @base to new mio
  *
  * Creates a new #MIO object by copying data from existing #MIO (@base).
- * The range for copying are given with @start and @size.
+ * The range for copying is given with @start and @size.
  * Copying data at the range from @start to the end of @base is
- * done if 0 is given as @size.
+ * done if -1 is given as @size.
  *
- * If @size(!= 0) is larger than the length from @start to the end of
- * @base, %NULL is return.
+ * If @size is larger than the length from @start to the end of
+ * @base, %NULL is returned.
  *
  * The function doesn't move the file position of @base.
  *
@@ -374,7 +374,7 @@ MIO *mio_new_memory (unsigned char *data,
  *
  */
 
-MIO *mio_new_mio (MIO *base, long start, size_t size)
+MIO *mio_new_mio (MIO *base, long start, long size)
 {
 	unsigned char *data;
 	long original_pos;
@@ -383,7 +383,7 @@ MIO *mio_new_mio (MIO *base, long start, size_t size)
 
 	original_pos = mio_tell (base);
 
-	if (size == 0)
+	if (size == -1)
 	{
 		long end;
 

--- a/main/mio.h
+++ b/main/mio.h
@@ -123,7 +123,7 @@ MIO *mio_new_memory (unsigned char *data,
 					 MIOReallocFunc realloc_func,
 					 MIODestroyNotify free_func);
 
-MIO *mio_new_mio    (MIO *base, long start, size_t size);
+MIO *mio_new_mio    (MIO *base, long start, long size);
 MIO *mio_ref        (MIO *mio);
 
 int mio_free (MIO *mio);

--- a/main/parse.c
+++ b/main/parse.c
@@ -854,7 +854,7 @@ struct getLangCtx {
 		    (mio_memory_get_data((_glc_)->input, NULL) == NULL)) \
 		{							\
 			MIO *tmp_ = (_glc_)->input;			\
-			(_glc_)->input = mio_new_mio (tmp_, 0, 0);	\
+			(_glc_)->input = mio_new_mio (tmp_, 0, -1);	\
 			mio_free (tmp_);				\
 			if (!(_glc_)->input) {				\
 				(_glc_)->err = true;			\

--- a/parsers/yacc.c
+++ b/parsers/yacc.c
@@ -102,22 +102,25 @@ static bool leave_union (const char *line CTAGS_ATTR_UNUSED,
 
 static void make_promise_for_epilogue (void)
 {
-	const unsigned char *tmp, *last;
+	const unsigned char *tmp;
 	long endCharOffset;
 	unsigned long c_start;
 	unsigned long c_source_start;
 	unsigned long c_end;
 
-	c_start = getInputLineNumber ();
-	c_source_start = getSourceLineNumber();
+	/* We are at line with %% so the next line is the start of epilogue */
+	c_start = getInputLineNumber () + 1;
+	c_source_start = getSourceLineNumber() + 1;
 
 	/* Skip the lines for finding the EOF. */
 	endCharOffset = 0;
-	last = NULL;
 	while ((tmp = readLineFromInputFile ()))
-		last = tmp;
-	if (last)
-		endCharOffset = strlen ((const char *)last);
+	{
+		/* We want to get strlen() of the last line only but because
+		 * readLineFromInputFile() invalidates the previous value, get
+		 * endCharOffset here while the tmp variable is valid. */
+		endCharOffset = strlen ((const char *)tmp);
+	}
 	/* If `last' is too long, strlen returns a too large value
 	   for the positive area of `endCharOffset'. */
 	if (endCharOffset < 0)
@@ -199,8 +202,7 @@ static void runYaccParser (void)
 		}
 		else if (parserState.area == YACC_C_EPILOGUE)
 		{
-			if (readLineFromInputFile ())
-				make_promise_for_epilogue ();
+			make_promise_for_epilogue ();
 		}
 		last_area = parserState.area;
 	}


### PR DESCRIPTION
Consider for instance the following HTML code where a subparser is called
on the contents of the <script> tags.

```
<script language="Javascript" src="./test.js"></script>
<script language="JavaScript">
...
</script>
```

Since the first <script> is empty, mio_new_mio() is called with 0 size
but with the current semantics of the API it creates MIO until the end of
the file so the whole source file to EOF is parsed. While it seems
no extra tags are generated in this case, the parsing happens
unnecessarily.

Instead of using 0, make size signed and use -1 when we want to create a
MIO till the end of the source MIO.

---

I actually noticed this problem in Geany rather than in ctags where tags started getting duplicated because of the multiple parsing. I haven't investigated enough to learn why there aren't duplicate tags in ctags in this case but I added some traces to the parsers and the extra parsing really happens when 0 is passed as the size in io_new_mio().

Also, I think it's cleaner to allow 0-sized MIO from the API point of view,