### PR TITLE
[GEANY] tlib: fix the way to detect a failre of test case

### DIFF
--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -175,11 +175,14 @@ tlib: $(MINI_GEANY_TEST)
 	builddir=$$(pwd); \
 	mkdir -p $${builddir}/misc; \
 	if test -s '$(MINI_GEANY_TEST)'; then \
-		$(SHELL) $(srcdir)/misc/tlib $(MINI_GEANY_TEST) \
+		if $(SHELL) $(srcdir)/misc/tlib $(MINI_GEANY_TEST) \
 			$(srcdir)/misc/mini-geany.expected \
 			$${builddir}/misc/mini-geany.actual \
-			$(VG); \
-		echo 'mini-geany: OK'; \
+			$(VG); then \
+			echo 'mini-geany: OK'; \
+		else \
+			echo 'mini-geany: FAILED'; \
+		fi; \
 	else \
 		echo 'mini-geany: SKIP'; \
 	fi

--- a/misc/mini-geany.expected
+++ b/misc/mini-geany.expected
@@ -16,6 +16,7 @@ v: variable
 x: externvar
 z: parameter
 L: label
+D: macroparam
 
 Parsing buffer:
 foo	line: 1	kind: function	 lang: C


### PR DESCRIPTION
Close #2143.

To GEANY team:
`D/macroparam` is added to C and CPreprocessor parsers.
See geany/geany/2227.