### PR TITLE
NSIS,comment: write the version of GPL explicitly

### DIFF
--- a/parsers/nsis.c
+++ b/parsers/nsis.c
@@ -3,7 +3,7 @@
 *   Copyright (c) 2009-2011, Enrico Tröger
 *
 *   This source code is released for free distribution under the terms of the
-*   GNU General Public License.
+*   GNU General Public License version 2 or (at your option) any later version.
 *
 *   This module contains functions for generating tags for NSIS scripts
 *   (https://en.wikipedia.org/wiki/Nullsoft_Scriptable_Install_System).


### PR DESCRIPTION
Close #2144.

Quoted from #2144:
============================================================

@masatake commented 18 hours ago
------------------------------------------------------------
@eht16, I imported your NSIS parser from Geany to Universal-ctags.

After merging, I noticed the version of GPL was not written explictly:

*   This source code is released for free distribution under the terms of the
*   GNU General Public License.

Can I change this to

*   This source code is released for free distribution under the terms of the
*   GNU General Public License version 2 or (at your option) any later version.

?

@eht16 commented 6 hours ago
------------------------------------------------------------
Yes, that's fine by me.
Thanks for taking care.