### PR TITLE
CSS: accept ~ char as a part of a selector

### DIFF
--- a/Units/parser-css.r/css-simple.d/expected.tags
+++ b/Units/parser-css.r/css-simple.d/expected.tags
@@ -6,5 +6,6 @@
 .red	input.css	/^.red { color: red }$/;"	c
 div.magic	input.css	/^div.magic $/;"	c
 html	input.css	/^html$/;"	s
+img ~ p	input.css	/^img ~ p {$/;"	s
 ul > li > a	input.css	/^ul > li > a {$/;"	s
 ul li	input.css	/^ul li { padding-left: 1em; }$/;"	s

--- a/Units/parser-css.r/css-simple.d/input.css
+++ b/Units/parser-css.r/css-simple.d/input.css
@@ -25,3 +25,9 @@ ul li { padding-left: 1em; }
 ul > li > a {
   font: monospace;
 }
+
+/* The general sibling combinator (~)
+ * See https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator */
+img ~ p {
+  color: red;
+}

--- a/parsers/css.c
+++ b/parsers/css.c
@@ -21,6 +21,7 @@
 		(c) == '-' || /* allowed char */ \
 		(c) == '+' || /* allow all sibling in a single tag */ \
 		(c) == '>' || /* allow all child in a single tag */ \
+		(c) == '~' || /* allow general sibling combinator */ \
 		(c) == '|' || /* allow namespace separator */ \
 		(c) == '(' || /* allow pseudo-class arguments */ \
 		(c) == ')' || \


### PR DESCRIPTION
`~' is a combinator as described in
https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_combinator

Signed-off-by: Masatake YAMATO <yamato@redhat.com>