### PR TITLE
Update the way to incorporate an optlib parser to ctags build process

### DIFF
--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -1833,15 +1833,12 @@ test case own *args.ctags*.
 Assume your test name is *swine-simile.d*. Put ``--option=swine`` in
 *Units/swine-simile.d/args.ctags*.
 
-Makefile.in
+Incorporating your parser to ctags build process
 ......................................................................
-Add your optlib file, *swine.ctags* to ``PRELOAD_OPTLIB`` variable of
-*Makefile.in*.
 
+Add your optlib file, *swine.ctags* to ``OPTLIB2C_INPUT`` variable of
++*makefiles/optlib2c_input.mak* in Universal-ctags source tree.
 
-If you don't want your optlib loaded automatically when ``ctags`` starts up,
-put your optlib file into ``OPTLIB`` of *Makefile.in* instead of
-``PRELOAD_OPTLIB``.
 
 Verification
 ......................................................................

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -1855,7 +1855,7 @@ Let's verify all your work here.
 	$ ./configure --prefix=/tmp/tmp
 	$ make
 	$ make install
-	$ /tmp/tmp/ctags -o - --option=swine something_input.swn
+	$ /tmp/tmp/ctags -o - --languages=Swine something_input.swn
 
 
 Pull-request


### PR DESCRIPTION
 Close #2033.

The old document refers PRELOAD_OPTLIB variable in Makefile.in.
OPTLIB2C_INPUT in makefiles/testing.mk makes the variable obsolete.

Suggested by @dreamtigers in #2033.