### PR TITLE
CXX: Improve parsing of private/public/protected

### DIFF
--- a/Units/parser-c.r/cxx-scope-keywords.d/expected.tags
+++ b/Units/parser-c.r/cxx-scope-keywords.d/expected.tags
@@ -16,3 +16,4 @@ bar	input.h	/^void bar(void) {$/;"	function	typeref:typename:void
 private	input.h	/^private :$/;"	label	function:bar	file:
 baz	input.h	/^void baz(void) {$/;"	function	typeref:typename:void
 private	input.h	/^ private\/* coment *\/:$/;"	label	function:baz	file:
+private	input.h	/^int private;$/;"	variable	typeref:typename:int

--- a/Units/parser-c.r/cxx-scope-keywords.d/input.h
+++ b/Units/parser-c.r/cxx-scope-keywords.d/input.h
@@ -35,3 +35,5 @@ void baz(void) {
  private/* coment */:
   return;
 }
+
+int private;

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1545,6 +1545,16 @@ bool cxxParserParseAccessSpecifier(void)
 {
 	CXX_DEBUG_ENTER();
 
+	CXX_DEBUG_ASSERT(
+			cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeKeyword) &&
+			(
+				(g_cxx.pToken->eKeyword == CXXKeywordPUBLIC) ||
+				(g_cxx.pToken->eKeyword == CXXKeywordPROTECTED) ||
+				(g_cxx.pToken->eKeyword == CXXKeywordPRIVATE)
+			),
+			"This must be called just after parinsg public/protected/private"
+		);
+
 	unsigned int uExtraType = 0;
 
 	enum CXXScopeType eScopeType = cxxScopeGetType();
@@ -1569,33 +1579,34 @@ bool cxxParserParseAccessSpecifier(void)
 
 		if(!g_cxx.bConfirmedCPPLanguage)
 		{
-			CXX_DEBUG_LEAVE_TEXT("C++ language is not confirmed: we try to be flexible and not bail out");
+			CXX_DEBUG_LEAVE_TEXT("C++ is not confirmed and the scope is not right: likely not access specifier");
+			g_cxx.pToken->eType = CXXTokenTypeIdentifier;
 			return true;
 		}
+
 		// this is a syntax error: we're in the wrong scope.
 		CXX_DEBUG_LEAVE_TEXT("C++ language is confirmed: bailing out to avoid reporting broken structure");
 		return false;
 	}
 
+	if(!g_cxx.bConfirmedCPPLanguage)
+	{
+		if(g_cxx.pToken->pPrev)
+		{
+			// ugly, there is something before the public/private/protected keyword.
+			// This is likely a type or something else.
+			CXX_DEBUG_LEAVE_TEXT(
+					"C++ is not confirmed and there is something before: likely not access specifier"
+				);
+			g_cxx.pToken->eType = CXXTokenTypeIdentifier;
+			return true;
+		}
+	}
 
 	if (cxxSubparserNotifyParseAccessSpecifier (pSubparsers))
 		uExtraType = CXXTokenTypeIdentifier;
 
-	switch(g_cxx.pToken->eKeyword)
-	{
-		case CXXKeywordPUBLIC:
-			cxxScopeSetAccess(CXXScopeAccessPublic);
-		break;
-		case CXXKeywordPRIVATE:
-			cxxScopeSetAccess(CXXScopeAccessPrivate);
-		break;
-		case CXXKeywordPROTECTED:
-			cxxScopeSetAccess(CXXScopeAccessProtected);
-		break;
-		default:
-			CXX_DEBUG_ASSERT(false,"Bad keyword in cxxParserParseAccessSpecifier!");
-		break;
-	}
+	CXXToken * pInitialToken = g_cxx.pToken;
 
 	// skip to the next :, without leaving scope.
  findColon:
@@ -1616,6 +1627,40 @@ bool cxxParserParseAccessSpecifier(void)
 		cxxSubparserNotifyfoundExtraIdentifierAsAccessSpecifier (pSubparsers,
 																 g_cxx.pToken);
 		goto findColon;
+	}
+
+	if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeSingleColon))
+	{
+		if(!pInitialToken->pPrev)
+		{
+			CXX_DEBUG_PRINT("The access specifier was the first token and I have found a colon: this is C++");
+			g_cxx.bConfirmedCPPLanguage = true;
+		}
+	} else {
+		if(!g_cxx.bConfirmedCPPLanguage)
+		{
+			pInitialToken->eType = CXXTokenTypeIdentifier;
+			// trace back one token so the caller can handle it
+			cxxParserUngetCurrentToken();
+			CXX_DEBUG_LEAVE_TEXT("C++ is not confirmed and there is no colon at the end: not access specifier?");
+			return true;
+		}
+	}
+
+	switch(pInitialToken->eKeyword)
+	{
+		case CXXKeywordPUBLIC:
+			cxxScopeSetAccess(CXXScopeAccessPublic);
+		break;
+		case CXXKeywordPRIVATE:
+			cxxScopeSetAccess(CXXScopeAccessPrivate);
+		break;
+		case CXXKeywordPROTECTED:
+			cxxScopeSetAccess(CXXScopeAccessProtected);
+		break;
+		default:
+			CXX_DEBUG_ASSERT(false,"Bad keyword in cxxParserParseAccessSpecifier!");
+		break;
 	}
 
 	cxxTokenChainClear(g_cxx.pTokenChain);

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1636,15 +1636,6 @@ bool cxxParserParseAccessSpecifier(void)
 			CXX_DEBUG_PRINT("The access specifier was the first token and I have found a colon: this is C++");
 			g_cxx.bConfirmedCPPLanguage = true;
 		}
-	} else {
-		if(!g_cxx.bConfirmedCPPLanguage)
-		{
-			pInitialToken->eType = CXXTokenTypeIdentifier;
-			// trace back one token so the caller can handle it
-			cxxParserUngetCurrentToken();
-			CXX_DEBUG_LEAVE_TEXT("C++ is not confirmed and there is no colon at the end: not access specifier?");
-			return true;
-		}
 	}
 
 	switch(pInitialToken->eKeyword)

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -1231,45 +1231,8 @@ bool cxxParserParseNextToken(void)
 			if(cxxKeywordIsDisabled((CXXKeyword)iCXXKeyword))
 			{
 				t->eType = CXXTokenTypeIdentifier;
-			} else if (isInputHeaderFile ()
-					   && (iCXXKeyword == CXXKeywordPUBLIC
-						   || iCXXKeyword == CXXKeywordPROTECTED
-						   || iCXXKeyword == CXXKeywordPRIVATE))
-			{
-				int c0 = g_cxx.iChar;
-
-				if (c0 == ':')
-				{
-					/* Specifying the scope of struct/union/class member */
-					goto assign_keyword;
-				}
-
-				if (cppIsspace (c0))
-				{
-					int c1;
-
-					cxxParserSkipToNonWhiteSpace ();
-					c1 = g_cxx.iChar;
-					cppUngetc (c1);
-					g_cxx.iChar = c0;
-
-					if (c1 == ':')
-					{
-						/* Specifying the scope of struct/union/class member */
-						goto assign_keyword;
-					}
-					else if (cppIsalpha(c1))
-					{
-						/* Specifying the scope of class inheritance */
-						goto assign_keyword;
-					}
-				}
-
-				t->eType = CXXTokenTypeIdentifier;
-				g_cxx.bConfirmedCPPLanguage = false;
-				cxxKeywordEnablePublicProtectedPrivate(false);
 			} else {
-			assign_keyword:
+
 				t->eType = CXXTokenTypeKeyword;
 				t->eKeyword = (CXXKeyword)iCXXKeyword;
 

--- a/parsers/cxx/cxx_qtmoc.c
+++ b/parsers/cxx/cxx_qtmoc.c
@@ -242,12 +242,14 @@ static bool unknownIdentifierInClassNotify (struct sCxxSubparser *pSubparser,
 	{
 	case KEYWORD_SIGNALS:
 		CXX_DEBUG_PRINT("Found \"signals\" QtMoc Keyword");
+		pToken->eType = CXXTokenTypeKeyword;
 		pToken->eKeyword = CXXKeywordPUBLIC;
 		cxxParserParseAccessSpecifier();
 		pQtMoc->eMemberMarker = QtMocMemberMarkerSignal;
 		return true;
 	case KEYWORD_SLOTS:
 		CXX_DEBUG_PRINT("Found \"slots\" QtMoc Keyword");
+		pToken->eType = CXXTokenTypeKeyword;
 		g_cxx.pToken->eKeyword = CXXKeywordPUBLIC; /* ??? */
 		cxxParserParseAccessSpecifier();
 		pQtMoc->eMemberMarker = QtMocMemberMarkerSlot;


### PR DESCRIPTION
Improve parsing of public/protected/private keywords so it does not need specialized code in token extraction path. This makes it a bit faster and additionally fixes a bug that caused corrupted inheritance information for base classes with names starting with an underscore (a common case in STL).