### PR TITLE
buildsys: remove COVERAGE make parameter

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -42,7 +42,7 @@ Before starting coverage measuring, you need to specify
 
 
 After doing ``make clean``, you can build coverage measuring ready
-ctags by ``make COVERAGE=1``. At this time *\*.gcno* files are generated
+ctags by ``make``. At this time *\*.gcno* files are generated
 by the compiler. *\*.gcno* files can be removed with ``make clean``.
 
 After building ctags, you can run run-gcov target.  When running

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -219,7 +219,7 @@ codecheck: $(CTAGS_TEST)
 	$(V_RUN) $(SHELL) misc/src-check
 
 #
-# Report coverage (usable only if ctags is built with COVERAGE=1.)
+# Report coverage (usable only if ctags is built with "configure --enable-coverage-gcov".)
 #
 run-gcov:
 	$(CTAGS_TEST) -o - $$(find ./Units -name 'input.*'| grep -v '.*b/.*') > /dev/null

--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -44,7 +44,7 @@ if [ "$TARGET" = "Unix" ]; then
         (
             cd "${BUILDDIR}"
             ${CONFIGURE_CMDLINE} --enable-coverage-gcov
-            make -j2 COVERAGE=1
+            make -j2
             echo 'List features'
             ./ctags --list-features
             echo 'Run "make check" with gcov'


### PR DESCRIPTION
Close #2057.

Specifying --enable-coverage-gcov option when running configure is
enough.

Suggested by @blueyed.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>