### PR TITLE
main,json-writer: allow the writer to disable "fixed" fields

### DIFF
--- a/Tmain/fixed-field-handling.d/input.c
+++ b/Tmain/fixed-field-handling.d/input.c
@@ -1,0 +1,1 @@
+void main(void) {}

--- a/Tmain/fixed-field-handling.d/run.sh
+++ b/Tmain/fixed-field-handling.d/run.sh
@@ -1,0 +1,45 @@
+# Copyright: 2019 Masatake YAMATO
+# License: GPL-2
+
+. ../utils.sh
+
+CTAGS="$1"
+
+is_feature_available "${CTAGS}" json
+
+CTAGS="${CTAGS} --quiet --options=NONE"
+
+echo '# writer=default'
+${CTAGS} --machinable --list-fields | grep '^[NFP]'
+
+list_fields()
+{
+	local f=$1
+	shift
+
+	echo "# writer=$f $o"
+	${CTAGS} --output-format=$f --machinable $@ --list-fields | grep '^[NFP]'
+}
+
+for f in u-ctags e-ctags etags xref json; do
+	list_fields $f
+done
+
+for f in xref json; do
+	for o in N F P; do
+		list_fields $f --fields=-$o
+	done
+done
+
+for o in N F P; do
+	O="--fields=-$o"
+	echo "# writer=json $O"
+	${CTAGS} --output-format=json $O input.c
+	O="--fields=$o"
+	echo "# writer=json $O"
+	${CTAGS} --output-format=json $O input.c
+done
+
+O="--fields="
+echo "# writer=json $O"
+${CTAGS} --output-format=json $O input.c

--- a/Tmain/fixed-field-handling.d/stdout-expected.txt
+++ b/Tmain/fixed-field-handling.d/stdout-expected.txt
@@ -1,0 +1,61 @@
+# writer=default
+N	name	yes	NONE	s--	yes	tag name
+F	input	yes	NONE	s--	yes	input file
+P	pattern	yes	NONE	s-b	yes	pattern
+# writer=u-ctags 
+N	name	yes	NONE	s--	yes	tag name
+F	input	yes	NONE	s--	yes	input file
+P	pattern	yes	NONE	s-b	yes	pattern
+# writer=e-ctags 
+N	name	yes	NONE	s--	yes	tag name
+F	input	yes	NONE	s--	yes	input file
+P	pattern	yes	NONE	s-b	yes	pattern
+# writer=etags 
+F	input	yes	NONE	s--	no	input file
+N	name	yes	NONE	s--	no	tag name
+P	pattern	yes	NONE	s-b	no	pattern
+# writer=xref 
+F	input	yes	NONE	s--	no	input file
+N	name	yes	NONE	s--	no	tag name
+P	pattern	yes	NONE	s-b	no	pattern
+# writer=json 
+F	input	yes	NONE	s--	no	input file
+N	name	yes	NONE	s--	no	tag name
+P	pattern	yes	NONE	s-b	no	pattern
+# writer=xref N
+F	input	yes	NONE	s--	no	input file
+N	name	no	NONE	s--	no	tag name
+P	pattern	yes	NONE	s-b	no	pattern
+# writer=xref F
+F	input	no	NONE	s--	no	input file
+N	name	yes	NONE	s--	no	tag name
+P	pattern	yes	NONE	s-b	no	pattern
+# writer=xref P
+F	input	yes	NONE	s--	no	input file
+N	name	yes	NONE	s--	no	tag name
+P	pattern	no	NONE	s-b	no	pattern
+# writer=json N
+F	input	yes	NONE	s--	no	input file
+N	name	no	NONE	s--	no	tag name
+P	pattern	yes	NONE	s-b	no	pattern
+# writer=json F
+F	input	no	NONE	s--	no	input file
+N	name	yes	NONE	s--	no	tag name
+P	pattern	yes	NONE	s-b	no	pattern
+# writer=json P
+F	input	yes	NONE	s--	no	input file
+N	name	yes	NONE	s--	no	tag name
+P	pattern	no	NONE	s-b	no	pattern
+# writer=json --fields=-N
+{"_type": "tag", "path": "input.c", "pattern": "/^void main(void) {}$/", "typeref": "typename:void", "kind": "function"}
+# writer=json --fields=N
+{"_type": "tag", "name": "main"}
+# writer=json --fields=-F
+{"_type": "tag", "name": "main", "pattern": "/^void main(void) {}$/", "typeref": "typename:void", "kind": "function"}
+# writer=json --fields=F
+{"_type": "tag", "path": "input.c"}
+# writer=json --fields=-P
+{"_type": "tag", "name": "main", "path": "input.c", "typeref": "typename:void", "kind": "function"}
+# writer=json --fields=P
+{"_type": "tag", "pattern": "/^void main(void) {}$/"}
+# writer=json --fields=

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -10,6 +10,7 @@
 #include "general.h"  /* must always come first */
 
 #include "entry_p.h"
+#include "field.h"
 #include "field_p.h"
 #include "mio.h"
 #include "options_p.h"
@@ -29,6 +30,7 @@ static int writeCtagsPtagEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 								const char *const fileName,
 								const char *const pattern,
 								const char *const parserName);
+static bool treatFieldAsFixed (int fieldType);
 
 struct rejection {
 	bool rejectionInThisInput;
@@ -39,6 +41,7 @@ tagWriter uCtagsWriter = {
 	.writePtagEntry = writeCtagsPtagEntry,
 	.preWriteEntry = NULL,
 	.postWriteEntry = NULL,
+	.treatFieldAsFixed = treatFieldAsFixed,
 	.defaultFileName = CTAGS_FILE,
 };
 
@@ -62,6 +65,7 @@ tagWriter eCtagsWriter = {
 	.writePtagEntry = writeCtagsPtagEntry,
 	.preWriteEntry = beginECtagsFile,
 	.postWriteEntry = endECTagsFile,
+	.treatFieldAsFixed = treatFieldAsFixed,
 	.defaultFileName = CTAGS_FILE,
 };
 
@@ -342,4 +346,17 @@ static int writeCtagsPtagEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 			      PSEUDO_TAG_PREFIX, desc->name,
 			      OPT(fileName), OPT(pattern));
 #undef OPT
+}
+
+static bool treatFieldAsFixed (int fieldType)
+{
+	switch (fieldType)
+	{
+	case FIELD_NAME:
+	case FIELD_INPUT_FILE:
+	case FIELD_PATTERN:
+		return true;
+	default:
+		return false;
+	}
 }

--- a/main/writer-etags.c
+++ b/main/writer-etags.c
@@ -34,6 +34,7 @@ tagWriter etagsWriter = {
 	.writePtagEntry = NULL,
 	.preWriteEntry = beginEtagsFile,
 	.postWriteEntry = endEtagsFile,
+	.treatFieldAsFixed = NULL,
 	.defaultFileName = ETAGS_FILE,
 };
 

--- a/main/writer-xref.c
+++ b/main/writer-xref.c
@@ -25,6 +25,7 @@ tagWriter xrefWriter = {
 	.writePtagEntry = NULL,
 	.preWriteEntry = NULL,
 	.postWriteEntry = NULL,
+	.treatFieldAsFixed = NULL,
 	.defaultFileName = NULL,
 };
 

--- a/main/writer.c
+++ b/main/writer.c
@@ -96,3 +96,10 @@ extern bool writerCanPrintPtag (void)
 {
 	return (writer->writePtagEntry)? true: false;
 }
+
+extern bool writerDoesTreatFieldAsFixed (int fieldType)
+{
+	if (writer->treatFieldAsFixed)
+		return writer->treatFieldAsFixed (fieldType);
+	return false;
+}

--- a/main/writer_p.h
+++ b/main/writer_p.h
@@ -41,6 +41,7 @@ struct sTagWriter {
 	/* Returning TRUE means the output file may be shrunk.
 	   In such case the callee may do truncate output file. */
 	bool (* postWriteEntry)  (tagWriter *writer, MIO * mio, const char* filename);
+	bool (* treatFieldAsFixed) (int fieldType);
 	const char *defaultFileName;
 
 	/* The value returned from preWriteEntry is stored `private' field.
@@ -71,5 +72,6 @@ extern bool ptagMakeJsonOutputVersion (ptagDesc *desc, void *data CTAGS_ATTR_UNU
 extern bool ptagMakeCtagsOutputMode (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED);
 
 extern bool writerCanPrintPtag (void);
+extern bool writerDoesTreatFieldAsFixed (int fieldType);
 
 #endif	/* CTAGS_MAIN_WRITER_PRIVATE_H */


### PR DESCRIPTION
Close #2065.

The tags format must include name, input, and pattern fields.
When running ctags, disabling them are not allowed. To implement
this rule, "fixed" fields were introduced to field.c.

However, this rule is applicable only to the ctags writer. The
other writer like json-writer doesn't need to follow the rule.

The fixed field is implemented in field.c. Now, it moves to writer-ctags.c.
As the result, json-writer can print the result with disabling
"name", "input", and/or "pattern".

Signed-off-by: Masatake YAMATO <yamato@redhat.com>