### PR TITLE
HTML: introduce "script" kind for tagging external script files specified in <script src=...

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -33,6 +33,7 @@ DTD            p/parameterEntity partOfAttDef        on      part of attribute d
 Elm            m/module          imported            on      imported module
 Go             p/package         imported            on      imported package
 Go             u/unknown         receiverType        on      receiver type
+HTML           C/stylesheet      extFile             on      referenced as external files
 HTML           J/script          extFile             on      referenced as external files
 Java           p/package         imported            on      imported package
 LdScript       i/inputSection    discarded           on      discarded when linking
@@ -95,6 +96,7 @@ DTD            p/parameterEntity partOfAttDef        on      part of attribute d
 Elm            m/module          imported            on      imported module
 Go             p/package         imported            on      imported package
 Go             u/unknown         receiverType        on      receiver type
+HTML           C/stylesheet      extFile             on      referenced as external files
 HTML           J/script          extFile             on      referenced as external files
 Java           p/package         imported            on      imported package
 LdScript       i/inputSection    discarded           on      discarded when linking

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -33,6 +33,7 @@ DTD            p/parameterEntity partOfAttDef        on      part of attribute d
 Elm            m/module          imported            on      imported module
 Go             p/package         imported            on      imported package
 Go             u/unknown         receiverType        on      receiver type
+HTML           J/script          extFile             on      referenced as external files
 Java           p/package         imported            on      imported package
 LdScript       i/inputSection    discarded           on      discarded when linking
 LdScript       i/inputSection    mapped              on      mapped to output section
@@ -94,6 +95,7 @@ DTD            p/parameterEntity partOfAttDef        on      part of attribute d
 Elm            m/module          imported            on      imported module
 Go             p/package         imported            on      imported package
 Go             u/unknown         receiverType        on      receiver type
+HTML           J/script          extFile             on      referenced as external files
 Java           p/package         imported            on      imported package
 LdScript       i/inputSection    discarded           on      discarded when linking
 LdScript       i/inputSection    mapped              on      mapped to output section

--- a/Units/parser-html.r/external-files.html.d/args.ctags
+++ b/Units/parser-html.r/external-files.html.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+gr
+--fields=+r

--- a/Units/parser-html.r/external-files.html.d/expected.tags
+++ b/Units/parser-html.r/external-files.html.d/expected.tags
@@ -1,4 +1,10 @@
+A.css	input.html	/^    <link href="A.css" rel="stylesheet" media="print">$/;"	C	roles:extFile
+B.css	input.html	/^    <link rel="stylesheet" media="print" href="B.css">$/;"	C	roles:extFile
+C.css	input.html	/^    <link media="print" href="C.css" rel="stylesheet">$/;"	C	roles:extFile
 https://cdn.jsdelivr.net/npm/vue	input.html	/^    <script src="https:\/\/cdn.jsdelivr.net\/npm\/vue"><\/script>$/;"	J	roles:extFile
+D.css	input.html	/^    <link rel="stylesheet" href="D.css" media="print">$/;"	C	roles:extFile
+E.css	input.html	/^    <link href="E.css" media="print" rel="stylesheet">$/;"	C	roles:extFile
+F.css	input.html	/^    <link media="print" rel="stylesheet" href="F.css">$/;"	C	roles:extFile
 js/three.min.js	input.html	/^    <script type="text\/javascript" src="js\/three.min.js"><\/script>$/;"	J	roles:extFile
 i	input.html	/^      var i;$/;"	v	roles:def
 j	input.html	/var j;/;"	v	roles:def

--- a/Units/parser-html.r/external-files.html.d/expected.tags
+++ b/Units/parser-html.r/external-files.html.d/expected.tags
@@ -1,0 +1,4 @@
+https://cdn.jsdelivr.net/npm/vue	input.html	/^    <script src="https:\/\/cdn.jsdelivr.net\/npm\/vue"><\/script>$/;"	J	roles:extFile
+js/three.min.js	input.html	/^    <script type="text\/javascript" src="js\/three.min.js"><\/script>$/;"	J	roles:extFile
+i	input.html	/^      var i;$/;"	v	roles:def
+j	input.html	/var j;/;"	v	roles:def

--- a/Units/parser-html.r/external-files.html.d/input.html
+++ b/Units/parser-html.r/external-files.html.d/input.html
@@ -1,0 +1,13 @@
+<html>
+  <head>
+    <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <script>
+      var i;
+      for (i = 0; i < 2; i++) {
+         console.log ("hello");
+      }
+    </script>
+    <script>var j;</script>
+    <script type="text/javascript" src="js/three.min.js"></script>
+  </head>
+</html>

--- a/Units/parser-html.r/external-files.html.d/input.html
+++ b/Units/parser-html.r/external-files.html.d/input.html
@@ -1,13 +1,21 @@
 <html>
   <head>
+    <link href="A.css" rel="stylesheet" media="print">
+    <link rel="stylesheet" media="print" href="B.css">
+    <link media="print" href="C.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/vue"></script>
+    <link rel="stylesheet" href="D.css" media="print">
     <script>
       var i;
       for (i = 0; i < 2; i++) {
          console.log ("hello");
       }
     </script>
+    <link href="E.css" media="print" rel="stylesheet">
     <script>var j;</script>
+    <link media="print" rel="stylesheet" href="F.css">
+    <script></script>
+    <script/>
     <script type="text/javascript" src="js/three.min.js"></script>
   </head>
 </html>

--- a/parsers/html.c
+++ b/parsers/html.c
@@ -30,15 +30,26 @@ typedef enum {
 	K_ANCHOR,
 	K_HEADING1,
 	K_HEADING2,
-	K_HEADING3
+	K_HEADING3,
+	K_SCRIPT,
 } htmlKind;
 
+
+typedef enum {
+	SCRIPT_KIND_EXTERNAL_FILE_ROLE,
+} ScriptRole;
+
+static roleDefinition ScriptRoles [] = {
+	{ true, "extFile", "referenced as external files" },
+};
 
 static kindDefinition HtmlKinds [] = {
 	{ true, 'a', "anchor",		"named anchors" },
 	{ true, 'h', "heading1",	"H1 headings" },
 	{ true, 'i', "heading2",	"H2 headings" },
-	{ true, 'j', "heading3",	"H3 headings" }
+	{ true, 'j', "heading3",	"H3 headings" },
+	{ true, 'J', "script",		"scripts",
+	  .referenceOnly = true, ATTACH_ROLES (ScriptRoles)},
 };
 
 typedef enum {
@@ -65,6 +76,7 @@ typedef enum {
 	KEYWORD_meta,
 	KEYWORD_param,
 	KEYWORD_source,
+	KEYWORD_src,
 	KEYWORD_track,
 	KEYWORD_wbr
 } keywordId;
@@ -93,6 +105,7 @@ static const keywordTable HtmlKeywordTable[] = {
 	{"meta", KEYWORD_meta},
 	{"param", KEYWORD_param},
 	{"source", KEYWORD_source},
+	{"src", KEYWORD_src},
 	{"track", KEYWORD_track},
 	{"wbr", KEYWORD_wbr},
 };
@@ -415,6 +428,22 @@ static void readTag (tokenInfo *token, vString *text, int depth)
 						readToken (token, true);
 						if (token->type == TOKEN_STRING || token->type == TOKEN_NAME)
 							makeSimpleTag (token->string, K_ANCHOR);
+					}
+				}
+			}
+			else if (startTag == KEYWORD_script && token->type == TOKEN_NAME)
+			{
+				keywordId attribute = lookupKeyword (vStringValue (token->string), Lang_html);
+
+				if (attribute == KEYWORD_src)
+				{
+					readToken (token, true);
+					if (token->type == TOKEN_EQUAL)
+					{
+						readToken (token, true);
+						if (token->type == TOKEN_STRING)
+							makeSimpleRefTag (token->string, K_SCRIPT,
+											  SCRIPT_KIND_EXTERNAL_FILE_ROLE);
 					}
 				}
 			}

--- a/parsers/html.c
+++ b/parsers/html.c
@@ -31,6 +31,7 @@ typedef enum {
 	K_HEADING1,
 	K_HEADING2,
 	K_HEADING3,
+	K_STYELSHEET,
 	K_SCRIPT,
 } htmlKind;
 
@@ -39,7 +40,15 @@ typedef enum {
 	SCRIPT_KIND_EXTERNAL_FILE_ROLE,
 } ScriptRole;
 
+typedef enum {
+	STYLESHEET_KIND_EXTERNAL_FILE_ROLE,
+} StylesheetRole;
+
 static roleDefinition ScriptRoles [] = {
+	{ true, "extFile", "referenced as external files" },
+};
+
+static roleDefinition StylesheetRoles [] = {
 	{ true, "extFile", "referenced as external files" },
 };
 
@@ -48,6 +57,8 @@ static kindDefinition HtmlKinds [] = {
 	{ true, 'h', "heading1",	"H1 headings" },
 	{ true, 'i', "heading2",	"H2 headings" },
 	{ true, 'j', "heading3",	"H3 headings" },
+	{ true, 'C', "stylesheet",	"stylesheets",
+	  .referenceOnly = true, ATTACH_ROLES (StylesheetRoles)},
 	{ true, 'J', "script",		"scripts",
 	  .referenceOnly = true, ATTACH_ROLES (ScriptRoles)},
 };
@@ -69,12 +80,14 @@ typedef enum {
 	KEYWORD_command,
 	KEYWORD_embed,
 	KEYWORD_hr,
+	KEYWORD_href,
 	KEYWORD_img,
 	KEYWORD_input,
 	KEYWORD_keygen,
 	KEYWORD_link,
 	KEYWORD_meta,
 	KEYWORD_param,
+	KEYWORD_rel,
 	KEYWORD_source,
 	KEYWORD_src,
 	KEYWORD_track,
@@ -98,12 +111,14 @@ static const keywordTable HtmlKeywordTable[] = {
 	{"command", KEYWORD_command},
 	{"embed", KEYWORD_embed},
 	{"hr", KEYWORD_hr},
+	{"href", KEYWORD_href},
 	{"img", KEYWORD_img},
 	{"input", KEYWORD_input},
 	{"keygen", KEYWORD_keygen},
 	{"link", KEYWORD_link},
 	{"meta", KEYWORD_meta},
 	{"param", KEYWORD_param},
+	{"rel", KEYWORD_rel},
 	{"source", KEYWORD_source},
 	{"src", KEYWORD_src},
 	{"track", KEYWORD_track},
@@ -403,6 +418,8 @@ static void readTag (tokenInfo *token, vString *text, int depth)
 		keywordId startTag;
 		bool isHeading;
 		bool isVoid;
+		vString *stylesheet = NULL;
+		bool stylesheet_expectation = false;
 
 		startTag = lookupKeyword (vStringValue (token->string), Lang_html);
 		isHeading = (startTag == KEYWORD_h1 || startTag == KEYWORD_h2 || startTag == KEYWORD_h3);
@@ -447,9 +464,55 @@ static void readTag (tokenInfo *token, vString *text, int depth)
 					}
 				}
 			}
+			else if (startTag == KEYWORD_link && token->type == TOKEN_NAME)
+			{
+				keywordId attribute = lookupKeyword (vStringValue (token->string), Lang_html);
+
+				if (attribute == KEYWORD_rel)
+				{
+					readToken (token, true);
+					if (token->type == TOKEN_EQUAL)
+					{
+						readToken (token, true);
+						if (token->type == TOKEN_STRING &&
+							/* strcmp is not enough:
+							 * e.g. <link href="fancy.css"
+							 *            rel="alternate stylesheet" title="Fancy"> */
+							vStringLength(token->string) >= 10 &&
+							strstr (vStringValue (token->string), "stylesheet"))
+							stylesheet_expectation = true;
+					}
+				}
+				else if (attribute == KEYWORD_href)
+				{
+					readToken (token, true);
+					if (token->type == TOKEN_EQUAL)
+					{
+						readToken (token, true);
+						if (token->type == TOKEN_STRING)
+						{
+							if (stylesheet == NULL)
+								stylesheet = vStringNewCopy (token->string);
+							else
+								vStringCopy (stylesheet, token->string);
+						}
+					}
+				}
+				if (stylesheet_expectation && stylesheet && !vStringIsEmpty (stylesheet))
+				{
+					makeSimpleRefTag (stylesheet, K_STYELSHEET,
+									  STYLESHEET_KIND_EXTERNAL_FILE_ROLE);
+					stylesheet_expectation = false;
+					if (stylesheet)
+						vStringClear (stylesheet);
+				}
+			}
 		}
 		while (token->type != TOKEN_TAG_END && token->type != TOKEN_TAG_END2 &&
 			   token->type != TOKEN_EOF);
+
+		vStringDelete (stylesheet);
+		stylesheet = NULL;
 
 		if (!isVoid && token->type == TOKEN_TAG_END && depth < MAX_DEPTH)
 		{


### PR DESCRIPTION
Such files are tagged with "extFile" role of "script" kind.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>