### PR TITLE
CXX: Improve function signature matching

### DIFF
--- a/Units/parser-cxx.r/functions.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/functions.cpp.d/expected.tags
@@ -35,5 +35,5 @@ p07	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	p	type
 p08	input.cpp	/^void (*p08(void (*)(int *p08a01)))(int *);$/;"	p	typeref:typename:void (*)(int *)	file:	signature:(void (*)(int * p08a01))
 t01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t01a01)	end:85
 t01a01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	z	function:t01	typeref:typename:T &&	file:
-t02	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t02a01)	end:90
+t02	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t02a01)	end:94
 t02a01	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	z	function:t02	typeref:typename:T &&	file:

--- a/Units/parser-cxx.r/functions.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/functions.cpp.d/input.cpp
@@ -84,12 +84,21 @@ template <typename T> std::unique_ptr<T> t01(T && t01a01)
     return std::unique_ptr<T>(NULL);
 }
 
+#define MACRO_TEXT ""
+
 template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>
 {
+	// throw may look like a prototype, but it isn't
+	throw std::string(MACRO_TEXT);
     return std::unique_ptr<T>(NULL);
 }
 
 // Things that might look similar to function prototypes but are NOT function prototypes (but still valid C++)
 std::string x01("test");
 
-
+#if NOTVALIDCPP
+	// This is not really valid C++ because it appears in the wrong context.
+	// However we simulate the parser being wrong about the current state (it happens).
+	// This should be NOT marked as a prototype even if found out of a function.
+	throw std::string(MACRO_TEXT);
+#endif

--- a/Units/parser-cxx.r/template-specializations.d/expected.tags
+++ b/Units/parser-cxx.r/template-specializations.d/expected.tags
@@ -11,4 +11,5 @@ g2	input.cpp	/^template<> void A<int>::g2<char>(int, char); \/\/ for X2 = char$/
 g1	input.cpp	/^template<> void A<int>::g1(int, char);$/;"	p	class:A	typeref:typename:void	file:	signature:(int,char)	template:<>	properties:scopespecialization,specialization
 m	input.cpp	/^template<typename X> void m(X)$/;"	f	typeref:typename:void	signature:(X)	template:<typename X>
 m	input.cpp	/^template<> void m<int>(int)$/;"	f	typeref:typename:void	signature:(int)	template:<>	properties:specialization
+m	input.cpp	/^template<> void m<A>(A)$/;"	f	typeref:typename:void	signature:(A)	template:<>	properties:specialization
 m	input.cpp	/^template<> void m(char)$/;"	f	typeref:typename:void	signature:(char)	template:<>	properties:specialization

--- a/Units/parser-cxx.r/template-specializations.d/input.cpp
+++ b/Units/parser-cxx.r/template-specializations.d/input.cpp
@@ -34,6 +34,11 @@ template<> void m<int>(int)
 {
 }
 
+// bug #2181
+template<> void m<A>(A)
+{
+}
+
 template<> void m(char)
 {
 }

--- a/Units/parser-cxx.r/template-specializations.d/input.cpp
+++ b/Units/parser-cxx.r/template-specializations.d/input.cpp
@@ -42,3 +42,8 @@ template<> void m<A>(A)
 template<> void m(char)
 {
 }
+
+#if HANDLE_BROKEN_INPUT
+	// This is broken input. Should *not* be extracted.
+	template <> void int<int>(int a);
+#endif

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -493,7 +493,7 @@ process_token:
 						// broken input and we might also be wrong about the current scope.
 						if((cxxScopeGetType() == CXXScopeTypeFunction) || (g_cxx.pTokenChain->iCount < 3))
 						{
-							CXX_DEBUG_LEAVE_TEXT("Skipping throw statement");
+							CXX_DEBUG_PRINT("Skipping throw statement");
 							if(!cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF,
 								   false))
 							{

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -485,13 +485,19 @@ process_token:
 						cxxParserNewStatement();
 					break;
 					case CXXKeywordTHROW:
-						// ignore when inside a function
-						if(cxxScopeGetType() == CXXScopeTypeFunction)
+						// We ignore whole "throw expressions" as they contain nothing useful
+						// and may confuse us. We keep "throw" when used as exception specification,
+						// and this is certainly outside of a function and when the token chain
+						// already contains at least a type, an identifier and a parenthesis.
+						// This check seems excessive but keep in mind that we deal with
+						// broken input and we might also be wrong about the current scope.
+						if((cxxScopeGetType() == CXXScopeTypeFunction) || (g_cxx.pTokenChain->iCount < 3))
 						{
+							CXX_DEBUG_LEAVE_TEXT("Skipping throw statement");
 							if(!cxxParserParseUpToOneOf(CXXTokenTypeSemicolon | CXXTokenTypeEOF,
 								   false))
 							{
-								CXX_DEBUG_LEAVE_TEXT("Failed to parse return/continue/break");
+								CXX_DEBUG_LEAVE_TEXT("Failed to skip throw statement");
 								return false;
 							}
 							cxxParserNewStatement();


### PR DESCRIPTION
Improve matching of template specializations.
Avoid matching throw statements even if state is wrong.

Fixes #2181 
