### PR TITLE
C++: Fix handling of operator[]

### DIFF
--- a/Units/parser-cxx.r/operators.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/operators.cpp.d/expected.tags
@@ -9,6 +9,7 @@ operator ()	input.cpp	/^	inline void *** operator()()$/;"	f	class:X	typeref:type
 operator ++	input.cpp	/^	inline X & operator++()$/;"	f	class:X	typeref:typename:X &	file:
 operator --	input.cpp	/^	X & operator--()$/;"	f	class:X	typeref:typename:X &	file:
 operator []	input.cpp	/^	int operator[](int)$/;"	f	class:X	typeref:typename:int	file:
+operator []	input.cpp	/^	int operator[](const X &a) const$/;"	f	class:X	typeref:typename:int	file:
 operator *	input.cpp	/^	inline friend X operator*(const X &a, const X &b)$/;"	f	typeref:typename:X	file:
 operator new	input.cpp	/^	void * operator new(size_t);$/;"	p	class:X	typeref:typename:void *	file:
 operator delete	input.cpp	/^	void operator delete(void *);$/;"	p	class:X	typeref:typename:void	file:

--- a/Units/parser-cxx.r/operators.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/operators.cpp.d/input.cpp
@@ -51,6 +51,11 @@ public:
 		return 0;
 	}
 	
+	int operator[](const X &a) const
+	{
+		return 0;
+	}
+	
 	// This should appear as member of the global namespace
 	inline friend X operator*(const X &a, const X &b)
 	{

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -132,6 +132,17 @@ CXXToken * cxxParserOpeningBracketIsLambda(void)
 		return NULL;
 	}
 
+	if(
+		t->pPrev &&
+		// namely: operator [], operator new[], operator delete[]
+		cxxTokenTypeIs(t->pPrev,CXXTokenTypeKeyword)
+	)
+	{
+		// case 6
+		CXX_DEBUG_LEAVE_TEXT("Not a lambda: keyword before []");
+		return NULL;
+	}
+
 	t = t->pNext;
 
 	if(cxxTokenTypeIs(t,CXXTokenTypeParenthesisChain))


### PR DESCRIPTION
Don't recognize operator[] as a lambda if it has a mutable or exception attribute.

Fixes #1950.