### PR TITLE
Check eof chars of vcxproj files at circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ jobs:
        - run:
            name: Test
            command: |
-             MAKE=bmake bmake validate-input check roundtrip CIRCLECI=1
+             MAKE=bmake bmake validate-input check roundtrip codecheck CIRCLECI=1
 
    centos_make:
      working_directory: ~/universal-ctags

--- a/main/entry_private.c
+++ b/main/entry_private.c
@@ -8,6 +8,7 @@
 *   main part private interface to entry.c
 */
 
+#include "general.h"
 #include "entry_p.h"
 #include "parse_p.h"
 

--- a/main/tokeninfo.c
+++ b/main/tokeninfo.c
@@ -9,6 +9,7 @@
 *   files.
 */
 
+#include "general.h"
 #include "tokeninfo.h"
 
 #include "entry.h"

--- a/main/trace.c
+++ b/main/trace.c
@@ -7,6 +7,7 @@
 *   Tracing facility.
 */
 
+#include "general.h"
 #include "trace.h"
 
 #ifdef DO_TRACING

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -212,8 +212,8 @@ endif
 #
 # Checking code in ctags own rules
 #
-	$(SHELL) misc/src-check
 codecheck: $(CTAGS_TEST)
+	$(V_RUN) $(SHELL) misc/src-check
 
 #
 # Report coverage (usable only if ctags is built with COVERAGE=1.)

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -212,8 +212,8 @@ endif
 #
 # Checking code in ctags own rules
 #
-codecheck:
 	$(SHELL) misc/src-check
+codecheck: $(CTAGS_TEST)
 
 #
 # Report coverage (usable only if ctags is built with COVERAGE=1.)

--- a/misc/src-check
+++ b/misc/src-check
@@ -62,7 +62,7 @@ check_name_cpp_macro()
     local n
 
     header "Check whether '_' is not used as ctags own macro name"
-    for f in $(find $dir -name '*.[ch]'); do
+    for f in $(find $dir -name '*.[ch]' | grep -v portable-dirent_p.h); do
 	if ${CTAGS} --language-force=C -x --_xformat='%F:%N' --kinds-C=d -o - $f | grep -q '.*:_.*H'; then
 	    for n in $(${CTAGS} --language-force=C -x --_xformat='%N' --kinds-C=d -o - $f | grep  '^_.*H'); do
 		echo "#" $n

--- a/misc/src-check
+++ b/misc/src-check
@@ -126,7 +126,7 @@ main()
 	i=$(expr $i + 1)
     fi
 
-    return 0
+    return $i
 }
 
 main "$@"

--- a/misc/src-check
+++ b/misc/src-check
@@ -89,6 +89,25 @@ check_vStringCatS_usage()
 
     return $i
 }
+
+check_eof_chars_in_vcxproj()
+{
+    local r=2
+    local f
+
+    for f in win32/ctags_vs2013.vcxproj win32/ctags_vs2013.vcxproj.filters; do
+	header "Check the EOF characters of $f"
+	local s=$(od -t c  -j $(expr $(stat -c %s $f) - 3) $f)
+	if echo "$s" | grep -q '>  \\r  \\n'; then
+	    r=$(expr $r - 1)
+	else
+	    echo "unexpected chars: $s"
+	fi
+    done
+
+    return $r
+}
+
 main()
 {
     local i=0
@@ -124,6 +143,10 @@ main()
     fi
 
     if ! check_vStringCatS_usage parsers; then
+	i=$(expr $i + 1)
+    fi
+
+    if ! check_eof_chars_in_vcxproj; then
 	i=$(expr $i + 1)
     fi
 

--- a/misc/src-check
+++ b/misc/src-check
@@ -41,7 +41,8 @@ check_include_general_h_first()
     local i=0
 
     header "Check whether general.h is included first: $1"
-    for f in $(find $1 -name '*.c'); do
+    # Added -maxdepth 1 to skip parsers/cxx
+    for f in $(find $1 -maxdepth 1 -name '*.c'); do
 	if grep -a -q -e '^#[[:space:]]*include' $f; then
 	    l=$()
 	    if ! ( grep -a -e '^#[[:space:]]*include' $f | head -1 | grep -q "general.h" ); then

--- a/misc/src-check
+++ b/misc/src-check
@@ -124,30 +124,51 @@ main()
 
     if ! check_include_general_h_first main; then
 	i=$(expr $i + 1)
+	echo "failed"
+    else
+	echo "ok"
     fi
 
     if ! check_include_general_h_first parsers; then
 	i=$(expr $i + 1)
+	echo "failed"
+    else
+	echo "ok"
     fi
 
     if ! check_name_cpp_macro main; then
 	i=$(expr $i + 1)
+	echo "failed"
+    else
+	echo "ok"
     fi
 
     if ! check_name_cpp_macro parsers; then
 	i=$(expr $i + 1)
+	echo "failed"
+    else
+	echo "ok"
     fi
 
     if ! check_vStringCatS_usage main; then
 	i=$(expr $i + 1)
+	echo "failed"
+    else
+	echo "ok"
     fi
 
     if ! check_vStringCatS_usage parsers; then
 	i=$(expr $i + 1)
+	echo "failed"
+    else
+	echo "ok"
     fi
 
     if ! check_eof_chars_in_vcxproj; then
 	i=$(expr $i + 1)
+	echo "failed"
+    else
+	echo "ok"
     fi
 
     return $i

--- a/parsers/typescript.c
+++ b/parsers/typescript.c
@@ -14,11 +14,12 @@
 /*
  *	 INCLUDE FILES
  */
+#include "general.h"    /* must always come first */
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
 
-#include "general.h"    /* must always come first */
 #include "parse.h"
 #include "objpool.h"
 #include "keyword.h"


### PR DESCRIPTION
make codecheck runs misc/src-check.
I added a function detecting CRCRLF sequence at the eof win32 build scripts to misc/src-check.
I made the codecheck target is run on fedora_bmake combination run at circlci, 
