### PR TITLE
Typescript: fixed parsing variables with `as` keyword

### DIFF
--- a/Units/parser-typescript.r/ts-function-variable-white.d/expected.tags
+++ b/Units/parser-typescript.r/ts-function-variable-white.d/expected.tags
@@ -35,3 +35,6 @@ second	input.ts	/^  let [first, second] = input$/;"	l	function:f4
 f5	input.ts	/^function f5([first, second]: [number, number]) {$/;"	f
 first	input.ts	/^function f5([first, second]: [number, number]) {$/;"	z	function:f5
 second	input.ts	/^function f5([first, second]: [number, number]) {$/;"	z	function:f5
+d	input.ts	/^function d(p: string): void {$/;"	f
+p	input.ts	/^function d(p: string): void {$/;"	z	function:d
+view	input.ts	/^    const view = p as BigTableView$/;"	C	function:d

--- a/Units/parser-typescript.r/ts-function-variable-white.d/input.ts
+++ b/Units/parser-typescript.r/ts-function-variable-white.d/input.ts
@@ -59,3 +59,7 @@ function f5([first, second]: [number, number]) {
   console.log(first)
   console.log(second)
 }
+
+function d(p: string): void {
+    const view = p as BigTableView
+}

--- a/Units/parser-typescript.r/ts-function-variable.d/expected.tags
+++ b/Units/parser-typescript.r/ts-function-variable.d/expected.tags
@@ -35,3 +35,6 @@ second	input.ts	/^  let [first, second] = input;$/;"	l	function:f4
 f5	input.ts	/^function f5([first, second]: [number, number]) {$/;"	f
 first	input.ts	/^function f5([first, second]: [number, number]) {$/;"	z	function:f5
 second	input.ts	/^function f5([first, second]: [number, number]) {$/;"	z	function:f5
+d	input.ts	/^function d(p: string): void {$/;"	f
+p	input.ts	/^function d(p: string): void {$/;"	z	function:d
+view	input.ts	/^    const view = p as BigTableView;$/;"	C	function:d

--- a/Units/parser-typescript.r/ts-function-variable.d/input.ts
+++ b/Units/parser-typescript.r/ts-function-variable.d/input.ts
@@ -59,3 +59,7 @@ function f5([first, second]: [number, number]) {
   console.log(first);
   console.log(second);
 }
+
+function d(p: string): void {
+    const view = p as BigTableView;
+}

--- a/parsers/typescript.c
+++ b/parsers/typescript.c
@@ -79,6 +79,7 @@ static objPool *TokenPool = NULL;
 /*	Used to specify type of keyword.
  */
 enum eKeywordId {
+	KEYWORD_as,
 	KEYWORD_async,
 	KEYWORD_await,
 	KEYWORD_class,
@@ -190,6 +191,7 @@ typedef struct sBlockState {
 
 static const keywordTable TsKeywordTable [] = {
 	/* keyword		  keyword ID */
+	{ "as"	        , KEYWORD_as          },
 	{ "async"       , KEYWORD_async       },
 	{ "await"       , KEYWORD_await       },
 	{ "class"       , KEYWORD_class       },
@@ -646,6 +648,7 @@ CTAGS_INLINE void parseFQIdentifier(const int c, tokenInfo *const token, int *pa
 	parseIdentifierCommon (c, token, parsed, result, true);
 }
 
+PARSER_DEF (AsKeyword, parseWord, "as", num)
 PARSER_DEF (AsyncKeyword, parseWord, "async", num)
 PARSER_DEF (AwaitKeyword, parseWord, "await", num)
 PARSER_DEF (ClassKeyword, parseWord, "class", num)
@@ -1184,6 +1187,7 @@ static void parseVariable (bool constVar, bool localVar, const int scope, tokenI
 								parseStringTemplate,
 								parseNumber,
 								parseArrow,
+								parseAsKeyword,
 								parseAwaitKeyword,
 								parseForKeyword,
 								parseFunctionKeyword,
@@ -1266,6 +1270,7 @@ static void parseVariable (bool constVar, bool localVar, const int scope, tokenI
 						case KEYWORD_enum:
 							parseEnum (scope, token);
 							break;
+						case KEYWORD_as:
 						case KEYWORD_of:
 						case KEYWORD_in:
 						case KEYWORD_await:


### PR DESCRIPTION
Fixes #2180