### PR TITLE
CPreProcessor: handle backslash escaping in a parameter list of a macro

### DIFF
--- a/Units/parser-cpreprocessor.r/backslash-in-parameters.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/backslash-in-parameters.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--fields=+Sn

--- a/Units/parser-cpreprocessor.r/backslash-in-parameters.d/expected.tags
+++ b/Units/parser-cpreprocessor.r/backslash-in-parameters.d/expected.tags
@@ -1,0 +1,1 @@
+IX_GET_BIT_FIELD16	input.h	/^#define IX_GET_BIT_FIELD16(/;"	d	line:2	signature:(arg_PackedData16,arg_FieldLSBBit,arg_FieldMSBBit)

--- a/Units/parser-cpreprocessor.r/backslash-in-parameters.d/input.h
+++ b/Units/parser-cpreprocessor.r/backslash-in-parameters.d/input.h
@@ -1,0 +1,8 @@
+/* Taken from u-boot */
+#define IX_GET_BIT_FIELD16(					  \
+                            arg_PackedData16, \
+                            arg_FieldLSBBit, \
+                            arg_FieldMSBBit \
+                          ) \
+                          (((ix_uint16)(arg_PackedData16) & IX_BIT_FIELD_MASK16(arg_FieldLSBBit, arg_FieldMSBBit)) >> \
+                             arg_FieldLSBBit)


### PR DESCRIPTION
Close #2118 partially.

Such backslashes can cause emitting a tag having newlines in its
signature field.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>