### PR TITLE
readtags: optimize the way to read fields

### DIFF
--- a/read/readtags.c
+++ b/read/readtags.c
@@ -334,6 +334,8 @@ static tagResult growFields (tagFile *const file)
 	return result;
 }
 
+#define CMP4(a, b) ((a)[0] == (b)[0] && (a)[1] == (b)[1] && (a)[2] == (b)[2] && (a)[3] == (b)[3])
+
 static void parseExtensionFields (tagFile *const file, tagEntry *const entry,
 								  char *const string)
 {
@@ -360,11 +362,11 @@ static void parseExtensionFields (tagFile *const file, tagEntry *const entry,
 				*colon = '\0';
 				if (key_len == 4)
 				{
-					if (strcmp (key, "kind") == 0)
+					if (CMP4 (key, "kind"))
 						entry->kind = value;
-					else if (strcmp (key, "file") == 0)
+					else if (CMP4 (key, "file"))
 						entry->fileScope = 1;
-					else if (strcmp (key, "line") == 0)
+					else if (CMP4 (key, "line"))
 						entry->address.lineNumber = atol (value);
 					else
 						goto normalField;

--- a/read/readtags.c
+++ b/read/readtags.c
@@ -356,15 +356,22 @@ static void parseExtensionFields (tagFile *const file, tagEntry *const entry,
 			{
 				const char *key = field;
 				const char *value = colon + 1;
+				const int key_len = colon - key;
 				*colon = '\0';
-				if (strcmp (key, "kind") == 0)
-					entry->kind = value;
-				else if (strcmp (key, "file") == 0)
-					entry->fileScope = 1;
-				else if (strcmp (key, "line") == 0)
-					entry->address.lineNumber = atol (value);
+				if (key_len == 4)
+				{
+					if (strcmp (key, "kind") == 0)
+						entry->kind = value;
+					else if (strcmp (key, "file") == 0)
+						entry->fileScope = 1;
+					else if (strcmp (key, "line") == 0)
+						entry->address.lineNumber = atol (value);
+					else
+						goto normalField;
+				}
 				else
 				{
+				normalField:
 					if (entry->fields.count == file->fields.max)
 						growFields (file);
 					file->fields.list [entry->fields.count].key = key;

--- a/read/readtags.c
+++ b/read/readtags.c
@@ -334,8 +334,6 @@ static tagResult growFields (tagFile *const file)
 	return result;
 }
 
-#define CMP4(a, b) ((a)[0] == (b)[0] && (a)[1] == (b)[1] && (a)[2] == (b)[2] && (a)[3] == (b)[3])
-
 static void parseExtensionFields (tagFile *const file, tagEntry *const entry,
 								  char *const string)
 {
@@ -362,11 +360,11 @@ static void parseExtensionFields (tagFile *const file, tagEntry *const entry,
 				*colon = '\0';
 				if (key_len == 4)
 				{
-					if (CMP4 (key, "kind"))
+					if (memcmp (key, "kind", 4) == 0)
 						entry->kind = value;
-					else if (CMP4 (key, "file"))
+					else if (memcmp (key, "file", 4) == 0)
 						entry->fileScope = 1;
-					else if (CMP4 (key, "line"))
+					else if (memcmp (key, "line", 4) == 0)
 						entry->address.lineNumber = atol (value);
 					else
 						goto normalField;


### PR DESCRIPTION
I measured performance of readtags by giving large tags file and found
strcmp in parseExtensionFields is a bottle neck.

This change reduces the number of calling strcmp in the function.

Without this change:
[yamato@slave]~/var/ctags-github% time readtags -t ~/.spelunker.d/kernel76/kernel76.tags  -l   > /dev/null (5 times)
<gs -t ~/.spelunker.d/kernel76/kernel76.tags  -l   > /dev/null
readtags -t ~/.spelunker.d/kernel76/kernel76.tags -l > /dev/null  3.62s user 0.29s system 99% cpu 3.918 total
readtags -t ~/.spelunker.d/kernel76/kernel76.tags -l > /dev/null  3.62s user 0.30s system 99% cpu 3.924 total
readtags -t ~/.spelunker.d/kernel76/kernel76.tags -l > /dev/null  3.64s user 0.28s system 99% cpu 3.930 total
readtags -t ~/.spelunker.d/kernel76/kernel76.tags -l > /dev/null  3.60s user 0.27s system 99% cpu 3.874 total
readtags -t ~/.spelunker.d/kernel76/kernel76.tags -l > /dev/null  3.65s user 0.25s system 99% cpu 3.909 total

With this change:
[yamato@slave]~/var/ctags-github% time readtags -t ~/.spelunker.d/kernel76/kernel76.tags  -l   > /dev/null (5 times)
readtags -t ~/.spelunker.d/kernel76/kernel76.tags -l > /dev/null  2.29s user 0.27s system 99% cpu 2.574 total
readtags -t ~/.spelunker.d/kernel76/kernel76.tags -l > /dev/null  2.24s user 0.27s system 99% cpu 2.518 total
readtags -t ~/.spelunker.d/kernel76/kernel76.tags -l > /dev/null  2.34s user 0.26s system 99% cpu 2.605 total
readtags -t ~/.spelunker.d/kernel76/kernel76.tags -l > /dev/null  2.27s user 0.26s system 99% cpu 2.530 total
readtags -t ~/.spelunker.d/kernel76/kernel76.tags -l > /dev/null  2.26s user 0.27s system 99% cpu 2.537 total

ctags with the change is about 1/3 faster than before.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>