### PR TITLE
Typescript: parsing multiple interface names in implements part

### DIFF
--- a/Units/parser-typescript.r/ts-class-white.d/args.ctags
+++ b/Units/parser-typescript.r/ts-class-white.d/args.ctags
@@ -1,2 +1,3 @@
 --sort=no
 --typescript-kinds=fcigemnzpvCgGal
+--fields=+i

--- a/Units/parser-typescript.r/ts-class-white.d/expected.tags
+++ b/Units/parser-typescript.r/ts-class-white.d/expected.tags
@@ -59,3 +59,5 @@ f	input.ts	/^    public f(a: T): number {$/;"	m	class:X
 a	input.ts	/^    public f(a: T): number {$/;"	z	method:X.f
 g	input.ts	/^    public g(a: T): number {$/;"	m	class:X
 a	input.ts	/^    public g(a: T): number {$/;"	z	method:X.g
+C	input.ts	/^class C extends A implements B, D {$/;"	c
+x	input.ts	/^    x: number$/;"	p	class:C

--- a/Units/parser-typescript.r/ts-class-white.d/expected.tags
+++ b/Units/parser-typescript.r/ts-class-white.d/expected.tags
@@ -8,7 +8,7 @@ BankAccount	input.ts	/^class BankAccount {$/;"	c
 balance	input.ts	/^  balance = 0$/;"	p	class:BankAccount
 deposit	input.ts	/^  deposit(credit: number) {$/;"	m	class:BankAccount
 credit	input.ts	/^  deposit(credit: number) {$/;"	z	method:BankAccount.deposit
-CheckingAccount	input.ts	/^class CheckingAccount extends BankAccount {$/;"	c
+CheckingAccount	input.ts	/^class CheckingAccount extends BankAccount {$/;"	c	inherits:BankAccount
 constructor	input.ts	/^  constructor(balance: number) {$/;"	m	class:CheckingAccount
 balance	input.ts	/^  constructor(balance: number) {$/;"	z	method:CheckingAccount.constructor
 writeCheck	input.ts	/^  writeCheck(debit: number) {$/;"	m	class:CheckingAccount
@@ -59,5 +59,8 @@ f	input.ts	/^    public f(a: T): number {$/;"	m	class:X
 a	input.ts	/^    public f(a: T): number {$/;"	z	method:X.f
 g	input.ts	/^    public g(a: T): number {$/;"	m	class:X
 a	input.ts	/^    public g(a: T): number {$/;"	z	method:X.g
-C	input.ts	/^class C extends A implements B, D {$/;"	c
+C	input.ts	/^class C extends A implements B, D {$/;"	c	inherits:A,B,D
 x	input.ts	/^    x: number$/;"	p	class:C
+Ct	input.ts	/^class Ct<T> extends A<T> implements B<T>, D, E<T> {$/;"	c	inherits:A,B,D,E
+x	input.ts	/^    x: number$/;"	p	class:Ct
+A	input.ts	/^class A<T> implements I<T>$/;"	c	inherits:I

--- a/Units/parser-typescript.r/ts-class-white.d/input.ts
+++ b/Units/parser-typescript.r/ts-class-white.d/input.ts
@@ -112,3 +112,7 @@ class X {
         return 1
     }
 }
+
+class C extends A implements B, D {
+    x: number
+}

--- a/Units/parser-typescript.r/ts-class-white.d/input.ts
+++ b/Units/parser-typescript.r/ts-class-white.d/input.ts
@@ -116,3 +116,11 @@ class X {
 class C extends A implements B, D {
     x: number
 }
+
+class Ct<T> extends A<T> implements B<T>, D, E<T> {
+    x: number
+}
+
+class A<T> implements I<T>
+{
+}

--- a/Units/parser-typescript.r/ts-class.d/args.ctags
+++ b/Units/parser-typescript.r/ts-class.d/args.ctags
@@ -1,2 +1,3 @@
 --sort=no
 --kinds-typescript=*
+--fields=+i

--- a/Units/parser-typescript.r/ts-class.d/expected.tags
+++ b/Units/parser-typescript.r/ts-class.d/expected.tags
@@ -59,3 +59,5 @@ f	input.ts	/^    public f(a: T): number {$/;"	m	class:X
 a	input.ts	/^    public f(a: T): number {$/;"	z	method:X.f
 g	input.ts	/^    public g(a: T): number {$/;"	m	class:X
 a	input.ts	/^    public g(a: T): number {$/;"	z	method:X.g
+C	input.ts	/^class C extends A implements B, D {$/;"	c
+x	input.ts	/^    x: number;$/;"	p	class:C

--- a/Units/parser-typescript.r/ts-class.d/expected.tags
+++ b/Units/parser-typescript.r/ts-class.d/expected.tags
@@ -8,7 +8,7 @@ BankAccount	input.ts	/^class BankAccount {$/;"	c
 balance	input.ts	/^  balance = 0;$/;"	p	class:BankAccount
 deposit	input.ts	/^  deposit(credit: number) {$/;"	m	class:BankAccount
 credit	input.ts	/^  deposit(credit: number) {$/;"	z	method:BankAccount.deposit
-CheckingAccount	input.ts	/^class CheckingAccount extends BankAccount {$/;"	c
+CheckingAccount	input.ts	/^class CheckingAccount extends BankAccount {$/;"	c	inherits:BankAccount
 constructor	input.ts	/^  constructor(balance: number) {$/;"	m	class:CheckingAccount
 balance	input.ts	/^  constructor(balance: number) {$/;"	z	method:CheckingAccount.constructor
 writeCheck	input.ts	/^  writeCheck(debit: number) {$/;"	m	class:CheckingAccount
@@ -59,5 +59,8 @@ f	input.ts	/^    public f(a: T): number {$/;"	m	class:X
 a	input.ts	/^    public f(a: T): number {$/;"	z	method:X.f
 g	input.ts	/^    public g(a: T): number {$/;"	m	class:X
 a	input.ts	/^    public g(a: T): number {$/;"	z	method:X.g
-C	input.ts	/^class C extends A implements B, D {$/;"	c
+C	input.ts	/^class C extends A implements B, D {$/;"	c	inherits:A,B,D
 x	input.ts	/^    x: number;$/;"	p	class:C
+Ct	input.ts	/^class Ct<T> extends A<T> implements B<T>, D, E<T> {$/;"	c	inherits:A,B,D,E
+x	input.ts	/^    x: number;$/;"	p	class:Ct
+A	input.ts	/^class A<T> implements I<T>$/;"	c	inherits:I

--- a/Units/parser-typescript.r/ts-class.d/input.ts
+++ b/Units/parser-typescript.r/ts-class.d/input.ts
@@ -116,3 +116,11 @@ class X {
 class C extends A implements B, D {
     x: number;
 }
+
+class Ct<T> extends A<T> implements B<T>, D, E<T> {
+    x: number;
+}
+
+class A<T> implements I<T>
+{
+}

--- a/Units/parser-typescript.r/ts-class.d/input.ts
+++ b/Units/parser-typescript.r/ts-class.d/input.ts
@@ -112,3 +112,7 @@ class X {
         return 1;
     }
 }
+
+class C extends A implements B, D {
+    x: number;
+}

--- a/parsers/typescript.c
+++ b/parsers/typescript.c
@@ -1622,7 +1622,7 @@ static void parseConstructorParams (const int classScope, const int constrScope,
 
 }
 
-MULTI_CHAR_PARSER_DEF (ClassBodyChars, "\n{", TOKEN_NL, TOKEN_OPEN_CURLY)
+MULTI_CHAR_PARSER_DEF (ClassBodyChars, "\n,{", TOKEN_NL, TOKEN_COMMA, TOKEN_OPEN_CURLY)
 MULTI_CHAR_PARSER_DEF (ClassBodyAfterCurlyChars, "\n}*@(:;=-+/^<>.,|&",
 		TOKEN_NL, TOKEN_CLOSE_CURLY, TOKEN_STAR, TOKEN_AT, TOKEN_OPEN_PAREN,
 		TOKEN_COLON, TOKEN_SEMICOLON, TOKEN_EQUAL_SIGN,


### PR DESCRIPTION
Typescript parser now handles properly multiple interface names in `implements` part of class declaration. Additionally outputs `inherits` field with all class and interface names used by the class.

Fixes #2178 

@masatake Class declarations using templates like `class A<T> implements I<T>` IMHO should output only class/interface name without parameters. They can be very complicated and long and I can't think of anything they could be used for (when putting them also in  `inherits` field).