### PR TITLE
PHP: use anonGenerate function

### DIFF
--- a/Units/parser-php.r/php-anonymous-classes.d/args.ctags
+++ b/Units/parser-php.r/php-anonymous-classes.d/args.ctags
@@ -1,1 +1,2 @@
 --fields=afikmsS
+--fields=+E

--- a/Units/parser-php.r/php-anonymous-classes.d/expected.tags
+++ b/Units/parser-php.r/php-anonymous-classes.d/expected.tags
@@ -1,14 +1,14 @@
-AnonymousClass1	input.php	/^$c = new class {$/;"	c
-AnonymousClass2	input.php	/^$d = new class(42) {$/;"	c
-AnonymousClass3	input.php	/^$e = new class(64) extends SomeClass implements SomeInterface {$/;"	c	inherits:SomeClass,SomeInterface
+AnonymousClassa6525f550100	input.php	/^$c = new class {$/;"	c	extras:anonymous
+AnonymousClassa6525f550200	input.php	/^$d = new class(42) {$/;"	c	extras:anonymous
+AnonymousClassa6525f550300	input.php	/^$e = new class(64) extends SomeClass implements SomeInterface {$/;"	c	inherits:SomeClass,SomeInterface	extras:anonymous
 SomeClass	input.php	/^class SomeClass {}$/;"	c
 SomeInterface	input.php	/^interface SomeInterface {}$/;"	i
 SomeTrait	input.php	/^trait SomeTrait {}$/;"	t
-__construct	input.php	/^	public function __construct($n) { echo $n; }$/;"	f	class:AnonymousClass2	access:public	signature:($n)
-__construct	input.php	/^	public function __construct($n) { echo $n; }$/;"	f	class:AnonymousClass3	access:public	signature:($n)
+__construct	input.php	/^	public function __construct($n) { echo $n; }$/;"	f	class:AnonymousClassa6525f550200	access:public	signature:($n)
+__construct	input.php	/^	public function __construct($n) { echo $n; }$/;"	f	class:AnonymousClassa6525f550300	access:public	signature:($n)
 c	input.php	/^$c = new class {$/;"	v
 d	input.php	/^$d = new class(42) {$/;"	v
 e	input.php	/^$e = new class(64) extends SomeClass implements SomeInterface {$/;"	v
-hello	input.php	/^	public function hello() { echo "hello"; }$/;"	f	class:AnonymousClass1	access:public	signature:()
-hello	input.php	/^	public function hello() { echo "hello"; }$/;"	f	class:AnonymousClass2	access:public	signature:()
-hello	input.php	/^	public function hello() { echo "hello"; }$/;"	f	class:AnonymousClass3	access:public	signature:()
+hello	input.php	/^	public function hello() { echo "hello"; }$/;"	f	class:AnonymousClassa6525f550100	access:public	signature:()
+hello	input.php	/^	public function hello() { echo "hello"; }$/;"	f	class:AnonymousClassa6525f550200	access:public	signature:()
+hello	input.php	/^	public function hello() { echo "hello"; }$/;"	f	class:AnonymousClassa6525f550300	access:public	signature:()


### PR DESCRIPTION
anonGenerate function defined in main part is for generating names
for anonymous tags. Unlike the current particular implementation
in php.c, the name generated by anonGenerate function is unique in
a tags file. The unique names may help a client tool implement
interesting features.

In addition to using the function, this change marks tags for
anonymous classes XTAG_ANONYMOUS. So a user can enable or disable
the emission of tags for anonymous classes with --extras='-{anonymous}'
option.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>