### PR TITLE
Go: don't try to solve the type for "_" variable

### DIFF
--- a/Units/parser-go.r/go-dont-solve-type-for-underscore-var.d/expected.tags
+++ b/Units/parser-go.r/go-dont-solve-type-for-underscore-var.d/expected.tags
@@ -1,0 +1,2 @@
+main	input.go	/^func main () {$/;"	f	package:main
+main	input.go	/^package main$/;"	p

--- a/Units/parser-go.r/go-dont-solve-type-for-underscore-var.d/input.go
+++ b/Units/parser-go.r/go-dont-solve-type-for-underscore-var.d/input.go
@@ -1,0 +1,8 @@
+package main
+
+var (
+	_ int   = 1
+)
+
+func main () {
+}

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -1134,7 +1134,7 @@ static void parseConstTypeVar (tokenInfo *const token, goKind kind, const int sc
 				else
 				{
 					int c = makeTag (token, kind, scope, NULL, NULL);
-					if (corks)
+					if (c != CORK_NIL && corks)
 						intArrayAdd (corks, c);
 				}
 				readToken (token);


### PR DESCRIPTION
To solve a type for a variable later, go parser stores the cork id of
the variable to integer array. However, the cork id for "_" variable
becomes CORK_NIL because makeTagFull() doesn't record "_" as a tag.

The original code has a bug that that go parser stores the CORK_NIL
for "_" to the intger array. The parser should not do so. When resolving
the type for the variable, go parser does (1) pick a cork id from the
intger array, (2) get a tagEntry for the cork id, then (3) access
the internal of the tagEntry. If the cork id is CORK_NIL here, ctags
crash at (3) because getEntryInCorkQueue returns NULL when receiving
CORK_NIL as a cork id.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>