### PR TITLE
Refine AppVeyor

### DIFF
--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -131,6 +131,8 @@ goto :eof
 @echo on
 PATH C:\%MSYS2_DIR%\%MSYSTEM%\bin;C:\%MSYS2_DIR%\usr\bin;%PATH%
 set CHERE_INVOKING=yes
+@rem Reduce time required to install packages by disabling pacman's disk space checking.
+bash -lc "sed -i 's/^CheckSpace/#CheckSpace/g' /etc/pacman.conf"
 if "%normalbuild%"=="no" (
   @rem Change build message: "Daily build: YYYY-MM-DD"
   for /f "tokens=2-4 delims=/ " %%i in ('date /t') do appveyor UpdateBuild -Message "Daily build: %%k-%%i-%%j"

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -185,7 +185,7 @@ if "%normalbuild%"=="yes" (
 )
 md package
 :: Build html docs and man pages
-bash -lc "make -C docs html && make -C man RST2HTML=rst2html3"
+bash -lc "make -C docs html && make -C man RST2HTML=rst2html3" || exit 1
 move docs\_build\html package\docs > nul
 rd /s/q package\docs\_sources
 


### PR DESCRIPTION
* Reduce time to install packages.
* Make CI fail if fail to generate docs.

(Both are mainly for ctags-win32 project.)