### PR TITLE
PHP: handle the case "namespace" as a method name

### DIFF
--- a/Units/parser-php.r/php-namespace-as-method-name.d/expected.tags
+++ b/Units/parser-php.r/php-namespace-as-method-name.d/expected.tags
@@ -1,0 +1,2 @@
+A	input.php	/^class A$/;"	c
+f	input.php	/^        public function f() {$/;"	f	class:A

--- a/Units/parser-php.r/php-namespace-as-method-name.d/input.php
+++ b/Units/parser-php.r/php-namespace-as-method-name.d/input.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+class A
+{
+        public function f() {
+                       $factory = new BuilderFactory;
+                       $node = $factory->namespace('Name\Space')
+                               ->addStmt($factory->use('Foo\Bar\SomeOtherClass'))
+                               ;
+               }
+}


### PR DESCRIPTION
Close #1985.

The php parser assumed the token "namespace" used as a keyword only.
However, "namespace" can be used as a method name.

e.g.

	https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/BuilderFactory.php

	class BuilderFactory
	{
	    /**
	     * Creates a namespace builder.
	     *
	     * @param null|string|Node\Name $name Name of the namespace
	     *
	     * @return Builder\Namespace_ The created namespace builder
	     */
	    public function namespace($name) : Builder\Namespace_ {
		return new Builder\Namespace_($name);
	    }
	    ...

The assumption causes a bug; the parser captures the token next to
"namespace" as a name space definition as reported in #1985.

This change modifies readToken(); in the case that "namespace" appears
just after "->", readToken() reports the token as an identifier, not a
keyword.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>