### PR TITLE
Revert "autotools.rst: add instructions to install dependencies"

### DIFF
--- a/docs/autotools.rst
+++ b/docs/autotools.rst
@@ -1,13 +1,5 @@
 Building with configure (\*nix including GNU/Linux)
 ---------------------------------------------------------------------
-
-To install Universal-ctags' dependencies on Debian-based systems, do::
-
-	$ sudo apt install \
-		  pkg-config autoconf python3-docutils \
-		  libseccomp-dev libseccomp2 \
-		  libjansson-dev libjansson4
-
 Like most Autotools-based projects, you need to do::
 
     $ ./autogen.sh


### PR DESCRIPTION
Reverts universal-ctags/ctags#2163

CURRENTLY I think we should not maintain the instructions to install u-ctags to various platforms.
See https://github.com/universal-ctags/ctags/pull/1730.