### PR TITLE
appveyor: Make only html for the man pages

### DIFF
--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -185,7 +185,7 @@ if "%normalbuild%"=="yes" (
 )
 md package
 :: Build html docs and man pages
-bash -lc "make -C docs html && make -C man RST2HTML=rst2html3" || exit 1
+bash -lc "make -C docs html && make -C man html RST2HTML=rst2html3" || exit 1
 move docs\_build\html package\docs > nul
 rd /s/q package\docs\_sources
 


### PR DESCRIPTION
Creating PDF fails on AppVeyor:
https://ci.appveyor.com/project/universalctags/ctags-win32/builds/26091558
Only html files are needed.