### PR TITLE
Go: fill more fields (revisied)

### DIFF
--- a/Units/parser-go.r/go-funcs.d/expected.tags
+++ b/Units/parser-go.r/go-funcs.d/expected.tags
@@ -1,4 +1,4 @@
-T	input.go	/^type T int$/;"	t	package:main
+T	input.go	/^type T int$/;"	t	package:main	typeref:typename:int
 f1	input.go	/^func f1() {$/;"	f	package:main	signature:()	end:6
 f2	input.go	/^func f2(a int) {$/;"	f	package:main	signature:(a int)	end:9
 f3	input.go	/^func f3(a int) string {$/;"	f	package:main	typeref:typename:string	signature:(a int)	end:13

--- a/Units/parser-go.r/go-funcs.d/expected.tags
+++ b/Units/parser-go.r/go-funcs.d/expected.tags
@@ -3,7 +3,7 @@ f1	input.go	/^func f1() {$/;"	f	package:main	signature:()	end:6
 f2	input.go	/^func f2(a int) {$/;"	f	package:main	signature:(a int)	end:9
 f3	input.go	/^func f3(a int) string {$/;"	f	package:main	typeref:typename:string	signature:(a int)	end:13
 f4	input.go	/^func f4(a, b, c <-chan int, d, e, f string) (A, B, C int, D string) {$/;"	f	package:main	typeref:typename:(A, B, C int, D string)	signature:(a, b, c <-chan int, d, e, f string)	end:17
-f5	input.go	/^func (t *T) f5(\/* comment *\/ a, \/*comment*\/ \/*comment*\/       b string, $/;"	f	unknown:main.T	typeref:typename:(int, string)	signature:(a, b string, c []int)	end:24
-f6	input.go	/^func (t *(T)) f6(r struct {a int `foo`; b string `bar`}) net.IP {$/;"	f	unknown:main.T	typeref:typename:net.IP	signature:(r struct {a int `foo`; b string `bar`})	end:28
+f5	input.go	/^func (t *T) f5(\/* comment *\/ a, \/*comment*\/ \/*comment*\/       b string, $/;"	f	type:main.T	typeref:typename:(int, string)	signature:(a, b string, c []int)	end:24
+f6	input.go	/^func (t *(T)) f6(r struct {a int `foo`; b string `bar`}) net.IP {$/;"	f	type:main.T	typeref:typename:net.IP	signature:(r struct {a int `foo`; b string `bar`})	end:28
 main	input.go	/^func main() {$/;"	f	package:main	signature:()	end:31
 main	input.go	/^package main$/;"	p

--- a/Units/parser-go.r/go-scope.d/expected.tags
+++ b/Units/parser-go.r/go-scope.d/expected.tags
@@ -5,14 +5,14 @@ X	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point	typeref:type
 main.Point.X	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point	typeref:typename:int
 Y	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point	typeref:typename:int
 main.Point.Y	input.go	/^type Point struct { X, Y int }$/;"	m	struct:main.Point	typeref:typename:int
-Render	input.go	/^func (p *Point) Render() {$/;"	f	unknown:main.Point
-main.Point.Render	input.go	/^func (p *Point) Render() {$/;"	f	unknown:main.Point
+Render	input.go	/^func (p *Point) Render() {$/;"	f	struct:main.Point
+main.Point.Render	input.go	/^func (p *Point) Render() {$/;"	f	struct:main.Point
 main	input.go	/^func main() {$/;"	f	package:main
 main.main	input.go	/^func main() {$/;"	f	package:main
-doNothing0	input.go	/^func (*Point) doNothing0() {$/;"	f	unknown:main.Point
-main.Point.doNothing0	input.go	/^func (*Point) doNothing0() {$/;"	f	unknown:main.Point
-doNothing1	input.go	/^func (Point) doNothing1() {$/;"	f	unknown:main.Point
-main.Point.doNothing1	input.go	/^func (Point) doNothing1() {$/;"	f	unknown:main.Point
+doNothing0	input.go	/^func (*Point) doNothing0() {$/;"	f	struct:main.Point
+main.Point.doNothing0	input.go	/^func (*Point) doNothing0() {$/;"	f	struct:main.Point
+doNothing1	input.go	/^func (Point) doNothing1() {$/;"	f	struct:main.Point
+main.Point.doNothing1	input.go	/^func (Point) doNothing1() {$/;"	f	struct:main.Point
 wrongSyntax0	input.go	/^func () wrongSyntax0() {$/;"	f	package:main
 main.wrongSyntax0	input.go	/^func () wrongSyntax0() {$/;"	f	package:main
 wrongSyntax1	input.go	/^func (+) wrongSyntax1() {$/;"	f	package:main

--- a/Units/parser-go.r/go-torture.d/expected.tags
+++ b/Units/parser-go.r/go-torture.d/expected.tags
@@ -26,8 +26,8 @@ _e	input.go	/^	_e float32$/;"	m	struct:main.T6	typeref:typename:float32
 a	input.go	/^var (a, b, c int$/;"	v	package:main	typeref:typename:int
 b	input.go	/^var (a, b, c int$/;"	v	package:main	typeref:typename:int
 c	input.go	/^var (a, b, c int$/;"	v	package:main	typeref:typename:int
-d	input.go	/^d T5$/;"	v	package:main	typeref:typename:T5
-e	input.go	/^e T4$/;"	v	package:main	typeref:typename:T4
+d	input.go	/^d T5$/;"	v	package:main	typeref:interface:T5
+e	input.go	/^e T4$/;"	v	package:main	typeref:type:T4
 f	input.go	/^f interface{})$/;"	v	package:main	typeref:typename:interface{}
 f1	input.go	/^func f1() {};func f2() {};type\/*no newline here*\/T9 int\/*var ignored int$/;"	f	package:main	signature:()
 f2	input.go	/^func f1() {};func f2() {};type\/*no newline here*\/T9 int\/*var ignored int$/;"	f	package:main	signature:()

--- a/Units/parser-go.r/go-torture.d/expected.tags
+++ b/Units/parser-go.r/go-torture.d/expected.tags
@@ -31,8 +31,8 @@ e	input.go	/^e T4$/;"	v	package:main
 f	input.go	/^f interface{})$/;"	v	package:main
 f1	input.go	/^func f1() {};func f2() {};type\/*no newline here*\/T9 int\/*var ignored int$/;"	f	package:main	signature:()
 f2	input.go	/^func f1() {};func f2() {};type\/*no newline here*\/T9 int\/*var ignored int$/;"	f	package:main	signature:()
-f3	input.go	/^func (t *T1) f3() (a, b int){$/;"	f	unknown:main.T1	typeref:typename:(a, b int)	signature:()
-f4	input.go	/^func (tt * T7) f4(a func () func ()) (func (), int) {return func (){}, 1};func f5(){};const H=1$/;"	f	unknown:main.T7	typeref:typename:(func (), int)	signature:(a func () func ())
+f3	input.go	/^func (t *T1) f3() (a, b int){$/;"	f	type:main.T1	typeref:typename:(a, b int)	signature:()
+f4	input.go	/^func (tt * T7) f4(a func () func ()) (func (), int) {return func (){}, 1};func f5(){};const H=1$/;"	f	type:main.T7	typeref:typename:(func (), int)	signature:(a func () func ())
 f5	input.go	/^func (tt * T7) f4(a func () func ()) (func (), int) {return func (){}, 1};func f5(){};const H=1$/;"	f	package:main	signature:()
 g	input.go	/^const ignored int*\/const (G=6); var g int$/;"	v	package:main
 h	input.go	/^}; var h int$/;"	v	package:main

--- a/Units/parser-go.r/go-torture.d/expected.tags
+++ b/Units/parser-go.r/go-torture.d/expected.tags
@@ -8,16 +8,16 @@ G	input.go	/^const ignored int*\/const (G=6); var g int$/;"	c	package:main
 H	input.go	/^func (tt * T7) f4(a func () func ()) (func (), int) {return func (){}, 1};func f5(){};const H=1$/;"	c	package:main
 I	input.go	/^	F=3.14*(1+2*3)\/34e7;I=1)$/;"	c	package:main
 T1	input.go	/^	T1 `annotation`$/;"	M	struct:main.T6	typeref:typename:T1
-T1	input.go	/^	T1 map[string]int$/;"	t	package:main
+T1	input.go	/^	T1 map[string]int$/;"	t	package:main	typeref:typename:map[string]int
 T2	input.go	/^	*T2$/;"	M	struct:main.T6	typeref:typename:*T2
-T2	input.go	/^	T2 <-chan float32$/;"	t	package:main
-T3	input.go	/^	T3 chan []string$/;"	t	package:main
-T4	input.go	/^	T4 chan<- *[12]string$/;"	t	package:main
+T2	input.go	/^	T2 <-chan float32$/;"	t	package:main	typeref:typename:<-chan float32
+T3	input.go	/^	T3 chan []string$/;"	t	package:main	typeref:typename:chan []string
+T4	input.go	/^	T4 chan<- *[12]string$/;"	t	package:main	typeref:typename:chan<- *[12]string
 T5	input.go	/^	T5 interface {$/;"	i	package:main
 T6	input.go	/^type T6 struct {$/;"	s	package:main
-T7	input.go	/^type (T7 func (a struct{_ int; _ float32}, b int) (int, map[string]int);T8 float32)$/;"	t	package:main
-T8	input.go	/^type (T7 func (a struct{_ int; _ float32}, b int) (int, map[string]int);T8 float32)$/;"	t	package:main
-T9	input.go	/^func f1() {};func f2() {};type\/*no newline here*\/T9 int\/*var ignored int$/;"	t	package:main
+T7	input.go	/^type (T7 func (a struct{_ int; _ float32}, b int) (int, map[string]int);T8 float32)$/;"	t	package:main	typeref:typename:func (a struct{_ int; _ float32}, b int) (int, map[string]int)
+T8	input.go	/^type (T7 func (a struct{_ int; _ float32}, b int) (int, map[string]int);T8 float32)$/;"	t	package:main	typeref:typename:float32
+T9	input.go	/^func f1() {};func f2() {};type\/*no newline here*\/T9 int\/*var ignored int$/;"	t	package:main	typeref:typename:int
 _a	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6	typeref:typename:int
 _b	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6	typeref:typename:int
 _c	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6	typeref:typename:int

--- a/Units/parser-go.r/go-torture.d/expected.tags
+++ b/Units/parser-go.r/go-torture.d/expected.tags
@@ -23,19 +23,19 @@ _b	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6	typeref:typename:int
 _c	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6	typeref:typename:int
 _d	input.go	/^	_a, _b, _c, _d int$/;"	m	struct:main.T6	typeref:typename:int
 _e	input.go	/^	_e float32$/;"	m	struct:main.T6	typeref:typename:float32
-a	input.go	/^var (a, b, c int$/;"	v	package:main
-b	input.go	/^var (a, b, c int$/;"	v	package:main
-c	input.go	/^var (a, b, c int$/;"	v	package:main
-d	input.go	/^d T5$/;"	v	package:main
-e	input.go	/^e T4$/;"	v	package:main
-f	input.go	/^f interface{})$/;"	v	package:main
+a	input.go	/^var (a, b, c int$/;"	v	package:main	typeref:typename:int
+b	input.go	/^var (a, b, c int$/;"	v	package:main	typeref:typename:int
+c	input.go	/^var (a, b, c int$/;"	v	package:main	typeref:typename:int
+d	input.go	/^d T5$/;"	v	package:main	typeref:typename:T5
+e	input.go	/^e T4$/;"	v	package:main	typeref:typename:T4
+f	input.go	/^f interface{})$/;"	v	package:main	typeref:typename:interface{}
 f1	input.go	/^func f1() {};func f2() {};type\/*no newline here*\/T9 int\/*var ignored int$/;"	f	package:main	signature:()
 f2	input.go	/^func f1() {};func f2() {};type\/*no newline here*\/T9 int\/*var ignored int$/;"	f	package:main	signature:()
 f3	input.go	/^func (t *T1) f3() (a, b int){$/;"	f	type:main.T1	typeref:typename:(a, b int)	signature:()
 f4	input.go	/^func (tt * T7) f4(a func () func ()) (func (), int) {return func (){}, 1};func f5(){};const H=1$/;"	f	type:main.T7	typeref:typename:(func (), int)	signature:(a func () func ())
 f5	input.go	/^func (tt * T7) f4(a func () func ()) (func (), int) {return func (){}, 1};func f5(){};const H=1$/;"	f	package:main	signature:()
-g	input.go	/^const ignored int*\/const (G=6); var g int$/;"	v	package:main
-h	input.go	/^}; var h int$/;"	v	package:main
+g	input.go	/^const ignored int*\/const (G=6); var g int$/;"	v	package:main	typeref:typename:int
+h	input.go	/^}; var h int$/;"	v	package:main	typeref:typename:int
 int	input.go	/^	int$/;"	M	struct:main.T6	typeref:typename:int
 main	input.go	/^func main() {$/;"	f	package:main	signature:()
 main	input.go	/^package main$/;"	p

--- a/Units/parser-go.r/go-vars.d/args.ctags
+++ b/Units/parser-go.r/go-vars.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--fields=+t

--- a/Units/parser-go.r/go-vars.d/expected.tags
+++ b/Units/parser-go.r/go-vars.d/expected.tags
@@ -1,0 +1,9 @@
+x	input.go	/^var x, y, z int$/;"	v	typeref:typename:int
+y	input.go	/^var x, y, z int$/;"	v	typeref:typename:int
+z	input.go	/^var x, y, z int$/;"	v	typeref:typename:int
+a	input.go	/^	a, b int$/;"	v	typeref:typename:int
+b	input.go	/^	a, b int$/;"	v	typeref:typename:int
+n	input.go	/^	n = 0$/;"	v
+s	input.go	/^	s string$/;"	v	typeref:typename:string
+i	input.go	/^	i interface{}$/;"	v	typeref:typename:interface{}
+c	input.go	/^const c int$/;"	c	typeref:typename:int

--- a/Units/parser-go.r/go-vars.d/input.go
+++ b/Units/parser-go.r/go-vars.d/input.go
@@ -1,0 +1,8 @@
+var x, y, z int
+var (
+	a, b int
+	n = 0
+	s string
+	i interface{}
+)
+const c int

--- a/main/htable.c
+++ b/main/htable.c
@@ -140,6 +140,14 @@ extern hashTable *hashTableNew    (unsigned int size,
 	return htable;
 }
 
+extern hashTable* hashTableIntNew (unsigned int size,
+								   hashTableHashFunc hashfn,
+								   hashTableEqualFunc equalfn,
+								   hashTableFreeFunc keyfreefn)
+{
+	return hashTableNew (size, hashfn, equalfn, keyfreefn, NULL);
+}
+
 extern void       hashTableDelete (hashTable *htable)
 {
 	if (!htable)

--- a/main/htable.h
+++ b/main/htable.h
@@ -12,6 +12,7 @@
 #define CTAGS_MAIN_HTABLE_H
 
 #include "general.h"
+#include <stdint.h>
 
 typedef struct sHashTable hashTable;
 typedef unsigned int (* hashTableHashFunc)  (const void * const key);
@@ -36,6 +37,7 @@ extern hashTable* hashTableNew         (unsigned int size,
 					hashTableEqualFunc equalfn,
 					hashTableFreeFunc keyfreefn,
 					hashTableFreeFunc valfreefn);
+
 extern void       hashTableDelete      (hashTable *htable);
 extern void       hashTableClear       (hashTable *htable);
 extern void       hashTablePutItem     (hashTable *htable, void *key, void *value);
@@ -44,5 +46,12 @@ extern bool    hashTableHasItem     (hashTable * htable, const void * key);
 extern bool    hashTableDeleteItem  (hashTable *htable, void *key);
 extern void       hashTableForeachItem (hashTable *htable, hashTableForeachFunc proc, void *user_data);
 extern int        hashTableCountItem   (hashTable *htable);
+
+extern hashTable* hashTableIntNew (unsigned int size,
+								   hashTableHashFunc hashfn,
+								   hashTableEqualFunc equalfn,
+								   hashTableFreeFunc keyfreefn);
+#define HT_PTR_TO_INT(P) ((int)(intptr_t)(P))
+#define HT_INT_TO_PTR(P) ((void*)(intptr_t)(P))
 
 #endif	/* CTAGS_MAIN_HTABLE_H */

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -968,6 +968,8 @@ static void parseConstTypeVar (tokenInfo *const token, goKind kind, const int sc
 	// VarSpec     = IdentifierList ( Type [ "=" ExpressionList ] | "=" ExpressionList ) .
 	bool usesParens = false;
 	int member_scope = scope;
+	intArray *corks
+		= (kind == GOTAG_VAR || kind == GOTAG_CONST)? intArrayNew (): NULL;
 
 	readToken (token);
 
@@ -1010,7 +1012,11 @@ static void parseConstTypeVar (tokenInfo *const token, goKind kind, const int sc
 					break;
 				}
 				else
-					makeTag (token, kind, scope, NULL, NULL);
+				{
+					int c = makeTag (token, kind, scope, NULL, NULL);
+					if (corks)
+						intArrayAdd (corks, c);
+				}
 				readToken (token);
 			}
 			if (!isType (token, TOKEN_COMMA))
@@ -1025,6 +1031,20 @@ static void parseConstTypeVar (tokenInfo *const token, goKind kind, const int sc
 			else
 				skipType (token, NULL);
 			deleteToken (typeToken);
+		}
+		else if (corks)
+		{
+			vString *buffer = vStringNew ();
+			collector collector = { .str = buffer, .last_len = 0, };
+
+			collectorAppendToken (&collector, token);
+			skipType (token, &collector);
+			collectorTruncate (&collector, true);
+
+			if (!vStringIsEmpty (buffer))
+				attachTypeRefField (corks, vStringValue (buffer));
+			vStringDelete (buffer);
+			intArrayClear (corks);
 		}
 		else
 			skipType (token, NULL);
@@ -1044,6 +1064,8 @@ static void parseConstTypeVar (tokenInfo *const token, goKind kind, const int sc
 	}
 	while (!isType (token, TOKEN_EOF) &&
 			usesParens && !isType (token, TOKEN_CLOSE_PAREN));
+
+	intArrayDelete (corks);
 }
 
 static void parseImportSpec (tokenInfo *const token)

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -291,7 +291,7 @@ static void collectorCat (collector *collector, vString *str)
 	vStringCat (collector->str, str);
 }
 
-static void appendTokenToVString (const tokenInfo *const token, collector *collector)
+static void collectorAppendToken (collector *collector, const tokenInfo *const token)
 {
 	if (token->type == TOKEN_LEFT_ARROW)
 		collectorCatS (collector, "<-");
@@ -487,7 +487,7 @@ getNextChar:
 	token->c = c;
 
 	if (collector && vStringLength (collector->str) < MAX_COLLECTOR_LENGTH)
-		appendTokenToVString (token, collector);
+		collectorAppendToken (collector, token);
 
 	lastTokenType = token->type;
 }
@@ -911,7 +911,7 @@ static void parseStructMembers (tokenInfo *const token, const int scope)
 			vString *typeForMember = vStringNew ();
 			collector collector = { .str = typeForMember, .last_len = 0, };
 
-			appendTokenToVString (token, &collector);
+			collectorAppendToken (&collector, token);
 			skipType (token, &collector);
 			collectorTruncate (&collector, true);
 

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -801,11 +801,22 @@ static void parseFunctionOrMethod (tokenInfo *const token, const int scope)
 
 static void attachTypeRefField (intArray *corks, const char *const type)
 {
+	tagEntryInfo *type_e = NULL;
+	void *p = hashTableGetItem (typeTable, type);
+	if (p)
+	{
+		int type_cork = HT_PTR_TO_INT(p);
+		type_e = getEntryInCorkQueue (type_cork);
+	}
+
 	for (unsigned int i = 0; i < intArrayCount (corks); i++)
 	{
 		int cork = intArrayItem (corks, i);
 		tagEntryInfo *e = getEntryInCorkQueue (cork);
-		e->extensionFields.typeRef [0] = eStrdup ("typename");
+		if (type_e)
+			e->extensionFields.typeRef [0] = eStrdup (GoKinds[type_e->kindIndex].name);
+		else
+			e->extensionFields.typeRef [0] = eStrdup ("typename");
 		e->extensionFields.typeRef [1] = eStrdup (type);
 	}
 }


### PR DESCRIPTION
This is revised version of #1878.

In #1878, I tried to make names for scope field shorten.
In this pull request, I don''t do so; this change focuses only on fillling more fields of  Go parser tag entries.
If shorter scope names are better, I expect users may let us know. I will rework if we get such request.