### PR TITLE
main,refactor: remove buildFqTagCache method of tagWriter

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -1211,6 +1211,11 @@ static bool isTagWritable(const tagEntryInfo *const tag)
 	return true;
 }
 
+static void buildFqTagCache (tagEntryInfo *const tag)
+{
+	getTagScopeInformation (tag, NULL, NULL);
+}
+
 static void writeTagEntry (const tagEntryInfo *const tag, bool checkingNeeded)
 {
 	int length = 0;
@@ -1227,7 +1232,7 @@ static void writeTagEntry (const tagEntryInfo *const tag, bool checkingNeeded)
 	    && doesInputLanguageRequestAutomaticFQTag ())
 	{
 		/* const is discarded to update the cache field of TAG. */
-		writerBuildFqTagCache ( (tagEntryInfo *const)tag);
+		buildFqTagCache ( (tagEntryInfo *const)tag);
 	}
 
 	length = writerWriteTag (TagFile.mio, tag);

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -29,7 +29,6 @@ static int writeCtagsPtagEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 								const char *const fileName,
 								const char *const pattern,
 								const char *const parserName);
-static void buildCtagsFqTagCache (tagWriter *writer CTAGS_ATTR_UNUSED, tagEntryInfo *const tag);
 
 struct rejection {
 	bool rejectedInThisRendering;
@@ -41,7 +40,6 @@ tagWriter uCtagsWriter = {
 	.writePtagEntry = writeCtagsPtagEntry,
 	.preWriteEntry = NULL,
 	.postWriteEntry = NULL,
-	.buildFqTagCache = buildCtagsFqTagCache,
 	.defaultFileName = CTAGS_FILE,
 };
 
@@ -65,7 +63,6 @@ tagWriter eCtagsWriter = {
 	.writePtagEntry = writeCtagsPtagEntry,
 	.preWriteEntry = beginECtagsFile,
 	.postWriteEntry = endECTagsFile,
-	.buildFqTagCache = buildCtagsFqTagCache,
 	.defaultFileName = CTAGS_FILE,
 };
 
@@ -298,10 +295,4 @@ static int writeCtagsPtagEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 			      PSEUDO_TAG_PREFIX, desc->name,
 			      OPT(fileName), OPT(pattern));
 #undef OPT
-}
-
-static void buildCtagsFqTagCache (tagWriter *writer CTAGS_ATTR_UNUSED, tagEntryInfo *const tag)
-{
-	escapeFieldValue (writer, tag, FIELD_SCOPE_KIND_LONG);
-	escapeFieldValue (writer, tag, FIELD_SCOPE);
 }

--- a/main/writer-json.c
+++ b/main/writer-json.c
@@ -38,14 +38,12 @@ static int writeJsonPtagEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 				const char *const fileName,
 				const char *const pattern,
 				const char *const parserName);
-static void buildJsonFqTagCache (tagWriter *writer, tagEntryInfo *const tag);
 
 tagWriter jsonWriter = {
 	.writeEntry = writeJsonEntry,
 	.writePtagEntry = writeJsonPtagEntry,
 	.preWriteEntry = NULL,
 	.postWriteEntry = NULL,
-	.buildFqTagCache = buildJsonFqTagCache,
 	.defaultFileName = NULL,
 };
 
@@ -184,12 +182,6 @@ static int writeJsonEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 	json_decref (response);
 
 	return length;
-}
-
-static void buildJsonFqTagCache (tagWriter *writer, tagEntryInfo *const tag)
-{
-	renderField (FIELD_SCOPE_KIND_LONG, tag, NO_PARSER_FIELD);
-	renderField (FIELD_SCOPE, tag, NO_PARSER_FIELD);
 }
 
 static int writeJsonPtagEntry (tagWriter *writer CTAGS_ATTR_UNUSED,

--- a/main/writer-xref.c
+++ b/main/writer-xref.c
@@ -19,14 +19,12 @@
 
 static int writeXrefEntry  (tagWriter *writer CTAGS_ATTR_UNUSED,
 							MIO * mio, const tagEntryInfo *const tag);
-static void buildXrefFqTagCache (tagWriter *writer, tagEntryInfo *const tag);
 
 tagWriter xrefWriter = {
 	.writeEntry = writeXrefEntry,
 	.writePtagEntry = NULL,
 	.preWriteEntry = NULL,
 	.postWriteEntry = NULL,
-	.buildFqTagCache = buildXrefFqTagCache,
 	.defaultFileName = NULL,
 };
 
@@ -62,10 +60,4 @@ static int writeXrefEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 	length++;
 
 	return length;
-}
-
-static void buildXrefFqTagCache (tagWriter *writer, tagEntryInfo *const tag)
-{
-	renderField (FIELD_SCOPE_KIND_LONG, tag, NO_PARSER_FIELD);
-	renderField (FIELD_SCOPE, tag, NO_PARSER_FIELD);
 }

--- a/main/writer.c
+++ b/main/writer.c
@@ -72,13 +72,6 @@ extern int writerWritePtag (MIO * mio,
 
 }
 
-extern void writerBuildFqTagCache (tagEntryInfo *const tag)
-{
-	if (writer->buildFqTagCache)
-		writer->buildFqTagCache (writer, tag);
-}
-
-
 extern bool ptagMakeCtagsOutputMode (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED)
 {
 	const char *mode ="";

--- a/main/writer_p.h
+++ b/main/writer_p.h
@@ -41,7 +41,6 @@ struct sTagWriter {
 	/* Returning TRUE means the output file may be shrunk.
 	   In such case the callee may do truncate output file. */
 	bool (* postWriteEntry)  (tagWriter *writer, MIO * mio, const char* filename);
-	void (* buildFqTagCache) (tagWriter *writer, tagEntryInfo *const tag);
 	const char *defaultFileName;
 
 	/* The value returned from preWriteEntry is stored `private' field.
@@ -61,8 +60,6 @@ int writerWritePtag (MIO * mio,
 					 const char *const fileName,
 					 const char *const pattern,
 					 const char *const parserName);
-
-extern void writerBuildFqTagCache (tagEntryInfo *const tag);
 
 extern const char *outputDefaultFileName (void);
 


### PR DESCRIPTION
The methods were introduced for making full qualified tags automatically
when corkAPI is enabled. However, it is nothing to do with tagWriter
backends. This change pulls up the code for making the cache to
tagEntryInfo layer.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>