### PR TITLE
cxx: Fix performance problem when parsing long array initializations

### DIFF
--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -116,6 +116,7 @@ CXXToken * cxxParserOpeningBracketIsLambda(void)
 	t = cxxTokenChainPreviousTokenOfType(
 			t,
 			CXXTokenTypeSquareParenthesisChain |
+			CXXTokenTypeBracketChain |
 			CXXTokenTypeAssignment |
 			CXXTokenTypeOperator
 		);


### PR DESCRIPTION
Consider for instance

Foo a[] = {
  {foo1, bar1, baz1},
  {foo2, bar2, baz2},
  ...
}

where the number of entries is very large - check for instance this file
for real-world example:

https://kernel.googlesource.com/pub/scm/linux/kernel/git/mchehab/linux-media/+/media/v4.7-2/drivers/gpu/drm/amd/powerplay/inc/fiji_pwrvirus.h

At the moment the cxxParserOpeningBracketIsLambda() function checks if {
is a beginning of lambda body by going back and finding some sentinel.
In this case, however, none of the checked sentinels is found and
with initializations like the above it has to go thousands of tokens
backwards for { on every line which leads to quadratic complexity.

I believe {} shouldn't appear within lambda declaration so it should
be safe to add this as an additional sentinel.

@pragmaware Does it look good to you? In case {} can appear within lambda declaration, I'd have to make some different check.