### PR TITLE
travis-ci: adjust lcoveralls --root argument for out-of-tree building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ after_success:
                     sed -i -e 's/severity.capitalize!/severity = severity.capitalize/' $f
             done
         ) || :
-        (cd linux-gcc-gcov; lcov -c -b . -d . -o coverage.info && lcoveralls --root . --retry-count 5 coverage.info)
+        (cd linux-gcc-gcov; lcov -c -b .. -d . -o coverage.info) && lcoveralls --root . --retry-count 5 linux-gcc-gcov/coverage.info
     fi
 
 # Build Matrix configuration


### PR DESCRIPTION
See the last comment in #2031 submitted by @k-takata .