### PR TITLE
Markdown: ignore GFM codeblock

### DIFF
--- a/Units/simple-markdown.d/input.md
+++ b/Units/simple-markdown.d/input.md
@@ -28,7 +28,29 @@
 ##### r #
 ##### s ######
 
+```sh
+# A COMMENT LINE in SHELL SYNTAX
+funciton x
+{
+	echo 'Hello, World!'
+}
+```
 ###### t #
+```sh
+# THE OTHER COMMENT LINE in SHELL SYNTAX
+funciton x
+{
+	cat <<<EOF
+	~~~
+# ANOTHER COMMENT LINE in SHELL SYNTAX
+	~~~
+~~~
+# ANOTHER COMMENT LINE in SHELL SYNTAX
+~~~
+EOF
+}
+```
+
 ###### u #######
 
 A
@@ -37,8 +59,30 @@ A
 B
 ==
 
+~~~perl
+# A COMMENT LINE in PERL SYNTAX
+sub f {
+    my ($line, $opts) = @_;
+	return $line;
+}
+~~~
 C
 ===
+
+~~~perl
+# THE OTHER COMMENT LINE in PERL SYNTAX
+sub g
+{
+    print <<EOF;
+	```
+# ANOTHER COMMENT LINE in PERL SYNTAX
+	```
+```
+# ANOTHER COMMENT LINE in PERL SYNTAX
+```
+EOF
+}
+~~~
 
 D
 -
@@ -48,4 +92,3 @@ E
 
 F
 ---
-

--- a/optlib/markdown.c
+++ b/optlib/markdown.c
@@ -13,10 +13,19 @@ static void initializeMarkdownParser (const langType language)
 
 	addLanguageRegexTable (language, "main");
 	addLanguageRegexTable (language, "sharp");
+	addLanguageRegexTable (language, "rest");
+	addLanguageRegexTable (language, "codeblockBacktick");
+	addLanguageRegexTable (language, "codeblockTildes");
 
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^#",
 	                               "", "", "{tjump=sharp}{_advanceTo=0start}", NULL);
+	addLanguageTagMultiTableRegex (language, "main",
+	                               "^[ \t]*````*[^`\n]*[\n]",
+	                               "", "", "{tenter=codeblockBacktick}", NULL);
+	addLanguageTagMultiTableRegex (language, "main",
+	                               "^[ \t]*~~~~*[^~\n]*[\n]",
+	                               "", "", "{tenter=codeblockTildes}", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^([^\n]+)[\n]=+[\n]",
 	                               "\\1", "c", "{_field=sectionMarker:=}", NULL);
@@ -77,6 +86,39 @@ static void initializeMarkdownParser (const langType language)
 	addLanguageTagMultiTableRegex (language, "sharp",
 	                               "^[^\n]+",
 	                               "", "", "{tjump=main}", NULL);
+	addLanguageTagMultiTableRegex (language, "rest",
+	                               "^[^\n]+[\n]",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "rest",
+	                               "^[\n]+",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "rest",
+	                               "^[^\n]+",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "codeblockBacktick",
+	                               "^[ \t]*````*[ \t]*[\n]",
+	                               "", "", "{tleave}", NULL);
+	addLanguageTagMultiTableRegex (language, "codeblockBacktick",
+	                               "^[^\n]+[\n]",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "codeblockBacktick",
+	                               "^[\n]+",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "codeblockBacktick",
+	                               "^[^\n]+",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "codeblockTildes",
+	                               "^[ \t]*~~~~*[ \t]*[\n]",
+	                               "", "", "{tleave}", NULL);
+	addLanguageTagMultiTableRegex (language, "codeblockTildes",
+	                               "^[^\n]+[\n]",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "codeblockTildes",
+	                               "^[\n]+",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "codeblockTildes",
+	                               "^[^\n]+",
+	                               "", "", "", NULL);
 }
 
 extern parserDefinition* MarkdownParser (void)

--- a/optlib/markdown.ctags
+++ b/optlib/markdown.ctags
@@ -41,14 +41,24 @@
 
 --_tabledef-Markdown=main
 --_tabledef-Markdown=sharp
+--_tabledef-Markdown=rest
 
+# Handle GFM style codeblock in this table.
+# https://github.github.com/gfm/#fenced-code-blocks
+--_tabledef-Markdown=codeblockBacktick
+--_tabledef-Markdown=codeblockTildes
+
+
+--_mtable-regex-Markdown=rest/^[^\n]+[\n]//
+--_mtable-regex-Markdown=rest/[\n]+//
+--_mtable-regex-Markdown=rest/^[^\n]+//
 
 --_mtable-regex-Markdown=main/^#///{tjump=sharp}{_advanceTo=0start}
+--_mtable-regex-Markdown=main/^[ \t]*````*[^`\n]*[\n]//{tenter=codeblockBacktick}
+--_mtable-regex-Markdown=main/^[ \t]*~~~~*[^~\n]*[\n]//{tenter=codeblockTildes}
 --_mtable-regex-Markdown=main/^([^\n]+)[\n]=+[\n]/\1/c/{_field=sectionMarker:=}
 --_mtable-regex-Markdown=main/^([^\n]+)[\n]-+[\n]/\1/s/{_field=sectionMarker:-}
---_mtable-regex-Markdown=main/^[^\n]+[\n]//
---_mtable-regex-Markdown=main/[\n]+//
---_mtable-regex-Markdown=main/^[^\n]+//
+--_mtable-extend-Markdown=main+rest
 
 
 --_mtable-regex-Markdown=sharp/^#[ \t]+([^\n]+)([ \t]+#+)[\n]/\1/c/{_field=sectionMarker:##}{tjump=main}
@@ -66,3 +76,9 @@
 --_mtable-regex-Markdown=sharp/^[^\n]+[\n]//{tjump=main}
 --_mtable-regex-Markdown=sharp/[\n]+//{tjump=main}
 --_mtable-regex-Markdown=sharp/^[^\n]+//{tjump=main}
+
+--_mtable-regex-Markdown=codeblockBacktick/^[ \t]*````*[ \t]*[\n]//{tleave}
+--_mtable-extend-Markdown=codeblockBacktick+rest
+
+--_mtable-regex-Markdown=codeblockTildes/^[ \t]*~~~~*[ \t]*[\n]//{tleave}
+--_mtable-extend-Markdown=codeblockTildes+rest


### PR DESCRIPTION
This is a bug fix discussed in https://github.com/Shougo/denite.nvim/issues/434.
@delphinus explain me the bug at the issue page.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>