### PR TITLE
Move CTagsSelfTestParser after PARSER_LIST

### DIFF
--- a/main/parse.c
+++ b/main/parse.c
@@ -121,7 +121,6 @@ static void uninstallTagXpathTable (const langType language);
 */
 static parserDefinition *CTagsSelfTestParser (void);
 static parserDefinitionFunc* BuiltInParsers[] = {
-	CTagsSelfTestParser,
 	PARSER_LIST,
 	XML_PARSER_LIST
 #ifdef HAVE_LIBXML
@@ -131,10 +130,11 @@ static parserDefinitionFunc* BuiltInParsers[] = {
 #ifdef HAVE_LIBYAML
 	,
 #endif
-       PEG_PARSER_LIST
+	PEG_PARSER_LIST
 #ifdef HAVE_PACKCC
-       ,
+	,
 #endif
+	CTagsSelfTestParser
 };
 static parserObject* LanguageTable = NULL;
 static unsigned int LanguageCount = 0;


### PR DESCRIPTION
Unless this causes some problems for uctags, it would be nice if
CTagsSelfTestParser could be moved after PARSER_LIST because for
Geany this means we have to shift parsers by 1 compared to what
is inside PARSER_LIST.

Without this change we either have to keep a diff against uctags by removing CTagsSelfTestParser or shift lang by 1 like in

https://github.com/geany/geany/pull/2132/commits/3de0df0872e237d955e291a27db913e650e8b8a9

which is a bit error-prone because it has to happen at multiple places.