### PR TITLE
dsl: return passed value instead of #t in "or" operator

### DIFF
--- a/Tmain/readtags-qualifier.d/run.sh
+++ b/Tmain/readtags-qualifier.d/run.sh
@@ -32,4 +32,6 @@ echo ';; (< 1 2)' &&
 ${V} ${READTAGS}  -e -t output.tags -Q '(< 1 2)' -l &&
 echo ';; (member "superClass" $roles)' &&
 ${V} ${READTAGS}  -e -n -t roles.tags -Q '(member "superClass" $roles)' -l &&
+echo ';; (substr? (or ($ "roles") "") "super")' &&
+${V} ${READTAGS}  -e -t roles.tags -Q '(substr? (or ($ "roles") "") "super")' -l &&
 :

--- a/Tmain/readtags-qualifier.d/stdout-expected.txt
+++ b/Tmain/readtags-qualifier.d/stdout-expected.txt
@@ -54,3 +54,6 @@ bw	base.py	/^    def bw ():$/;"	kind:member	language:Python	scope:class:Baz	acce
 ;; (member "superClass" $roles)
 Foo	base.py	/^class Bar (Foo):$/;"	kind:class	line:13	language:Python	roles:superClass
 Foo	base.py	/^class Baz (Foo): $/;"	kind:class	line:21	language:Python	roles:superClass
+;; (substr? (or ($ "roles") "") "super")
+Foo	base.py	/^class Bar (Foo):$/;"	kind:class	language:Python	roles:superClass
+Foo	base.py	/^class Baz (Foo): $/;"	kind:class	language:Python	roles:superClass

--- a/dsl/qualifier.c
+++ b/dsl/qualifier.c
@@ -306,7 +306,7 @@ static EsObject* builtin_or  (EsObject *args, tagEntry *entry)
 		o = es_car (args);
 		o = eval (o, entry);
 		if (! es_object_equal (o, es_false))
-			return es_true;
+			return o;
 		else if (es_error_p (o))
 			return o;
 		args = es_cdr (args);

--- a/dsl/qualifier.c
+++ b/dsl/qualifier.c
@@ -100,10 +100,9 @@ struct sCode {
 	{ "substr?", builtin_substr, NULL, CHECK_ARITY, 2,
 	  .helpstr = "(substr? TARGET<string> SUBSTR<string>) -> <boolean>" },
 	{ "member",  builtin_member, NULL, CHECK_ARITY, 2,
-	  .helpstr = "(member ELEMENT LIST) -> #f|<list>'" },
+	  .helpstr = "(member ELEMENT LIST) -> #f|<list>" },
 	{ "$",       builtin_entry_ref, NULL, CHECK_ARITY, 1,
-	  .helpstr = "($ NAME) -> #f|<string>'" },
-
+	  .helpstr = "($ NAME) -> #f|<string>" },
 	{ "$name",           value_name,           NULL, MEMORABLE, 0UL,},
 	{ "$input",          value_input,          NULL, MEMORABLE, 0UL,
 	  .helpstr = "input file name" },
@@ -684,7 +683,7 @@ enum QRESULT q_is_acceptable  (QCode *code, tagEntry *entry)
 		i = Q_REJECT;
 	else if (es_error_p (r))
 	{
-		MIO  *mioerr = mio_new_fp (stderr, NULL);;
+		MIO  *mioerr = mio_new_fp (stderr, NULL);
 
 		fprintf(stderr, "GOT ERROR in QUALIFYING: %s: ",
 			 es_error_name (r));

--- a/dsl/qualifier.c
+++ b/dsl/qualifier.c
@@ -58,6 +58,7 @@ static EsObject* builtin_suffix (EsObject *args, tagEntry *entry);
 static EsObject* builtin_substr (EsObject *args, tagEntry *entry);
 static EsObject* builtin_member (EsObject *args, tagEntry *entry);
 static EsObject* builtin_entry_ref (EsObject *args, tagEntry *entry);
+static EsObject* bulitin_debug_print (EsObject *args, tagEntry *entry);
 
 
 static EsObject* value_name (EsObject *args, tagEntry *entry);
@@ -103,6 +104,9 @@ struct sCode {
 	  .helpstr = "(member ELEMENT LIST) -> #f|<list>" },
 	{ "$",       builtin_entry_ref, NULL, CHECK_ARITY, 1,
 	  .helpstr = "($ NAME) -> #f|<string>" },
+	{ "print",   bulitin_debug_print, NULL, CHECK_ARITY, 1,
+	  .helpstr = "(print OBJ) -> OBJ" },
+
 	{ "$name",           value_name,           NULL, MEMORABLE, 0UL,},
 	{ "$input",          value_input,          NULL, MEMORABLE, 0UL,
 	  .helpstr = "input file name" },
@@ -518,6 +522,18 @@ static EsObject* builtin_entry_ref (EsObject *args, tagEntry *entry)
 		return entry_xget_string (entry, es_string_get (key));
 }
 
+static MIO  *miodebug;
+static EsObject* bulitin_debug_print (EsObject *args, tagEntry *entry)
+{
+	if (miodebug == NULL)
+		miodebug = mio_new_fp (stderr, NULL);
+
+	EsObject *o = es_car(args);
+	es_print(o, miodebug);
+	putc('\n', stderr);
+
+	return o;
+}
 
 static EsObject* value_name (EsObject *args, tagEntry *entry)
 {

--- a/dsl/qualifier.c
+++ b/dsl/qualifier.c
@@ -284,7 +284,7 @@ static EsObject* builtin_null  (EsObject *args, tagEntry *entry)
 
 static EsObject* builtin_and  (EsObject *args, tagEntry *entry)
 {
-	EsObject *o;
+	EsObject *o = es_true;
 
 	while (! es_null (args))
 	{
@@ -297,7 +297,7 @@ static EsObject* builtin_and  (EsObject *args, tagEntry *entry)
 		args = es_cdr (args);
 	}
 
-	return es_true;
+	return o;
 }
 
 static EsObject* builtin_or  (EsObject *args, tagEntry *entry)


### PR DESCRIPTION
Currently, if "or" finds an non-false value in operands, it returns #t.
Its upper context may want the value, not #t.
Actually, a scheme interpreter returns the value.

    $ gosh
    gosh> (or #f #f 3)
    3

Signed-off-by: Masatake YAMATO <yamato@redhat.com>