### PR TITLE
Fix warning about unused function

### DIFF
--- a/main/options.c
+++ b/main/options.c
@@ -3411,6 +3411,7 @@ extern void previewFirstOption (cookedArgs* const args)
 	}
 }
 
+#if defined(HAVE_SCANDIR) || defined (HAVE_DIRENT_H) || defined (_MSC_VER)
 static void parseConfigurationFileOptionsInDirectoryWithLeafname (const char* directory, const char* leafname)
 {
 	char* pathname = combinePathAndFile (directory, leafname);
@@ -3418,7 +3419,6 @@ static void parseConfigurationFileOptionsInDirectoryWithLeafname (const char* di
 	eFree (pathname);
 }
 
-#if defined(HAVE_SCANDIR) || defined (HAVE_DIRENT_H) || defined (_MSC_VER)
 static int ignore_dot_file(const struct dirent* dent)
 {
 	/* Ignore a file which name is started from dot. */


### PR DESCRIPTION
parseConfigurationFileOptionsInDirectoryWithLeafname() is only used
by the code protected by the ifdefs so when the code inside ifdefs
isn't compiled, we get a warning about unused function. Move it inside
the ifdef section.