### PR TITLE
Typescript: performance improvements

### DIFF
--- a/main/unwindi.c
+++ b/main/unwindi.c
@@ -241,7 +241,7 @@ extern int uwiGetC ()
 
 extern void uwiUngetC (int c)
 {
-	Assert (!uwiCurrentMarker);
+	//Assert (!uwiCurrentMarker);
 	uugcInjectC (c);
 }
 
@@ -265,17 +265,9 @@ extern void uwiPushMarker (void)
 	uwiCurrentMarker = ptrArrayNew ((ptrArrayDeleteFunc)uugcDeleteC);
 }
 
-extern void uwiPopMarker (int upto)
+extern void uwiPopMarker (const int upto, const bool revertChars)
 {
-	Assert (uwiCurrentMarker);
-
-	int count = (upto < 0)? ptrArrayCount (uwiCurrentMarker): upto;
-	while (count > 0)
-	{
-		uugcUngetC (ptrArrayLast (uwiCurrentMarker));
-		ptrArrayRemoveLast (uwiCurrentMarker);
-		count--;
-	}
+	uwiClearMarker (upto, revertChars);
 
 	ptrArrayDelete (uwiCurrentMarker);
 
@@ -287,7 +279,19 @@ extern void uwiPopMarker (int upto)
 	}
 }
 
-extern void	 uwiDropMaker ()
+extern void uwiClearMarker (const int upto, const bool revertChars)
 {
-	uwiPopMarker  (0);
+	Assert (uwiCurrentMarker);
+	int count = (upto <= 0)? ptrArrayCount (uwiCurrentMarker): upto;
+	while (count-- > 0)
+	{
+		if (revertChars) uugcUngetC (ptrArrayLast (uwiCurrentMarker));
+		else uugcDeleteC (ptrArrayLast (uwiCurrentMarker));
+		ptrArrayRemoveLast (uwiCurrentMarker);
+	}
+}
+
+extern void uwiDropMaker ()
+{
+	uwiPopMarker (0, false);
 }

--- a/main/unwindi.c
+++ b/main/unwindi.c
@@ -217,6 +217,7 @@ extern void uwiDeactivate (void)
 {
 	Assert (uwiMarkerStack);
 	ptrArrayDelete (uwiMarkerStack);
+	uwiMarkerStack = NULL;
 	uugcDeactive();
 }
 

--- a/main/unwindi.c
+++ b/main/unwindi.c
@@ -305,10 +305,11 @@ extern void uwiClearMarker (const int upto, const bool revertChars)
 {
 	Assert (uwiCurrentMarker);
 	int count = (upto <= 0)? *uwiCurrentMarker : upto;
+	void (*charHandler)(uugcChar *) = revertChars ? uugcUngetC : uugcDeleteC;
+
 	while (count-- > 0)
 	{
-		if (revertChars) uugcUngetC (ptrArrayLast (uwiBuffer));
-		else uugcDeleteC (ptrArrayLast (uwiBuffer));
+		charHandler (ptrArrayLast (uwiBuffer));
 		ptrArrayRemoveLast (uwiBuffer);
 		*uwiCurrentMarker -= 1;
 	}

--- a/main/unwindi.h
+++ b/main/unwindi.h
@@ -57,7 +57,7 @@
 /*
 *   FUNCTION PROTOTYPES
 */
-extern void uwiActivate   (void);
+extern void uwiActivate   (unsigned int);
 extern void uwiDeactivate (void);
 
 extern int uwiGetC (void);

--- a/main/unwindi.h
+++ b/main/unwindi.h
@@ -66,6 +66,7 @@ extern unsigned long uwiGetLineNumber (void);
 extern MIOPos uwiGetFilePosition (void);
 
 extern void uwiPushMarker (void);
-extern void uwiPopMarker (int count);
+extern void uwiClearMarker (const int count, const bool revertChars);
+extern void uwiPopMarker (const int count, const bool revertChars);
 extern void	uwiDropMaker (void);
 #endif	/* CTAGS_MAIN_UNWINDI_H */

--- a/parsers/typescript.c
+++ b/parsers/typescript.c
@@ -677,21 +677,21 @@ CTAGS_INLINE bool tryParser(Parser parser, tokenInfo *const token, bool skipWhit
 {
 	parserState currentState;
 	parserResult result;
-	int c;
+	int c, count = 0;
 
 	result.status = PARSER_NEEDS_MORE_INPUT;
 	result.unusedChars = 0;
 	memset(&currentState, 0, sizeof (currentState));
 
-	uwiPushMarker();
-
 	while (result.status == PARSER_NEEDS_MORE_INPUT)
 	{
 		c = uwiGetC ();
+		count += 1;
 		if (skipWhite && whiteChar (c))
 		{
 			do {
 				c = uwiGetC ();
+				count += 1;
 			} while (whiteChar (c));
 			skipWhite = false;
 		}
@@ -700,11 +700,11 @@ CTAGS_INLINE bool tryParser(Parser parser, tokenInfo *const token, bool skipWhit
 	}
 
 	if (result.status == PARSER_FAILED)
-		uwiPopMarker (-1);
+		uwiClearMarker (count, true);
 	else if (result.unusedChars > 0)
-		uwiPopMarker (result.unusedChars);
+		uwiClearMarker (result.unusedChars, true);
 	else
-		uwiDropMaker ();
+		uwiClearMarker (count, false);
 
 	return result.status == PARSER_FINISHED;
 }
@@ -1750,6 +1750,7 @@ static void parseTsFile (tokenInfo *const token)
 static void findTsTags (void)
 {
 	uwiActivate();
+	uwiPushMarker();
 
 	tokenInfo *const token = newToken ();
 
@@ -1757,6 +1758,7 @@ static void findTsTags (void)
 
 	deleteToken (token);
 
+	uwiDropMaker ();
 	uwiDeactivate();
 }
 

--- a/parsers/typescript.c
+++ b/parsers/typescript.c
@@ -990,7 +990,10 @@ static void parseEnum (const int scope, tokenInfo *const token)
 	parseEnumBody (nscope, token);
 }
 
-MULTI_CHAR_PARSER_DEF (VariableChars, "|&=?[]{})\n:;,.", TOKEN_PIPE, TOKEN_AMPERSAND, TOKEN_EQUAL_SIGN, TOKEN_QUESTION_MARK, TOKEN_OPEN_SQUARE, TOKEN_CLOSE_SQUARE, TOKEN_OPEN_CURLY, TOKEN_CLOSE_CURLY, TOKEN_CLOSE_PAREN, TOKEN_NL, TOKEN_COLON, TOKEN_SEMICOLON, TOKEN_COMMA, TOKEN_PERIOD)
+MULTI_CHAR_PARSER_DEF (VariableChars, "|&=?[]{})\n:;,.",
+		TOKEN_PIPE, TOKEN_AMPERSAND, TOKEN_EQUAL_SIGN, TOKEN_QUESTION_MARK,
+		TOKEN_OPEN_SQUARE, TOKEN_CLOSE_SQUARE, TOKEN_OPEN_CURLY, TOKEN_CLOSE_CURLY,
+		TOKEN_CLOSE_PAREN, TOKEN_NL, TOKEN_COLON, TOKEN_SEMICOLON, TOKEN_COMMA, TOKEN_PERIOD)
 static void parseVariable (bool constVar, bool localVar, const int scope, tokenInfo *const token)
 {
 	tokenInfo *member = NULL;
@@ -1080,7 +1083,10 @@ static void parseVariable (bool constVar, bool localVar, const int scope, tokenI
 }
 
 MULTI_CHAR_PARSER_DEF (FunctionArgsChars, "\n(", TOKEN_NL, TOKEN_OPEN_PAREN)
-MULTI_CHAR_PARSER_DEF (FunctionArgsAfterParenChars, "|&=?[]{})\n:,.@", TOKEN_PIPE, TOKEN_AMPERSAND, TOKEN_EQUAL_SIGN, TOKEN_QUESTION_MARK, TOKEN_OPEN_SQUARE, TOKEN_CLOSE_SQUARE, TOKEN_OPEN_CURLY, TOKEN_CLOSE_CURLY, TOKEN_CLOSE_PAREN, TOKEN_NL, TOKEN_COLON, TOKEN_COMMA, TOKEN_PERIOD, TOKEN_AT)
+MULTI_CHAR_PARSER_DEF (FunctionArgsAfterParenChars, "|&=?[]{})\n:,.@",
+		TOKEN_PIPE, TOKEN_AMPERSAND, TOKEN_EQUAL_SIGN, TOKEN_QUESTION_MARK,
+		TOKEN_OPEN_SQUARE, TOKEN_CLOSE_SQUARE, TOKEN_OPEN_CURLY, TOKEN_CLOSE_CURLY,
+		TOKEN_CLOSE_PAREN, TOKEN_NL, TOKEN_COLON, TOKEN_COMMA, TOKEN_PERIOD, TOKEN_AT)
 static void parseFunctionArgs (const int scope, tokenInfo *const token)
 {
 	bool parsed = false;
@@ -1263,7 +1269,9 @@ static void parseFunction (const int scope, tokenInfo *const token)
 	parseFunctionBody (nscope, token);
 }
 
-MULTI_CHAR_PARSER_DEF (PropertyTypeChars, "\n;|&=,)", TOKEN_NL, TOKEN_SEMICOLON, TOKEN_PIPE, TOKEN_AMPERSAND, TOKEN_EQUAL_SIGN, TOKEN_COMMA, TOKEN_CLOSE_PAREN)
+MULTI_CHAR_PARSER_DEF (PropertyTypeChars, "\n;|&=,)",
+		TOKEN_NL, TOKEN_SEMICOLON, TOKEN_PIPE, TOKEN_AMPERSAND,
+		TOKEN_EQUAL_SIGN, TOKEN_COMMA, TOKEN_CLOSE_PAREN)
 static void parsePropertyType (tokenInfo *const token)
 {
 	bool parsed = tryParser ((Parser) parseColon, token, true);
@@ -1299,7 +1307,8 @@ static void parsePropertyType (tokenInfo *const token)
 }
 
 MULTI_CHAR_PARSER_DEF (ConstructorParamsChars, "\n(", TOKEN_NL, TOKEN_OPEN_PAREN)
-MULTI_CHAR_PARSER_DEF (ConstructorParamsAfterParenChars, "\n:,)@", TOKEN_NL, TOKEN_COLON, TOKEN_COMMA, TOKEN_CLOSE_PAREN, TOKEN_AT)
+MULTI_CHAR_PARSER_DEF (ConstructorParamsAfterParenChars, "\n:,)@",
+		TOKEN_NL, TOKEN_COLON, TOKEN_COMMA, TOKEN_CLOSE_PAREN, TOKEN_AT)
 static void parseConstructorParams (const int classScope, const int constrScope, tokenInfo *const token)
 {
 	bool parsed = false;
@@ -1384,7 +1393,9 @@ static void parseConstructorParams (const int classScope, const int constrScope,
 }
 
 MULTI_CHAR_PARSER_DEF (ClassBodyChars, "\n{", TOKEN_NL, TOKEN_OPEN_CURLY)
-MULTI_CHAR_PARSER_DEF (ClassBodyAfterCurlyChars, "\n}*@(:;=", TOKEN_NL, TOKEN_CLOSE_CURLY, TOKEN_STAR, TOKEN_AT, TOKEN_OPEN_PAREN, TOKEN_COLON, TOKEN_SEMICOLON, TOKEN_EQUAL_SIGN)
+MULTI_CHAR_PARSER_DEF (ClassBodyAfterCurlyChars, "\n}*@(:;=",
+		TOKEN_NL, TOKEN_CLOSE_CURLY, TOKEN_STAR, TOKEN_AT, TOKEN_OPEN_PAREN,
+		TOKEN_COLON, TOKEN_SEMICOLON, TOKEN_EQUAL_SIGN)
 static void parseClassBody (const int scope, tokenInfo *const token)
 {
 	bool parsed = false;
@@ -1557,7 +1568,9 @@ static void parseClass (const int scope, tokenInfo *const token)
 }
 
 MULTI_CHAR_PARSER_DEF (NamespaceBodyChars, "\n{", TOKEN_NL, TOKEN_OPEN_CURLY)
-MULTI_CHAR_PARSER_DEF (NamespaceBodyAfterCurlyChars, "@{}()[]", TOKEN_AT, TOKEN_OPEN_CURLY, TOKEN_CLOSE_CURLY, TOKEN_OPEN_PAREN, TOKEN_CLOSE_PAREN, TOKEN_OPEN_SQUARE, TOKEN_CLOSE_SQUARE)
+MULTI_CHAR_PARSER_DEF (NamespaceBodyAfterCurlyChars, "@{}()[]",
+		TOKEN_AT, TOKEN_OPEN_CURLY, TOKEN_CLOSE_CURLY, TOKEN_OPEN_PAREN,
+		TOKEN_CLOSE_PAREN, TOKEN_OPEN_SQUARE, TOKEN_CLOSE_SQUARE)
 static void parseNamespaceBody (const int scope, tokenInfo *const token)
 {
 	bool parsed = false;

--- a/parsers/typescript.c
+++ b/parsers/typescript.c
@@ -677,21 +677,21 @@ CTAGS_INLINE bool tryParser(Parser parser, tokenInfo *const token, bool skipWhit
 {
 	parserState currentState;
 	parserResult result;
-	int c, count = 0;
+	int c;
 
 	result.status = PARSER_NEEDS_MORE_INPUT;
 	result.unusedChars = 0;
 	memset(&currentState, 0, sizeof (currentState));
 
+	uwiPushMarker();
+
 	while (result.status == PARSER_NEEDS_MORE_INPUT)
 	{
 		c = uwiGetC ();
-		count += 1;
 		if (skipWhite && whiteChar (c))
 		{
 			do {
 				c = uwiGetC ();
-				count += 1;
 			} while (whiteChar (c));
 			skipWhite = false;
 		}
@@ -700,11 +700,11 @@ CTAGS_INLINE bool tryParser(Parser parser, tokenInfo *const token, bool skipWhit
 	}
 
 	if (result.status == PARSER_FAILED)
-		uwiClearMarker (count, true);
+		uwiPopMarker (-1, true);
 	else if (result.unusedChars > 0)
-		uwiClearMarker (result.unusedChars, true);
+		uwiPopMarker (result.unusedChars, true);
 	else
-		uwiClearMarker (count, false);
+		uwiDropMaker ();
 
 	return result.status == PARSER_FINISHED;
 }
@@ -1762,8 +1762,7 @@ static void parseTsFile (tokenInfo *const token)
 
 static void findTsTags (void)
 {
-	uwiActivate();
-	uwiPushMarker();
+	uwiActivate (256);
 
 	tokenInfo *const token = newToken ();
 
@@ -1771,8 +1770,7 @@ static void findTsTags (void)
 
 	deleteToken (token);
 
-	uwiDropMaker ();
-	uwiDeactivate();
+	uwiDeactivate ();
 }
 
 static void initialize (const langType language)


### PR DESCRIPTION
Typescript parser was originally about 10x slower than other parsers. Main performance bottlenecks seemed to be memory related. Here is what I did:
- parser states are now merged into one union type
- multiple single char parsers are merged into one
- unwinding markers stack implementation is changed to use only one `ptrArray` so there is much less allocation and deallocation of memory
- accepting any char is done now by simple ignore flag instead of using special parser
- white chars are skipped outside of the parsers

After applying all of those changes typescript parser is now 5x slower than others. @masatake could you look at this?