### PR TITLE
[WITHDRAW] External parser list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ man/ctags-optlib.7
 man/ctags-optlib.7.html
 man/ctags-optlib.7.rst
 misc/mini-geany.actual
+Tlib/Makefile
+Tlib/Makefile.in
 Tmain/**/Makefile
 Tmain/**/Makefile.am
 Tmain/**/Makefile.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -77,7 +77,9 @@ endif
 PARSER_SRCS += $(PEG_SRCS)
 PARSER_HEADS += $(PEG_HEADS) $(PEG_EXTRA_HEADS)
 
-libctags_a_CPPFLAGS = -I. -I$(srcdir) -I$(srcdir)/main -DHAVE_PACKCC
+libctags_a_CPPFLAGS =
+libctags_a_CPPFLAGS+= $(EXTRA_CPPFLAGS)
+libctags_a_CPPFLAGS+= -I. -I$(srcdir) -I$(srcdir)/main -DHAVE_PACKCC
 if ENABLE_DEBUGGING
 libctags_a_CPPFLAGS+= $(DEBUG_CPPFLAGS)
 endif

--- a/Tlib/Makefile.am
+++ b/Tlib/Makefile.am
@@ -1,0 +1,5 @@
+EXTRA_DIST= \
+	extra_parser_list.h \
+	\
+	$(NULL)
+

--- a/Tlib/extra_parser_list.h
+++ b/Tlib/extra_parser_list.h
@@ -1,0 +1,8 @@
+/* An example of external parser list
+ *
+ * Run following command line at the top directory of source tree:
+ *
+ * $ make EXTRA_CPPFLAGS=-DEXTERNAL_PARSER_LIST="\\\"Tlib/extra_parser_list.h\\\"" V=1
+ *
+ */
+CParser,

--- a/configure.ac
+++ b/configure.ac
@@ -772,6 +772,7 @@ AC_CONFIG_FILES([Makefile
 		 man/ctags.1.rst
 		 man/ctags-incompatibilities.7.rst
 		 man/ctags-optlib.7.rst
+		 Tlib/Makefile
 		 ])
 m4_include([Tmain/dist.m4])
 m4_include([Units/dist.m4])

--- a/main/parse.c
+++ b/main/parse.c
@@ -121,6 +121,9 @@ static void uninstallTagXpathTable (const langType language);
 */
 static parserDefinition *CTagsSelfTestParser (void);
 static parserDefinitionFunc* BuiltInParsers[] = {
+#ifdef EXTERNAL_PARSER_LIST
+#include EXTERNAL_PARSER_LIST
+#else  /* ! EXTERNAL_PARSER_LIST */
 	CTagsSelfTestParser,
 	PARSER_LIST,
 	XML_PARSER_LIST
@@ -135,6 +138,7 @@ static parserDefinitionFunc* BuiltInParsers[] = {
 #ifdef HAVE_PACKCC
        ,
 #endif
+#endif	/* EXTERNAL_PARSER_LIST */
 };
 static parserObject* LanguageTable = NULL;
 static unsigned int LanguageCount = 0;

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -4,7 +4,7 @@
 EXTRA_DIST += misc/units
 EXTRA_DIST += misc/tlib misc/mini-geany.expected
 
-DIST_SUBDIRS = Tmain Units
+DIST_SUBDIRS = Tmain Units Tlib
 
 check: tmain units tlib
 

--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -39,6 +39,16 @@ if [ "$TARGET" = "Unix" ]; then
             make clean
         )
 
+        BUILDDIR=${BUILDDIR0}-external_parser_list
+        mkdir -p "${BUILDDIR}"
+        (
+            cd "${BUILDDIR}"
+            ${CONFIGURE_CMDLINE}
+            make -j2 EXTRA_CPPFLAGS=-DEXTERNAL_PARSER_LIST="\\\"Tlib/extra_parser_list.h\\\""
+			test $(./ctags --list-languages | wc -l) = 1
+            make clean
+        )
+
         BUILDDIR=${BUILDDIR0}-gcov
         mkdir -p "${BUILDDIR}"
         (


### PR DESCRIPTION
Close #2087.

An example usage:
```
[yamato@slave]~/var/ctags-github% cat Tlib/extra_parser_list.h
CParser,
[yamato@slave]~/var/ctags-github% make clean
...
make[1]: Leaving directory '/home/yamato/var/ctags-github'
[yamato@slave]~/var/ctags-github% make EXTRA_CPPFLAGS=-DEXTERNAL_PARSER_LIST="\\\"Tlib/extra_parser_list.h\\\"" -j 9
REPOINFO   main/repoinfo.h
make  all-recursive
make[1]: Entering directory '/home/yamato/var/ctags-github'
make[2]: Entering directory '/home/yamato/var/ctags-github'
REPOINFO   main/repoinfo.h
  CC       misc/packcc/packcc-packcc.o
  ...
  CC       peg/libctags_a-varlink.o
  AR       libctags.a
  CCLD     mini-geany
  CCLD     ctags
make[2]: Leaving directory '/home/yamato/var/ctags-github'
make[1]: Leaving directory '/home/yamato/var/ctags-github'

[yamato@slave]~/var/ctags-github% ./ctags --quiet --options=NONE --list-languages
C
```

