### PR TITLE
Allow compilation when either scandir() or dirent.h aren't available

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -85,7 +85,7 @@ static bool createTagsForEntry (const char *const entryName);
 *   FUNCTION DEFINITIONS
 */
 
-#if defined (HAVE_OPENDIR)
+#if defined (HAVE_OPENDIR) && (defined (HAVE_DIRENT_H) || defined (_MSC_VER))
 static bool recurseUsingOpendir (const char *const dirName)
 {
 	bool resize = false;
@@ -178,7 +178,7 @@ static bool recurseIntoDirectory (const char *const dirName)
 	else
 	{
 		verbose ("RECURSING into directory \"%s\"\n", dirName);
-#if defined (HAVE_OPENDIR)
+#if defined (HAVE_OPENDIR) && (defined (HAVE_DIRENT_H) || defined (_MSC_VER))
 		resize = recurseUsingOpendir (dirName);
 #elif defined (HAVE__FINDFIRST)
 		{

--- a/main/options.c
+++ b/main/options.c
@@ -538,7 +538,7 @@ static struct Feature {
 #ifdef DEBUG
 	{"debug", "TO BE WRITTEN"},
 #endif
-#if defined(HAVE_SCANDIR) || defined (HAVE_DIRENT_H) || defined (_MSC_VER)
+#if defined (HAVE_DIRENT_H) || defined (_MSC_VER)
 	{"option-directory", "TO BE WRITTEN"},
 #endif
 #ifdef HAVE_LIBXML
@@ -3410,7 +3410,11 @@ extern void previewFirstOption (cookedArgs* const args)
 	}
 }
 
-#if defined(HAVE_SCANDIR) || defined (HAVE_DIRENT_H) || defined (_MSC_VER)
+#if defined (HAVE_DIRENT_H) || defined (_MSC_VER)
+extern int scanDirectory (const char *directory_name,
+						  struct dirent ***array_pointer, int (*select_function) (const struct dirent *),
+						  int (*compare_function) (const struct dirent **, const struct dirent **));
+
 static void parseConfigurationFileOptionsInDirectoryWithLeafname (const char* directory, const char* leafname)
 {
 	char* pathname = combinePathAndFile (directory, leafname);

--- a/main/portable-dirent_p.h
+++ b/main/portable-dirent_p.h
@@ -941,7 +941,4 @@ dirent_set_errno(
 }
 #endif
 #endif /*DIRENT_H*/
-
-#else
-#error "dirent.h is not available."
 #endif /* HAVE_DIRENT_H */

--- a/main/portable-scandir.c
+++ b/main/portable-scandir.c
@@ -111,9 +111,12 @@
 #include "routines.h"
 #include "routines_p.h"
 
-#ifdef HAVE_SCANDIR
+#if defined (HAVE_SCANDIR) && defined (HAVE_DIRENT_H)
 #include <dirent.h>
-#else
+#elif defined (HAVE_DIRENT_H) || defined (_MSC_VER)
+# ifdef HAVE_DIRENT_H
+# include <dirent.h>
+# endif
 #define USE_SCANDIR_COMPARE_STRUCT_DIRENT
 
 #include <sys/types.h>
@@ -227,9 +230,11 @@ scandir(const char *directory_name,
 }
 #endif
 
+#if defined (HAVE_DIRENT_H) || defined (_MSC_VER)
 int scanDirectory (const char *directory_name,
 				   struct dirent ***array_pointer, int (*select_function) (const struct dirent *),
 				   int (*compare_function) (const struct dirent **, const struct dirent **))
 {
 	return scandir (directory_name, array_pointer, select_function, compare_function);
 }
+#endif

--- a/main/routines_p.h
+++ b/main/routines_p.h
@@ -14,6 +14,7 @@
 */
 #include "general.h"  /* must always come first */
 #include "mio.h"
+#include "portable-dirent_p.h"
 
 /*
  *  Portability macros
@@ -93,11 +94,5 @@ extern char* relativeFilename (const char *file, const char *dir);
 extern MIO *tempFile (const char *const mode, char **const pName);
 
 extern char* baseFilenameSansExtensionNew (const char *const fileName, const char *const templateExt);
-
-#include "portable-dirent_p.h"
-
-extern int scanDirectory (const char *directory_name,
-						  struct dirent ***array_pointer, int (*select_function) (const struct dirent *),
-						  int (*compare_function) (const struct dirent **, const struct dirent **));
 
 #endif  /* CTAGS_MAIN_ROUTINES_PRIVATE_H */


### PR DESCRIPTION
At the moment, when you comment-out HAVE_SCANDIR or HAVE_DIRENT_H in
config.h (which is the configuration we use in Geany because we don't
need this functionality), one gets a compilation error.

This patch enables all possible combinations of HAVE_SCANDIR and
HAVE_DIRENT_H:
1. It removes the error from portable-dirent.h when neither HAVE_DIRENT_H
is defined nor _MSC_VER is used (the header does nothing in this case).
2. Inside portable-scandir.c, the checks are more precise - scandir() from
dirent.h is only used when both HAVE_SCANDIR and HAVE_DIRENT_H are
defined and the scandir() implementation is only compiled when
HAVE_DIRENT_H is available or _MSC_VER (which implies dirent from
portable-dirent is used) is defined. This means we have
scandir() -- either the system one or the ctags one -- when
HAVE_DIRENT_H is available or _MSC_VER is defined.
3. Inside options.c, the #ifdef checks can be reduced to
#if defined (HAVE_DIRENT_H) || defined (_MSC_VER) because of the above.
4. scanDirectory() extern declaration is moved from routines_p.h
inside options.c because it's the only place where it's used and it can
be protected here by the corresponding ifdefs.
5. Inside main.c ifdef HAVE_OPENDIR checks are extended by HAVE_DIRENT_H
or _MSC_VER because of the DIR structure declaration (either declared
inside dirent.h or portable-dirent_p.h).
