### PR TITLE
main: accept whiespace in tagEntryInfo even in e-ctags output mode

### DIFF
--- a/Tmain/e-ctags-output.d/input_file.cc
+++ b/Tmain/e-ctags-output.d/input_file.cc
@@ -1,0 +1,28 @@
+/* Could NOT be parsed well.
+   The signature should be  recorded well. */
+int32 test(int32 a)
+{
+    return 0;
+}
+/* Can be parsed */
+int32 test2(void)
+{
+    return 0;
+}
+
+/* A tab is included in signature.
+   However, it should be recorded well after converting
+   the tab to a whitespace. */
+int32 test3(int32	a)
+{
+    return 0;
+}
+
+/* A newline is included in signature.
+   However, it should be recorded well after converting
+   the newline to a whitespace. */
+int32 test4(int32
+a)
+{
+    return 0;
+}

--- a/Tmain/e-ctags-output.d/input_scope.rst
+++ b/Tmain/e-ctags-output.d/input_scope.rst
@@ -1,0 +1,21 @@
+===========
+title
+===========
+
+
+X	tab	Y
+===========
+This one will not be recorded.
+
+topic in tab
+----------------------
+This one will not be recorded if --fileds=+s is given
+because a tab char is in the scope field.
+
+X space Y
+===========
+This one will be recorded.
+
+topic in space
+----------------------
+This one will be recorded.

--- a/Tmain/e-ctags-output.d/input_space.rst
+++ b/Tmain/e-ctags-output.d/input_space.rst
@@ -1,0 +1,4 @@
+===================================
+A spaces B
+===================================
+Ths should be recorded in e-ctags output.

--- a/Tmain/e-ctags-output.d/input_tab.rst
+++ b/Tmain/e-ctags-output.d/input_tab.rst
@@ -1,0 +1,4 @@
+===================================
+A	tabs	B
+===================================
+Ths should not be recorded in e-ctags output.

--- a/Tmain/e-ctags-output.d/run.sh
+++ b/Tmain/e-ctags-output.d/run.sh
@@ -1,0 +1,26 @@
+# Copyright: 2019 Masatake YAMATO
+# License: GPL-2
+# The original bug is reported by @elecalion in #2014.
+
+CTAGS=$1
+
+tmp="input file.cc"
+cp input_file.cc "${tmp}"
+"${CTAGS}" --quiet --options=NONE --output-format=e-ctags \
+		   --kinds-c++=+p --fields=+iaSs \
+		   -o - \
+		   "${tmp}" \
+		   input_tab.rst input_space.rst
+rm "${tmp}"
+
+echo "# WITH SCOPE"
+"${CTAGS}" --quiet --options=NONE --output-format=e-ctags \
+		   --fields=+s \
+		   -o - \
+		   input_scope.rst
+
+echo "# WITHOUT SCOPE"
+"${CTAGS}" --quiet --options=NONE --output-format=e-ctags \
+		   --fields=-s \
+		   -o - \
+		   input_scope.rst

--- a/Tmain/e-ctags-output.d/stdout-expected.txt
+++ b/Tmain/e-ctags-output.d/stdout-expected.txt
@@ -1,0 +1,14 @@
+A spaces B	input_space.rst	/^A spaces B$/;"	c
+test	input file.cc	/^int32 test(int32 a)$/;"	f	typeref:typename:int32	signature:(int32 a)
+test2	input file.cc	/^int32 test2(void)$/;"	f	typeref:typename:int32	signature:(void)
+test3	input file.cc	/^int32 test3(int32	a)$/;"	f	typeref:typename:int32	signature:(int32 a)
+test4	input file.cc	/^int32 test4(int32$/;"	f	typeref:typename:int32	signature:(int32 a)
+# WITH SCOPE
+X space Y	input_scope.rst	/^X space Y$/;"	c
+title	input_scope.rst	/^title$/;"	c
+topic in space	input_scope.rst	/^topic in space$/;"	s	chapter:X space Y
+# WITHOUT SCOPE
+X space Y	input_scope.rst	/^X space Y$/;"	c
+title	input_scope.rst	/^title$/;"	c
+topic in space	input_scope.rst	/^topic in space$/;"	s
+topic in tab	input_scope.rst	/^topic in tab$/;"	s

--- a/main/field.c
+++ b/main/field.c
@@ -66,10 +66,10 @@ static const char *renderFieldXpath (const tagEntryInfo *const tag, const char *
 static const char *renderFieldScopeKindName(const tagEntryInfo *const tag, const char *value, vString* b);
 static const char *renderFieldEnd (const tagEntryInfo *const tag, const char *value, vString* b);
 
-static bool hasWhitespaceInName (const tagEntryInfo *const tag, const char *value);
-static bool hasWhitespaceInInput (const tagEntryInfo *const tag, const char*value);
-static bool hasWhitespaceInFieldScope (const tagEntryInfo *const tag, const char *value);
-static bool hasWhitespaceInSignature (const tagEntryInfo *const tag, const char *value);
+static bool hasTabCharInName (const tagEntryInfo *const tag, const char *value);
+static bool hasTabCharInInput (const tagEntryInfo *const tag, const char*value);
+static bool hasTabCharInFieldScope (const tagEntryInfo *const tag, const char *value);
+static bool hasTabCharInSignature (const tagEntryInfo *const tag, const char *value);
 
 static bool     isLanguageFieldAvailable  (const tagEntryInfo *const tag);
 static bool     isTyperefFieldAvailable   (const tagEntryInfo *const tag);
@@ -93,7 +93,7 @@ static bool     isEndFieldAvailable       (const tagEntryInfo *const tag);
 		.enabled       = V,		\
 		.render        = RE,		\
 		.renderNoEscaping= RN,		\
-		.hasWhitespaceChar = HSC, \
+		.hasTabChar = HSC, \
 		.isValueAvailable = A,		\
 		.dataType = DT, \
 	}
@@ -107,13 +107,13 @@ static fieldDefinition fieldDefinitionsFixed [] = {
 			  NULL,
 			  FIELDTYPE_STRING,
 			  renderFieldName, renderFieldNameNoEscape,
-			  hasWhitespaceInName),
+			  hasTabCharInName),
 	DEFINE_FIELD_FULL ('F', "input",    true,
 			   "input file",
 			   NULL,
 			   FIELDTYPE_STRING,
 			   renderFieldInput, renderFieldInputNoEscape,
-			   hasWhitespaceInInput),
+			   hasTabCharInInput),
 	DEFINE_FIELD ('P', "pattern",  true,
 			   "pattern",
 			   FIELDTYPE_STRING|FIELDTYPE_BOOL,
@@ -169,13 +169,13 @@ static fieldDefinition fieldDefinitionsExuberant [] = {
 			   isSignatureFieldAvailable,
 			   FIELDTYPE_STRING,
 			   renderFieldSignature, renderFieldSignatureNoEscape,
-			   hasWhitespaceInSignature),
+			   hasTabCharInSignature),
 	DEFINE_FIELD_FULL ('s', NULL,             true,
 			   "Scope of tag definition (`p' can be used for printing its kind)",
 			   NULL,
 			   FIELDTYPE_STRING,
 			   renderFieldScope, renderFieldScopeNoEscape,
-			   hasWhitespaceInFieldScope),
+			   hasTabCharInFieldScope),
 	DEFINE_FIELD_FULL ('t', "typeref",        true,
 			   "Type and name of a variable or typedef",
 			   isTyperefFieldAvailable,
@@ -205,7 +205,7 @@ static fieldDefinition fieldDefinitionsUniversal [] = {
 			   /* Following renderer is for handling --_xformat=%{scope};
 			      and is not for tags output. */
 			   renderFieldScope, renderFieldScopeNoEscape,
-			   hasWhitespaceInFieldScope),
+			   hasTabCharInFieldScope),
 	DEFINE_FIELD_FULL ('E', "extras",   false,
 			   "Extra tag type information",
 			   isExtrasFieldAvailable,
@@ -435,9 +435,9 @@ static const char *renderFieldNameNoEscape (const tagEntryInfo *const tag, const
 	return renderAsIs (b, tag->name);
 }
 
-static bool hasWhitespaceInName (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED)
+static bool hasTabCharInName (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED)
 {
-	return strpbrk (tag->name, " \t")? true: false;
+	return strchr (tag->name, '\t')? true: false;
 }
 
 static const char *renderFieldInput (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
@@ -459,14 +459,14 @@ static const char *renderFieldInputNoEscape (const tagEntryInfo *const tag, cons
 	return renderAsIs (b, f);
 }
 
-static bool hasWhitespaceInInput (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED)
+static bool hasTabCharInInput (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED)
 {
 	const char *f = tag->inputFileName;
 
 	if (Option.lineDirectives && tag->sourceFileName)
 		f = tag->sourceFileName;
 
-	return strpbrk (f, " \t")? true: false;
+	return strchr (f, '\t')? true: false;
 }
 
 static const char *renderFieldSignature (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED, vString* b)
@@ -480,9 +480,9 @@ static const char *renderFieldSignatureNoEscape (const tagEntryInfo *const tag, 
 	return renderAsIs (b, WITH_DEFUALT_VALUE (tag->extensionFields.signature));
 }
 
-static bool hasWhitespaceInSignature (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED)
+static bool hasTabCharInSignature (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED)
 {
-	return (tag->extensionFields.signature && strpbrk(tag->extensionFields.signature, " \t"))
+	return (tag->extensionFields.signature && strchr(tag->extensionFields.signature, '\t'))
 		? true
 		: false;
 }
@@ -503,12 +503,12 @@ static const char *renderFieldScopeNoEscape (const tagEntryInfo *const tag, cons
 	return scope? renderAsIs (b, scope): NULL;
 }
 
-static bool hasWhitespaceInFieldScope (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED)
+static bool hasTabCharInFieldScope (const tagEntryInfo *const tag, const char *value CTAGS_ATTR_UNUSED)
 {
 	const char* scope;
 
 	getTagScopeInformation ((tagEntryInfo *const)tag, NULL, &scope);
-	return (scope && strpbrk (scope, " \t"));
+	return (scope && strchr (scope, '\t'));
 }
 
 
@@ -572,12 +572,12 @@ extern const char* renderFieldNoEscaping (fieldType type, const tagEntryInfo *ta
 	return renderFieldCommon (type, tag, index, true);
 }
 
-extern bool  doesFieldHaveWhitespaceChar (fieldType type, const tagEntryInfo *tag, int index)
+extern bool  doesFieldHaveTabChar (fieldType type, const tagEntryInfo *tag, int index)
 {
 	fieldObject *fobj = fieldObjects + type;
 	const char *value;
 
-	if (!fobj->def->hasWhitespaceChar)
+	if (!fobj->def->hasTabChar)
 		return false;
 
 	Assert (tag);
@@ -592,7 +592,7 @@ extern bool  doesFieldHaveWhitespaceChar (fieldType type, const tagEntryInfo *ta
 	else
 		value = NULL;
 
-	return fobj->def->hasWhitespaceChar (tag, value);
+	return fobj->def->hasTabChar (tag, value);
 }
 
 /*  Writes "line", stripping leading and duplicate white space.
@@ -1043,7 +1043,7 @@ extern int defineField (fieldDefinition *def, langType language)
 	{
 		def->render = defaultRenderer;
 		def->renderNoEscaping = NULL;
-		def->hasWhitespaceChar = NULL;
+		def->hasTabChar = NULL;
 	}
 
 	if (! def->dataType)

--- a/main/field.h
+++ b/main/field.h
@@ -86,7 +86,7 @@ struct sFieldDefinition {
 
 	fieldRenderer render;
 	fieldRenderer renderNoEscaping;
-	bool (*hasWhitespaceChar) (const tagEntryInfo *const, const char*);
+	bool (*hasTabChar) (const tagEntryInfo *const, const char*);
 
 	bool (* isValueAvailable) (const tagEntryInfo *const);
 

--- a/main/field_p.h
+++ b/main/field_p.h
@@ -58,7 +58,7 @@ extern bool doesFieldHaveValue (fieldType type, const tagEntryInfo *tag);
 
 extern const char* renderField (fieldType type, const tagEntryInfo *tag, int index);
 extern const char* renderFieldNoEscaping (fieldType type, const tagEntryInfo *tag, int index);
-extern bool  doesFieldHaveWhitespaceChar (fieldType type, const tagEntryInfo *tag, int index);
+extern bool  doesFieldHaveTabChar (fieldType type, const tagEntryInfo *tag, int index);
 
 extern void initFieldObjects (void);
 extern int countFields (void);

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -72,7 +72,7 @@ static const char* escapeFieldValue (tagWriter *writer, const tagEntryInfo * tag
 	{
 		struct rejection * rej = writer->private;
 		if (!rej->rejectedInThisRendering)
-			rej->rejectedInThisRendering = doesFieldHaveWhitespaceChar (ftype, tag, NO_PARSER_FIELD);
+			rej->rejectedInThisRendering = doesFieldHaveTabChar (ftype, tag, NO_PARSER_FIELD);
 	}
 
 	if (writer->type == WRITER_E_CTAGS && doesFieldHaveRenderer(ftype, true))
@@ -109,7 +109,7 @@ static int addParserFields (tagWriter *writer, MIO * mio, const tagEntryInfo *co
 			continue;
 
 		if (rej && (!rej->rejectedInThisRendering))
-			rej->rejectedInThisRendering = doesFieldHaveWhitespaceChar (f->ftype, tag, NO_PARSER_FIELD);
+			rej->rejectedInThisRendering = doesFieldHaveTabChar (f->ftype, tag, NO_PARSER_FIELD);
 
 		const char *v;
 		if (writer->type == WRITER_E_CTAGS && doesFieldHaveRenderer(f->ftype, true))


### PR DESCRIPTION
The original code rejects printing a tagEntryInfo that includes whiespace or tab chars
in e-ctags output mode.

This is reported as a bug in #2014 by @elecalion.
I myself also reported in #1969.

What we should reject is just tab char.

NOTE: This char doesn't fix the original bug perfectly.  If --sort=no
is given, e-ctags output mode doesn't reject a tagEntryInfo including
'\t'. The code for rejecting depends on wrong assumption that the
output stream (to tags file) is rewindable. This is not true if the
output is connected to stdout directly. The options combination, "-o
-" and "--sort=no" breaks my assumption.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>