### PR TITLE
Sample client app using ctags as a library plus all the related changes in ctags

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -156,7 +156,7 @@ extern const char *tagFileName (void)
 
 extern void abort_if_ferror(MIO *const mio)
 {
-	if (mio_error (mio))
+	if (mio != NULL && mio_error (mio))
 		error (FATAL | PERROR, "cannot write tag file");
 }
 
@@ -1688,12 +1688,14 @@ extern void invalidatePatternCache(void)
 
 extern void tagFilePosition (MIOPos *p)
 {
-	mio_getpos (TagFile.mio, p);
+	if (TagFile.mio)
+		mio_getpos (TagFile.mio, p);
 }
 
 extern void setTagFilePosition (MIOPos *p)
 {
-	mio_setpos (TagFile.mio, p);
+	if (TagFile.mio)
+		mio_setpos (TagFile.mio, p);
 }
 
 extern const char* getTagFileDirectory (void)

--- a/main/main.c
+++ b/main/main.c
@@ -643,7 +643,7 @@ static void sanitizeEnviron (void)
  *		Start up code
  */
 
-extern int main (int argc CTAGS_ATTR_UNUSED, char **argv)
+extern int ctags_main (int argc CTAGS_ATTR_UNUSED, char **argv)
 {
 	cookedArgs *args;
 

--- a/main/mini-geany.c
+++ b/main/mini-geany.c
@@ -1,0 +1,346 @@
+/*
+*   Copyright (c) 2019, Jiri Techet
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   Provides a simple application using ctags as a library and using the same
+*   set of ctags functions as the Geany editor
+*/
+
+#include "general.h"  /* must always come first */
+
+#include "types.h"
+#include "routines.h"
+#include "mio.h"
+#include "error_p.h"
+#include "writer_p.h"
+#include "parse_p.h"
+#include "options_p.h"
+#include "trashbox_p.h"
+#include "field_p.h"
+#include "xtag_p.h"
+#include "entry_p.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+static int writeEntry (tagWriter *writer, MIO * mio, const tagEntryInfo *const tag);
+static void rescanFailed (tagWriter *writer, unsigned long validTagNum);
+
+/* we need to be able to provide a custom writer using which we collect the tags */
+tagWriter customWriter = {
+	.writeEntry = writeEntry,
+	.writePtagEntry = NULL,
+	.preWriteEntry = NULL,
+	.postWriteEntry = NULL,
+	.rescanFailedEntry = rescanFailed,
+	.treatFieldAsFixed = NULL,
+	.defaultFileName = "tags_file_which_should_never_appear_anywhere",
+	.private = NULL,
+	.type = WRITER_U_CTAGS /* not really but for now we must use some of the builtin types */
+};
+
+
+/* we need to be able to provide an error printer which doesn't crash Geany on error */
+static bool nofatalErrorPrinter (const errorSelection selection,
+					  const char *const format,
+					  va_list ap, void *data CTAGS_ATTR_UNUSED)
+{
+	fprintf (stderr, "%s: ", (selection & WARNING) ? "Warning: " : "Error");
+	vfprintf (stderr, format, ap);
+	if (selection & PERROR)
+#ifdef HAVE_STRERROR
+		fprintf (stderr, " : %s", strerror (errno));
+#else
+		perror (" ");
+#endif
+	fputs ("\n", stderr);
+
+	return false;
+}
+
+
+/* we need to be able to enable all kinds for all languages (some are disabled by default) */
+static void enableAllLangKinds()
+{
+	unsigned int lang;
+
+	for (lang = 0; lang < countParsers(); lang++)
+	{
+		unsigned int kindNum = countLanguageKinds(lang);
+		unsigned int kind;
+
+		for (kind = 0; kind < kindNum; kind++)
+		{
+			kindDefinition *def = getLanguageKind(lang, kind);
+			enableKind(def, true);
+		}
+	}
+}
+
+
+/* we need to be able to initialize ctags like in main() but skipping some things */
+static void ctagsInit(void)
+{
+	initDefaultTrashBox ();
+
+	setErrorPrinter (nofatalErrorPrinter, NULL);
+	setCustomTagWriter (&customWriter);
+
+	checkRegex ();
+	initFieldObjects ();
+	initXtagObjects ();
+
+	initializeParsing ();
+	initOptions ();
+
+	/* make sure all parsers are initialized */
+	initializeParser (LANG_AUTO);
+
+	/* change default value which is false */
+	enableXtag(XTAG_TAGS_GENERATED_BY_GUEST_PARSERS, true);
+
+	/* some kinds we are interested in are disabled by default */
+	enableAllLangKinds();
+}
+
+
+/* we need to be able to get a name of a given language */
+static const char *ctagsGetLangName(int lang)
+{
+	return getLanguageName(lang);
+}
+
+
+/* we need to be able to get an int representing a given language */
+static int ctagsGetNamedLang(const char *name)
+{
+	return getNamedLanguage(name, 0);
+}
+
+
+/* we need to be able to get kind letters provided by a given language */
+static const char *ctagsGetLangKinds(int lang)
+{
+	unsigned int kindNum = countLanguageKinds(lang);
+	static char kinds[257];
+	unsigned int i;
+
+	for (i = 0; i < kindNum; i++)
+		kinds[i] = getLanguageKind(lang, i)->letter;
+	kinds[i] = '\0';
+
+	return kinds;
+}
+
+
+/* we need to be able to get kind name from a kind letter for a given language */
+static const char *ctagsGetKindName(char kind, int lang)
+{
+	kindDefinition *def = getLanguageKindForLetter (lang, kind);
+	return def ? def->name : "unknown";
+}
+
+
+/* we need to be able to get kind letter from a kind name for a given language */
+static char ctagsGetKindFromName(const char *name, int lang)
+{
+	kindDefinition *def = getLanguageKindForName (lang, name);
+	return def ? def->letter : '-';
+}
+
+
+/* we need to be able to get kind letter from a kind index */
+static char ctagsGetKindFromIndex(int index, int lang)
+{
+	return getLanguageKind(lang, index)->letter;
+}
+
+
+/* we need to be able to get the number of parsers */
+static unsigned int ctagsGetLangCount(void)
+{
+	return countParsers();
+}
+
+/*******************************************************************************
+ * So let's just use what we have for our great client...
+ ******************************************************************************/
+
+/* our internal tag representation - this is all the tag information we use in Geany */
+typedef struct {
+	char *name;
+	char *signature;
+	char *scopeName;
+	char *inheritance;
+	char *varType;
+	char *access;
+	char *implementation;
+	char kindLetter;
+	bool isFileScope;
+	unsigned long lineNumber;
+	int lang;
+} Tag;
+
+/* this is where we store the collected tags
+ * NOTE: Geany doesn't use the ptrArray type - it is used just for the purpose of this demo */
+static ptrArray *tagArray;
+
+
+static Tag *createTag(const tagEntryInfo *info)
+{
+	Tag *tag = xCalloc(1, Tag);
+	if (info->name)
+		tag->name = eStrdup(info->name);
+	if (info->extensionFields.signature)
+		tag->signature = eStrdup(info->extensionFields.signature);
+	if (info->extensionFields.scopeName)
+		tag->scopeName = eStrdup(info->extensionFields.scopeName);
+	if (info->extensionFields.inheritance)
+		tag->inheritance = eStrdup(info->extensionFields.inheritance);
+	if (info->extensionFields.typeRef[1])
+		tag->varType = eStrdup(info->extensionFields.typeRef[1]);
+	if (info->extensionFields.access)
+		tag->access = eStrdup(info->extensionFields.access);
+	if (info->extensionFields.implementation)
+		tag->implementation = eStrdup(info->extensionFields.implementation);
+	tag->kindLetter = ctagsGetKindFromIndex(info->kindIndex, info->langType);
+	tag->isFileScope = info->isFileScope;
+	tag->lineNumber = info->lineNumber;
+	tag->lang = info->langType;
+	return tag;
+}
+
+
+static void destroyTag(Tag *tag)
+{
+	if (tag->name)
+		eFree(tag->name);
+	if (tag->signature)
+		eFree(tag->signature);
+	if (tag->scopeName)
+		eFree(tag->scopeName);
+	if (tag->inheritance)
+		eFree(tag->inheritance);
+	if (tag->varType)
+		eFree(tag->varType);
+	if (tag->access)
+		eFree(tag->access);
+	if (tag->implementation)
+		eFree(tag->implementation);
+	eFree(tag);
+}
+
+
+/* callback from ctags informing us about a new tag */
+static int writeEntry (tagWriter *writer, MIO *mio, const tagEntryInfo *const tag)
+{
+	Tag *t;
+
+	/* apparently we have to call this to get the scope info - maybe we can
+	 * specify some option during initialization so we don't have to cal this
+	 * ?????? */
+	getTagScopeInformation((tagEntryInfo *)tag, NULL, NULL);
+
+	/* convert tags into our internal representation and store them into an array */
+	t = createTag(tag);
+	ptrArrayAdd(tagArray, t);
+
+	/* output length - we don't write anything to the MIO */
+	return 0;
+}
+
+
+/* scan has failed so we have invalid tags in our array - validTagNum should
+ * tell us the number of valid tags so remove all the extra tags and shrink the array */
+static void rescanFailed (tagWriter *writer, unsigned long validTagNum)
+{
+	int num = ptrArrayCount(tagArray);
+
+	if (num > validTagNum)
+	{
+		int i;
+		for (i = validTagNum; i < num; i++)
+		{
+			Tag *tag = ptrArrayLast(tagArray);
+			destroyTag(tag);
+			ptrArrayRemoveLast(tagArray);
+		}
+	}
+}
+
+
+/* do whatever we want to do with the tags */
+static void processCollectedTags()
+{
+	int i;
+	int num = ptrArrayCount(tagArray);
+
+	for (i = 0; i < num; i++)
+	{
+		Tag *tag = ptrArrayItem(tagArray, i);
+		printf("%s\tline: %lu\tkind: %s\t lang: %s\n",
+			tag->name,
+			tag->lineNumber,
+			ctagsGetKindName(tag->kindLetter, tag->lang),
+			ctagsGetLangName(tag->lang));
+	}
+
+	/* prepare for the next parsing by clearing the tag array */
+	ptrArrayClear(tagArray);
+}
+
+
+extern int main (int argc, char **argv)
+{
+	/* called once when Geany starts */
+	ctagsInit();
+	/* create empty tag array */
+	tagArray = ptrArrayNew((ptrArrayDeleteFunc)destroyTag);
+
+	printf("This parser only parses C files - provide them as arguments on the "
+			"command line or get a hard-coded buffer parsed when no arguments "
+			"are provided\n\n");
+	if (argc == 1)  /* parsing contents of a buffer */
+	{
+		char *program = "int foo() {}\n\n int bar() {}\n\n int main() {}\n";
+		int lang = ctagsGetNamedLang("C");
+		const char *kinds = ctagsGetLangKinds(lang);
+		int i;
+
+		printf("Number of all parsers is: %d\n", ctagsGetLangCount());
+		printf("We are parsing %s which provides the following kinds:\n",
+			ctagsGetLangName(lang));
+		for (i = 0; kinds[i] != '\0'; i++)
+		{
+			printf("%c: %s\n",
+				/* back and forth conversion - the same like just kinds[i] */
+				ctagsGetKindFromName(ctagsGetKindName(kinds[i], lang), lang),
+				ctagsGetKindName(kinds[i], lang));
+		}
+
+		printf("\nParsing buffer:\n");
+		/* we always specify the language by ourselves and don't use ctags detection */
+		createTags((unsigned char *)program, strlen(program), "whatever", lang);
+
+		processCollectedTags();
+	}
+	else  /* parsing contents of a file */
+	{
+		int i;
+		for (i = 1; i < argc; i++)
+		{
+			printf("\nParsing %s:\n", argv[i]);
+			/* createTags() is called repeatadly during Geany execution */
+			createTags(NULL, 0, argv[i], getNamedLanguage("C", 0));
+
+			processCollectedTags();
+		}
+	}
+
+	ptrArrayDelete(tagArray);
+
+	return 0;
+}

--- a/main/mini-geany.c
+++ b/main/mini-geany.c
@@ -99,8 +99,9 @@ static void ctagsInit(void)
 	/* make sure all parsers are initialized */
 	initializeParser (LANG_AUTO);
 
-	/* change default value which is false */
+	/* change default values which are false */
 	enableXtag(XTAG_TAGS_GENERATED_BY_GUEST_PARSERS, true);
+	enableXtag(XTAG_REFERENCE_TAGS, true);
 
 	/* some kinds we are interested in are disabled by default */
 	enableAllLangKinds();

--- a/main/parse.c
+++ b/main/parse.c
@@ -3344,6 +3344,7 @@ static bool createTagsWithFallback1 (const langType language,
 			*/
 			setTagFilePosition (&tagfpos);
 			setNumTagsAdded (numTags);
+			writerRescanFailed (numTags);
 			tagFileResized = true;
 			breakPromisesAfter(lastPromise);
 		}
@@ -3425,6 +3426,26 @@ static bool createTagsWithFallback (
 	closeInputFile ();
 
 	return tagFileResized;
+}
+
+extern void createTags(unsigned char *buffer, size_t bufferSize,
+	const char *fileName, const langType language)
+{
+	MIO *mio = NULL;
+
+	if (buffer)
+		mio = mio_new_memory (buffer, bufferSize, NULL, NULL);
+
+	/* keep in sync with parseFileWithMio() */
+	setupWriter ();
+	setupAnon ();
+	initParserTrashBox ();
+
+	createTagsWithFallback (fileName, language, mio);
+
+	finiParserTrashBox ();
+	teardownAnon ();
+	teardownWriter(fileName);
 }
 
 static void printGuessedParser (const char* const fileName, langType language)

--- a/main/parse_p.h
+++ b/main/parse_p.h
@@ -158,4 +158,7 @@ extern bool makeKindDescriptionsPseudoTags (const langType language,
 
 extern void printLanguageMultitableStatistics (langType language, FILE *vfp);
 
+extern void createTags(unsigned char *buffer, size_t bufferSize,
+	const char *fileName, const langType language);
+
 #endif	/* CTAGS_MAIN_PARSE_PRIVATE_H */

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -41,6 +41,7 @@ tagWriter uCtagsWriter = {
 	.writePtagEntry = writeCtagsPtagEntry,
 	.preWriteEntry = NULL,
 	.postWriteEntry = NULL,
+	.rescanFailedEntry = NULL,
 	.treatFieldAsFixed = treatFieldAsFixed,
 	.defaultFileName = CTAGS_FILE,
 };
@@ -65,6 +66,7 @@ tagWriter eCtagsWriter = {
 	.writePtagEntry = writeCtagsPtagEntry,
 	.preWriteEntry = beginECtagsFile,
 	.postWriteEntry = endECTagsFile,
+	.rescanFailedEntry = NULL,
 	.treatFieldAsFixed = treatFieldAsFixed,
 	.defaultFileName = CTAGS_FILE,
 };

--- a/main/writer-etags.c
+++ b/main/writer-etags.c
@@ -34,6 +34,7 @@ tagWriter etagsWriter = {
 	.writePtagEntry = NULL,
 	.preWriteEntry = beginEtagsFile,
 	.postWriteEntry = endEtagsFile,
+	.rescanFailedEntry = NULL,
 	.treatFieldAsFixed = NULL,
 	.defaultFileName = ETAGS_FILE,
 };

--- a/main/writer-json.c
+++ b/main/writer-json.c
@@ -44,6 +44,7 @@ tagWriter jsonWriter = {
 	.writePtagEntry = writeJsonPtagEntry,
 	.preWriteEntry = NULL,
 	.postWriteEntry = NULL,
+	.rescanFailedEntry = NULL,
 	.treatFieldAsFixed = NULL,
 	.defaultFileName = NULL,
 };

--- a/main/writer-xref.c
+++ b/main/writer-xref.c
@@ -25,6 +25,7 @@ tagWriter xrefWriter = {
 	.writePtagEntry = NULL,
 	.preWriteEntry = NULL,
 	.postWriteEntry = NULL,
+	.rescanFailedEntry = NULL,
 	.treatFieldAsFixed = NULL,
 	.defaultFileName = NULL,
 };

--- a/main/writer.c
+++ b/main/writer.c
@@ -27,6 +27,11 @@ static tagWriter *writerTable [WRITER_COUNT] = {
 
 static tagWriter *writer;
 
+extern void setCustomTagWriter(tagWriter *w)
+{
+	writer = w;
+}
+
 extern void setTagWriter (writerType wtype)
 {
 	writer = writerTable [wtype];
@@ -70,6 +75,12 @@ extern int writerWritePtag (MIO * mio,
 	return writer->writePtagEntry (writer, mio, desc, fileName,
 								   pattern, parserName);
 
+}
+
+extern void writerRescanFailed (unsigned long validTagNum)
+{
+	if (writer->rescanFailedEntry)
+		writer->rescanFailedEntry(writer, validTagNum);
 }
 
 extern bool ptagMakeCtagsOutputMode (ptagDesc *desc, void *data CTAGS_ATTR_UNUSED)

--- a/main/writer_p.h
+++ b/main/writer_p.h
@@ -41,6 +41,7 @@ struct sTagWriter {
 	/* Returning TRUE means the output file may be shrunk.
 	   In such case the callee may do truncate output file. */
 	bool (* postWriteEntry)  (tagWriter *writer, MIO * mio, const char* filename);
+	void (* rescanFailedEntry) (tagWriter *writer, unsigned long validTagNum);
 	bool (* treatFieldAsFixed) (int fieldType);
 	const char *defaultFileName;
 
@@ -61,6 +62,9 @@ int writerWritePtag (MIO * mio,
 					 const char *const fileName,
 					 const char *const pattern,
 					 const char *const parserName);
+
+extern void setCustomTagWriter(tagWriter *w);
+void writerRescanFailed (unsigned long validTagNum);
 
 extern const char *outputDefaultFileName (void);
 

--- a/source.mak
+++ b/source.mak
@@ -106,6 +106,7 @@ MAIN_SRCS =				\
 	main/lxpath.c			\
 	main/main.c			\
 	main/mbcs.c			\
+	main/mini-geany.c			\
 	main/nestlevel.c		\
 	main/numarray.c			\
 	main/objpool.c			\


### PR DESCRIPTION
This patch demonstrates how we use ctags in Geany as a library. The
patch tries to be minimalistic to demonstrate only the things we
need in ctags so it just directly replaces the ctags code with what
we need and the generated "ctags" binary is the demo app. For this
to be mergeable to ctags, there have to be some ifdefs specifying
whether ctags should be compiled as a library and mini-geany has
to be a separate binary.

@masatake Here you are - this should give you a pretty detailed idea about how we use ctags in Geany. I'll definitely welcome any suggestions if you think some of the ctags changes can be done in a better way - you are definitely more familiar with it than I am and I could have missed some things.

For anyone interested in the related discussion in Geany, please see https://github.com/geany/geany/issues/2119.