### PR TITLE
Fix the behavior in "-o - --sort=no --output-format=e-ctags" combination (was: Overhaul the code handling tab chars in parser specific fields)

### DIFF
--- a/Tmain/e-ctags-output.d/run.sh
+++ b/Tmain/e-ctags-output.d/run.sh
@@ -5,22 +5,33 @@
 CTAGS=$1
 
 tmp="input file.cc"
-cp input_file.cc "${tmp}"
-"${CTAGS}" --quiet --options=NONE --output-format=e-ctags \
-		   --kinds-c++=+p --fields=+iaSs \
-		   -o - \
-		   "${tmp}" \
-		   input_tab.rst input_space.rst
-rm "${tmp}"
 
-echo "# WITH SCOPE"
-"${CTAGS}" --quiet --options=NONE --output-format=e-ctags \
-		   --fields=+s \
-		   -o - \
-		   input_scope.rst
+run()
+{
+	echo '#'
+	echo '#' with $1
+	echo '#'
 
-echo "# WITHOUT SCOPE"
-"${CTAGS}" --quiet --options=NONE --output-format=e-ctags \
-		   --fields=-s \
-		   -o - \
-		   input_scope.rst
+	cp input_file.cc "${tmp}"
+	"${CTAGS}" --quiet --options=NONE ${1} --output-format=e-ctags \
+			   --kinds-c++=+p --fields=+iaSs \
+			   -o - \
+			   "${tmp}" \
+			   input_tab.rst input_space.rst
+	rm "${tmp}"
+
+	echo "# WITH SCOPE"
+	"${CTAGS}" --quiet --options=NONE ${1} --output-format=e-ctags \
+			   --fields=+s \
+			   -o - \
+			   input_scope.rst
+
+	echo "# WITHOUT SCOPE"
+	"${CTAGS}" --quiet --options=NONE ${1} --output-format=e-ctags \
+			   --fields=-s \
+			   -o - \
+			   input_scope.rst
+}
+
+run "--sort=yes"
+run "--sort=no"

--- a/Tmain/e-ctags-output.d/stdout-expected.txt
+++ b/Tmain/e-ctags-output.d/stdout-expected.txt
@@ -1,3 +1,6 @@
+#
+# with --sort=yes
+#
 A spaces B	input_space.rst	/^A spaces B$/;"	c
 test	input file.cc	/^int32 test(int32 a)$/;"	f	typeref:typename:int32	signature:(int32 a)
 test2	input file.cc	/^int32 test2(void)$/;"	f	typeref:typename:int32	signature:(void)
@@ -12,3 +15,20 @@ X space Y	input_scope.rst	/^X space Y$/;"	c
 title	input_scope.rst	/^title$/;"	c
 topic in space	input_scope.rst	/^topic in space$/;"	s
 topic in tab	input_scope.rst	/^topic in tab$/;"	s
+#
+# with --sort=no
+#
+test	input file.cc	/^int32 test(int32 a)$/;"	f	typeref:typename:int32	signature:(int32 a)
+test2	input file.cc	/^int32 test2(void)$/;"	f	typeref:typename:int32	signature:(void)
+test3	input file.cc	/^int32 test3(int32	a)$/;"	f	typeref:typename:int32	signature:(int32 a)
+test4	input file.cc	/^int32 test4(int32$/;"	f	typeref:typename:int32	signature:(int32 a)
+A spaces B	input_space.rst	/^A spaces B$/;"	c
+# WITH SCOPE
+title	input_scope.rst	/^title$/;"	c
+X space Y	input_scope.rst	/^X space Y$/;"	c
+topic in space	input_scope.rst	/^topic in space$/;"	s	chapter:X space Y
+# WITHOUT SCOPE
+title	input_scope.rst	/^title$/;"	c
+topic in tab	input_scope.rst	/^topic in tab$/;"	s
+X space Y	input_scope.rst	/^X space Y$/;"	c
+topic in space	input_scope.rst	/^topic in space$/;"	s

--- a/Tmain/tab-in-parser-specific-field.d/foo.ctags
+++ b/Tmain/tab-in-parser-specific-field.d/foo.ctags
@@ -1,0 +1,6 @@
+--langdef=foo
+--map-foo=.foo
+--_fielddef-foo=fprop,property attached to a function
+--kinddef-foo=f,func,functions
+--fields-foo=+{fprop}
+--regex-foo=/^def +([^@]+)@prop(\([^\)]*\)):/\1/f/{_field=fprop:\2}

--- a/Tmain/tab-in-parser-specific-field.d/input.foo
+++ b/Tmain/tab-in-parser-specific-field.d/input.foo
@@ -1,6 +1,6 @@
-def fun0@prop(arg0, arg1):
+def b@prop(arg0, arg1):
     pass
 
 # TAB char betwen arg0 and arg1
-def fun1@prop(arg0,	arg1):
+def a@prop(arg0,	arg1):
     pass

--- a/Tmain/tab-in-parser-specific-field.d/input.foo
+++ b/Tmain/tab-in-parser-specific-field.d/input.foo
@@ -1,0 +1,6 @@
+def fun0@prop(arg0, arg1):
+    pass
+
+# TAB char betwen arg0 and arg1
+def fun1@prop(arg0,	arg1):
+    pass

--- a/Tmain/tab-in-parser-specific-field.d/run.sh
+++ b/Tmain/tab-in-parser-specific-field.d/run.sh
@@ -5,9 +5,19 @@ CTAGS=$1
 
 . ../utils.sh
 
-echo "# Universal-ctags output format"
-$CTAGS --options=NONE --options=./foo.ctags --output-format=u-ctags  -o - input.foo
+run()
+{
+	echo '#'
+	echo '#' with $1
+	echo '#'
 
-echo "# Exuberant-ctags output format"
-echo "# fun1 has a tab char in fprop fields. So ctags drops it silent."
-$CTAGS --options=NONE --options=./foo.ctags --output-format=e-ctags  -o - input.foo
+	echo "# Universal-ctags output format"
+	$CTAGS --options=NONE --options=./foo.ctags "$1" --output-format=u-ctags  -o - input.foo
+
+	echo "# Exuberant-ctags output format"
+	echo "# 'a' has a tab char in fprop fields. So ctags drops it silent."
+	$CTAGS --options=NONE --options=./foo.ctags "$1" --output-format=e-ctags  -o - input.foo
+}
+
+run "--sort=yes"
+run "--sort=no"

--- a/Tmain/tab-in-parser-specific-field.d/run.sh
+++ b/Tmain/tab-in-parser-specific-field.d/run.sh
@@ -1,0 +1,13 @@
+# Copyright: 2019 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+. ../utils.sh
+
+echo "# Universal-ctags output format"
+$CTAGS --options=NONE --options=./foo.ctags --output-format=u-ctags  -o - input.foo
+
+echo "# Exuberant-ctags output format"
+echo "# fun1 has a tab char in fprop fields. So ctags drops it silent."
+$CTAGS --options=NONE --options=./foo.ctags --output-format=e-ctags  -o - input.foo

--- a/Tmain/tab-in-parser-specific-field.d/stdout-expected.txt
+++ b/Tmain/tab-in-parser-specific-field.d/stdout-expected.txt
@@ -1,0 +1,6 @@
+# Universal-ctags output format
+fun0	input.foo	/^def fun0@prop(arg0, arg1):$/;"	f	fprop:(arg0, arg1)
+fun1	input.foo	/^def fun1@prop(arg0,	arg1):$/;"	f	fprop:(arg0,\targ1)
+# Exuberant-ctags output format
+# fun1 has a tab char in fprop fields. So ctags drops it silent.
+fun0	input.foo	/^def fun0@prop(arg0, arg1):$/;"	f	fprop:(arg0, arg1)

--- a/Tmain/tab-in-parser-specific-field.d/stdout-expected.txt
+++ b/Tmain/tab-in-parser-specific-field.d/stdout-expected.txt
@@ -1,6 +1,18 @@
+#
+# with --sort=yes
+#
 # Universal-ctags output format
-fun0	input.foo	/^def fun0@prop(arg0, arg1):$/;"	f	fprop:(arg0, arg1)
-fun1	input.foo	/^def fun1@prop(arg0,	arg1):$/;"	f	fprop:(arg0,\targ1)
+a	input.foo	/^def a@prop(arg0,	arg1):$/;"	f	fprop:(arg0,\targ1)
+b	input.foo	/^def b@prop(arg0, arg1):$/;"	f	fprop:(arg0, arg1)
 # Exuberant-ctags output format
-# fun1 has a tab char in fprop fields. So ctags drops it silent.
-fun0	input.foo	/^def fun0@prop(arg0, arg1):$/;"	f	fprop:(arg0, arg1)
+# 'a' has a tab char in fprop fields. So ctags drops it silent.
+b	input.foo	/^def b@prop(arg0, arg1):$/;"	f	fprop:(arg0, arg1)
+#
+# with --sort=no
+#
+# Universal-ctags output format
+b	input.foo	/^def b@prop(arg0, arg1):$/;"	f	fprop:(arg0, arg1)
+a	input.foo	/^def a@prop(arg0,	arg1):$/;"	f	fprop:(arg0,\targ1)
+# Exuberant-ctags output format
+# 'a' has a tab char in fprop fields. So ctags drops it silent.
+b	input.foo	/^def b@prop(arg0, arg1):$/;"	f	fprop:(arg0, arg1)

--- a/main/entry.c
+++ b/main/entry.c
@@ -1249,8 +1249,11 @@ static void writeTagEntry (const tagEntryInfo *const tag, bool checkingNeeded)
 
 	length = writerWriteTag (TagFile.mio, tag);
 
-	++TagFile.numTags.added;
-	rememberMaxLengths (strlen (tag->name), (size_t) length);
+	if (length > 0)
+	{
+		++TagFile.numTags.added;
+		rememberMaxLengths (strlen (tag->name), (size_t) length);
+	}
 	DebugStatement ( mio_flush (TagFile.mio); )
 
 	abort_if_ferror (TagFile.mio);

--- a/main/field.c
+++ b/main/field.c
@@ -1025,7 +1025,7 @@ static const char* defaultRenderer (const tagEntryInfo *const tag CTAGS_ATTR_UNU
 				    const char *value,
 				    vString * buffer CTAGS_ATTR_UNUSED)
 {
-	return value;
+	return renderEscapedString (value, tag, buffer);
 }
 
 extern int defineField (fieldDefinition *def, langType language)

--- a/main/field.c
+++ b/main/field.c
@@ -572,16 +572,27 @@ extern const char* renderFieldNoEscaping (fieldType type, const tagEntryInfo *ta
 	return renderFieldCommon (type, tag, index, true);
 }
 
+static bool defaultHasTabChar (const tagEntryInfo *const tag CTAGS_ATTR_UNUSED, const char* value)
+{
+	return strchr (value, '\t')? true: false;
+}
+
 extern bool  doesFieldHaveTabChar (fieldType type, const tagEntryInfo *tag, int index)
 {
 	fieldObject *fobj = fieldObjects + type;
 	const char *value;
-
-	if (!fobj->def->hasTabChar)
-		return false;
+	bool (* hasTabChar) (const tagEntryInfo *const, const char*) = fobj->def->hasTabChar;
 
 	Assert (tag);
-	Assert (index < 0 || ((unsigned int)index) < tag->usedParserFields);
+	Assert (index == NO_PARSER_FIELD || ((unsigned int)index) < tag->usedParserFields);
+
+	if (hasTabChar == NULL)
+	{
+		if (index == NO_PARSER_FIELD)
+			return false;
+		else
+			hasTabChar = defaultHasTabChar;
+	}
 
 	if (index >= 0)
 	{
@@ -592,7 +603,7 @@ extern bool  doesFieldHaveTabChar (fieldType type, const tagEntryInfo *tag, int 
 	else
 		value = NULL;
 
-	return fobj->def->hasTabChar (tag, value);
+	return (* hasTabChar) (tag, value);
 }
 
 /*  Writes "line", stripping leading and duplicate white space.

--- a/main/parse.c
+++ b/main/parse.c
@@ -3616,9 +3616,6 @@ extern bool parseFileWithMio (const char *const fileName, MIO *mio)
 #ifdef HAVE_ICONV
 		closeConverter ();
 #endif
-		if (req.type == GLR_OPEN && req.mio)
-			mio_free (req.mio);
-		return tagFileResized;
 	}
 
 	if (req.type == GLR_OPEN && req.mio)

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -31,8 +31,8 @@ static int writeCtagsPtagEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 								const char *const parserName);
 
 struct rejection {
-	bool rejectedInThisRendering;
-	bool rejectedInThisInput;
+	bool rejectionInThisRendering;
+	bool rejectionInThisInput;
 };
 
 tagWriter uCtagsWriter = {
@@ -47,7 +47,7 @@ static void *beginECtagsFile (tagWriter *writer CTAGS_ATTR_UNUSED, MIO * mio CTA
 {
 	static struct rejection rej;
 
-	rej.rejectedInThisInput = false;
+	rej.rejectionInThisInput = false;
 
 	return &rej;
 }
@@ -55,7 +55,7 @@ static void *beginECtagsFile (tagWriter *writer CTAGS_ATTR_UNUSED, MIO * mio CTA
 static bool endECTagsFile (tagWriter *writer, MIO * mio CTAGS_ATTR_UNUSED, const char* filename CTAGS_ATTR_UNUSED)
 {
 	struct rejection *rej = writer->private;
-	return rej->rejectedInThisInput;
+	return rej->rejectionInThisInput;
 }
 
 tagWriter eCtagsWriter = {
@@ -71,8 +71,8 @@ static const char* escapeFieldValue (tagWriter *writer, const tagEntryInfo * tag
 	if (writer->private)
 	{
 		struct rejection * rej = writer->private;
-		if (!rej->rejectedInThisRendering)
-			rej->rejectedInThisRendering = doesFieldHaveTabChar (ftype, tag, NO_PARSER_FIELD);
+		if (!rej->rejectionInThisRendering)
+			rej->rejectionInThisRendering = doesFieldHaveTabChar (ftype, tag, NO_PARSER_FIELD);
 	}
 
 	if (writer->type == WRITER_E_CTAGS && doesFieldHaveRenderer(ftype, true))
@@ -108,8 +108,8 @@ static int addParserFields (tagWriter *writer, MIO * mio, const tagEntryInfo *co
 		if (! isFieldEnabled (f->ftype))
 			continue;
 
-		if (rej && (!rej->rejectedInThisRendering))
-			rej->rejectedInThisRendering = doesFieldHaveTabChar (f->ftype, tag, i);
+		if (rej && (!rej->rejectionInThisRendering))
+			rej->rejectionInThisRendering = doesFieldHaveTabChar (f->ftype, tag, i);
 
 		const char *v;
 		if (writer->type == WRITER_E_CTAGS && doesFieldHaveRenderer(f->ftype, true))
@@ -236,7 +236,7 @@ static int writeCtagsEntry (tagWriter *writer,
 		struct rejection *rej = writer->private;
 
 		origin = mio_tell (mio);
-		rej->rejectedInThisRendering = false;
+		rej->rejectionInThisRendering = false;
 
 	}
 
@@ -267,12 +267,12 @@ static int writeCtagsEntry (tagWriter *writer,
 	length += mio_printf (mio, "\n");
 
 	if (writer->private
-		&& ((struct rejection *)(writer->private))->rejectedInThisRendering)
+		&& ((struct rejection *)(writer->private))->rejectionInThisRendering)
 	{
 		mio_seek (mio, origin, SEEK_SET);
 
 		/* Truncation is needed. */
-		((struct rejection *)(writer->private))->rejectedInThisInput = true;
+		((struct rejection *)(writer->private))->rejectionInThisInput = true;
 
 		length = 0;
 	}

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -109,7 +109,7 @@ static int addParserFields (tagWriter *writer, MIO * mio, const tagEntryInfo *co
 			continue;
 
 		if (rej && (!rej->rejectedInThisRendering))
-			rej->rejectedInThisRendering = doesFieldHaveTabChar (f->ftype, tag, NO_PARSER_FIELD);
+			rej->rejectedInThisRendering = doesFieldHaveTabChar (f->ftype, tag, i);
 
 		const char *v;
 		if (writer->type == WRITER_E_CTAGS && doesFieldHaveRenderer(f->ftype, true))


### PR DESCRIPTION
During working on #2015, I found some broken code for handling tab chars in parser specific fields.
It was not well considered.
The test code in this PR explains how the code was broken.

~~"--sort=no" issue I reported in #2015 is not fixed in this PR yet.~~

I also fixed the bug found in the option combination in "-o - --sort=no --output-format=e-ctags".
Close #1969 and #2014.

