### PR TITLE
ActionScript: Fix and improve the parser

### DIFF
--- a/Tmain/list-roles-with-kind-names.d/stdout-expected.txt
+++ b/Tmain/list-roles-with-kind-names.d/stdout-expected.txt
@@ -24,6 +24,7 @@ CPreProcessor  h/header    local     on      local header
 CPreProcessor  h/header    system    on      system header
 CUDA           h/header    local     on      local header
 CUDA           h/header    system    on      system header
+Flex           I/import    import    on      imports
 M4             I/macrofile included  on      included macro
 M4             I/macrofile sincluded on      silently included macro
 Make           I/makefile  included  on      included

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -31,6 +31,7 @@ DTD            p/parameterEntity condition           on      conditions
 DTD            p/parameterEntity elementName         on      element names
 DTD            p/parameterEntity partOfAttDef        on      part of attribute definition
 Elm            m/module          imported            on      imported module
+Flex           I/import          import              on      imports
 Go             p/package         imported            on      imported package
 Go             u/unknown         receiverType        on      receiver type
 HTML           C/stylesheet      extFile             on      referenced as external files
@@ -95,6 +96,7 @@ DTD            p/parameterEntity condition           on      conditions
 DTD            p/parameterEntity elementName         on      element names
 DTD            p/parameterEntity partOfAttDef        on      part of attribute definition
 Elm            m/module          imported            on      imported module
+Flex           I/import          import              on      imports
 Go             p/package         imported            on      imported package
 Go             u/unknown         receiverType        on      receiver type
 HTML           C/stylesheet      extFile             on      referenced as external files

--- a/Units/parser-flex.r/as-first-token.d/expected.tags
+++ b/Units/parser-flex.r/as-first-token.d/expected.tags
@@ -1,0 +1,1 @@
+f1	input.as	/^function f1():void {}$/;"	f

--- a/Units/parser-flex.r/as-first-token.d/input.as
+++ b/Units/parser-flex.r/as-first-token.d/input.as
@@ -1,0 +1,1 @@
+function f1():void {}

--- a/Units/parser-flex.r/classes.d/args.ctags
+++ b/Units/parser-flex.r/classes.d/args.ctags
@@ -1,0 +1,2 @@
+--fields=+Z
+--extras=+q

--- a/Units/parser-flex.r/classes.d/expected.tags
+++ b/Units/parser-flex.r/classes.d/expected.tags
@@ -1,0 +1,9 @@
+C1	input.as	/^  class C1 {$/;"	c
+C1.m1	input.as	/^    public function m1():Boolean { return 0; }$/;"	m	scope:class:C1
+C2	input.as	/^  class C2 extends C1 {}$/;"	c
+C3	input.as	/^  class C3 {}$/;"	c
+C4	input.as	/^  class C4 implements I1 {}$/;"	c
+C5	input.as	/^  class C5 extends C3 implements I1 {}$/;"	c
+C6	input.as	/^  class C6 extends C3 implements I1, I2 {}$/;"	c
+C7	input.as	/^  dynamic class C7{}$/;"	c
+m1	input.as	/^    public function m1():Boolean { return 0; }$/;"	m	scope:class:C1

--- a/Units/parser-flex.r/classes.d/expected.tags
+++ b/Units/parser-flex.r/classes.d/expected.tags
@@ -6,4 +6,8 @@ C4	input.as	/^  class C4 implements I1 {}$/;"	c
 C5	input.as	/^  class C5 extends C3 implements I1 {}$/;"	c
 C6	input.as	/^  class C6 extends C3 implements I1, I2 {}$/;"	c
 C7	input.as	/^  dynamic class C7{}$/;"	c
+I1	input.as	/^  interface I1 {}$/;"	i
+I2	input.as	/^  interface I2 {}$/;"	i
+I3	input.as	/^  interface I3 extends I1, I2 {}$/;"	i
+I4	input.as	/^  interface I4 extends I3 {}$/;"	i
 m1	input.as	/^    public function m1():Boolean { return 0; }$/;"	m	scope:class:C1

--- a/Units/parser-flex.r/classes.d/input.as
+++ b/Units/parser-flex.r/classes.d/input.as
@@ -1,0 +1,14 @@
+package {
+  class C1 {
+    public function m1():Boolean { return 0; }
+  }
+  class C2 extends C1 {}
+  class C3 {}
+  interface I1 {}
+  interface I2 {}
+  class C4 implements I1 {}
+  class C5 extends C3 implements I1 {}
+  class C6 extends C3 implements I1, I2 {}
+
+  dynamic class C7{}
+}

--- a/Units/parser-flex.r/classes.d/input.as
+++ b/Units/parser-flex.r/classes.d/input.as
@@ -6,6 +6,8 @@ package {
   class C3 {}
   interface I1 {}
   interface I2 {}
+  interface I3 extends I1, I2 {}
+  interface I4 extends I3 {}
   class C4 implements I1 {}
   class C5 extends C3 implements I1 {}
   class C6 extends C3 implements I1, I2 {}

--- a/Units/parser-flex.r/const.d/args.ctags
+++ b/Units/parser-flex.r/const.d/args.ctags
@@ -1,0 +1,1 @@
+--flex-kinds=+l

--- a/Units/parser-flex.r/const.d/expected.tags
+++ b/Units/parser-flex.r/const.d/expected.tags
@@ -1,0 +1,5 @@
+AlarmClock	input.as	/^public class AlarmClock {$/;"	c
+MODE_AUDIO	input.as	/^  public static const MODE_AUDIO  = 2;$/;"	C	class:AlarmClock
+MODE_BOTH	input.as	/^  public static const MODE_BOTH   = 3;$/;"	C	class:AlarmClock
+MODE_VISUAL	input.as	/^  public static const MODE_VISUAL = 1;$/;"	C	class:AlarmClock
+mode	input.as	/^  private var mode = AlarmClock.MODE_AUDIO;$/;"	l	class:AlarmClock

--- a/Units/parser-flex.r/const.d/input.as
+++ b/Units/parser-flex.r/const.d/input.as
@@ -1,0 +1,8 @@
+// https://www.oreilly.com/library/view/essential-actionscript-30/0596526946/ch04s02.html
+public class AlarmClock {
+  public static const MODE_VISUAL = 1;
+  public static const MODE_AUDIO  = 2;
+  public static const MODE_BOTH   = 3;
+
+  private var mode = AlarmClock.MODE_AUDIO;
+}

--- a/Units/parser-flex.r/const2.d/expected.tags
+++ b/Units/parser-flex.r/const2.d/expected.tags
@@ -1,0 +1,2 @@
+MIN_AGE	input.as	/^const MIN_AGE:int = 21;$/;"	C
+product_array	input.as	/^const product_array:Array = new Array("Studio", "Dreamweaver", "Flash", "ColdFusion", "Contribut/;"	C

--- a/Units/parser-flex.r/const2.d/input.as
+++ b/Units/parser-flex.r/const2.d/input.as
@@ -1,0 +1,7 @@
+// https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/statements.html#const
+const MIN_AGE:int = 21;
+
+const product_array:Array = new Array("Studio", "Dreamweaver", "Flash", "ColdFusion", "Contribute", "Breeze"); 
+product_array.push("Flex"); // array operations are allowed
+product_array = ["Other"];  // assignment is an error
+trace(product_array);

--- a/Units/parser-flex.r/flex_only_mxml.mxml.d/expected.tags
+++ b/Units/parser-flex.r/flex_only_mxml.mxml.d/expected.tags
@@ -1,8 +1,8 @@
-Array.forms	input.mxml	/^	<mx:Array id="forms">$/;"	x
-Button.ls_bt_log_in_out	input.mxml	/^					<mx:Button id="ls_bt_log_in_out" x="240" y="238" label="{logInOut}" enabled="true" click="o/;"	x
-Form.form_login_screen	input.mxml	/^		<mx:Form label="{logInOut}" width="100%" height="100%" id="form_login_screen">$/;"	x
-HTTPService.myHTTPService	input.mxml	/^		id="myHTTPService"$/;"	x
-Label.ls_lb_welcome	input.mxml	/^					<mx:Label x="194" y="287" width="315" id="ls_lb_welcome" fontSize="16" fontWeight="bold"\/>$/;"	x
-TextInput.ls_ti_passwd	input.mxml	/^					<mx:TextInput id="ls_ti_passwd" x="240" y="206" displayAsPassword="true" text="Demo05"\/>$/;"	x
-TextInput.ls_ti_username	input.mxml	/^					<mx:TextInput id="ls_ti_username" x="240" y="174" text="admin"\/>$/;"	x
-ViewStack.viewstack1	input.mxml	/^	<mx:ViewStack x="149" y="55" id="viewstack1" width="831" height="605" change="onChangeViewStack/;"	x
+form_login_screen	input.mxml	/^		<mx:Form label="{logInOut}" width="100%" height="100%" id="form_login_screen">$/;"	x	mxtag:Form
+forms	input.mxml	/^	<mx:Array id="forms">$/;"	x	mxtag:Array
+ls_bt_log_in_out	input.mxml	/^					<mx:Button id="ls_bt_log_in_out" x="240" y="238" label="{logInOut}" enabled="true" click="o/;"	x	mxtag:Button
+ls_lb_welcome	input.mxml	/^					<mx:Label x="194" y="287" width="315" id="ls_lb_welcome" fontSize="16" fontWeight="bold"\/>$/;"	x	mxtag:Label
+ls_ti_passwd	input.mxml	/^					<mx:TextInput id="ls_ti_passwd" x="240" y="206" displayAsPassword="true" text="Demo05"\/>$/;"	x	mxtag:TextInput
+ls_ti_username	input.mxml	/^					<mx:TextInput id="ls_ti_username" x="240" y="174" text="admin"\/>$/;"	x	mxtag:TextInput
+myHTTPService	input.mxml	/^		id="myHTTPService"$/;"	x	mxtag:HTTPService
+viewstack1	input.mxml	/^	<mx:ViewStack x="149" y="55" id="viewstack1" width="831" height="605" change="onChangeViewStack/;"	x	mxtag:ViewStack

--- a/Units/parser-flex.r/flex_with_actionscript.mxml.d/expected.tags
+++ b/Units/parser-flex.r/flex_with_actionscript.mxml.d/expected.tags
@@ -1,2 +1,2 @@
-HTTPService.ajaxData	input.mxml	/^		id="ajaxData"$/;"	x
+ajaxData	input.mxml	/^		id="ajaxData"$/;"	x	mxtag:HTTPService
 dateToYYYYMMDD	input.mxml	/^	public function dateToYYYYMMDD(aDate:Date):String {$/;"	f

--- a/Units/parser-flex.r/method-attributes.d/expected.tags
+++ b/Units/parser-flex.r/method-attributes.d/expected.tags
@@ -1,0 +1,9 @@
+C	input.as	/^class C {$/;"	c
+f1	input.as	/^  public function f1():void {}$/;"	m	class:C
+f2	input.as	/^  private function f2():void {}$/;"	m	class:C
+f3	input.as	/^  protected function f3():void {}$/;"	m	class:C
+f4	input.as	/^  internal function f4():void {}$/;"	m	class:C
+f5	input.as	/^  public function f5():void {}$/;"	m	class:C
+f6	input.as	/^  public override function f6():void {}$/;"	m	class:C
+f7	input.as	/^  final function f7():void {}$/;"	m	class:C
+f8	input.as	/^  native function f8():void {}$/;"	m	class:C

--- a/Units/parser-flex.r/method-attributes.d/input.as
+++ b/Units/parser-flex.r/method-attributes.d/input.as
@@ -1,0 +1,12 @@
+/* Not sure it's really valid, but the goal is to check not choking on
+ * attributes, so so long as it's valid attributes it's fine */
+class C {
+  public function f1():void {}
+  private function f2():void {}
+  protected function f3():void {}
+  internal function f4():void {}
+  public function f5():void {}
+  public override function f6():void {}
+  final function f7():void {}
+  native function f8():void {}
+}

--- a/Units/parser-flex.r/packages.d/expected.tags
+++ b/Units/parser-flex.r/packages.d/expected.tags
@@ -3,3 +3,4 @@ P1	input.as	/^package P1 {}$/;"	P
 P2	input.as	/^package P2 {$/;"	P
 P3	input.as	/^package P3 {$/;"	P
 f1	input.as	/^  function f1() {}$/;"	f	function:P2
+qualified.test.pkg	input.as	/^package qualified.test . pkg {$/;"	P

--- a/Units/parser-flex.r/packages.d/expected.tags
+++ b/Units/parser-flex.r/packages.d/expected.tags
@@ -1,0 +1,5 @@
+C1	input.as	/^  class C1 {}$/;"	c	class:P3
+P1	input.as	/^package P1 {}$/;"	P
+P2	input.as	/^package P2 {$/;"	P
+P3	input.as	/^package P3 {$/;"	P
+f1	input.as	/^  function f1() {}$/;"	f	function:P2

--- a/Units/parser-flex.r/packages.d/input.as
+++ b/Units/parser-flex.r/packages.d/input.as
@@ -1,0 +1,7 @@
+package P1 {}
+package P2 {
+  function f1() {}
+}
+package P3 {
+  class C1 {}
+}

--- a/Units/parser-flex.r/packages.d/input.as
+++ b/Units/parser-flex.r/packages.d/input.as
@@ -5,3 +5,5 @@ package P2 {
 package P3 {
   class C1 {}
 }
+package qualified.test . pkg {
+}

--- a/Units/parser-flex.r/sampler.d/args.ctags
+++ b/Units/parser-flex.r/sampler.d/args.ctags
@@ -1,0 +1,3 @@
+--flex-kinds=+l
+--fields=+rZ
+--extras=+r

--- a/Units/parser-flex.r/sampler.d/expected.tags
+++ b/Units/parser-flex.r/sampler.d/expected.tags
@@ -1,0 +1,15 @@
+assert	input.as	/^        private function assert(e:Boolean, mess:String=null):void {$/;"	m	scope:class:sampleTypes	roles:def
+b	input.as	/^      var b:Boolean = true$/;"	l	scope:class:sampleTypes	roles:def
+cpuSamples	input.as	/^            var cpuSamples:Array=[];$/;"	l	scope:class:sampleTypes.sampleTypes	roles:def
+delSamples	input.as	/^            var delSamples:Array=[];$/;"	l	scope:class:sampleTypes.sampleTypes	roles:def
+dos	input.as	/^                var dos = DeleteObjectSample(s);$/;"	l	scope:class:sampleTypes.sampleTypes	roles:def
+flash.display.Sprite	input.as	/^    import flash.display.Sprite$/;"	I	roles:import
+flash.sampler.*	input.as	/^    import flash.sampler.*$/;"	I	roles:import
+flash.system.*	input.as	/^    import flash.system.*$/;"	I	roles:import
+flash.utils.*	input.as	/^    import flash.utils.*$/;"	I	roles:import
+ids	input.as	/^            var ids:Array=[]$/;"	l	scope:class:sampleTypes.sampleTypes	roles:def
+lastTime	input.as	/^            var lastTime:Number=0;$/;"	l	scope:class:sampleTypes.sampleTypes	roles:def
+newSamples	input.as	/^            var newSamples:Array=[];$/;"	l	scope:class:sampleTypes.sampleTypes	roles:def
+nos	input.as	/^                var nos = NewObjectSample(s);$/;"	l	scope:class:sampleTypes.sampleTypes	roles:def
+sampleTypes	input.as	/^        public function sampleTypes() {$/;"	m	scope:class:sampleTypes	roles:def
+sampleTypes	input.as	/^    public class sampleTypes extends Sprite$/;"	c	roles:def

--- a/Units/parser-flex.r/sampler.d/input.as
+++ b/Units/parser-flex.r/sampler.d/input.as
@@ -1,0 +1,66 @@
+// https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/sampler/Sample.html
+package 
+{
+    import flash.sampler.*
+    import flash.system.*
+    import flash.utils.*
+    import flash.display.Sprite
+    public class sampleTypes extends Sprite
+    {
+      var b:Boolean = true
+        public function sampleTypes() {
+            flash.sampler.startSampling();
+            for(var i:int=0;i<10000;i++)
+              new Object();
+
+            var cpuSamples:Array=[];
+            var newSamples:Array=[];
+            var delSamples:Array=[];
+            var ids:Array=[]
+
+            var lastTime:Number=0;
+            for each(var s:Sample in getSamples()) {
+              
+              assert(s.time > 0); // positive
+              assert(Math.floor(s.time) == s.time, s.time); // integral
+              assert(s.time >= lastTime, s.time + ":" + lastTime); // ascending
+              assert(s.stack == null || s.stack is Array)
+              if(s.stack) {
+                assert(s.stack[0] is StackFrame);
+                assert(s.stack[0].name is String);
+            }
+              
+              if(s is NewObjectSample) {
+                var nos = NewObjectSample(s);
+                assert(s.id > 0, s.id);
+                assert(s.type is Class, getQualifiedClassName(s.type));
+                newSamples.push(s);
+                ids[s.id] = "got one";
+              } else if(s is DeleteObjectSample) {
+                var dos = DeleteObjectSample(s);
+                delSamples.push(s);
+                assert(ids[dos.id] == "got one");
+              } else if(s is Sample)
+                cpuSamples.push(s);
+              else {
+                assert(false);
+              }
+              lastTime = s.time;
+            }
+
+            trace(b)
+            trace(newSamples.length > 0)
+            trace(cpuSamples.length > 0)
+            trace(delSamples.length > 0)
+
+        }
+
+        private function assert(e:Boolean, mess:String=null):void {
+          b = e && b;
+          if(true && !e) {
+            if(mess) trace(mess);
+            trace(new Error().getStackTrace());
+          }     
+        }         
+    }
+}

--- a/Units/review-needed.r/flex_override.mxml.t/expected.tags
+++ b/Units/review-needed.r/flex_override.mxml.t/expected.tags
@@ -1,2 +1,3 @@
+myGet	input.mxml	/^			public override function get myGet():MyClass$/;"	f
 myOverride	input.mxml	/^			public override function myOverride():void$/;"	f
 save	input.mxml	/^			private function save():void$/;"	f

--- a/Units/review-needed.r/flex_override.mxml.t/expected.tags
+++ b/Units/review-needed.r/flex_override.mxml.t/expected.tags
@@ -1,3 +1,3 @@
-myGet	input.mxml	/^			public override function get myGet():MyClass$/;"	f
+myGet	input.mxml	/^			public override function get myGet():MyClass$/;"	p
 myOverride	input.mxml	/^			public override function myOverride():void$/;"	f
 save	input.mxml	/^			private function save():void$/;"	f

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -271,6 +271,20 @@ static void copyToken (tokenInfo *const dest, tokenInfo *const src,
  *	 Tag generation functions
  */
 
+static vString *buildQualifiedName (const tokenInfo *const token)
+{
+	vString *qualified = vStringNew ();
+
+	if (vStringLength (token->scope) > 0)
+	{
+		vStringCopy (qualified, token->scope);
+		vStringPut (qualified, '.');
+	}
+	vStringCat (qualified, token->string);
+
+	return qualified;
+}
+
 static void makeConstTag (tokenInfo *const token, const flexKind kind)
 {
 	if (FlexKinds [kind].enabled && ! token->ignoreTag )
@@ -302,6 +316,17 @@ static void makeConstTag (tokenInfo *const token, const flexKind kind)
 		}
 
 		makeTagEntry (&e);
+
+		/* make qualified tags for compatibility if requested */
+		if (isXtagEnabled (XTAG_QUALIFIED_TAGS))
+		{
+			vString *qualified = buildQualifiedName (token);
+
+			markTagExtraBit (&e, XTAG_QUALIFIED_TAGS);
+			e.name = vStringValue (qualified);
+			makeTagEntry (&e);
+			vStringDelete (qualified);
+		}
 	}
 }
 

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -67,6 +67,7 @@ enum eKeywordId {
 	KEYWORD_capital_object,
 	KEYWORD_prototype,
 	KEYWORD_var,
+	KEYWORD_const,
 	KEYWORD_new,
 	KEYWORD_this,
 	KEYWORD_for,
@@ -166,6 +167,7 @@ typedef enum {
 	FLEXTAG_PROPERTY,
 	FLEXTAG_VARIABLE,
 	FLEXTAG_LOCALVAR,
+	FLEXTAG_CONST,
 	FLEXTAG_IMPORT,
 	FLEXTAG_MXTAG,
 	FLEXTAG_COUNT
@@ -188,6 +190,7 @@ static kindDefinition FlexKinds [] = {
 	{ true,  'p', "property",	  "properties"		   },
 	{ true,  'v', "variable",	  "global variables"   },
 	{ false, 'l', "localvar",	  "local variables"   },
+	{ true,  'C', "constant",	  "constants"		   },
 	{ true,  'I', "import",		  "imports",
 	  .referenceOnly = true, ATTACH_ROLES (FlexImportRoles) },
 	{ true,  'x', "mxtag",		  "mxtags" 			   }
@@ -204,6 +207,7 @@ static const keywordTable FlexKeywordTable [] = {
 	{ "Object",		KEYWORD_capital_object		},
 	{ "prototype",	KEYWORD_prototype			},
 	{ "var",		KEYWORD_var					},
+	{ "const",		KEYWORD_const				},
 	{ "new",		KEYWORD_new					},
 	{ "this",		KEYWORD_this				},
 	{ "for",		KEYWORD_for					},
@@ -1459,6 +1463,7 @@ static bool parseVar (tokenInfo *const token, bool is_public)
 {
 	tokenInfo *const name = newToken ();
 	bool is_terminated = true;
+	flexKind kind = is_public ? FLEXTAG_VARIABLE : FLEXTAG_LOCALVAR;
 
 	/*
 	 * Variables are defined as:
@@ -1468,6 +1473,11 @@ static bool parseVar (tokenInfo *const token, bool is_public)
 
 	if ( isKeyword(token, KEYWORD_var) )
 	{
+		readToken(token);
+	}
+	else if (isKeyword(token, KEYWORD_const))
+	{
+		kind = FLEXTAG_CONST;
 		readToken(token);
 	}
 
@@ -1490,7 +1500,7 @@ static bool parseVar (tokenInfo *const token, bool is_public)
 
 	if ( isType (token, TOKEN_SEMICOLON) )
 	{
-		makeFlexTag (name, is_public ? FLEXTAG_VARIABLE: FLEXTAG_LOCALVAR);
+		makeFlexTag (name, kind);
 	}
 
 	deleteToken (name);
@@ -1741,6 +1751,7 @@ static bool parseStatement (tokenInfo *const token)
 				goto cleanUp;
 				break;
 			case KEYWORD_var:
+			case KEYWORD_const:
 				is_terminated = parseVar (token, is_public);
 				goto cleanUp;
 				break;

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -196,7 +196,7 @@ static const keywordTable FlexKeywordTable [] = {
 static void parseFunction (tokenInfo *const token);
 static bool parseBlock (tokenInfo *const token, tokenInfo *const parent);
 static bool parseLine (tokenInfo *const token);
-static bool parseActionScript (tokenInfo *const token);
+static bool parseActionScript (tokenInfo *const token, bool readNext);
 static bool parseMXML (tokenInfo *const token);
 
 static tokenInfo *newToken (void)
@@ -1966,7 +1966,7 @@ static bool parseCDATA (tokenInfo *const token)
 					readToken (token);
 					if (isType (token, TOKEN_OPEN_SQUARE))
 					{
-						parseActionScript (token);
+						parseActionScript (token, true);
 						if (isType (token, TOKEN_CLOSE_SQUARE))
 						{
 							readToken (token);
@@ -1982,7 +1982,7 @@ static bool parseCDATA (tokenInfo *const token)
 	}
 	else
 	{
-		parseActionScript (token);
+		parseActionScript (token, false);
 	}
 	return true;
 }
@@ -2195,11 +2195,14 @@ cleanUp:
 	return true;
 }
 
-static bool parseActionScript (tokenInfo *const token)
+static bool parseActionScript (tokenInfo *const token, bool readNext)
 {
 	do
 	{
-		readToken (token);
+		if (! readNext)
+			readNext = true;
+		else
+			readToken (token);
 
 		if (isType (token, TOKEN_LESS_THAN))
 		{
@@ -2340,7 +2343,7 @@ static void parseFlexFile (tokenInfo *const token)
 		}
 		else
 		{
-			parseActionScript (token);
+			parseActionScript (token, false);
 		}
 	} while (!isEOF (token));
 }

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -16,6 +16,7 @@
  *	 Flex 3 language reference
  *		 http://livedocs.adobe.com/flex/3/langref/index.html
  * 		 https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/language-elements.html
+ * 		 https://www.adobe.com/devnet/actionscript/learning/as3-fundamentals/packages.html
  */
 
 /*
@@ -1504,12 +1505,23 @@ static void parsePackage (tokenInfo *const token)
 	if (isKeyword (token, KEYWORD_package))
 		readToken(token);
 
-	/* name is optional (?) */
+	/* name is optional and can be qualified */
 	if (isType (token, TOKEN_IDENTIFIER))
 	{
 		name = newToken ();
 		copyToken (name, token, true);
 		readToken (token);
+
+		while (isType (token, TOKEN_PERIOD))
+		{
+			vStringPut (name->string, '.');
+			readToken (token);
+			if (isType (token, TOKEN_IDENTIFIER))
+			{
+				vStringCat (name->string, token->string);
+				readToken (token);
+			}
+		}
 	}
 
 	if (isType (token, TOKEN_OPEN_CURLY))

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -158,6 +158,7 @@ typedef enum {
 	FLEXTAG_METHOD,
 	FLEXTAG_PROPERTY,
 	FLEXTAG_VARIABLE,
+	FLEXTAG_LOCALVAR,
 	FLEXTAG_MXTAG,
 	FLEXTAG_COUNT
 } flexKind;
@@ -168,6 +169,7 @@ static kindDefinition FlexKinds [] = {
 	{ true,  'm', "method",		  "methods"			   },
 	{ true,  'p', "property",	  "properties"		   },
 	{ true,  'v', "variable",	  "global variables"   },
+	{ false, 'l', "localvar",	  "local variables"   },
 	{ true,  'x', "mxtag",		  "mxtags" 			   }
 };
 
@@ -1420,15 +1422,7 @@ static bool parseVar (tokenInfo *const token, bool is_public)
 
 	if ( isType (token, TOKEN_SEMICOLON) )
 	{
-		/*
-		 * Only create variables for global scope
-		 */
-		/* if ( token->nestLevel == 0 && is_global ) */
-		if ( is_public )
-		{
-			if (isType (token, TOKEN_SEMICOLON))
-				makeFlexTag (name, FLEXTAG_VARIABLE);
-		}
+		makeFlexTag (name, is_public ? FLEXTAG_VARIABLE: FLEXTAG_LOCALVAR);
 	}
 
 	deleteToken (name);

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -87,6 +87,7 @@ enum eKeywordId {
 	KEYWORD_dynamic,
 	KEYWORD_class,
 	KEYWORD_interface,
+	KEYWORD_package,
 	KEYWORD_extends,
 	KEYWORD_static,
 	KEYWORD_implements,
@@ -159,6 +160,7 @@ typedef enum {
 	FLEXTAG_FUNCTION,
 	FLEXTAG_CLASS,
 	FLEXTAG_INTERFACE,
+	FLEXTAG_PACKAGE,
 	FLEXTAG_METHOD,
 	FLEXTAG_PROPERTY,
 	FLEXTAG_VARIABLE,
@@ -180,6 +182,7 @@ static kindDefinition FlexKinds [] = {
 	{ true,  'f', "function",	  "functions"		   },
 	{ true,  'c', "class",		  "classes"			   },
 	{ true,  'i', "interface",	  "interfaces"		   },
+	{ true,  'P', "package",	  "packages"		   },
 	{ true,  'm', "method",		  "methods"			   },
 	{ true,  'p', "property",	  "properties"		   },
 	{ true,  'v', "variable",	  "global variables"   },
@@ -221,6 +224,7 @@ static const keywordTable FlexKeywordTable [] = {
 	{ "dynamic",	KEYWORD_dynamic				},
 	{ "class",		KEYWORD_class				},
 	{ "interface",	KEYWORD_interface			},
+	{ "package",	KEYWORD_package				},
 	{ "extends",	KEYWORD_extends				},
 	{ "static",		KEYWORD_static				},
 	{ "implements",	KEYWORD_implements			},
@@ -1488,6 +1492,32 @@ static bool parseVar (tokenInfo *const token, bool is_public)
 	return is_terminated;
 }
 
+static void parsePackage (tokenInfo *const token)
+{
+	tokenInfo *name = NULL;
+
+	if (isKeyword (token, KEYWORD_package))
+		readToken(token);
+
+	/* name is optional (?) */
+	if (isType (token, TOKEN_IDENTIFIER))
+	{
+		name = newToken ();
+		copyToken (name, token, true);
+		readToken (token);
+	}
+
+	if (isType (token, TOKEN_OPEN_CURLY))
+	{
+		if (name)
+			makeFlexTag (name, FLEXTAG_PACKAGE);
+		parseBlock (token, name ? name->string : NULL);
+	}
+
+	if (name)
+		deleteToken (name);
+}
+
 static bool parseClass (tokenInfo *const token)
 {
 	tokenInfo *const name = newToken ();
@@ -1676,6 +1706,10 @@ static bool parseStatement (tokenInfo *const token)
 				break;
 			case KEYWORD_switch:
 				parseSwitch (token);
+				break;
+			case KEYWORD_package:
+				parsePackage (token);
+				goto cleanUp;
 				break;
 			case KEYWORD_class:
 				parseClass (token);

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -84,6 +84,7 @@ enum eKeywordId {
 	KEYWORD_internal,
 	KEYWORD_final,
 	KEYWORD_native,
+	KEYWORD_dynamic,
 	KEYWORD_class,
 	KEYWORD_static,
 	KEYWORD_get,
@@ -197,6 +198,7 @@ static const keywordTable FlexKeywordTable [] = {
 	{ "internal",	KEYWORD_internal			},
 	{ "final",		KEYWORD_final				},
 	{ "native",		KEYWORD_native				},
+	{ "dynamic",	KEYWORD_dynamic				},
 	{ "class",		KEYWORD_class				},
 	{ "static",		KEYWORD_static				},
 	{ "get",		KEYWORD_get					},
@@ -1553,6 +1555,7 @@ static bool parseStatement (tokenInfo *const token)
 	       isKeyword (token, KEYWORD_static) ||
 	       isKeyword (token, KEYWORD_internal) ||
 	       isKeyword (token, KEYWORD_native) ||
+	       isKeyword (token, KEYWORD_dynamic) ||
 	       isKeyword (token, KEYWORD_final))
 	{
 		if (isKeyword(token, KEYWORD_public))

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -1423,11 +1423,7 @@ static bool parseVar (tokenInfo *const token, bool is_public)
 			readToken (token);
 	}
 
-	while (! (isType (token, TOKEN_SEMICOLON) ||
-		  isEOF (token)))
-	{
-		readToken (token);
-	}
+	is_terminated = findCmdTerm (token, true, false);
 
 	if ( isType (token, TOKEN_SEMICOLON) )
 	{
@@ -1610,7 +1606,7 @@ static bool parseStatement (tokenInfo *const token)
 				goto cleanUp;
 				break;
 			case KEYWORD_var:
-				parseVar (token, is_public);
+				is_terminated = parseVar (token, is_public);
 				goto cleanUp;
 				break;
 			default:

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -352,21 +352,10 @@ static void makeFlexTag (tokenInfo *const token, flexKind kind)
 
 static void makeClassTag (tokenInfo *const token)
 {
-	vString *	fulltag;
-
 	if ( ! token->ignoreTag )
 	{
-		fulltag = vStringNew ();
-		if (vStringLength (token->scope) > 0)
-		{
-			vStringCopy(fulltag, token->scope);
-			vStringPut (fulltag, '.');
-			vStringCat (fulltag, token->string);
-		}
-		else
-		{
-			vStringCopy(fulltag, token->string);
-		}
+		vString *fulltag = buildQualifiedName (token);
+
 		if ( ! stringListHas(ClassNames, vStringValue (fulltag)) )
 		{
 			stringListAdd (ClassNames, vStringNewCopy (fulltag));
@@ -378,43 +367,18 @@ static void makeClassTag (tokenInfo *const token)
 
 static void makeMXTag (tokenInfo *const token)
 {
-	vString *	fulltag;
-
 	if ( ! token->ignoreTag )
 	{
-		fulltag = vStringNew ();
-		if (vStringLength (token->scope) > 0)
-		{
-			vStringCopy(fulltag, token->scope);
-			vStringPut (fulltag, '.');
-			vStringCat (fulltag, token->string);
-		}
-		else
-		{
-			vStringCopy(fulltag, token->string);
-		}
 		makeFlexTag (token, FLEXTAG_MXTAG);
-		vStringDelete (fulltag);
 	}
 }
 
 static void makeFunctionTag (tokenInfo *const token)
 {
-	vString *	fulltag;
-
 	if ( ! token->ignoreTag )
 	{
-		fulltag = vStringNew ();
-		if (vStringLength (token->scope) > 0)
-		{
-			vStringCopy(fulltag, token->scope);
-			vStringPut (fulltag, '.');
-			vStringCat (fulltag, token->string);
-		}
-		else
-		{
-			vStringCopy(fulltag, token->string);
-		}
+		vString *fulltag = buildQualifiedName (token);
+
 		if ( ! stringListHas(FunctionNames, vStringValue (fulltag)) )
 		{
 			stringListAdd (FunctionNames, vStringNewCopy (fulltag));

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -86,7 +86,9 @@ enum eKeywordId {
 	KEYWORD_native,
 	KEYWORD_dynamic,
 	KEYWORD_class,
+	KEYWORD_extends,
 	KEYWORD_static,
+	KEYWORD_implements,
 	KEYWORD_get,
 	KEYWORD_set,
 	KEYWORD_id,
@@ -200,7 +202,9 @@ static const keywordTable FlexKeywordTable [] = {
 	{ "native",		KEYWORD_native				},
 	{ "dynamic",	KEYWORD_dynamic				},
 	{ "class",		KEYWORD_class				},
+	{ "extends",	KEYWORD_extends				},
 	{ "static",		KEYWORD_static				},
+	{ "implements",	KEYWORD_implements			},
 	{ "get",		KEYWORD_get					},
 	{ "set",		KEYWORD_set					},
 	{ "id",			KEYWORD_id					},
@@ -1478,6 +1482,25 @@ static bool parseClass (tokenInfo *const token)
 				, vStringValue(token->string)
 				);
 			);
+
+	if (isKeyword (token, KEYWORD_extends))
+	{
+		readToken (token);
+		if (isType (token, TOKEN_IDENTIFIER))
+			readToken (token);
+	}
+
+	if (isKeyword (token, KEYWORD_implements))
+	{
+		do
+		{
+			readToken (token);
+			if (isType (token, TOKEN_IDENTIFIER))
+				readToken (token);
+		}
+		while (isType (token, TOKEN_COMMA));
+	}
+
 	if ( isType (token, TOKEN_OPEN_CURLY) )
 	{
 		makeClassTag (name);

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -82,6 +82,8 @@ enum eKeywordId {
 	KEYWORD_private,
 	KEYWORD_class,
 	KEYWORD_static,
+	KEYWORD_get,
+	KEYWORD_set,
 	KEYWORD_id,
 	KEYWORD_name,
 	KEYWORD_script,
@@ -189,6 +191,8 @@ static const keywordTable FlexKeywordTable [] = {
 	{ "private",	KEYWORD_private				},
 	{ "class",		KEYWORD_class				},
 	{ "static",		KEYWORD_static				},
+	{ "get",		KEYWORD_get					},
+	{ "set",		KEYWORD_set					},
 	{ "id",			KEYWORD_id					},
 	{ "name",		KEYWORD_name				},
 	{ "script",		KEYWORD_script				},
@@ -1120,9 +1124,18 @@ static void parseFunction (tokenInfo *const token)
 	/*
 	 * This deals with these formats
      *     private static function ioErrorHandler( event:IOErrorEvent ):void {
+     *     public function get prop():String {}
+     *     public function set prop(param:String):void {}
 	 */
 
 	if ( isKeyword(token, KEYWORD_function) )
+	{
+		readToken (token);
+	}
+
+	/* getter and setter */
+	if (isKeyword (token, KEYWORD_get) ||
+		isKeyword (token, KEYWORD_set))
 	{
 		readToken (token);
 	}

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -80,6 +80,10 @@ enum eKeywordId {
 	KEYWORD_return,
 	KEYWORD_public,
 	KEYWORD_private,
+	KEYWORD_protected,
+	KEYWORD_internal,
+	KEYWORD_final,
+	KEYWORD_native,
 	KEYWORD_class,
 	KEYWORD_static,
 	KEYWORD_get,
@@ -189,6 +193,10 @@ static const keywordTable FlexKeywordTable [] = {
 	{ "return",		KEYWORD_return				},
 	{ "public",		KEYWORD_public				},
 	{ "private",	KEYWORD_private				},
+	{ "protected",	KEYWORD_protected			},
+	{ "internal",	KEYWORD_internal			},
+	{ "final",		KEYWORD_final				},
+	{ "native",		KEYWORD_native				},
 	{ "class",		KEYWORD_class				},
 	{ "static",		KEYWORD_static				},
 	{ "get",		KEYWORD_get					},
@@ -1537,20 +1545,20 @@ static bool parseStatement (tokenInfo *const token)
 	 *	   Database.prototype.validMethodThree = Database_getTodaysDate;
 	 */
 
-	if ( isKeyword(token, KEYWORD_public) )
+	/* skip attributes */
+	while (isKeyword (token, KEYWORD_public) ||
+	       isKeyword (token, KEYWORD_protected) ||
+	       isKeyword (token, KEYWORD_private) ||
+	       isKeyword (token, KEYWORD_override) ||
+	       isKeyword (token, KEYWORD_static) ||
+	       isKeyword (token, KEYWORD_internal) ||
+	       isKeyword (token, KEYWORD_native) ||
+	       isKeyword (token, KEYWORD_final))
 	{
-		is_public = true;
-		readToken(token);
-	}
+		if (isKeyword(token, KEYWORD_public))
+			is_public = true;
 
-	if ( isKeyword(token, KEYWORD_private) )
-	{
-		readToken(token);
-	}
-
-	if ( isKeyword(token, KEYWORD_static) )
-	{
-		readToken(token);
+		readToken (token);
 	}
 
 	if (isType(token, TOKEN_KEYWORD))
@@ -2353,41 +2361,7 @@ static bool parseActionScript (tokenInfo *const token, bool readNext)
 		}
 		else
 		{
-			if (isType(token, TOKEN_KEYWORD))
-			{
-				if (isKeyword (token, KEYWORD_private)   ||
-				    isKeyword (token, KEYWORD_public)    ||
-				    isKeyword (token, KEYWORD_override)  )
-				{
-					/*
-					 * Methods can be defined as:
-					 *     private function f_name
-					 *     public override function f_name
-					 *     override private function f_name
-					 * Ignore these keywords if present.
-					 */
-					readToken (token);
-				}
-				if (isKeyword (token, KEYWORD_private)   ||
-				    isKeyword (token, KEYWORD_public)    ||
-				    isKeyword (token, KEYWORD_override)  )
-				{
-					/*
-					 * Methods can be defined as:
-					 *     private function f_name
-					 *     public override function f_name
-					 *     override private function f_name
-					 * Ignore these keywords if present.
-					 */
-					readToken (token);
-				}
-
-				parseLine (token);
-			}
-			else
-			{
-				parseLine (token);
-			}
+			parseLine (token);
 		}
 	} while (!isEOF (token));
 	return true;

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -1191,6 +1191,7 @@ static bool parseImport (tokenInfo *const token)
 static void parseFunction (tokenInfo *const token)
 {
 	tokenInfo *const name = newToken ();
+	flexKind kind = FLEXTAG_FUNCTION;
 
 	/*
 	 * This deals with these formats
@@ -1208,6 +1209,7 @@ static void parseFunction (tokenInfo *const token)
 	if (isKeyword (token, KEYWORD_get) ||
 		isKeyword (token, KEYWORD_set))
 	{
+		kind = FLEXTAG_PROPERTY;
 		readToken (token);
 	}
 
@@ -1283,7 +1285,10 @@ static void parseFunction (tokenInfo *const token)
 					, vStringValue(name->string)
 					);
 				);
-		makeFunctionTag (name);
+		if (kind == FLEXTAG_FUNCTION)
+			makeFunctionTag (name);
+		else
+			makeFlexTag (name, kind);
 	}
 
 	findCmdTerm (token, false, false);

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -1395,11 +1395,8 @@ cleanUp:
 static bool parseVar (tokenInfo *const token, bool is_public)
 {
 	tokenInfo *const name = newToken ();
-	tokenInfo *const secondary_name = newToken ();
-	vString * saveScope = vStringNew ();
 	bool is_terminated = true;
 
-	vStringCopy (saveScope, token->scope);
 	/*
 	 * Variables are defined as:
 	 *     private static var lastFaultMessage:Date = new Date( 0 );
@@ -1445,10 +1442,7 @@ static bool parseVar (tokenInfo *const token, bool is_public)
 		}
 	}
 
-	vStringCopy(token->scope, saveScope);
 	deleteToken (name);
-	deleteToken (secondary_name);
-	vStringDelete(saveScope);
 
 	return is_terminated;
 }

--- a/parsers/flex.c
+++ b/parsers/flex.c
@@ -1173,7 +1173,8 @@ static void parseFunction (tokenInfo *const token)
 		 *   function fname ():ReturnType
 		 */
 		readToken (token);
-		readToken (token);
+		if (isType (token, TOKEN_IDENTIFIER))
+			readToken (token);
 	}
 
 	if ( isType (token, TOKEN_OPEN_CURLY) )
@@ -1407,7 +1408,8 @@ static bool parseVar (tokenInfo *const token, bool is_public)
 		 *   var vname ():DataType;
 		 */
 		readToken (token);
-		readToken (token);
+		if (isType (token, TOKEN_IDENTIFIER))
+			readToken (token);
 	}
 
 	while (! (isType (token, TOKEN_SEMICOLON) ||
@@ -1728,7 +1730,8 @@ nextVar:
 			 *   function fname ():ReturnType {
 			 */
 			readToken (token);
-			readToken (token);
+			if (isType (token, TOKEN_IDENTIFIER))
+				readToken (token);
 		}
 
 		if ( isType (token, TOKEN_OPEN_SQUARE) )


### PR DESCRIPTION
The Flex parser has 2 parts: ActionScript (which is close to JavaScript) and MXLM (which is an XML dialect).  The Flex parser was built around an older version of the JavaScript parser, before the latter got a lot of fixes and overhauls.
This means I had to port a *lot* of fixes over from the JavaScript parser, so the approach I took in https://github.com/universal-ctags/ctags/commit/8bbb9d0d4177c07985ab4af12d746c33707dcaaa was to simply compare the two parsers at their current state and sync what can be.  This was a lot less painful than applying every single fix, with the conflicts due to the divergence and such.  So if one want to review the changes, it's interesting to check against jscript.c as well (and good luck).

After that "synchronizing" commit (it's actually sill different in some area, but a lot closer, and a lot less buggy), comes simpler improvements, fixing or adding support for specific syntax.  That part is fairly straightforward.

There is still room for improvements here, and the most obvious are:
* Make MXLM a proper separate parser that uses the ActionScript parser as a subparser;
* Share code between ActionScript and JavaScript parsers that are both ECMA-262-based languages (what does that mean when they don't have the same syntax?  I don't know, but the parsers sure do share a lot of code);
* Report more details (signature, visibility, inheritance…);
* Fix scope type properly.

I might work on some or all of those at some point, but I don't have time right now, but needed a working ActionScript parser to replace Geany's previous regex one, which to my knowledge is now the case, within its limits.