### PR TITLE
main: allow specifying alternative parser list

### DIFF
--- a/main/parse.c
+++ b/main/parse.c
@@ -121,6 +121,9 @@ static void uninstallTagXpathTable (const langType language);
 */
 static parserDefinition *CTagsSelfTestParser (void);
 static parserDefinitionFunc* BuiltInParsers[] = {
+#ifdef EXTERNAL_PARSER_LIST
+	EXTERNAL_PARSER_LIST
+#else  /* ! EXTERNAL_PARSER_LIST */
 	CTagsSelfTestParser,
 	PARSER_LIST,
 	XML_PARSER_LIST
@@ -135,6 +138,7 @@ static parserDefinitionFunc* BuiltInParsers[] = {
 #ifdef HAVE_PACKCC
        ,
 #endif
+#endif	/* EXTERNAL_PARSER_LIST */
 };
 static parserObject* LanguageTable = NULL;
 static unsigned int LanguageCount = 0;

--- a/main/parse_p.h
+++ b/main/parse_p.h
@@ -18,6 +18,9 @@
 #include "parse.h"
 #include "parsers_p.h"  /* contains list of parsers */
 #include "strlist.h"
+#ifdef EXTERNAL_PARSER_LIST_FILE
+#include EXTERNAL_PARSER_LIST_FILE
+#endif
 
 /*
 *   MACROS
@@ -41,6 +44,9 @@ typedef enum {
  * return a structure allocated using parserNew(). This structure must,
  * at minimum, set the `parser' field.
  */
+#ifdef EXTERNAL_PARSER_LIST
+extern parserDefinitionFunc EXTERNAL_PARSER_LIST;
+#else /* ! EXTERNAL_PARSER_LIST */
 extern parserDefinitionFunc PARSER_LIST;
 #ifdef HAVE_LIBXML
 extern parserDefinitionFunc XML_PARSER_LIST;
@@ -51,6 +57,7 @@ extern parserDefinitionFunc YAML_PARSER_LIST;
 #ifdef HAVE_PACKCC
 extern parserDefinitionFunc PEG_PARSER_LIST;
 #endif
+#endif /* EXTERNAL_PARSER_LIST */
 
 extern bool doesLanguageAllowNullTag (const langType language);
 extern bool doesLanguageRequestAutomaticFQTag (const langType language);


### PR DESCRIPTION
Allow applications which use ctags as a library provide their own
list of parsers. This list has to be declared as a define called
EXTERNAL_PARSER_LIST inside an external header. ctags will use the
EXTERNAL_PARSER_LIST_FILE define to detect the presence of such a
header and it should contain path to the header. When not defined,
internal parsers are used.

I've tested this against Geany and it seems to work.