### PR TITLE
C++: print real name of popped scope

### DIFF
--- a/parsers/cxx/cxx_scope.c
+++ b/parsers/cxx/cxx_scope.c
@@ -227,11 +227,7 @@ void cxxScopePushTop(CXXToken * t)
 	cxxTokenChainAppend(g_pScope,t);
 	g_bScopeNameDirty = true;
 
-#ifdef CXX_DO_DEBUGGING
-	const char * szScopeName = cxxScopeGetFullName();
-
-	CXX_DEBUG_PRINT("Pushed scope: '%s'",szScopeName ? szScopeName : "");
-#endif
+	CXX_DEBUG_PRINT("Pushed scope: '%s'",cxxScopeGetFullName() ?: "");
 }
 
 CXXToken * cxxScopeTakeTop(void)
@@ -240,15 +236,11 @@ CXXToken * cxxScopeTakeTop(void)
 			g_pScope->iCount > 0,
 			"When popping as scope there must be a scope to pop"
 		);
+	CXX_DEBUG_PRINT("Popped scope: '%s'",cxxScopeGetFullName() ?: "");
 
 	CXXToken * t = cxxTokenChainTakeLast(g_pScope);
 	g_bScopeNameDirty = true;
 
-#ifdef CXX_DO_DEBUGGING
-	const char * szScopeName = cxxScopeGetFullName();
-
-	CXX_DEBUG_PRINT("Popped scope: '%s'",szScopeName ? szScopeName : "");
-#endif
 	return t;
 }
 


### PR DESCRIPTION
 * Move call of cxxScopeGetFullName before cxxTokenChainTakeLast.
 * Also do not double check CXX_DO_DEBUGGING - explicitly via #ifdef and inside CXX_DEBUG_PRINT macro.