### PR TITLE
ObjectiveC: fix about memory management for the parser specific dyanamic fields

### DIFF
--- a/Units/parser-objectivec.r/crash-in-parsing-protocol.d/README
+++ b/Units/parser-objectivec.r/crash-in-parsing-protocol.d/README
@@ -1,1 +1,0 @@
-Input files are Taken from https://github.com/gnustep/libs-base.git

--- a/Units/parser-objectivec.r/crash-in-parsing-protocol.d/README
+++ b/Units/parser-objectivec.r/crash-in-parsing-protocol.d/README
@@ -1,0 +1,1 @@
+Input files are Taken from https://github.com/gnustep/libs-base.git

--- a/Units/parser-objectivec.r/crash-in-parsing-protocol.d/args.ctags
+++ b/Units/parser-objectivec.r/crash-in-parsing-protocol.d/args.ctags
@@ -1,0 +1,2 @@
+--languages=ObjectiveC
+--fields=+i

--- a/Units/parser-objectivec.r/crash-in-parsing-protocol.d/expected.tags
+++ b/Units/parser-objectivec.r/crash-in-parsing-protocol.d/expected.tags
@@ -1,0 +1,5 @@
+NSFileAccessIntent	input.h	/^@interface NSFileAccessIntent : NSObject$/;"	i	inherits:NSObject
+NSFileCoordinator	input.h	/^@interface NSFileCoordinator : NSObject$/;"	i	inherits:NSObject
+NSFilePresenter	input-0.h	/^@protocol NSFilePresenter <NSObject>$/;"	P
+__NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE	input-0.h	/^#define __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE$/;"	M
+__NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE	input.h	/^#define __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE$/;"	M

--- a/Units/parser-objectivec.r/crash-in-parsing-protocol.d/expected.tags
+++ b/Units/parser-objectivec.r/crash-in-parsing-protocol.d/expected.tags
@@ -1,5 +1,5 @@
 NSFileAccessIntent	input.h	/^@interface NSFileAccessIntent : NSObject$/;"	i	inherits:NSObject
 NSFileCoordinator	input.h	/^@interface NSFileCoordinator : NSObject$/;"	i	inherits:NSObject
-NSFilePresenter	input-0.h	/^@protocol NSFilePresenter <NSObject>$/;"	P
+NSFilePresenter	input-0.h	/^@protocol NSFilePresenter <NSObject>$/;"	P	protocols:NSObject
 __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE	input-0.h	/^#define __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE$/;"	M
 __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE	input.h	/^#define __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE$/;"	M

--- a/Units/parser-objectivec.r/crash-in-parsing-protocol.d/input-0.h
+++ b/Units/parser-objectivec.r/crash-in-parsing-protocol.d/input-0.h
@@ -1,0 +1,11 @@
+#ifndef __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE
+#define __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE
+
+#import <Foundation/NSObject.h>
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_7,GS_API_LATEST)
+@protocol NSFilePresenter <NSObject>
+@end
+
+#endif
+#endif

--- a/Units/parser-objectivec.r/crash-in-parsing-protocol.d/input-0.h
+++ b/Units/parser-objectivec.r/crash-in-parsing-protocol.d/input-0.h
@@ -1,3 +1,4 @@
+// Input files are Taken from https://github.com/gnustep/libs-base.git
 #ifndef __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE
 #define __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE
 

--- a/Units/parser-objectivec.r/crash-in-parsing-protocol.d/input.h
+++ b/Units/parser-objectivec.r/crash-in-parsing-protocol.d/input.h
@@ -1,0 +1,15 @@
+#ifndef __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE
+#define __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE
+
+#import <Foundation/NSObject.h>
+
+#if OS_API_VERSION(MAC_OS_X_VERSION_10_7,GS_API_LATEST)
+
+@interface NSFileAccessIntent : NSObject
+@end
+
+@interface NSFileCoordinator : NSObject
+@end
+
+#endif
+#endif

--- a/Units/parser-objectivec.r/crash-in-parsing-protocol.d/input.h
+++ b/Units/parser-objectivec.r/crash-in-parsing-protocol.d/input.h
@@ -1,3 +1,4 @@
+// Input files are Taken from https://github.com/gnustep/libs-base.git
 #ifndef __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE
 #define __NSFileCoordinator_h_GNUSTEP_BASE_INCLUDE
 

--- a/main/entry.c
+++ b/main/entry.c
@@ -977,7 +977,11 @@ extern void attachParserFieldToCorkEntry (int index,
 	Assert (tag != NULL);
 
 	v = eStrdup (value);
+
+	bool dynfields_allocated = tag->parserFieldsDynamic? true: false;
 	attachParserFieldGeneric (tag, ftype, v, true);
+	if (!dynfields_allocated && tag->parserFieldsDynamic)
+		PARSER_TRASH_BOX_TAKE_BACK(tag->parserFieldsDynamic);
 }
 
 extern const tagField* getParserField (const tagEntryInfo * tag, int index)

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -905,8 +905,8 @@ static void parseProtocol (vString * const ident, objcToken what)
 {
 	if (what == ObjcIDENTIFIER)
 	{
-		addTag (ident, K_PROTOCOL);
-		pushEnclosingContext (ident, K_PROTOCOL);
+		unsigned int index = addTag (ident, K_PROTOCOL);
+		pushEnclosingContextFull (ident, K_PROTOCOL, index);
 	}
 	toDoNext = &parseMethods;
 }

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -484,6 +484,7 @@ static void pushEnclosingContextFull (const vString * parent, objcKind type, uns
 static void popEnclosingContext (void)
 {
 	vStringClear (parentName);
+	parentCorkIndex = CORK_NIL;
 }
 
 static void pushCategoryContext (unsigned int category_index)
@@ -1290,6 +1291,7 @@ static void findObjcTags (void)
 	prevIdent = NULL;
 	fullMethodName = NULL;
 	categoryCorkIndex = CORK_NIL;
+	parentCorkIndex = CORK_NIL;
 }
 
 static void objcInitialize (const langType language)


### PR DESCRIPTION
This fix a bug I introduced to the objc parser in these days.
I will merge in soon.