### PR TITLE
travis: rearrange installed lcoveralls scripts for fixing wrong usage…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,9 @@ after_success:
             for f in /home/travis/.rvm/gems/ruby-2*/gems/lcoveralls-*/lib/lcoveralls/color_formatter.rb; do
                     sed -i -e 's/severity.capitalize!/severity = severity.capitalize/' $f
             done
+            for f in /home/travis/.rvm/gems/ruby-2*/gems/lcoveralls-*/lib/lcoveralls/runner.rb; do
+                    sed -i -e 's/\(.*format.*f\)\(%\)\('"'"'.*$\)/\1%%\3/' $f
+            done
         )
 
         (cd linux-gcc-gcov; lcov -c -b .. -d . -o coverage.info)


### PR DESCRIPTION
… of '%' in format ()

Close #2074.

It seems that the usage of '%' char in format() is more strict in new
ruby implementation available in travis these days.
As the result, the converge summarization is failed with following message:

```
Traceback (most recent call last):
	12: from /home/travis/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `<main>'
	11: from /home/travis/.rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `eval'
	10: from /home/travis/.rvm/gems/ruby-2.5.3/bin/lcoveralls:23:in `<main>'
	 9: from /home/travis/.rvm/gems/ruby-2.5.3/bin/lcoveralls:23:in `load'
	 8: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/bin/lcoveralls:23:in `<top (required)>'
	 7: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:265:in `run'
	 6: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:116:in `get_source_files'
	 5: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:116:in `each'
	 4: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:122:in `block in get_source_files'
	 3: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:122:in `each'
	 2: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:158:in `block (2 levels) in get_source_files'
	 1: from /home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:97:in `get_percentage'
/home/travis/.rvm/gems/ruby-2.5.3/gems/lcoveralls-0.2.3/lib/lcoveralls/runner.rb:97:in `format': incomplete format specifier; use %% (double %) instead (ArgumentError)
```

This change replaces '%' with '%%' to fix the wrong usage.
TODO: this change should go the upstream project.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>