### PR TITLE
Defining interface for parsers (part 6 of 6)

### DIFF
--- a/main/field.c
+++ b/main/field.c
@@ -59,8 +59,7 @@ static const char *renderFieldAccess (const tagEntryInfo *const tag, const char 
 static const char *renderFieldKindLetter (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
 static const char *renderFieldImplementation (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
 static const char *renderFieldFile (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldPatternCommon (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldPatternCtags (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
+static const char *renderFieldPattern (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
 static const char *renderFieldRoles (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
 static const char *renderFieldRefMarker (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
 static const char *renderFieldExtras (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
@@ -114,9 +113,7 @@ static fieldDefinition fieldDefinitionsFixed [] = {
 	DEFINE_FIELD ('P', "pattern",  true,
 			   "pattern",
 			   FIELDTYPE_STRING|FIELDTYPE_BOOL,
-			   [WRITER_U_CTAGS] = renderFieldPatternCtags,
-			   [WRITER_XREF]    = renderFieldPatternCommon,
-			   [WRITER_JSON]    = renderFieldPatternCommon,
+			   [WRITER_U_CTAGS] = renderFieldPattern,
 		),
 };
 
@@ -716,7 +713,7 @@ static const char *renderFieldFile (const tagEntryInfo *const tag,
 	return renderAsIs (b, tag->isFileScope? "file": "-");
 }
 
-static const char *renderFieldPatternCommon (const tagEntryInfo *const tag,
+static const char *renderFieldPattern (const tagEntryInfo *const tag,
 				       const char *value CTAGS_ATTR_UNUSED,
 				       vString* b,
 					   bool *rejected CTAGS_ATTR_UNUSED)
@@ -734,22 +731,6 @@ static const char *renderFieldPatternCommon (const tagEntryInfo *const tag,
 		eFree (tmp);
 	}
 	return vStringValue (b);
-}
-
-static const char *renderFieldPatternCtags (const tagEntryInfo *const tag,
-				       const char *value,
-				       vString* b,
-					   bool *rejected)
-{
-	/* This is for handling 'common' of 'fortran'.  See the
-	   description of --excmd=mixed in ctags.1.  In tags output, what
-	   we call "pattern" is instructions for vi.
-
-	   However, in the other formats, pattern should be pattern as its name. */
-	if (tag->lineNumberEntry)
-		return NULL;
-
-	return renderFieldPatternCommon(tag, value, b, rejected);
 }
 
 static const char *renderFieldRefMarker (const tagEntryInfo *const tag,

--- a/main/field.c
+++ b/main/field.c
@@ -21,6 +21,7 @@
 #include "entry.h"
 #include "entry_p.h"
 #include "field.h"
+#include "field_p.h"
 #include "kind.h"
 #include "options_p.h"
 #include "parse_p.h"

--- a/main/field.c
+++ b/main/field.c
@@ -39,33 +39,34 @@ typedef struct sFieldObject {
 	fieldType sibling;
 } fieldObject;
 
-static const char *renderFieldName (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldNameNoEscape (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
-											bool *rejected);
-static const char *renderFieldInput (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldInputNoEscape (const tagEntryInfo *const tag, const char *value, vString* b,
-											 bool *rejected);
-static const char *renderFieldCompactInputLine (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldSignature (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldScope (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldScopeNoEscape (const tagEntryInfo *const tag, const char *value, vString* b,
-											 bool *rejected);
-static const char *renderFieldTyperef (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldInherits (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldKindName (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldLineNumber (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldLanguage (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldAccess (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldKindLetter (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldImplementation (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldFile (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldPattern (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldRoles (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldRefMarker (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldExtras (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldXpath (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldScopeKindName(const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
-static const char *renderFieldEnd (const tagEntryInfo *const tag, const char *value, vString* b, bool *rejected);
+static const char *renderFieldName (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldNameNoEscape (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b);
+static const char *renderFieldInput (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldInputNoEscape (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldCompactInputLine (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldSignature (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldScope (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldScopeNoEscape (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldTyperef (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldInherits (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldKindName (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldLineNumber (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldLanguage (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldAccess (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldKindLetter (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldImplementation (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldFile (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldPattern (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldRoles (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldRefMarker (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldExtras (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldXpath (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldScopeKindName(const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldEnd (const tagEntryInfo *const tag, const char *value, vString* b);
+
+static bool hasWhitespaceInName (const tagEntryInfo *const tag, const char *value);
+static bool hasWhitespaceInInput (const tagEntryInfo *const tag, const char*value);
+static bool hasWhitespaceInFieldScope (const tagEntryInfo *const tag, const char *value);
 
 static bool     isLanguageFieldAvailable  (const tagEntryInfo *const tag);
 static bool     isTyperefFieldAvailable   (const tagEntryInfo *const tag);
@@ -79,15 +80,17 @@ static bool     isXpathFieldAvailable     (const tagEntryInfo *const tag);
 static bool     isEndFieldAvailable       (const tagEntryInfo *const tag);
 
 
-#define DEFINE_FIELD(L, N, V, H, DT, ...)				\
-	DEFINE_FIELD_FULL (L, N, V, H, NULL, DT, __VA_ARGS__)
-#define DEFINE_FIELD_FULL(L, N, V, H, A, DT, ...)	\
+#define DEFINE_FIELD(L, N, V, H, DT, RE)				\
+	DEFINE_FIELD_FULL (L, N, V, H, NULL, DT, RE, NULL, NULL)
+#define DEFINE_FIELD_FULL(L, N, V, H, A, DT, RE, RN, HSC)	\
 	{					\
 		.letter        = L,		\
 		.name          = N,		\
 		.description   = H,		\
 		.enabled       = V,		\
-		.renderEscaped = { __VA_ARGS__ },		\
+		.render        = RE,		\
+		.renderNoEscaping= RN,		\
+		.hasWhitespaceChar = HSC, \
 		.isValueAvailable = A,		\
 		.dataType = DT, \
 	}
@@ -96,131 +99,128 @@ static bool     isEndFieldAvailable       (const tagEntryInfo *const tag);
 
 static fieldDefinition fieldDefinitionsFixed [] = {
         /* FIXED FIELDS */
-	DEFINE_FIELD ('N', "name",     true,
+	DEFINE_FIELD_FULL ('N', "name",     true,
 			  "tag name",
+			  NULL,
 			  FIELDTYPE_STRING,
-			  [WRITER_U_CTAGS] = renderFieldName,
-			  [WRITER_E_CTAGS] = renderFieldNameNoEscape,
-			  [WRITER_JSON]    = renderFieldNameNoEscape,
-			  ),
-	DEFINE_FIELD ('F', "input",    true,
+			  renderFieldName, renderFieldNameNoEscape,
+			  hasWhitespaceInName),
+	DEFINE_FIELD_FULL ('F', "input",    true,
 			   "input file",
+			   NULL,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldInput,
-			   [WRITER_E_CTAGS] = renderFieldInputNoEscape,
-			   [WRITER_JSON]    = renderFieldInputNoEscape,
-		),
+			   renderFieldInput, renderFieldInputNoEscape,
+			   hasWhitespaceInInput),
 	DEFINE_FIELD ('P', "pattern",  true,
 			   "pattern",
 			   FIELDTYPE_STRING|FIELDTYPE_BOOL,
-			   [WRITER_U_CTAGS] = renderFieldPattern,
-		),
+			   renderFieldPattern),
 };
 
 static fieldDefinition fieldDefinitionsExuberant [] = {
 	DEFINE_FIELD ('C', "compact",        false,
 			   "compact input line (used only in xref output)",
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldCompactInputLine),
+			   renderFieldCompactInputLine),
 
 	/* EXTENSION FIELDS */
 	DEFINE_FIELD_FULL ('a', "access",         false,
 		      "Access (or export) of class members",
 			  isAccessFieldAvailable,
 			  FIELDTYPE_STRING,
-		      [WRITER_U_CTAGS] = renderFieldAccess),
+		      renderFieldAccess, NULL, NULL),
 	DEFINE_FIELD_FULL ('f', "file",           true,
 		      "File-restricted scoping",
 			  isFileFieldAvailable,
 			  FIELDTYPE_BOOL,
-		      [WRITER_U_CTAGS] = renderFieldFile),
+		      renderFieldFile, NULL, NULL),
 	DEFINE_FIELD_FULL ('i', "inherits",       false,
 		      "Inheritance information",
 			  isInheritsFieldAvailable,
 			  FIELDTYPE_STRING|FIELDTYPE_BOOL,
-		      [WRITER_U_CTAGS] = renderFieldInherits),
+		      renderFieldInherits, NULL, NULL),
 	DEFINE_FIELD ('K', NULL,             false,
 		      "Kind of tag as full name",
 		      FIELDTYPE_STRING,
-		      [WRITER_U_CTAGS] = renderFieldKindName),
+		      renderFieldKindName),
 	DEFINE_FIELD ('k', NULL,             true,
 			   "Kind of tag as a single letter",
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldKindLetter),
+			   renderFieldKindLetter),
 	DEFINE_FIELD_FULL ('l', "language",       false,
 			   "Language of input file containing tag",
 			   isLanguageFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldLanguage),
+			   renderFieldLanguage, NULL, NULL),
 	DEFINE_FIELD_FULL ('m', "implementation", false,
 			   "Implementation information",
 			   isImplementationFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldImplementation),
+			   renderFieldImplementation, NULL, NULL),
 	DEFINE_FIELD ('n', "line",           false,
 			   "Line number of tag definition",
 			   FIELDTYPE_INTEGER,
-			   [WRITER_U_CTAGS] = renderFieldLineNumber),
+			   renderFieldLineNumber),
 	DEFINE_FIELD_FULL ('S', "signature",	     false,
 			   "Signature of routine (e.g. prototype or parameter list)",
 			   isSignatureFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldSignature),
-	DEFINE_FIELD ('s', NULL,             true,
+			   renderFieldSignature, NULL, NULL),
+	DEFINE_FIELD_FULL ('s', NULL,             true,
 			   "Scope of tag definition (`p' can be used for printing its kind)",
+			   NULL,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldScope,
-			   [WRITER_E_CTAGS] = renderFieldScopeNoEscape,
-			   [WRITER_JSON]    = renderFieldScopeNoEscape),
+			   renderFieldScope, renderFieldScopeNoEscape,
+			   hasWhitespaceInFieldScope),
 	DEFINE_FIELD_FULL ('t', "typeref",        true,
 			   "Type and name of a variable or typedef",
 			   isTyperefFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldTyperef),
+			   renderFieldTyperef, NULL, NULL),
 	DEFINE_FIELD ('z', "kind",           false,
 			   "Include the \"kind:\" key in kind field (use k or K) in tags output, kind full name in xref output",
 			   FIELDTYPE_STRING,
 			   /* Following renderer is for handling --_xformat=%{kind};
 			      and is not for tags output. */
-			   [WRITER_U_CTAGS] = renderFieldKindName),
+			   renderFieldKindName),
 };
 
 static fieldDefinition fieldDefinitionsUniversal [] = {
 	DEFINE_FIELD ('r', "roles",    false,
 			   "Roles",
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldRoles),
+			   renderFieldRoles),
 	DEFINE_FIELD ('R',  NULL,     false,
 			   "Marker (R or D) representing whether tag is definition or reference",
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldRefMarker),
-	DEFINE_FIELD ('Z', "scope",   false,
+			   renderFieldRefMarker),
+	DEFINE_FIELD_FULL ('Z', "scope",   false,
 			  "Include the \"scope:\" key in scope field (use s) in tags output, scope name in xref output",
+			   NULL,
 			   FIELDTYPE_STRING,
 			   /* Following renderer is for handling --_xformat=%{scope};
 			      and is not for tags output. */
-			   [WRITER_U_CTAGS] = renderFieldScope,
-			   [WRITER_E_CTAGS] = renderFieldScopeNoEscape,
-			   [WRITER_JSON]    = renderFieldScopeNoEscape),
+			   renderFieldScope, renderFieldScopeNoEscape,
+			   hasWhitespaceInFieldScope),
 	DEFINE_FIELD_FULL ('E', "extras",   false,
 			   "Extra tag type information",
 			   isExtrasFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldExtras),
+			   renderFieldExtras, NULL, NULL),
 	DEFINE_FIELD_FULL ('x', "xpath",   false,
 			   "xpath for the tag",
 			   isXpathFieldAvailable,
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldXpath),
+			   renderFieldXpath, NULL, NULL),
 	DEFINE_FIELD ('p', "scopeKind", false,
 			   "Kind of scope as full name",
 			   FIELDTYPE_STRING,
-			   [WRITER_U_CTAGS] = renderFieldScopeKindName),
+			   renderFieldScopeKindName),
 	DEFINE_FIELD_FULL ('e', "end", false,
 			   "end lines of various items",
 			   isEndFieldAvailable,
 			   FIELDTYPE_INTEGER,
-			   [WRITER_U_CTAGS] = renderFieldEnd),
+			   renderFieldEnd, NULL, NULL),
 };
 
 
@@ -421,25 +421,22 @@ static const char *renderEscapedName (const bool isTagName,
 	return renderEscapedString (s, tag, b);
 }
 
-static const char *renderFieldName (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
-									bool *rejected CTAGS_ATTR_UNUSED)
+static const char *renderFieldName (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	return renderEscapedName (true, tag->name, tag, b);
 }
 
-static const char *renderFieldNameNoEscape (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
-											bool *rejected)
+static const char *renderFieldNameNoEscape (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
-	if (strpbrk (tag->name, " \t"))
-	{
-		*rejected = true;
-		return NULL;
-	}
 	return renderAsIs (b, tag->name);
 }
 
-static const char *renderFieldInput (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
-									 bool *rejected CTAGS_ATTR_UNUSED)
+static bool hasWhitespaceInName (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED)
+{
+	return strpbrk (tag->name, " \t")? true: false;
+}
+
+static const char *renderFieldInput (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	const char *f = tag->inputFileName;
 
@@ -448,32 +445,33 @@ static const char *renderFieldInput (const tagEntryInfo *const tag, const char *
 	return renderEscapedString (f, tag, b);
 }
 
-static const char *renderFieldInputNoEscape (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
-											 bool *rejected)
+static const char *renderFieldInputNoEscape (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	const char *f = tag->inputFileName;
 
 	if (Option.lineDirectives && tag->sourceFileName)
 		f = tag->sourceFileName;
 
-	if (strpbrk (f, " \t"))
-	{
-		*rejected = true;
-		return NULL;
-	}
-
 	return renderAsIs (b, f);
 }
 
-static const char *renderFieldSignature (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
-										 bool *rejected CTAGS_ATTR_UNUSED)
+static bool hasWhitespaceInInput (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED)
+{
+	const char *f = tag->inputFileName;
+
+	if (Option.lineDirectives && tag->sourceFileName)
+		f = tag->sourceFileName;
+
+	return strpbrk (f, " \t")? true: false;
+}
+
+static const char *renderFieldSignature (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	return renderEscapedString (WITH_DEFUALT_VALUE (tag->extensionFields.signature),
 				    tag, b);
 }
 
-static const char *renderFieldScope (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
-									 bool *rejected CTAGS_ATTR_UNUSED)
+static const char *renderFieldScope (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	const char* scope;
 
@@ -481,30 +479,30 @@ static const char *renderFieldScope (const tagEntryInfo *const tag, const char *
 	return scope? renderEscapedName (false, scope, tag, b): NULL;
 }
 
-static const char *renderFieldScopeNoEscape (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
-											 bool *rejected)
+static const char *renderFieldScopeNoEscape (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	const char* scope;
 
 	getTagScopeInformation ((tagEntryInfo *const)tag, NULL, &scope);
-	if (scope && strpbrk (scope, " \t"))
-	{
-		*rejected = true;
-		return NULL;
-	}
-
 	return scope? renderAsIs (b, scope): NULL;
 }
 
-static const char *renderFieldInherits (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
-										bool *rejected CTAGS_ATTR_UNUSED)
+static bool hasWhitespaceInFieldScope (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED)
+{
+	const char* scope;
+
+	getTagScopeInformation ((tagEntryInfo *const)tag, NULL, &scope);
+	return (scope && strpbrk (scope, " \t"));
+}
+
+
+static const char *renderFieldInherits (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	return renderEscapedString (WITH_DEFUALT_VALUE (tag->extensionFields.inheritance),
 				    tag, b);
 }
 
-static const char *renderFieldTyperef (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
-									   bool *rejected CTAGS_ATTR_UNUSED)
+static const char *renderFieldTyperef (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	/* Return "-" instead of "-:-". */
 	if (tag->extensionFields.typeRef [0] == NULL
@@ -517,22 +515,17 @@ static const char *renderFieldTyperef (const tagEntryInfo *const tag, const char
 }
 
 
-extern const char* renderFieldEscaped (writerType writer,
-				      fieldType type,
-				       const tagEntryInfo *tag,
-				       int index,
-					   bool *rejected)
+static const char* renderFieldCommon (fieldType type,
+									  const tagEntryInfo *tag,
+									  int index,
+									  bool noEscaping)
 {
 	fieldObject *fobj = fieldObjects + type;
 	const char *value;
-	renderEscaped rfn;
-	bool stub;
+	fieldRenderer rfn;
 
 	Assert (tag);
-	Assert (fobj->def->renderEscaped);
 	Assert (index < 0 || ((unsigned int)index) < tag->usedParserFields);
-
-	fobj->buffer = vStringNewOrClearWithAutoRelease (fobj->buffer);
 
 	if (index >= 0)
 	{
@@ -543,13 +536,47 @@ extern const char* renderFieldEscaped (writerType writer,
 	else
 		value = NULL;
 
-	rfn = fobj->def->renderEscaped [writer];
-	if (rfn == NULL)
-		rfn = fobj->def->renderEscaped [WRITER_DEFAULT];
+	if (noEscaping)
+		rfn = fobj->def->renderNoEscaping;
+	else
+		rfn = fobj->def->render;
+	Assert (rfn);
 
-	if (!rejected)
-		rejected = &stub;
-	return rfn (tag, value, fobj->buffer, rejected);
+	fobj->buffer = vStringNewOrClearWithAutoRelease (fobj->buffer);
+	return rfn (tag, value, fobj->buffer);
+}
+
+extern const char* renderField (fieldType type, const tagEntryInfo *tag, int index)
+{
+	return renderFieldCommon (type, tag, index, false);
+}
+
+extern const char* renderFieldNoEscaping (fieldType type, const tagEntryInfo *tag, int index)
+{
+	return renderFieldCommon (type, tag, index, true);
+}
+
+extern bool  doesFieldHaveWhitespaceChar (fieldType type, const tagEntryInfo *tag, int index)
+{
+	fieldObject *fobj = fieldObjects + type;
+	const char *value;
+
+	if (!fobj->def->hasWhitespaceChar)
+		return false;
+
+	Assert (tag);
+	Assert (index < 0 || ((unsigned int)index) < tag->usedParserFields);
+
+	if (index >= 0)
+	{
+		const tagField *f = getParserField (tag, index);
+
+		value = f->value;
+	}
+	else
+		value = NULL;
+
+	return fobj->def->hasWhitespaceChar (tag, value);
 }
 
 /*  Writes "line", stripping leading and duplicate white space.
@@ -584,8 +611,7 @@ static const char* renderCompactInputLine (vString *b,  const char *const line)
 	return vStringValue (b);
 }
 
-static const char *renderFieldKindName (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b,
-										bool *rejected CTAGS_ATTR_UNUSED)
+static const char *renderFieldKindName (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
 {
 	const char* name = getTagKindName (tag);
 	return renderAsIs (b, name);
@@ -593,8 +619,7 @@ static const char *renderFieldKindName (const tagEntryInfo *const tag, const cha
 
 static const char *renderFieldCompactInputLine (const tagEntryInfo *const tag,
 						const char *value CTAGS_ATTR_UNUSED,
-						 vString* b,
-						bool *rejected CTAGS_ATTR_UNUSED)
+						 vString* b)
 {
 	const char *line;
 	static vString *tmp;
@@ -618,8 +643,7 @@ static const char *renderFieldCompactInputLine (const tagEntryInfo *const tag,
 
 static const char *renderFieldLineNumber (const tagEntryInfo *const tag,
 					  const char *value CTAGS_ATTR_UNUSED,
-					  vString* b,
-					  bool *rejected CTAGS_ATTR_UNUSED)
+					  vString* b)
 {
 	long ln = tag->lineNumber;
 	char buf[32] = {[0] = '\0'};
@@ -633,8 +657,7 @@ static const char *renderFieldLineNumber (const tagEntryInfo *const tag,
 
 static const char *renderFieldRoles (const tagEntryInfo *const tag,
 				    const char *value CTAGS_ATTR_UNUSED,
-				    vString* b,
-					bool *rejected CTAGS_ATTR_UNUSED)
+				    vString* b)
 {
 	roleBitsType rbits = tag->extensionFields.roleBits;
 	const roleDefinition * role;
@@ -664,8 +687,7 @@ static const char *renderFieldRoles (const tagEntryInfo *const tag,
 
 static const char *renderFieldLanguage (const tagEntryInfo *const tag,
 					const char *value CTAGS_ATTR_UNUSED,
-					vString* b,
-					bool *rejected CTAGS_ATTR_UNUSED)
+					vString* b)
 {
 	const char *l;
 
@@ -679,16 +701,14 @@ static const char *renderFieldLanguage (const tagEntryInfo *const tag,
 
 static const char *renderFieldAccess (const tagEntryInfo *const tag,
 				      const char *value CTAGS_ATTR_UNUSED,
-				      vString* b,
-					  bool *rejected CTAGS_ATTR_UNUSED)
+				      vString* b)
 {
 	return renderAsIs (b, WITH_DEFUALT_VALUE (tag->extensionFields.access));
 }
 
 static const char *renderFieldKindLetter (const tagEntryInfo *const tag,
 					  const char *value CTAGS_ATTR_UNUSED,
-					  vString* b,
-					  bool *rejected CTAGS_ATTR_UNUSED)
+					  vString* b)
 {
 	static char c[2] = { [1] = '\0' };
 
@@ -699,24 +719,21 @@ static const char *renderFieldKindLetter (const tagEntryInfo *const tag,
 
 static const char *renderFieldImplementation (const tagEntryInfo *const tag,
 					      const char *value CTAGS_ATTR_UNUSED,
-					      vString* b,
-						  bool *rejected CTAGS_ATTR_UNUSED)
+					      vString* b)
 {
 	return renderAsIs (b, WITH_DEFUALT_VALUE (tag->extensionFields.implementation));
 }
 
 static const char *renderFieldFile (const tagEntryInfo *const tag,
 				    const char *value CTAGS_ATTR_UNUSED,
-				    vString* b,
-					bool *rejected CTAGS_ATTR_UNUSED)
+				    vString* b)
 {
 	return renderAsIs (b, tag->isFileScope? "file": "-");
 }
 
 static const char *renderFieldPattern (const tagEntryInfo *const tag,
 				       const char *value CTAGS_ATTR_UNUSED,
-				       vString* b,
-					   bool *rejected CTAGS_ATTR_UNUSED)
+				       vString* b)
 {
 	if (tag->isFileEntry)
 		return NULL;
@@ -735,8 +752,7 @@ static const char *renderFieldPattern (const tagEntryInfo *const tag,
 
 static const char *renderFieldRefMarker (const tagEntryInfo *const tag,
 					 const char *value CTAGS_ATTR_UNUSED,
-					 vString* b,
-					 bool *rejected CTAGS_ATTR_UNUSED)
+					 vString* b)
 {
 	static char c[2] = { [1] = '\0' };
 
@@ -747,8 +763,7 @@ static const char *renderFieldRefMarker (const tagEntryInfo *const tag,
 
 static const char *renderFieldExtras (const tagEntryInfo *const tag,
 				     const char *value CTAGS_ATTR_UNUSED,
-				     vString* b,
-					 bool *rejected CTAGS_ATTR_UNUSED)
+				     vString* b)
 {
 	int i;
 	bool hasExtra = false;
@@ -779,8 +794,7 @@ static const char *renderFieldExtras (const tagEntryInfo *const tag,
 
 static const char *renderFieldXpath (const tagEntryInfo *const tag,
 				     const char *value CTAGS_ATTR_UNUSED,
-				     vString* b,
-					 bool *rejected CTAGS_ATTR_UNUSED)
+				     vString* b)
 {
 #ifdef HAVE_LIBXML
 	if (tag->extensionFields.xpath)
@@ -792,8 +806,7 @@ static const char *renderFieldXpath (const tagEntryInfo *const tag,
 
 static const char *renderFieldScopeKindName(const tagEntryInfo *const tag,
 					    const char *value CTAGS_ATTR_UNUSED,
-					    vString* b,
-						bool *rejected CTAGS_ATTR_UNUSED)
+					    vString* b)
 {
 	const char* kind;
 
@@ -803,8 +816,7 @@ static const char *renderFieldScopeKindName(const tagEntryInfo *const tag,
 
 static const char *renderFieldEnd (const tagEntryInfo *const tag,
 				   const char *value CTAGS_ATTR_UNUSED,
-				   vString* b,
-				   bool *rejected CTAGS_ATTR_UNUSED)
+				   vString* b)
 {
 	static char buf[16];
 
@@ -944,9 +956,12 @@ extern unsigned int getFieldDataType (fieldType type)
 	return getFieldObject(type)->def->dataType;
 }
 
-extern bool doesFieldHaveRenderer (fieldType type)
+extern bool doesFieldHaveRenderer (fieldType type, bool noEscaping)
 {
-	return getFieldObject(type)->def->renderEscaped [WRITER_DEFAULT]? true: false;
+	if (noEscaping)
+		return getFieldObject(type)->def->renderNoEscaping? true: false;
+	else
+		return getFieldObject(type)->def->render? true: false;
 }
 
 extern int countFields (void)
@@ -981,8 +996,7 @@ static void updateSiblingField (fieldType type, const char* name)
 
 static const char* defaultRenderer (const tagEntryInfo *const tag CTAGS_ATTR_UNUSED,
 				    const char *value,
-				    vString * buffer CTAGS_ATTR_UNUSED,
-					bool *rejected CTAGS_ATTR_UNUSED)
+				    vString * buffer CTAGS_ATTR_UNUSED)
 {
 	return value;
 }
@@ -1009,8 +1023,12 @@ extern int defineField (fieldDefinition *def, langType language)
 	fobj = fieldObjects + (fieldObjectUsed);
 	def->ftype = fieldObjectUsed++;
 
-	if (def->renderEscaped [WRITER_DEFAULT] == NULL)
-		def->renderEscaped [WRITER_DEFAULT] = defaultRenderer;
+	if (def->render == NULL)
+	{
+		def->render = defaultRenderer;
+		def->renderNoEscaping = NULL;
+		def->hasWhitespaceChar = NULL;
+	}
 
 	if (! def->dataType)
 		def->dataType = FIELDTYPE_STRING;

--- a/main/field.c
+++ b/main/field.c
@@ -944,7 +944,7 @@ extern unsigned int getFieldDataType (fieldType type)
 	return getFieldObject(type)->def->dataType;
 }
 
-extern bool isFieldRenderable (fieldType type)
+extern bool doesFieldHaveRenderer (fieldType type)
 {
 	return getFieldObject(type)->def->renderEscaped [WRITER_DEFAULT]? true: false;
 }

--- a/main/field.h
+++ b/main/field.h
@@ -58,7 +58,6 @@ typedef const char* (* renderEscaped) (const tagEntryInfo *const tag,
 				       const char *value,
 				       vString * buffer,
 					   bool *rejected);
-typedef bool (* isValueAvailable) (const struct sTagEntryInfo *const tag);
 
 #define fieldDataTypeFalgs "sib" /* used in --list-fields */
 typedef enum eFieldDataType {
@@ -80,7 +79,7 @@ struct sFieldDefinition {
 	const char* description;
 	bool enabled;
 	renderEscaped renderEscaped [WRITER_COUNT];
-	isValueAvailable isValueAvailable;
+	bool (* isValueAvailable) (const tagEntryInfo *const);
 	fieldDataType dataType; /* used in json output */
 
 	unsigned int ftype;	/* Given from the main part */

--- a/main/field.h
+++ b/main/field.h
@@ -112,7 +112,7 @@ extern void printFields (int language);
 
 /* Whether the field specified with TYPE has a
    method for rendering in the current format. */
-extern bool isFieldRenderable (fieldType type);
+extern bool doesFieldHaveRenderer (fieldType type);
 
 extern bool doesFieldHaveValue (fieldType type, const tagEntryInfo *tag);
 extern const char* renderFieldEscaped (writerType writer, fieldType type, const tagEntryInfo *tag, int index,

--- a/main/field.h
+++ b/main/field.h
@@ -12,11 +12,18 @@
 #ifndef CTAGS_MAIN_FIELD_H
 #define CTAGS_MAIN_FIELD_H
 
+/*
+*   INCLUDE FILES
+*/
+
 #include "general.h"
-#include "colprint_p.h"
 #include "types.h"
 
 #include "vstring.h"
+
+/*
+*   DATA DECLARATIONS
+*/
 
 typedef enum eFieldType { /* extension field content control */
 	FIELD_UNKNOWN = -1,
@@ -89,52 +96,10 @@ struct sFieldDefinition {
 };
 
 
-extern fieldType getFieldTypeForOption (char letter);
-
 /*
-   `getFieldTypeForName' is for looking for a field not owned by any parser,
+*   FUNCTION PROTOTYPES
+*/
 
-   `getFieldTypeForNameAndLanguage' can be used for getting all fields having
-   the same name; specify `LANG_AUTO' as `language' parameter to get the first
-   field having the name. With the returned fieldType, `nextSiblingField' gets
-   the next field having the same name. `nextSiblingField' returns `FIELD_UNKNOWN'
-   at the end of iteration.
-
-   Specifying `LANG_IGNORE' has the same effects as `LANG_AUTO'. However,
-   internally, each parser is not initialized. `LANG_IGNORE' is a bit faster. */
-extern fieldType getFieldTypeForName (const char *name);
-extern fieldType getFieldTypeForNameAndLanguage (const char *fieldName, langType language);
 extern bool isFieldEnabled (fieldType type);
-extern bool enableField (fieldType type, bool state, bool warnIfFixedField);
-extern bool isCommonField (fieldType type);
-extern int     getFieldOwner (fieldType type);
-extern const char* getFieldName (fieldType type);
-extern unsigned int getFieldDataType (fieldType type);
-extern void printFields (int language);
-
-/* Whether the field specified with TYPE has a
-   method for rendering in the current format. */
-extern bool doesFieldHaveRenderer (fieldType type, bool noEscaping);
-
-extern bool doesFieldHaveValue (fieldType type, const tagEntryInfo *tag);
-
-extern const char* renderField (fieldType type, const tagEntryInfo *tag, int index);
-extern const char* renderFieldNoEscaping (fieldType type, const tagEntryInfo *tag, int index);
-extern bool  doesFieldHaveWhitespaceChar (fieldType type, const tagEntryInfo *tag, int index);
-
-extern void initFieldObjects (void);
-extern int countFields (void);
-
-/* language should be typed to langType.
-   Use int here to avoid circular dependency */
-extern int defineField (fieldDefinition *spec, langType language);
-extern fieldType nextSiblingField (fieldType type);
-
-/* --list-fields implementation. LANGUAGE must be initialized. */
-extern struct colprintTable * fieldColprintTableNew (void);
-extern void fieldColprintAddCommonLines (struct colprintTable *table);
-extern void fieldColprintAddLanguageLines (struct colprintTable *table, langType language);
-extern void fieldColprintTablePrint (struct colprintTable *table,
-									 bool withListHeader, bool machinable, FILE *fp);
 
 #endif	/* CTAGS_MAIN_FIELD_H */

--- a/main/field_p.h
+++ b/main/field_p.h
@@ -1,0 +1,78 @@
+/*
+ *
+ *  Copyright (c) 2015, Red Hat, Inc.
+ *  Copyright (c) 2015, Masatake YAMATO
+ *
+ *  Author: Masatake YAMATO <yamato@redhat.com>
+ *
+ *   This source code is released for free distribution under the terms of the
+ *   GNU General Public License version 2 or (at your option) any later version.
+ *
+ */
+#ifndef CTAGS_MAIN_FIELD_PRIVATE_H
+#define CTAGS_MAIN_FIELD_PRIVATE_H
+
+/*
+*   INCLUDE FILES
+*/
+#include "general.h"
+#include "colprint_p.h"
+#include "field.h"
+
+/*
+*   DATA DECLARATIONS
+*/
+
+
+/*
+*   FUNCTION PROTOTYPES
+*/
+
+extern fieldType getFieldTypeForOption (char letter);
+
+/*
+   `getFieldTypeForName' is for looking for a field not owned by any parser,
+
+   `getFieldTypeForNameAndLanguage' can be used for getting all fields having
+   the same name; specify `LANG_AUTO' as `language' parameter to get the first
+   field having the name. With the returned fieldType, `nextSiblingField' gets
+   the next field having the same name. `nextSiblingField' returns `FIELD_UNKNOWN'
+   at the end of iteration.
+
+   Specifying `LANG_IGNORE' has the same effects as `LANG_AUTO'. However,
+   internally, each parser is not initialized. `LANG_IGNORE' is a bit faster. */
+extern fieldType getFieldTypeForName (const char *name);
+extern fieldType getFieldTypeForNameAndLanguage (const char *fieldName, langType language);
+extern bool enableField (fieldType type, bool state, bool warnIfFixedField);
+extern bool isCommonField (fieldType type);
+extern int     getFieldOwner (fieldType type);
+extern const char* getFieldName (fieldType type);
+extern unsigned int getFieldDataType (fieldType type);
+extern void printFields (int language);
+
+/* Whether the field specified with TYPE has a
+   method for rendering in the current format. */
+extern bool doesFieldHaveRenderer (fieldType type, bool noEscaping);
+
+extern bool doesFieldHaveValue (fieldType type, const tagEntryInfo *tag);
+
+extern const char* renderField (fieldType type, const tagEntryInfo *tag, int index);
+extern const char* renderFieldNoEscaping (fieldType type, const tagEntryInfo *tag, int index);
+extern bool  doesFieldHaveWhitespaceChar (fieldType type, const tagEntryInfo *tag, int index);
+
+extern void initFieldObjects (void);
+extern int countFields (void);
+
+/* language should be typed to langType.
+   Use int here to avoid circular dependency */
+extern int defineField (fieldDefinition *spec, langType language);
+extern fieldType nextSiblingField (fieldType type);
+
+/* --list-fields implementation. LANGUAGE must be initialized. */
+extern struct colprintTable * fieldColprintTableNew (void);
+extern void fieldColprintAddCommonLines (struct colprintTable *table);
+extern void fieldColprintAddLanguageLines (struct colprintTable *table, langType language);
+extern void fieldColprintTablePrint (struct colprintTable *table,
+									 bool withListHeader, bool machinable, FILE *fp);
+
+#endif	/* CTAGS_MAIN_FIELD_PRIVATE_H */

--- a/main/fmt.c
+++ b/main/fmt.c
@@ -60,8 +60,7 @@ static int printTagField (fmtSpec* fspec, MIO* fp, const tagEntryInfo * tag)
 	ftype = fspec->field.ftype;
 
 	if (isCommonField (ftype))
-		/* TODO: Don't use WRITER_XREF directly */
-		str = renderFieldEscaped (WRITER_XREF, ftype, tag, NO_PARSER_FIELD, NULL);
+		str = renderField (ftype, tag, NO_PARSER_FIELD);
 	else
 	{
 		unsigned int findex;
@@ -77,9 +76,7 @@ static int printTagField (fmtSpec* fspec, MIO* fp, const tagEntryInfo * tag)
 		if (findex == tag->usedParserFields)
 			str = "";
 		else if (isFieldEnabled (f->ftype))
-			/* TODO: Don't use WRITER_XREF directly */
-			str = renderFieldEscaped (WRITER_XREF, f->ftype,
-						  tag, findex, NULL);
+			str = renderField (f->ftype, tag, findex);
 	}
 
 	if (str == NULL)
@@ -192,7 +189,7 @@ static fmtElement** queueTagField (fmtElement **last, long width, bool truncatio
 			error (FATAL, "No such field letter: %c", field_letter);
 	}
 
-	if (!doesFieldHaveRenderer (ftype))
+	if (!doesFieldHaveRenderer (ftype, false))
 	{
 		Assert (field_letter != NUL_FIELD_LETTER);
 		error (FATAL, "The field cannot be printed in format output: %c", field_letter);

--- a/main/fmt.c
+++ b/main/fmt.c
@@ -15,6 +15,7 @@
 #include "entry_p.h"
 #include "fmt_p.h"
 #include "field.h"
+#include "field_p.h"
 #include "parse.h"
 #include "routines.h"
 #include <string.h>

--- a/main/fmt.c
+++ b/main/fmt.c
@@ -192,7 +192,7 @@ static fmtElement** queueTagField (fmtElement **last, long width, bool truncatio
 			error (FATAL, "No such field letter: %c", field_letter);
 	}
 
-	if (!isFieldRenderable (ftype))
+	if (!doesFieldHaveRenderer (ftype))
 	{
 		Assert (field_letter != NUL_FIELD_LETTER);
 		error (FATAL, "The field cannot be printed in format output: %c", field_letter);

--- a/main/kind.c
+++ b/main/kind.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "colprint_p.h"
 #include "ctags.h"
 #include "debug.h"
 #include "entry.h"

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -28,6 +28,7 @@
 #include "debug.h"
 #include "colprint_p.h"
 #include "entry_p.h"
+#include "field_p.h"
 #include "flags_p.h"
 #include "htable.h"
 #include "kind.h"

--- a/main/main.c
+++ b/main/main.c
@@ -65,7 +65,7 @@
 #include "debug.h"
 #include "entry_p.h"
 #include "error_p.h"
-#include "field.h"
+#include "field_p.h"
 #include "keyword_p.h"
 #include "main_p.h"
 #include "options_p.h"

--- a/main/options.c
+++ b/main/options.c
@@ -25,7 +25,7 @@
 
 #include "ctags.h"
 #include "debug.h"
-#include "field.h"
+#include "field_p.h"
 #include "gvars.h"
 #include "keyword_p.h"
 #include "main_p.h"

--- a/main/parse.c
+++ b/main/parse.c
@@ -22,6 +22,7 @@
 #include "ctags.h"
 #include "debug.h"
 #include "entry_p.h"
+#include "field_p.h"
 #include "flags_p.h"
 #include "htable.h"
 #include "keyword.h"

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -241,6 +241,11 @@ static int writeCtagsEntry (tagWriter *writer,
 			      escapeFieldValue (writer, tag, FIELD_NAME),
 			      escapeFieldValue (writer, tag, FIELD_INPUT_FILE));
 
+	/* This is for handling 'common' of 'fortran'.  See the
+	   description of --excmd=mixed in ctags.1.  In tags output, what
+	   we call "pattern" is instructions for vi.
+
+	   However, in the other formats, pattern should be pattern as its name. */
 	if (tag->lineNumberEntry)
 		length += writeLineNumberEntry (writer, mio, tag);
 	else

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -10,6 +10,7 @@
 #include "general.h"  /* must always come first */
 
 #include "entry_p.h"
+#include "field_p.h"
 #include "mio.h"
 #include "options_p.h"
 #include "parse_p.h"

--- a/main/writer-json.c
+++ b/main/writer-json.c
@@ -51,7 +51,13 @@ tagWriter jsonWriter = {
 
 static json_t* escapeFieldValue (const tagEntryInfo * tag, fieldType ftype, bool returnEmptyStringAsNoValue)
 {
-	const char *str = renderFieldEscaped (jsonWriter.type, ftype, tag, NO_PARSER_FIELD, NULL);
+	const char *str;
+
+	if (doesFieldHaveRenderer (ftype, true))
+		str = renderFieldNoEscaping (ftype, tag, NO_PARSER_FIELD);
+	else
+		str = renderField (ftype, tag, NO_PARSER_FIELD);
+
 	if (str)
 	{
 		unsigned int dt = getFieldDataType(ftype);
@@ -90,7 +96,7 @@ static void renderExtensionFieldMaybe (int xftype, const tagEntryInfo *const tag
 {
 	const char *fname = getFieldName (xftype);
 
-	if (fname && doesFieldHaveRenderer (xftype) && isFieldEnabled (xftype) && doesFieldHaveValue (xftype, tag))
+	if (fname && doesFieldHaveRenderer (xftype, false) && isFieldEnabled (xftype) && doesFieldHaveValue (xftype, tag))
 	{
 		switch (xftype)
 		{
@@ -181,10 +187,8 @@ static int writeJsonEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 
 static void buildJsonFqTagCache (tagWriter *writer, tagEntryInfo *const tag)
 {
-	renderFieldEscaped (writer->type, FIELD_SCOPE_KIND_LONG, tag,
-			    NO_PARSER_FIELD, NULL);
-	renderFieldEscaped (writer->type, FIELD_SCOPE, tag,
-			    NO_PARSER_FIELD, NULL);
+	renderField (FIELD_SCOPE_KIND_LONG, tag, NO_PARSER_FIELD);
+	renderField (FIELD_SCOPE, tag, NO_PARSER_FIELD);
 }
 
 static int writeJsonPtagEntry (tagWriter *writer CTAGS_ATTR_UNUSED,

--- a/main/writer-json.c
+++ b/main/writer-json.c
@@ -90,7 +90,7 @@ static void renderExtensionFieldMaybe (int xftype, const tagEntryInfo *const tag
 {
 	const char *fname = getFieldName (xftype);
 
-	if (fname && isFieldRenderable (xftype) && isFieldEnabled (xftype) && doesFieldHaveValue (xftype, tag))
+	if (fname && doesFieldHaveRenderer (xftype) && isFieldEnabled (xftype) && doesFieldHaveValue (xftype, tag))
 	{
 		switch (xftype)
 		{

--- a/main/writer-json.c
+++ b/main/writer-json.c
@@ -11,6 +11,7 @@
 
 #include "debug.h"
 #include "entry_p.h"
+#include "field_p.h"
 #include "mio.h"
 #include "options_p.h"
 #include "read.h"

--- a/main/writer-xref.c
+++ b/main/writer-xref.c
@@ -65,8 +65,6 @@ static int writeXrefEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 
 static void buildXrefFqTagCache (tagWriter *writer, tagEntryInfo *const tag)
 {
-	renderFieldEscaped (writer->type, FIELD_SCOPE_KIND_LONG, tag,
-			    NO_PARSER_FIELD, NULL);
-	renderFieldEscaped (writer->type, FIELD_SCOPE, tag,
-			    NO_PARSER_FIELD, NULL);
+	renderField (FIELD_SCOPE_KIND_LONG, tag, NO_PARSER_FIELD);
+	renderField (FIELD_SCOPE, tag, NO_PARSER_FIELD);
 }

--- a/main/writer-xref.c
+++ b/main/writer-xref.c
@@ -10,6 +10,7 @@
 #include "general.h"  /* must always come first */
 
 #include "entry.h"
+#include "field_p.h"
 #include "fmt_p.h"
 #include "mio.h"
 #include "options_p.h"

--- a/source.mak
+++ b/source.mak
@@ -14,6 +14,7 @@ MIO_SRCS  = main/mio.c
 MAIN_PUBLIC_HEADS =		\
 		main/dependency.h\
 		main/entry.h	\
+		main/field.h	\
 		main/gcc-attr.h	\
 		main/gvars.h	\
 		main/htable.h	\
@@ -51,6 +52,7 @@ MAIN_PRIVATE_HEADS =		\
 	main/dependency_p.h	\
 	main/entry_p.h		\
 	main/error_p.h		\
+	main/field_p.h		\
 	main/flags_p.h		\
 	main/fmt_p.h		\
 	main/interactive_p.h	\
@@ -79,7 +81,6 @@ MAIN_PRIVATE_HEADS =		\
 
 MAIN_HEADS =			\
 	main/ctags.h		\
-	main/field.h		\
 	main/general.h		\
 	\
 	$(MAIN_PUBLIC_HEADS)    \

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -259,6 +259,7 @@
     <ClInclude Include="..\main\entry_p.h" />
     <ClInclude Include="..\main\error_p.h" />
     <ClInclude Include="..\main\field.h" />
+    <ClInclude Include="..\main\field_p.h" />
     <ClInclude Include="..\main\flags_p.h" />
     <ClInclude Include="..\main\fmt_p.h" />
     <ClInclude Include="..\main\gcc-attr.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -527,6 +527,9 @@
     <ClInclude Include="..\main\field.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\main\field_p.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\main\flags_p.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
This is the last PR for splitting the header files into two categories.
One is for parsers (public).
Another is for the main part (private).