### PR TITLE
readtags: refactor for adding sorter

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,8 +39,8 @@ bin_PROGRAMS+= readtags
 readtags_CPPFLAGS = -I. -I$(srcdir) -I$(srcdir)/main -I$(srcdir)/read
 readtags_CFLAGS = $(COVERAGE_CFLAGS)
 dist_readtags_SOURCES = $(READTAGS_SRCS) $(READTAGS_HEADS)
-readtags_CPPFLAGS += -DQUALIFIER -I$(srcdir)/dsl
-dist_readtags_SOURCES += $(QUALIFIER_SRCS) $(QUALIFIER_HEADS)
+readtags_CPPFLAGS += -DREADTAGS_DSL -I$(srcdir)/dsl
+dist_readtags_SOURCES += $(READTAGS_DSL_SRCS) $(READTAGS_DSL_HEADS)
 endif
 
 if !HAVE_FNMATCH

--- a/main/mio.c
+++ b/main/mio.c
@@ -18,7 +18,7 @@
  *
  */
 
-#ifndef QUALIFIER
+#ifndef READTAGS_DSL
 #include "general.h"  /* must always come first */
 
 #include "routines.h"
@@ -32,7 +32,7 @@
 #ifdef HAVE_STDBOOL_H
 #include <stdbool.h>
 #endif
-#endif
+#endif	/* READTAGS_DSL */
 
 #include "mio.h"
 
@@ -43,7 +43,7 @@
 #include <stdlib.h>
 #include <limits.h>
 
-#ifdef QUALIFIER
+#ifdef READTAGS_DSL
 #define xMalloc(n,Type)    (Type *)eMalloc((size_t)(n) * sizeof (Type))
 #define xRealloc(p,n,Type) (Type *)eRealloc((p), (n) * sizeof (Type))
 
@@ -84,7 +84,7 @@ static void eFree (void *const ptr)
 
 #  define Assert(c) do {} while(0)
 #  define AssertNotReached() do {} while(0)
-#endif
+#endif	/* READTAGS_DSL */
 
 /* minimal reallocation chunk size */
 #define MIO_CHUNK_SIZE 4096

--- a/read/readtags-cmd.c
+++ b/read/readtags-cmd.c
@@ -18,7 +18,7 @@ static int SortOverride;
 static sortType SortMethod;
 static int allowPrintLineNumber;
 static int debugMode;
-#ifdef QUALIFIER
+#ifdef READTAGS_DSL
 #include "dsl/qualifier.h"
 static QCode *Qualifier;
 #endif
@@ -67,7 +67,7 @@ static void walkTags (tagFile *const file, tagEntry *first_entry,
 {
 	do
 	{
-#ifdef QUALIFIER
+#ifdef READTAGS_DSL
 		if (Qualifier)
 		{
 			int i = q_is_acceptable (Qualifier, first_entry);
@@ -132,7 +132,7 @@ static const char *const Usage =
 	"Usage: \n"
 	"    %s -h\n"
 	"    %s [-ilp] [-n] "
-#ifdef QUALIFIER
+#ifdef READTAGS_DSL
 	"[-Q EXP] "
 #endif
 	"[-s[0|1]] [-t file] [-] [name(s)]\n\n"
@@ -144,7 +144,7 @@ static const char *const Usage =
 	"    -l           List all tags.\n"
 	"    -n           Allow print line numbers if -e option is given.\n"
 	"    -p           Perform partial matching.\n"
-#ifdef QUALIFIER
+#ifdef READTAGS_DSL
 	"    -Q EXP       Filter the result with EXP.\n"
 #endif
 	"    -s[0|1|2]    Override sort detection of tag file.\n"
@@ -155,14 +155,14 @@ static const char *const Usage =
 static void printUsage(FILE* stream, int exitCode)
 {
 	fprintf (stream, Usage, ProgramName, ProgramName);
-#ifdef QUALIFIER
+#ifdef READTAGS_DSL
 	fprintf (stream, "\nFilter expression: \n");
 	q_help (stream);
 #endif
 	exit (exitCode);
 }
 
-#ifdef QUALIFIER
+#ifdef READTAGS_DSL
 static QCode *convertToQualifier(const char* exp)
 {
 	EsObject *sexp = es_read_from_string (exp, NULL);
@@ -243,7 +243,7 @@ extern int main (int argc, char **argv)
 						else
 							printUsage(stderr, 1);
 						break;
-#ifdef QUALIFIER
+#ifdef READTAGS_DSL
 					case 'Q':
 						if (i + 1 == argc)
 							printUsage(stderr, 1);

--- a/read/readtags-cmd.c
+++ b/read/readtags-cmd.c
@@ -116,22 +116,25 @@ static void listTags (void)
 	}
 	else
 	{
-		while (tagsNext (file, &entry) == TagSuccess)
+		if (tagsFirst (file, &entry) == TagSuccess)
 		{
-#ifdef QUALIFIER
-			if (Qualifier)
+			do
 			{
-				int i = q_is_acceptable (Qualifier, &entry);
-				switch (i)
+#ifdef QUALIFIER
+				if (Qualifier)
 				{
-				case Q_REJECT:
-					continue;
-				case Q_ERROR:
-					exit (1);
+					int i = q_is_acceptable (Qualifier, &entry);
+					switch (i)
+					{
+					case Q_REJECT:
+						continue;
+					case Q_ERROR:
+						exit (1);
+					}
 				}
-			}
 #endif
-			printTag (&entry);
+				printTag (&entry);
+			} while (tagsNext (file, &entry) == TagSuccess);
 		}
 		tagsClose (file);
 	}

--- a/read/readtags.c
+++ b/read/readtags.c
@@ -218,7 +218,8 @@ static int growString (vstring *s)
 	{
 		newLength = 128;
 		newLine = (char*) malloc (newLength);
-		*newLine = '\0';
+		if (newLine)
+			*newLine = '\0';
 	}
 	else
 	{

--- a/read/readtags.h
+++ b/read/readtags.h
@@ -106,7 +106,8 @@ typedef struct {
 		/* name of tag */
 	const char *name;
 
-		/* path of source file containing definition of tag */
+		/* path of source file containing definition of tag.
+		   For a broken tags file, this can be NULL. */
 	const char *file;
 
 		/* address for locating tag in source file */

--- a/source.mak
+++ b/source.mak
@@ -307,21 +307,23 @@ WIN32_HEADS = main/e_msoft.h
 WIN32_SRCS = win32/mkstemp/mkstemp.c
 WIN32_OBJS = $(WIN32_SRCS:.c=.$(OBJEXT))
 
-QUALIFIER_HEADS = dsl/es-lang-c-stdc99.h \
-		 dsl/qualifier.h \
-		 \
-		 $(MIO_HEADS) \
-		 \
-		 $(NULL)
+READTAGS_DSL_HEADS = \
+	dsl/es-lang-c-stdc99.h \
+	dsl/qualifier.h \
+	\
+	$(MIO_HEADS) \
+	\
+	$(NULL)
 
-QUALIFIER_SRCS = dsl/es-lang-c-stdc99.c \
-		 dsl/qualifier.c \
-		 \
-		 $(MIO_SRCS) \
-		 \
-		 $(NULL)
+READTAGS_DSL_SRCS = \
+	dsl/es-lang-c-stdc99.c \
+	dsl/qualifier.c \
+	\
+	 $(MIO_SRCS) \
+	\
+	$(NULL)
 
-QUALIFIER_OBJS = $(QUALIFIER_SRCS:.c=.$(OBJEXT))
+READTAGS_DSL_OBJS = $(QUALIFIER_SRCS:.c=.$(OBJEXT))
 
 ALL_OBJS = \
 	$(ALL_SRCS:.c=.$(OBJEXT)) \


### PR DESCRIPTION
I'm thinking about adding "--sort expr" option to the readtags command.
This PR cleans up the code for adding the new feature.