### PR TITLE
Remove link to snap repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ Go to [ctags-docker](https://github.com/universal-ctags/ctags-docker) and follow
 instructions to download the `uctags` script. Docker will automatically fetch
 the image from Docker Hub.
 
-### Snap
-Go to [ctags-snap](https://github.com/universal-ctags/ctags-snap) and
-clone the `ctags-snap` repo. Then, follow instructions to build the
-snap package of ctags. Snapcraft will automatically fetch the source
-code from GitHub.
-
 ## How to build and install ##
 
 To build with Autotools, see `docs/autotools.rst` for more information.


### PR DESCRIPTION
It seems that the snap repo is not maintained.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>