### PR TITLE
Check for interactive feature in sandbox tests

### DIFF
--- a/Tmain/gcov-sandbox.d/run.sh
+++ b/Tmain/gcov-sandbox.d/run.sh
@@ -7,6 +7,7 @@ CTAGS=$1
 
 . ../utils.sh
 is_feature_available $CTAGS sandbox
+is_feature_available ${CTAGS} interactive
 is_feature_available ${CTAGS} gcov
 
 {

--- a/Tmain/sandbox-crash.d/run.sh
+++ b/Tmain/sandbox-crash.d/run.sh
@@ -8,6 +8,7 @@ CTAGS=$1
 . ../utils.sh
 is_feature_available $CTAGS debug
 is_feature_available $CTAGS sandbox
+is_feature_available ${CTAGS} interactive
 is_feature_available ${CTAGS} '!' gcov
 
 {

--- a/Tmain/sandbox-default-req.d/run.sh
+++ b/Tmain/sandbox-default-req.d/run.sh
@@ -7,6 +7,7 @@ CTAGS=$1
 
 . ../utils.sh
 is_feature_available $CTAGS sandbox
+is_feature_available ${CTAGS} interactive
 is_feature_available ${CTAGS} '!' gcov
 
 {

--- a/Tmain/sandbox-no-eager-guessing.d/run.sh
+++ b/Tmain/sandbox-no-eager-guessing.d/run.sh
@@ -7,6 +7,7 @@ CTAGS=$1
 
 . ../utils.sh
 is_feature_available $CTAGS sandbox
+is_feature_available ${CTAGS} interactive
 is_feature_available ${CTAGS} '!' gcov
 
 {

--- a/Tmain/sandbox-unknown-submode.d/run.sh
+++ b/Tmain/sandbox-unknown-submode.d/run.sh
@@ -7,6 +7,7 @@ CTAGS=$1
 
 . ../utils.sh
 is_feature_available $CTAGS sandbox
+is_feature_available ${CTAGS} interactive
 is_feature_available ${CTAGS} '!' gcov
 
 {

--- a/Tmain/sandbox-with-eager-guessing.d/run.sh
+++ b/Tmain/sandbox-with-eager-guessing.d/run.sh
@@ -7,6 +7,7 @@ CTAGS=$1
 
 . ../utils.sh
 is_feature_available $CTAGS sandbox
+is_feature_available ${CTAGS} interactive
 is_feature_available ${CTAGS} '!' gcov
 
 {

--- a/Tmain/sandbox.d/run.sh
+++ b/Tmain/sandbox.d/run.sh
@@ -7,6 +7,7 @@ CTAGS=$1
 
 . ../utils.sh
 is_feature_available $CTAGS sandbox
+is_feature_available ${CTAGS} interactive
 is_feature_available ${CTAGS} '!' gcov
 
 {


### PR DESCRIPTION
The sandbox tests pass the --_interactive option to ctags, which is only present if ctags was built with json support. Add check for the interactive feature in the tests skipping the tests if the feature is not present.

Closes: #2072