### PR TITLE
main,Flex,JavaScriupt,SQL,refactor: introduce a helper function to skip two character sequence

### DIFF
--- a/main/read.c
+++ b/main/read.c
@@ -948,6 +948,19 @@ extern int skipToCharacterInInputFile (int c)
 	return d;
 }
 
+extern int skipToCharacterInInputFile2 (int c0, int c1)
+{
+	int d;
+	do
+	{
+		skipToCharacterInInputFile(c0);
+		do
+			d = getcFromInputFile ();
+		while (d == c0 && d != c1);
+	} while (d != EOF && d != c1);
+	return d;
+}
+
 /*  An alternative interface to getcFromInputFile (). Do not mix use of readLineFromInputFile()
  *  and getcFromInputFile() for the same file. The returned string does not contain
  *  the terminating newline. A NULL return value means that all lines in the

--- a/main/read.h
+++ b/main/read.h
@@ -71,6 +71,7 @@ extern const unsigned char *getInputFileData (size_t *size);
 extern int getcFromInputFile (void);
 extern int getNthPrevCFromInputFile (unsigned int nth, int def);
 extern int skipToCharacterInInputFile (int c);
+extern int skipToCharacterInInputFile2 (int c0, int c1);
 extern void ungetcToInputFile (int c);
 extern const unsigned char *readLineFromInputFile (void);
 

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -457,15 +457,7 @@ getNextChar:
 					  {
 						  if (d == '*')
 						  {
-							  do
-							  {
-								  skipToCharacterInInputFile ('*');
-								  c = getcFromInputFile ();
-								  if (c == '/')
-									  break;
-								  else
-									  ungetcToInputFile (c);
-							  } while (c != EOF && c != '\0');
+							  skipToCharacterInInputFile2('*', '/');
 							  goto getNextChar;
 						  }
 						  else if (d == '/')	/* is this the start of a comment?  */

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -946,15 +946,7 @@ getNextChar:
 							  repr->buffer[--repr->length] = 0;
 						  if (d == '*')
 						  {
-							  do
-							  {
-								  skipToCharacterInInputFile ('*');
-								  c = getcFromInputFile ();
-								  if (c == '/')
-									  break;
-								  else
-									  ungetcToInputFile (c);
-							  } while (c != EOF && c != '\0');
+							  skipToCharacterInInputFile2('*', '/');
 							  goto getNextChar;
 						  }
 						  else if (d == '/')	/* is this the start of a comment?  */

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -659,15 +659,7 @@ getNextChar:
 					  {
 						  if (d == '*')
 						  {
-							  do
-							  {
-								  skipToCharacterInInputFile ('*');
-								  c = getcFromInputFile ();
-								  if (c == '/')
-									  break;
-								  else
-									  ungetcToInputFile (c);
-							  } while (c != EOF && c != '\0');
+							  skipToCharacterInInputFile2('*', '/');
 							  goto getNextChar;
 						  }
 						  else if (d == '/')	/* is this the start of a comment?  */


### PR DESCRIPTION
/* ... */ style comment syntax is used variety languages.
Each parser implements code skipping comments.

This change introduces skipToCharacterInInputFile2 helper function for
unifying the implementations.

The original code handles '\0' char specially.
skipToCharacterInInputFile2 doesn't do so. I don't understand the need.

(About C and C++ parsers they are handled in CPreProcessor parser.
They are out of scope of this change.)

Signed-off-by: Masatake YAMATO <yamato@redhat.com>