### PR TITLE
php: Do not get fooled by keywords used in class context

### DIFF
--- a/Units/parser-php.r/php-semi-reserved-keywords.d/expected.tags
+++ b/Units/parser-php.r/php-semi-reserved-keywords.d/expected.tags
@@ -2,14 +2,34 @@ C	input.php	/^class C {$/;"	c
 abstract	input.php	/^    public function abstract() {}$/;"	f	class:C
 c	input.php	/^$c = C::new();$/;"	v
 call_c_function	input.php	/^function call_c_function($c) {$/;"	f
-class	input.php	/^    public function class() {}$/;"	f	class:C
+class	input.php	/^    public static function class() { return new self; }$/;"	f	class:C
 const	input.php	/^    const const = 1;$/;"	d	class:C
 for	input.php	/^    public function for() {}$/;"	f	class:C
+func1	input.php	/^function func1() {}$/;"	f
+func2	input.php	/^function func2() {}$/;"	f
+func3	input.php	/^function func3() {}$/;"	f
+func4	input.php	/^function func4() {}$/;"	f
+func5	input.php	/^function func5() {}$/;"	f
+func6	input.php	/^function func6() {}$/;"	f
+func7	input.php	/^function func7() {}$/;"	f
+func8	input.php	/^function func8() {}$/;"	f
+func9	input.php	/^function func9() {}$/;"	f
 function	input.php	/^    public function function() {}$/;"	f	class:C
+namespace	input.php	/^    public static function namespace() { return new self; }$/;"	f	class:C
 new	input.php	/^    public static function new() { return new self; }$/;"	f	class:C
 private	input.php	/^    private function private() {}$/;"	f	class:C
 protected	input.php	/^    protected function protected() {}$/;"	f	class:C
 public	input.php	/^    public function public() {}$/;"	f	class:C
 something	input.php	/^function something() {}$/;"	f
 static	input.php	/^    const static = 2;$/;"	d	class:C
+test1	input.php	/^    public function test1() {}$/;"	f	class:C
+test2	input.php	/^    public function test2() {}$/;"	f	class:C
+test3	input.php	/^    public function test3() {}$/;"	f	class:C
+test4	input.php	/^    public function test4() {}$/;"	f	class:C
+test5	input.php	/^    public function test5() {}$/;"	f	class:C
+test6	input.php	/^    public function test6() {}$/;"	f	class:C
+test7	input.php	/^    public function test7() {}$/;"	f	class:C
+test8	input.php	/^    public function test8() {}$/;"	f	class:C
+test9	input.php	/^    public function test9() {}$/;"	f	class:C
+trait	input.php	/^    public static function trait() { return new self; }$/;"	f	class:C
 while	input.php	/^    public function while() {}$/;"	f	class:C

--- a/Units/parser-php.r/php-semi-reserved-keywords.d/input.php
+++ b/Units/parser-php.r/php-semi-reserved-keywords.d/input.php
@@ -6,13 +6,25 @@ class C {
     
     public static function new() { return new self; }
     public function function() {}
-    public function class() {}
+    public static function class() { return new self; }
     public function for() {}
     public function while() {}
     public function abstract() {}
     public function public() {}
     protected function protected() {}
     private function private() {}
+    public static function namespace() { return new self; }
+    public static function trait() { return new self; }
+
+    public function test1() {}
+    public function test2() {}
+    public function test3() {}
+    public function test4() {}
+    public function test5() {}
+    public function test6() {}
+    public function test7() {}
+    public function test8() {}
+    public function test9() {}
 }
 
 function call_c_function($c) {
@@ -22,5 +34,28 @@ function call_c_function($c) {
 $c = C::new();
 call_c_function($c);
 $c->class();
+$c->namespace();
+$c->trait();
+
+$c->class()->test1();
+function func1() {}
+$c->namespace()->test2();
+function func2() {}
+$c->trait()->test3();
+function func3() {}
+
+$c->class()->namespace()->test4();
+function func4() {}
+$c->namespace()->trait()->test5();
+function func5() {}
+$c->trait()->class()->test6();
+function func6() {}
+
+C::class()->test7();
+function func7() {}
+C::namespace()->test8();
+function func8() {}
+C::trait()->test9();
+function func9() {}
 
 function something() {}


### PR DESCRIPTION
https://wiki.php.net/rfc/context_sensitive_lexer

Based on a patch from @masatake; closes #1986.

Fixes #1985.