### PR TITLE
more complete support for $ in C/C++ identifiers

### DIFF
--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1565,7 +1565,7 @@ static void saveMacro(const char * macro)
 		return;
 	}
 
-	if(!(isalpha(*c) || (*c == '_')))
+	if(!(isalpha(*c) || (*c == '_' || (*c == '$') )))
 	{
 		CXX_DEBUG_LEAVE_TEXT("Macro does not start with an alphanumeric character");
 		return; // must be a sequence of letters and digits
@@ -1573,7 +1573,7 @@ static void saveMacro(const char * macro)
 
 	const char * identifierBegin = c;
 
-	while(*c && (isalnum(*c) || (*c == '_')))
+	while(*c && (isalnum(*c) || (*c == '_') || (*c == '$') ))
 		c++;
 
 	const char * identifierEnd = c;

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -286,7 +286,7 @@ static CXXCharTypeData g_aCharTable[128] =
 	},
 	// 036 (0x24) '$'
 	{
-		0,
+		CXXCharTypeStartOfIdentifier | CXXCharTypePartOfIdentifier,
 		0,
 		0
 	},


### PR DESCRIPTION
ctags seemed to have some support for $ in identifiers, like it would index $BAR from `#define $BAR` but not `$name` from `extern int $name;`. Similarly it wouldn't let me define replacement macros e.g., `'-D$my$struct=struct` and then have foo from  `$my$struct foo` indexed. This minipatch appears to fix these issues. 