### PR TITLE
Fix bug in elixir function tag missing a char

### DIFF
--- a/Units/parser-elixir.r/elixir-functions.d/expected.tags
+++ b/Units/parser-elixir.r/elixir-functions.d/expected.tags
@@ -6,3 +6,4 @@ func_one_arity	input.ex	/^  def func_one_arity(string1, nil, _separator) do$/;"	
 normal_func	input.ex	/^  def normal_func(string1, string2, separator) do$/;"	function	module:FunctionModule
 private_func	input.ex	/^  defp private_func(a), do: a <> " alone"$/;"	function	module:FunctionModule
 private_func_no_params	input.ex	/^  defp private_func_no_params do$/;"	function	module:FunctionModule
+function_with_comma	input.ex	/^  def function_with_comma,$/;"	function	module:FunctionModule

--- a/Units/parser-elixir.r/elixir-functions.d/input.ex
+++ b/Units/parser-elixir.r/elixir-functions.d/input.ex
@@ -24,4 +24,7 @@ defmodule FunctionModule do
   defp private_func_no_params do
     #
   end
+
+  def function_with_comma,
+    do: :some_constant
 end

--- a/optlib/elixir.c
+++ b/optlib/elixir.c
@@ -71,7 +71,7 @@ extern parserDefinition* ElixirParser (void)
 		"m", "{scope=set}", NULL, false},
 		{"^[ \t]*def((p?)|macro(p?))[ \t]+([a-zA-Z0-9_?!]+)[ \t]+([\\|\\^/&<>~.=!*+-]{1,3}|and|or|in|not|when|not in)[ \t]+[a-zA-Z0-9_?!]", "\\5",
 		"o", "{scope=ref}{exclusive}", NULL, false},
-		{"^[ \t]*def(p?)[ \t]+([a-z_][a-zA-Z0-9_?!]*)(.[^\\|\\^/&<>~.=!*+-]+)", "\\2",
+		{"^[ \t]*def(p?)[ \t]+([a-z_][a-zA-Z0-9_?!]*)", "\\2",
 		"f", "{scope=ref}", NULL, false},
 		{"^[ \t]*(@|def)callback[ \t]+([a-z_][a-zA-Z0-9_?!]*)", "\\2",
 		"c", "{scope=ref}", NULL, false},

--- a/optlib/elixir.ctags
+++ b/optlib/elixir.ctags
@@ -67,7 +67,7 @@
 
 --regex-Elixir=/^[ \t]*defmodule[ \t]+([A-Z][a-zA-Z0-9_]*\.)*([A-Z][a-zA-Z0-9_?!]*)/\2/m/{scope=set}
 --regex-Elixir=/^[ \t]*def((p?)|macro(p?))[ \t]+([a-zA-Z0-9_?!]+)[ \t]+([\|\^\/&<>~.=!*+-]{1,3}|and|or|in|not|when|not in)[ \t]+[a-zA-Z0-9_?!]/\5/o/{scope=ref}{exclusive}
---regex-Elixir=/^[ \t]*def(p?)[ \t]+([a-z_][a-zA-Z0-9_?!]*)(.[^\|\^\/&<>~.=!*+-]+)/\2/f/{scope=ref}
+--regex-Elixir=/^[ \t]*def(p?)[ \t]+([a-z_][a-zA-Z0-9_?!]*)/\2/f/{scope=ref}
 --regex-Elixir=/^[ \t]*(@|def)callback[ \t]+([a-z_][a-zA-Z0-9_?!]*)/\2/c/{scope=ref}
 --regex-Elixir=/^[ \t]*defdelegate[ \t]+([a-z_][a-zA-Z0-9_?!]*)/\1/d/{scope=ref}
 --regex-Elixir=/^[ \t]*defexception[ \t]+([A-Z][a-zA-Z0-9_]*\.)*([A-Z][a-zA-Z0-9_?!]*)/\2/e/{scope=ref}


### PR DESCRIPTION
Quick fix for #2043 
* Removed unnecessary atom in the regex for the function kind.
* Expanded `elixir-functions` test case to include case present in the issue above.

The removed atom was there to deal with a problem present when parsing operators, but I forgot to remove it when the operators problem was fixed.

A quick run of the tests shows them all passing, as before.