### PR TITLE
Add support for special Inko method names

### DIFF
--- a/Units/parser-inko.r/methods.d/expected.tags
+++ b/Units/parser-inko.r/methods.d/expected.tags
@@ -6,3 +6,11 @@ C	input.inko	/^object C {$/;"	o
 D	input.inko	/^  object D {$/;"	o	object:C
 E	input.inko	/^    object E {$/;"	o	object:C.D
 method_e	input.inko	/^      def method_e {}$/;"	m	object:C.D.E
++	input.inko	/^def + {}$/;"	m
+-	input.inko	/^def - {}$/;"	m
+*	input.inko	/^def * {}$/;"	m
+/	input.inko	/^def \/ {}$/;"	m
+%	input.inko	/^def % {}$/;"	m
+^	input.inko	/^def ^ {}$/;"	m
+[]	input.inko	/^def [] {}$/;"	m
+[]=	input.inko	/^def []= {}$/;"	m

--- a/Units/parser-inko.r/methods.d/input.inko
+++ b/Units/parser-inko.r/methods.d/input.inko
@@ -13,3 +13,12 @@ object C {
     }
   }
 }
+
+def + {}
+def - {}
+def * {}
+def / {}
+def % {}
+def ^ {}
+def [] {}
+def []= {}

--- a/optlib/inko.c
+++ b/optlib/inko.c
@@ -65,7 +65,7 @@ static void initializeInkoParser (const langType language)
 	                               "^.",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "method",
-	                               "^([a-zA-Z0-9_?]+)[^{]*",
+	                               "^([a-zA-Z0-9_?]+|\\[\\]=?|\\^|&|\\||\\*|\\+|\\-|/|>>|<<|%)[^{]*",
 	                               "\\1", "m", "{scope=push}", NULL);
 	addLanguageTagMultiTableRegex (language, "method",
 	                               "^\\{",

--- a/optlib/inko.ctags
+++ b/optlib/inko.ctags
@@ -59,7 +59,7 @@
 --_mtable-regex-Inko=trait/\{//{tleave}
 --_mtable-regex-Inko=trait/.//
 
---_mtable-regex-Inko=method/([a-zA-Z0-9_?]+)[^{]*/\1/m/{scope=push}
+--_mtable-regex-Inko=method/([a-zA-Z0-9_?]+|\[\]=?|\^|&|\||\*|\+|\-|\/|>>|<<|%)[^{]*/\1/m/{scope=push}
 --_mtable-regex-Inko=method/\{//{tleave}
 --_mtable-regex-Inko=method/.//
 


### PR DESCRIPTION
Inko allows you to use certain special characters for method names. For
example: +, -, /, [], and []=. This adds support for creating tags for
such methods, which would previously not be tagged.