### PR TITLE
Perl,Moose: support Moo extension in Moose parser

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -46,6 +46,7 @@ M4             I/macrofile       sincluded           on      silently included m
 M4             d/macro           undef               on      undefined
 Make           I/makefile        included            on      included
 Make           I/makefile        optional            on      optionally included
+Perl           M/module          used                on      specified in `use' built-in function
 Python         i/module          imported            on      imported modules
 Python         i/module          indirectly-imported on      module imported in alternative name
 Python         i/module          namespace           on      namespace from where classes/variables/functions are imported
@@ -111,6 +112,7 @@ M4             I/macrofile       sincluded           on      silently included m
 M4             d/macro           undef               on      undefined
 Make           I/makefile        included            on      included
 Make           I/makefile        optional            on      optionally included
+Perl           M/module          used                on      specified in `use' built-in function
 Python         i/module          imported            on      imported modules
 Python         i/module          indirectly-imported on      module imported in alternative name
 Python         i/module          namespace           on      namespace from where classes/variables/functions are imported

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -46,6 +46,7 @@ M4             I/macrofile       sincluded           on      silently included m
 M4             d/macro           undef               on      undefined
 Make           I/makefile        included            on      included
 Make           I/makefile        optional            on      optionally included
+Perl           M/module          unused              on      specified in `no' built-in function
 Perl           M/module          used                on      specified in `use' built-in function
 Python         i/module          imported            on      imported modules
 Python         i/module          indirectly-imported on      module imported in alternative name
@@ -112,6 +113,7 @@ M4             I/macrofile       sincluded           on      silently included m
 M4             d/macro           undef               on      undefined
 Make           I/makefile        included            on      included
 Make           I/makefile        optional            on      optionally included
+Perl           M/module          unused              on      specified in `no' built-in function
 Perl           M/module          used                on      specified in `use' built-in function
 Python         i/module          imported            on      imported modules
 Python         i/module          indirectly-imported on      module imported in alternative name

--- a/Units/parser-perl.r/perl-module.d/args.ctags
+++ b/Units/parser-perl.r/perl-module.d/args.ctags
@@ -1,0 +1,4 @@
+--sort=no
+--fields=+rEn
+--extras=+r
+--kinds-Perl=+M

--- a/Units/parser-perl.r/perl-module.d/expected.tags
+++ b/Units/parser-perl.r/perl-module.d/expected.tags
@@ -1,0 +1,12 @@
+constant	input.pl	/^use constant$/;"	M	line:2	roles:used	extras:reference
+ONE	input.pl	/^ONE => 1;$/;"	c	line:3	roles:def
+diagnostics	input.pl	/^use diagnostics;$/;"	M	line:4	roles:used	extras:reference
+integer	input.pl	/^use integer;$/;"	M	line:5	roles:used	extras:reference
+sigtrap	input.pl	/^use sigtrap  qw(SEGV BUS);$/;"	M	line:6	roles:used	extras:reference
+strict	input.pl	/^use strict   qw(subs vars refs);$/;"	M	line:7	roles:used	extras:reference
+subs	input.pl	/^use subs     qw(afunc blurfl);$/;"	M	line:8	roles:used	extras:reference
+warnings	input.pl	/^use warnings qw(all);$/;"	M	line:9	roles:used	extras:reference
+sort	input.pl	/^use sort     qw(stable _quicksort _mergesort);$/;"	M	line:10	roles:used	extras:reference
+integer	input.pl	/^no integer;$/;"	M	line:12	roles:unused	extras:reference
+strict	input.pl	/^no strict 'refs';$/;"	M	line:13	roles:unused	extras:reference
+warnings	input.pl	/^no warnings;$/;"	M	line:14	roles:unused	extras:reference

--- a/Units/parser-perl.r/perl-module.d/input.pl
+++ b/Units/parser-perl.r/perl-module.d/input.pl
@@ -1,0 +1,14 @@
+# Taken from https://perldoc.perl.org/functions/use.html
+use constant
+ONE => 1;
+use diagnostics;
+use integer;
+use sigtrap  qw(SEGV BUS);
+use strict   qw(subs vars refs);
+use subs     qw(afunc blurfl);
+use warnings qw(all);
+use sort     qw(stable _quicksort _mergesort);
+
+no integer;
+no strict 'refs';
+no warnings;

--- a/Units/simple-moose.d/args.ctags
+++ b/Units/simple-moose.d/args.ctags
@@ -1,3 +1,8 @@
 --sort=no
 --fields=+lineK
 --extras=+s
+#
+# NOTE: Moose parser works without following options.
+#
+--kinds-Perl=+M
+--extras=+r

--- a/Units/simple-moose.d/expected.tags
+++ b/Units/simple-moose.d/expected.tags
@@ -35,3 +35,13 @@ Point4D	input.pl	/^package Point4D;$/;"	class	line:48	language:Moose	inherits:Po
 clear	input.pl	/^override "clear" => sub {$/;"	method	line:54	language:Moose	class:Point4D
 Moose	input.pl	/^no Moose;$/;"	module	line:57	language:Perl
 Line	input.pl	/^package Line;$/;"	package	line:58	language:Perl
+Cat::Food	input-0.pl	/^package Cat::Food;$/;"	package	line:2	language:Perl
+Moo	input-0.pl	/^use Moo;$/;"	module	line:4	language:Perl
+Cat::Food	input-0.pl	/^package Cat::Food;$/;"	class	line:2	language:Moose	end:31
+strictures	input-0.pl	/^use strictures 2;$/;"	module	line:5	language:Perl
+namespace::clean	input-0.pl	/^use namespace::clean;$/;"	module	line:6	language:Perl
+feed_lion	input-0.pl	/^sub feed_lion {$/;"	subroutine	line:8	language:Perl
+feed_lion	input-0.pl	/^sub feed_lion {$/;"	method	line:8	language:Moose	class:Cat::Food
+taste	input-0.pl	/^has taste => ($/;"	attribute	line:15	language:Moose	class:Cat::Food
+brand	input-0.pl	/^has brand => ($/;"	attribute	line:19	language:Moose	class:Cat::Food
+pounds	input-0.pl	/^has pounds => ($/;"	attribute	line:26	language:Moose	class:Cat::Food

--- a/Units/simple-moose.d/expected.tags
+++ b/Units/simple-moose.d/expected.tags
@@ -1,4 +1,5 @@
 Point	input.pl	/^package Point;$/;"	package	line:2	language:Perl
+Moose	input.pl	/^use Moose; # automatically turns on strict and warnings$/;"	module	line:3	language:Perl
 Point	input.pl	/^package Point;$/;"	class	line:2	language:Moose
 x	input.pl	/^has 'x' => (is => 'rw', isa => 'Int');$/;"	attribute	line:5	language:Moose	class:Point
 y	input.pl	/^has 'y' => (is => 'rw', isa => 'Int');$/;"	attribute	line:6	language:Moose	class:Point
@@ -19,14 +20,18 @@ z7	input.pl	/^has ([qw|z6	z7|] => (is => 'rw'), (is => 'rw'));$/;"	attribute	lin
 clear	input.pl	/^sub clear {$/;"	subroutine	line:23	language:Perl
 clear	input.pl	/^sub clear {$/;"	method	line:23	language:Moose	class:Point
 Point3D	input.pl	/^package Point3D;$/;"	package	line:29	language:Perl
+Moose	input.pl	/^use Moose;$/;"	module	line:30	language:Perl
 Point3D	input.pl	/^package Point3D;$/;"	class	line:29	language:Moose	inherits:Point
 z	input.pl	/^has 'z' => (is => 'rw', isa => 'Int');$/;"	attribute	line:34	language:Moose	class:Point3D
 clear	input.pl	/^before 'clear' => sub {$/;"	wrapper	line:36	language:Moose	class:Point3D	wrapping:before
 clear	input.pl	/^after 'clear' => sub {$/;"	wrapper	line:39	language:Moose	class:Point3D	wrapping:after
 clear	input.pl	/^around 'clear' => sub {$/;"	wrapper	line:42	language:Moose	class:Point3D	wrapping:around
 TimeAxis	input.pl	/^package TimeAxis;$/;"	package	line:45	language:Perl
+Moose	input.pl	/^use Moose;$/;"	module	line:46	language:Perl
 TimeAxis	input.pl	/^package TimeAxis;$/;"	class	line:45	language:Moose
 Point4D	input.pl	/^package Point4D;$/;"	package	line:48	language:Perl
+Moose	input.pl	/^use Moose;$/;"	module	line:49	language:Perl
 Point4D	input.pl	/^package Point4D;$/;"	class	line:48	language:Moose	inherits:Point3D,TimeAxis	end:57
 clear	input.pl	/^override "clear" => sub {$/;"	method	line:54	language:Moose	class:Point4D
+Moose	input.pl	/^no Moose;$/;"	module	line:57	language:Perl
 Line	input.pl	/^package Line;$/;"	package	line:58	language:Perl

--- a/Units/simple-moose.d/input-0.pl
+++ b/Units/simple-moose.d/input-0.pl
@@ -1,0 +1,31 @@
+# Taken from https://metacpan.org/pod/Moo
+package Cat::Food;
+ 
+use Moo;
+use strictures 2;
+use namespace::clean;
+ 
+sub feed_lion {
+  my $self = shift;
+  my $amount = shift || 1;
+ 
+  $self->pounds( $self->pounds - $amount );
+}
+ 
+has taste => (
+  is => 'ro',
+);
+ 
+has brand => (
+  is  => 'ro',
+  isa => sub {
+    die "Only SWEET-TREATZ supported!" unless $_[0] eq 'SWEET-TREATZ'
+  },
+);
+ 
+has pounds => (
+  is  => 'rw',
+  isa => sub { die "$_[0] is too much cat food!" unless $_[0] < 15 },
+);
+ 
+1;

--- a/parsers/moose.c
+++ b/parsers/moose.c
@@ -6,6 +6,18 @@
  *
  *   This module contains functions for generating tags for Moose perl extension.
  *   https://metacpan.org/pod/Moose
+ *
+ *   This module can gather tags for Moo perl extension, too.
+ *   https://metacpan.org/pod/Moo
+ *
+ *   From the output of this parser, a client cannot know which extension is used
+ *   in the input source file. However, perl parser can give you hints about the
+ *   extension; with "--extras=+r --kinds-Perl=+M" options, the perl parser tags
+ *   module names specified as arguments for `use' perl built-in function.
+ *   You don't need the options if you just want to run This parser.
+ *   This parser just needs --extras=+s option that run subparsers including this
+ *   parser.
+ *
  */
 
 /* NOTE about kind/role design:
@@ -171,12 +183,14 @@ static void makeTagEntryNotify (subparser *s, const tagEntryInfo *tag, int corkI
 	{
 		if (isRoleAssigned(tag, ROLE_PERL_MODULE_USED))
 		{
-			if (strcmp (tag->name, "Moose") == 0)
+			if (strcmp (tag->name, "Moose") == 0
+				|| strcmp (tag->name, "Moo") == 0)
 				enterMoose (moose);
 		}
 		else if (isRoleAssigned(tag, ROLE_PERL_MODULE_UNUSED))
 		{
-			if (strcmp (tag->name, "Moose") == 0)
+			if (strcmp (tag->name, "Moose") == 0
+				|| strcmp (tag->name, "Moo") == 0)
 				leaveMoose (moose);
 		}
 	}

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -32,6 +32,11 @@
 *   DATA DEFINITIONS
 */
 typedef enum PerlKindType perlKind;
+typedef enum PerlModuleRoleType perlModuleRole;
+
+static roleDefinition PerlModuleRoles [] = {
+	{ true, "used",   "specified in `use' built-in function" },
+};
 
 static kindDefinition PerlKinds [] = {
 	{ true,  'c', "constant",               "constants" },
@@ -40,6 +45,8 @@ static kindDefinition PerlKinds [] = {
 	{ true,  'p', "package",                "packages" },
 	{ true,  's', "subroutine",             "subroutines" },
 	{ false, 'd', "subroutineDeclaration",  "subroutine declarations" },
+	{ false, 'M', "module",                 "modules",
+	  .referenceOnly = true,  ATTACH_ROLES(PerlModuleRoles)},
 };
 
 /*
@@ -235,6 +242,13 @@ static void makeTagFromLeftSide (const char *begin, const char *end,
 	}
 }
 
+static void makeTagForModule (const char *name, int role)
+{
+	tagEntryInfo entry;
+	initRefTagEntry(&entry, name, KIND_PERL_MODULE, role);
+	makeTagEntry(&entry);
+}
+
 enum const_state { CONST_STATE_NEXT_LINE, CONST_STATE_HIT_END };
 
 /* Parse a single line, find as many NAME => VALUE pairs as we can and try
@@ -384,15 +398,30 @@ static void findPerlTags (void)
 				++cp;
 			if (strncmp((const char*) cp, "AutoLoader", (size_t) 10) == 0) {
 				respect_token &= ~RESPECT_END;
+				makeTagForModule("AutoLoader", ROLE_PERL_MODULE_USED);
 				continue;
 			}
 			if (strncmp((const char*) cp, "SelfLoader", (size_t) 10) == 0) {
 				respect_token &= ~RESPECT_DATA;
+				makeTagForModule("SelfLoader", ROLE_PERL_MODULE_USED);
 				continue;
 			}
-			if (strncmp((const char*) cp, "constant", (size_t) 8) != 0)
-				continue;
-			cp += 8;
+
+			vString *module = NULL;
+			while (isalnum(*cp) || *cp == ':' || *cp == '.') {
+				if (!module)
+					module = vStringNew();
+				vStringPut(module, *cp);
+				++cp;
+			}
+			if (module) {
+				bool isConstant = (strcmp(vStringValue(module), "constant") == 0);
+				makeTagForModule(vStringValue(module), ROLE_PERL_MODULE_USED);
+				vStringDelete(module);
+				if (!isConstant)
+					continue;
+			}
+
 			/* Skip up to the first non-space character, skipping empty
 			 * and comment lines.
 			 */

--- a/parsers/perl.h
+++ b/parsers/perl.h
@@ -18,6 +18,7 @@ typedef struct sPerlSubparser perlSubparser;
 
 enum PerlModuleRoleType {
 	ROLE_PERL_MODULE_USED,
+	ROLE_PERL_MODULE_UNUSED,
 };
 
 enum PerlKindType {

--- a/parsers/perl.h
+++ b/parsers/perl.h
@@ -16,6 +16,10 @@
 
 typedef struct sPerlSubparser perlSubparser;
 
+enum PerlModuleRoleType {
+	ROLE_PERL_MODULE_USED,
+};
+
 enum PerlKindType {
 	KIND_PERL_NONE = -1,
 	KIND_PERL_CONSTANT,
@@ -23,7 +27,8 @@ enum PerlKindType {
 	KIND_PERL_LABEL,
 	KIND_PERL_PACKAGE,
 	KIND_PERL_SUBROUTINE,
-	KIND_PERL_SUBROUTINE_DECLARATION
+	KIND_PERL_SUBROUTINE_DECLARATION,
+	KIND_PERL_MODULE,
 };
 
 struct sPerlSubparser {


### PR DESCRIPTION
Close  #2103.
The design discussion was done at #2070.

To support Moo extension in Moose parser, I made perl parser captures module names specified in use build-in function and no built-in function. (I don't touch `require` in this commits because it is not needed to support Moo. However, we can add it to our TODO list.)

Module names are captured as reference tags. So if we don't pass --extras=+r and --kinds-Perl=+m options, the module names are never printed.
