### PR TITLE
appveyor: Use rst2html instead of rst2html3

### DIFF
--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -185,7 +185,7 @@ if "%normalbuild%"=="yes" (
 )
 md package
 :: Build html docs and man pages
-bash -lc "make -C docs html && make -C man html RST2HTML=rst2html3" || exit 1
+bash -lc "make -C docs html && make -C man html" || exit 1
 move docs\_build\html package\docs > nul
 rd /s/q package\docs\_sources
 


### PR DESCRIPTION
The rst2html3 command from the python3-docutils package was renamed to
rst2html a few weeks ago. No need to set RST2HTML variable anymore.

An error occurs without this fix:
https://ci.appveyor.com/project/universalctags/ctags-win32/builds/27311853/job/bu0ignl4x15w473g#L1177