### PR TITLE
main,win32: Use _getdrive() also on MinGW

### DIFF
--- a/main/routines.c
+++ b/main/routines.c
@@ -128,7 +128,7 @@
 /*  Hack for ridiculous practice of Microsoft Visual C++.
  */
 #if defined (WIN32)
-# if defined (_MSC_VER)
+# if defined (_MSC_VER) || defined (__MINGW32__)
 #  define stat    _stat
 #  define getcwd  _getcwd
 #  define currentdrive() (_getdrive() + 'A' - 1)


### PR DESCRIPTION
absoluteFilename() always returned C: drive when compiled with MinGW.
MinGW also has _getdrive(), so use it.