### PR TITLE
Support more translators

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -79,14 +79,17 @@ nodist_ctags_SOURCES = $(REPOINFO_HEADS)
 BUILT_SOURCES = $(REPOINFO_HEADS)
 CLEANFILES = $(REPOINFO_HEADS)
 $(REPOINFO_OBJS): $(REPOINFO_SRCS) $(REPOINFO_HEADS)
+repoinfo_verbose = $(repoinfo_verbose_@AM_V@)
+repoinfo_verbose_ = $(repoinfo_verbose_@AM_DEFAULT_V@)
+repoinfo_verbose_0 = @echo REPOINFO "  $@";
 if BUILD_IN_GIT_REPO
 GEN_REPOINFO = $(srcdir)/misc/gen-repoinfo
 $(REPOINFO_HEADS): FORCE
-	$(GEN_REPOINFO) $@
+	$(repoinfo_verbose)$(GEN_REPOINFO) $@
 FORCE:
 else
 $(REPOINFO_HEADS):
-	echo > $@
+	$(repoinfo_verbose)echo > $@
 endif
 
 if RUN_OPTLIB2C

--- a/Makefile.am
+++ b/Makefile.am
@@ -99,8 +99,10 @@ optlib2c_verbose = $(optlib2c_verbose_@AM_V@)
 optlib2c_verbose_ = $(optlib2c_verbose_@AM_DEFAULT_V@)
 optlib2c_verbose_0 = @echo OPTLIB2C "  $@";
 OPTLIB2C = $(srcdir)/misc/optlib2c
-%.c: %.ctags $(OPTLIB2C) Makefile
+SUFFIXES += .ctags
+.ctags.c:
 	$(optlib2c_verbose)$(OPTLIB2C) $< > $@
+$(OPTLIB2C_INPUT): $(OPTLIB2C) Makefile
 endif
 dist_ctags_SOURCES = $(ALL_HEADS) $(ALL_SRCS)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -92,6 +92,8 @@ $(REPOINFO_HEADS):
 	$(repoinfo_verbose)echo > $@
 endif
 
+SUFFIXES=
+
 if RUN_OPTLIB2C
 optlib2c_verbose = $(optlib2c_verbose_@AM_V@)
 optlib2c_verbose_ = $(optlib2c_verbose_@AM_DEFAULT_V@)
@@ -120,7 +122,7 @@ man_MANS = man/ctags.1 man/ctags-incompatibilities.7 man/ctags-optlib.7
 rst2man_verbose = $(rst2man_verbose_@AM_V@)
 rst2man_verbose_ = $(rst2man_verbose_@AM_DEFAULT_V@)
 rst2man_verbose_0 = @echo RST2MAN "  $@";
-SUFFIXES = .1.rst .1 .7.rst .7
+SUFFIXES += .1.rst .1 .7.rst .7
 # See man/Makefile
 RST2MAN_OPTIONS=--syntax-highlight=none
 .1.rst.1:

--- a/Tmain/pretend-option.d/run.sh
+++ b/Tmain/pretend-option.d/run.sh
@@ -1,0 +1,6 @@
+# Copyright: 2018 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+"${CTAGS}" --quiet --options=NONE --with-list-header=no --_pretend-Lisp=C --list-kinds=C

--- a/Tmain/pretend-option.d/stdout-expected.txt
+++ b/Tmain/pretend-option.d/stdout-expected.txt
@@ -1,0 +1,1 @@
+f  functions

--- a/autogen.sh
+++ b/autogen.sh
@@ -16,7 +16,7 @@ if [ -z "${MAKE}" ]; then
 	fi
 fi
 
-ctags_files=`${MAKE} -s -f makefiles/list-translator-input.mak`
+ctags_files=`${MAKE} -s -f makefiles/list-optlib2c-input.mak`
 misc/dist-test-cases && \
     if autoreconf -vfi; then
 	if type perl > /dev/null; then

--- a/configure.ac
+++ b/configure.ac
@@ -385,8 +385,8 @@ AC_EGREP_HEADER(clock_t, time.h, AC_MSG_RESULT(yes),
 
 AC_CHECK_HEADERS([stdbool.h],
 [
-	AH_TEMPLATE([USE_STDBOOL_H], [whether or not to use <stdbool.h>.])
-	AC_DEFINE([USE_STDBOOL_H])
+	AH_TEMPLATE([HAVE_STDBOOL_H], [whether or not to use <stdbool.h>.])
+	AC_DEFINE([HAVE_STDBOOL_H])
 ],
 [
 	AH_TEMPLATE([bool],  [type for 'bool' if <stdbool.h> is missing or broken.])

--- a/main/general.h
+++ b/main/general.h
@@ -47,7 +47,7 @@
 *   DATA DECLARATIONS
 */
 
-#ifdef USE_STDBOOL_H
+#ifdef HAVE_STDBOOL_H
 # include <stdbool.h>
 #endif
 

--- a/main/mio.c
+++ b/main/mio.c
@@ -29,7 +29,7 @@
 #include <config.h>
 #endif
 
-#ifdef USE_STDBOOL_H
+#ifdef HAVE_STDBOOL_H
 #include <stdbool.h>
 #endif
 #endif

--- a/main/options.c
+++ b/main/options.c
@@ -473,6 +473,8 @@ static optionDescription ExperimentalLongOptionDescription [] = {
  {1,"       Define multitable regular expression for locating tags in specific language."},
  {1,"  --_mtable-totals=[yes|no]"},
  {1,"       Print statistics about mtable usage [no]."},
+ {1,"  --_pretend-<NEWLANG>=<OLDLANG>"},
+ {1,"       Make NEWLANG parser pretend OLDLANG parser in lang: field."},
  {1,"  --_roledef-<LANG>=kind_letter.role_name,role_desc"},
  {1,"       Define new role for kind specified with <kind_letter> in <LANG>."},
  {1,"  --_scopesep-<LANG>=[parent_kind_letter]/child_kind_letter:separator"},
@@ -748,8 +750,9 @@ extern void checkOptions (void)
 	}
 }
 
-extern langType getLanguageComponentInOption (const char *const option,
-											  const char *const prefix)
+extern langType getLanguageComponentInOptionFull (const char *const option,
+												  const char *const prefix,
+												  bool noPretending)
 {
 	size_t prefix_len;
 	langType language;
@@ -774,11 +777,17 @@ extern langType getLanguageComponentInOption (const char *const option,
 	colon = strchr (lang, ':');
 	if (colon)
 		lang_len = colon - lang;
-	language = getNamedLanguage (lang, lang_len);
+	language = getNamedLanguageFull (lang, lang_len, noPretending);
 	if (language == LANG_IGNORE)
 		error (FATAL, "Unknown language \"%s\" in \"%s\" option", lang, option);
 
 	return language;
+}
+
+extern langType getLanguageComponentInOption (const char *const option,
+											  const char *const prefix)
+{
+	return getLanguageComponentInOptionFull (option, prefix, false);
 }
 
 static void setEtagsMode (void)
@@ -3188,6 +3197,8 @@ static void processLongOption (
 	else if (processRoledefOption (option, parameter))
 		;
 	else if (processScopesepOption (option, parameter))
+		;
+	else if (processPretendOption (option, parameter))
 		;
 	else
 		error (FATAL, "Unknown option: --%s", option);

--- a/main/options_p.h
+++ b/main/options_p.h
@@ -164,6 +164,8 @@ extern void freeOptionResources (void);
 
 extern langType getLanguageComponentInOption (const char *const option,
 					      const char *const prefix);
+extern langType getLanguageComponentInOptionFull (const char *const option,
+					      const char *const prefix, bool noPretending);
 
 extern void processLanguageDefineOption (const char *const option, const char *const parameter);
 extern bool processMapOption (const char *const option, const char *const parameter);
@@ -179,6 +181,7 @@ extern bool processLanguageEncodingOption (const char *const option, const char 
 #endif
 extern bool processRoledefOption (const char *const option, const char *const parameter);
 extern bool processScopesepOption (const char *const option, const char *const parameter);
+extern bool processPretendOption (const char *const option, const char *const parameter);
 
 extern void setMainLoop (mainLoopFunc func, void *data);
 

--- a/main/parse.c
+++ b/main/parse.c
@@ -91,6 +91,14 @@ typedef struct sParserObject {
 	struct slaveControlBlock *slaveControlBlock;
 	struct kindControlBlock  *kindControlBlock;
 	struct lregexControlBlock *lregexControlBlock;
+
+	langType pretendingAsLanguage; /* OLDLANG in --_pretend-<NEWLANG>=<OLDLANG>
+									  is set here if this parser is NEWLANG.
+									  LANG_IGNORE is set if no pretending. */
+	langType pretendedAsLanguage;  /* NEWLANG in --_pretend-<NEWLANG>=<OLDLANG>
+									  is set here if this parser is OLDLANG.
+									  LANG_IGNORE is set if no being pretended. */
+
 } parserObject;
 
 /*
@@ -224,17 +232,35 @@ extern bool doesLanguageRequestAutomaticFQTag (const langType language)
 	return LanguageTable [language].def->requestAutomaticFQTag;
 }
 
-extern const char *getLanguageName (const langType language)
+static const char *getLanguageNameFull (const langType language, bool noPretending)
 {
 	const char* result;
+
 	if (language == LANG_IGNORE)
 		result = "unknown";
 	else
 	{
 		Assert (0 <= language  &&  language < (int) LanguageCount);
-		result = LanguageTable [language].def->name;
+		if (noPretending)
+			result = LanguageTable [language].def->name;
+		else
+		{
+			langType real_language = LanguageTable [language].pretendingAsLanguage;
+			if (real_language == LANG_IGNORE)
+				result = LanguageTable [language].def->name;
+			else
+			{
+				Assert (0 <= real_language  &&  real_language < (int) LanguageCount);
+				result = LanguageTable [real_language].def->name;
+			}
+		}
 	}
 	return result;
+}
+
+extern const char *getLanguageName (const langType language)
+{
+	return getLanguageNameFull (language, false);
 }
 
 extern const char *getLanguageKindName (const langType language, const int kindIndex)
@@ -321,7 +347,7 @@ extern roleDefinition* getLanguageRoleForName (const langType language, int kind
 	return getRoleForName (LanguageTable [language].kindControlBlock, kindIndex, roleName);
 }
 
-extern langType getNamedLanguage (const char *const name, size_t len)
+extern langType getNamedLanguageFull (const char *const name, size_t len, bool noPretending)
 {
 	langType result = LANG_IGNORE;
 	unsigned int i;
@@ -345,7 +371,18 @@ extern langType getNamedLanguage (const char *const name, size_t len)
 				result = i;
 			vStringDelete (vstr);
 		}
+
+	if (result != LANG_IGNORE
+		&& (!noPretending)
+		&& LanguageTable [result].pretendedAsLanguage != LANG_IGNORE)
+		result = LanguageTable [result].pretendedAsLanguage;
+
 	return result;
+}
+
+extern langType getNamedLanguage (const char *const name, size_t len)
+{
+	return getNamedLanguageFull (name, len, false);
 }
 
 static langType getNameOrAliasesLanguageAndSpec (const char *const key, langType start_index,
@@ -1844,6 +1881,11 @@ extern void initializeParsing (void)
 	builtInCount = ARRAY_SIZE (BuiltInParsers);
 	LanguageTable = xMalloc (builtInCount, parserObject);
 	memset(LanguageTable, 0, builtInCount * sizeof (parserObject));
+	for (i = 0; i < builtInCount; ++i)
+	{
+		LanguageTable [i].pretendingAsLanguage = LANG_IGNORE;
+		LanguageTable [i].pretendedAsLanguage = LANG_IGNORE;
+	}
 
 	LanguageHTable = hashTableNew (127,
 								   hashCstrcasehash,
@@ -2118,6 +2160,8 @@ extern void processLanguageDefineOption (
 
 		LanguageTable [def->id].currentPatterns = stringListNew ();
 		LanguageTable [def->id].currentExtensions = stringListNew ();
+		LanguageTable [def->id].pretendingAsLanguage = LANG_IGNORE;
+		LanguageTable [def->id].pretendedAsLanguage = LANG_IGNORE;
 
 		eFree (name);
 	}
@@ -3386,7 +3430,9 @@ static void printGuessedParser (const char* const fileName, langType language)
 		parserName = RSV_NONE;
 	}
 	else
-		parserName = LanguageTable [language].def->name;
+	{
+		parserName = getLanguageName (language);
+	}
 
 	printf("%s: %s\n", fileName, parserName);
 }
@@ -4238,6 +4284,54 @@ extern void addLanguageTagMultiTableRegex(const langType language,
 	parserObject* const parser = LanguageTable + language;
 	addTagMultiTableRegex (parser->lregexControlBlock, table_name, regex,
 						   name, kinds, flags, disabled);
+}
+
+extern bool processPretendOption (const char *const option, const char *const parameter)
+{
+	langType new_language, old_language;
+
+#define pretendOptionPrefix "_pretend-"
+	new_language = getLanguageComponentInOptionFull (option, pretendOptionPrefix, true);
+	if (new_language == LANG_IGNORE)
+		return false;
+
+	if (parameter == NULL || parameter[0] == '\0')
+		error (FATAL, "A parameter is needed after \"%s\" option", option);
+
+	old_language = getNamedLanguageFull (parameter, 0, true);
+	if (old_language == LANG_IGNORE)
+		error (FATAL, "Unknown language \"%s\" in option \"--%s=%s\"",
+			   parameter, option, parameter);
+
+	if (LanguageTable [new_language].pretendingAsLanguage != LANG_IGNORE)
+	{
+		error (FATAL, "%s parser pretends as %s already\n",
+			   getLanguageNameFull (new_language, true),
+			   getLanguageNameFull (LanguageTable [new_language].pretendingAsLanguage, true));
+	}
+	if (LanguageTable [old_language].pretendedAsLanguage != LANG_IGNORE)
+	{
+		error (FATAL, "%s parser is pretended as %s already\n",
+			   getLanguageNameFull (old_language, true),
+			   getLanguageNameFull (LanguageTable [old_language].pretendedAsLanguage, true));
+	}
+
+	verbose ("%s pretends %s\n",
+			 getLanguageNameFull (new_language, true),
+			 getLanguageNameFull (old_language, true));
+
+	LanguageTable [new_language].pretendingAsLanguage = old_language;
+	LanguageTable [old_language].pretendedAsLanguage  = new_language;
+
+	verbose ("force enabling %s\n",
+			 getLanguageNameFull (new_language, true));
+	enableLanguage (new_language, true);
+
+	verbose ("force disbling %s\n",
+			 getLanguageNameFull (old_language, true));
+	enableLanguage (old_language, false);
+
+	return true;
 }
 
 /*

--- a/main/parse_p.h
+++ b/main/parse_p.h
@@ -52,6 +52,8 @@ extern parserDefinitionFunc YAML_PARSER_LIST;
 extern bool doesLanguageAllowNullTag (const langType language);
 extern bool doesLanguageRequestAutomaticFQTag (const langType language);
 
+extern langType getNamedLanguageFull (const char *const name, size_t len, bool noPretending);
+
 extern kindDefinition* getLanguageKind(const langType language, int kindIndex);
 extern kindDefinition* getLanguageKindForName (const langType language, const char *kindName);
 extern roleDefinition* getLanguageRole(const langType language, int kindIndex, int roleIndex);

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -130,6 +130,12 @@ extern void vStringNCatS (
 	stringCat (string, s, len);
 }
 
+extern void vStringNCatSUnsafe (
+		vString *const string, const char *const s, const size_t length)
+{
+	stringCat (string, s, length);
+}
+
 extern void vStringCat (vString *const string, const vString *const s)
 {
 	size_t len = vStringLength (s);

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -66,7 +66,15 @@ extern void vStringStripTrailing (vString *const string);
 extern void vStringCat (vString *const string, const vString *const s);
 extern void vStringCatS (vString *const string, const char *const s);
 extern void vStringNCat (vString *const string, const vString *const s, const size_t length);
+
+/* vStringNCatS calls strlen(S) thought it takes LENGTH because
+ * the handle the case that strlen(S) is smaller than LENGTH.
+ *
+ * In the case a caller knows strlen(S) equals to or is greater than LENGTH,
+ * calling strlen is just overhead. vStringNCatSUnsafe doesn't call strlen. */
 extern void vStringNCatS (vString *const string, const char *const s, const size_t length);
+extern void vStringNCatSUnsafe (vString *const string, const char *const s, const size_t length);
+
 extern vString *vStringNewCopy (const vString *const string);
 extern vString *vStringNewInit (const char *const s);
 extern vString *vStringNewNInit (const char *const s, const size_t length);

--- a/makefiles/help.mak
+++ b/makefiles/help.mak
@@ -24,6 +24,7 @@ help:
 	@echo "CATEGORIES=<category>             - Only run tests available under folder Units/<category>.r"
 	@echo "UNITS=<case>[,<case>]             - Only run tests named Units/[category.r/]/<case>.d in units target"
 	@echo "                                                         Tmain/<case>.d in tmain target"
+	@echo "PMAP=<newlang>/<oldlang>[,...]    - Make <newlang> parser pretend <oldlang> (units target only)"
 	@echo ""
 	@echo "Input validation target:"
 	@echo ""

--- a/makefiles/list-optlib2c-input.mak
+++ b/makefiles/list-optlib2c-input.mak
@@ -1,0 +1,5 @@
+# -*- makefile -*-
+include makefiles/optlib2c_input.mak
+.PHONY: list-optlib2c-input
+list-optlib2c-input:
+	@for x in $(OPTLIB2C_INPUT); do echo $$x; done

--- a/makefiles/list-translator-input.mak
+++ b/makefiles/list-translator-input.mak
@@ -1,5 +1,0 @@
-# -*- makefile -*-
-include makefiles/translator_input.mak
-.PHONY: list-translator-input
-list-translator-input:
-	@for x in $(TRANSLATOR_INPUT); do echo $$x; done

--- a/makefiles/optlib2c_input.mak
+++ b/makefiles/optlib2c_input.mak
@@ -1,5 +1,5 @@
 # -*- makefile -*-
-TRANSLATOR_INPUT = \
+OPTLIB2C_INPUT = \
 	optlib/RSpec.ctags			\
 	optlib/cmake.ctags			\
 	optlib/ctags-optlib.ctags		\

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -20,6 +20,7 @@ endif
 LANGUAGES=
 CATEGORIES=
 UNITS=
+PMAP=
 
 SILENT = $(SILENT_@AM_V@)
 SILENT_ = $(SILENT_@AM_DEFAULT_V@)
@@ -111,6 +112,7 @@ units: $(CTAGS_TEST)
 		--languages=$(LANGUAGES) \
 		--categories=$(CATEGORIES) \
 		--units=$(UNITS) \
+		--with-pretense-map=$(PMAP) \
 		$${VALGRIND} --run-shrink \
 		--with-timeout=`expr $(TIMEOUT) '*' 10`\
 		$${SHOW_DIFF_OUTPUT}"; \

--- a/misc/units
+++ b/misc/units
@@ -35,6 +35,7 @@ COLORIZED_OUTPUT=yes
 CATEGORIES=
 UNITS=
 LANGUAGES=
+PRETENSE_OPTS=
 RUN_SHRINK=
 QUIET=
 SHOW_DIFF_OUTPUT=
@@ -559,7 +560,7 @@ run_tcase ()
     #
     # Build _CMDLINE
     #
-    _CMDLINE="${CTAGS} --verbose --options=NONE --optlib-dir=+$t/optlib -o -"
+    _CMDLINE="${CTAGS} --verbose --options=NONE $PRETENSE_OPTS --optlib-dir=+$t/optlib -o -"
     [ -f "${fargs}" ] && _CMDLINE="${_CMDLINE} --options=${fargs}"
 
     if [ -f "${fargs}" ] && ! ${_CMDLINE} --_force-quit=0 > /dev/null 2>&1; then
@@ -900,6 +901,30 @@ run_summary ()
     fi
 }
 
+make_pretense_map ()
+{
+    local ifs=$IFS
+    local p
+    local r
+
+    IFS=,
+    for p in $1; do
+	newlang=${p%/*}
+	oldlang=${p#*/}
+
+	if [ -z "$newlang" ]; then
+	    ERROR 1 "newlang part of --pretend option arg is empty"
+	fi
+	if [ -z "$oldlang" ]; then
+	    ERROR 1 "oldlang part of --pretend option arg is empty"
+	fi
+
+	r="$r --_pretend-$newlang=$oldlang"
+    done
+    IFS=$ifs
+    echo $r
+}
+
 action_run ()
 {
     local action="$1"
@@ -983,6 +1008,15 @@ action_run ()
 		;;
 	    --show-diff-output)
 		SHOW_DIFF_OUTPUT=yes
+		shift
+		;;
+	    --with-pretense-map)
+		shift
+		PRETENSE_OPTS=$(make_pretense_map "$1")
+		shift
+		;;
+	    --with-pretense-map=*)
+		PRETENSE_OPTS=$(make_pretense_map "${1#--with-pretense-map=}")
 		shift
 		;;
 	    -*)
@@ -1088,6 +1122,8 @@ $0 run [OPTIONS] UNITS-DIR
 			       If this option given, DURATION is changed to
 			       DURATION := DURATION * ${_VG_TIMEOUT_FACTOR}
 		--show-diff-output: show diff output for failed test cases in the summary.
+		--with-pretense-map=NEWLANG0/OLDLANG0[,...]: make NEWLANG parser pretend
+							     OLDLANG.
 EOF
 }
 

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -53,7 +53,7 @@ V_OPTLIB2C_1 =
 .c.o:
 	$(V_CC) $(CC) -c $(OPT) $(CFLAGS) $(DEFINES) $(INCLUDES) -o $@ $<
 
-.ctags.c: $(OPTLIB2C)
+%.c: %.ctags $(OPTLIB2C)
 	$(V_OPTLIB2C) $(OPTLIB2C) $< > $@
 
 all: ctags.exe readtags.exe

--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -10,8 +10,8 @@
 include source.mak
 
 OBJEXT = obj
-REGEX_DEFINES = -DHAVE_REGCOMP -D__USE_GNU -Dbool=int -Dfalse=0 -Dtrue=1 -Dstrcasecmp=stricmp -DHAVE_REPOINFO_H
-DEFINES = -DWIN32 $(REGEX_DEFINES)
+DEFINES = -DWIN32 -DHAVE_REGCOMP -D__USE_GNU -Dstrcasecmp=stricmp -DHAVE_REPOINFO_H
+REGEX_DEFINES = -Dbool=int -Dfalse=0 -Dtrue=1 $(DEFINES)
 INCLUDES = -I. -Imain -Ignu_regex -Ifnmatch -Iparsers
 OPT = /O2 /WX
 REGEX_OBJS = $(REGEX_SRCS:.c=.obj)
@@ -66,7 +66,7 @@ readtags.exe: $(READTAGS_OBJS) $(READTAGS_HEADS)
 	$(CC) $(OPT) /Fe$@ $(READTAGS_OBJS) /link setargv.obj $(PDBFLAG)
 
 $(REGEX_OBJS): $(REGEX_SRCS)
-	$(CC) /c $(OPT) /Fo$@ $(INCLUDES) $(DEFINES) $(REGEX_SRCS)
+	$(CC) /c $(OPT) /Fo$@ $(INCLUDES) $(REGEX_DEFINES) $(REGEX_SRCS)
 
 $(FNMATCH_OBJS): $(FNMATCH_SRCS)
 	$(CC) /c $(OPT) /Fo$@ $(INCLUDES) $(DEFINES) $(FNMATCH_SRCS)

--- a/source.mak
+++ b/source.mak
@@ -137,8 +137,8 @@ MAIN_SRCS =				\
 	\
 	$(NULL)
 
-include makefiles/translator_input.mak
-TRANSLATED_SRCS = $(TRANSLATOR_INPUT:.ctags=.c)
+include makefiles/optlib2c_input.mak
+OPTLIB2C_SRCS = $(OPTLIB2C_INPUT:.ctags=.c)
 
 PARSER_HEADS = \
 	parsers/cxx/cxx_debug.h \
@@ -255,7 +255,7 @@ PARSER_SRCS =				\
 	parsers/yacc.c			\
 	parsers/yumrepo.c		\
 	\
-	$(TRANSLATED_SRCS)		\
+	$(OPTLIB2C_SRCS)		\
 	\
 	$(NULL)
 


### PR DESCRIPTION
This pull request is a spin-off of #1847.

In #1847, I  tried to introduce packcc parser generator to implement new java parser.
However, what the result I got is that the parser is too slow. So I wonder whether I should introduce the parser generator or not to ctags.

However, the partial results of introducing the parser generator are useful even if I don't introduce it.
* build scripts are improved to utilize another code generator than optlib2c.
* `_prepend-<NEWLANG>=<OLDLANG>` option helps us reimplement or improve existing parser.