### PR TITLE
travis: specify libxml2-dev explicitly as a required package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ addons:
       - libjansson-dev
       - libyaml-dev
       - libseccomp-dev
+      - libxml2-dev
       - gdb
       - valgrind
 


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>