### PR TITLE
optlib2c: escape a double quote char in a description string w backslash

### DIFF
--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -569,6 +569,23 @@ sub emit_patterns {
     emit_list $_[0], "patterns";
 }
 
+sub escape_dquotes {
+    my $input = shift;
+    my $output = "";
+
+    my $c;
+
+    foreach $c (split //, $input) {
+	if ($c eq '"') {
+	    $output = $output . '\\' . '"';
+	} else {
+	    $output = $output . $c;
+	}
+    }
+
+    return $output;
+}
+
 sub emit_roledefs {
     my $opts = shift;
 
@@ -580,8 +597,9 @@ sub emit_roledefs {
 	static roleDefinition $opts->{'Clangdef'}${Kind}RoleTable [] = {
 EOF
 	for (@{$_->{'roles'}}) {
+	    my $desc = escape_dquotes $_->{'desc'};
 	    print <<EOF;
-		{ true, "$_->{'name'}", "$_->{'desc'}" },
+		{ true, "$_->{'name'}", "$desc" },
 EOF
 	}
 
@@ -652,8 +670,9 @@ EOF
       print <<EOF;
 		{
 EOF
+      my $desc = escape_dquotes $_->{'desc'};
       print <<EOF;
-		  $enabled, \'$_->{'letter'}\', "$_->{'name'}", "$_->{'desc'}",
+		  $enabled, \'$_->{'letter'}\', "$_->{'name'}", "$desc",
 EOF
       if ($_->{'refonly'}) {
 	  print <<EOF;
@@ -744,11 +763,12 @@ sub emit_xtags {
 EOF
     for (@{$opts->{'extradefs'}}) {
       my $enabled = $_->{"enabled"}? "true": "false";
+      my $desc = escape_dquotes $_->{'desc'};
       print <<EOF;
 		{
 		  .enabled     = $enabled,
 		  .name        = "$_->{'name'}",
-		  .description = "$_->{'desc'}",
+		  .description = "$desc",
 		},
 EOF
     }
@@ -767,11 +787,12 @@ sub emit_fields {
 EOF
     for (@{$opts->{'fielddefs'}}) {
       my $enabled = $_->{"enabled"}? "true": "false";
+      my $desc = escape_dquotes $_->{'desc'};
       print <<EOF;
 		{
 		  .enabled     = $enabled,
 		  .name        = "$_->{'name'}",
-		  .description = "$_->{'desc'}",
+		  .description = "$desc",
 		},
 EOF
     }


### PR DESCRIPTION
Hello, I'm interested in picking up the elixir branch (`elixir-optlib`) of this repo, and noticed that said branch has two commits: the first one, is this one I'm doing the pull request for, in which @masatake added the code to escape a double quote char in a string, and the second one, which has the code to parse elixir code.

I noticed that the first commit isn't actually related to Elixir (or at least isn't in a way I could see), so it shouldn't be in the elixir branch, and it's useful enough to be merged into master. That's the reason I took this commit and rebased it to `master`, fixing a small conflict in the process. So now optlib should be able to parse the double quote char in a description string, and I should be free to hack on `elixir-optlib` after rebasing it to `master`.

I'm not 100% sure how to test it, but what I did was 
```
$ ./autogen.sh
$ ./configure
$ make validate-input check
```
And it ran without any error I could notice.

Any help or thought related to the commit or how to test is well received.