### PR TITLE
Cxx: add a field for recording macro definition to macro kind

### DIFF
--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -5,12 +5,15 @@ p       UCTAGSscopeKind     no      NONE             s--    no    Kind of scope 
 r       UCTAGSroles         no      NONE             s--    no    Roles
 x       UCTAGSxpath         no      NONE             s--    no    xpath for the tag
 -       UCTAGSproperties    no      AutoIt           s--    no    properties (static, volatile, ...)
+-       UCTAGSmacrodef      no      C                s--    no    macro definition
 -       UCTAGSproperties    no      C                s--    no    properties (static, inline, mutable,...)
 -       UCTAGScaptures      no      C++              s--    no    lambda capture list
+-       UCTAGSmacrodef      no      C++              s--    no    macro definition
 -       UCTAGSname          yes     C++              s--    no    aliased names
 -       UCTAGSproperties    no      C++              s--    no    properties (static, inline, mutable,...)
 -       UCTAGStemplate      no      C++              s--    no    template parameters
 -       UCTAGSmacrodef      no      CPreProcessor    s--    no    macro definition
+-       UCTAGSmacrodef      no      CUDA             s--    no    macro definition
 -       UCTAGSproperties    no      CUDA             s--    no    properties (static, inline, mutable,...)
 -       UCTAGSaccess        yes     Elixir           s--    no    access
 -       UCTAGShowImported   no      Go               s--    no    how the package is imported ("inline" for `.' or "init" for `_')

--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -10,6 +10,7 @@ x       UCTAGSxpath         no      NONE             s--    no    xpath for the 
 -       UCTAGSname          yes     C++              s--    no    aliased names
 -       UCTAGSproperties    no      C++              s--    no    properties (static, inline, mutable,...)
 -       UCTAGStemplate      no      C++              s--    no    template parameters
+-       UCTAGSmacrodef      no      CPreProcessor    s--    no    macro definition
 -       UCTAGSproperties    no      CUDA             s--    no    properties (static, inline, mutable,...)
 -       UCTAGSaccess        yes     Elixir           s--    no    access
 -       UCTAGShowImported   no      Go               s--    no    how the package is imported ("inline" for `.' or "init" for `_')

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -28,6 +28,7 @@ z	kind	no	NONE	s--	no	Include the "kind:" key in kind field (use k or K) in tags
 -	name	yes	C++	s--	no	aliased names
 -	properties	no	C++	s--	no	properties (static, inline, mutable,...)
 -	template	no	C++	s--	no	template parameters
+-	macrodef	no	CPreProcessor	s--	no	macro definition
 -	properties	no	CUDA	s--	no	properties (static, inline, mutable,...)
 -	access	yes	Elixir	s--	no	access
 -	howImported	no	Go	s--	no	how the package is imported ("inline" for `.' or "init" for `_')

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -23,12 +23,15 @@ t	typeref	yes	NONE	s--	no	Type and name of a variable or typedef
 x	xpath	no	NONE	s--	no	xpath for the tag
 z	kind	no	NONE	s--	no	Include the "kind:" key in kind field (use k or K) in tags output, kind full name in xref output
 -	properties	no	AutoIt	s--	no	properties (static, volatile, ...)
+-	macrodef	no	C	s--	no	macro definition
 -	properties	no	C	s--	no	properties (static, inline, mutable,...)
 -	captures	no	C++	s--	no	lambda capture list
+-	macrodef	no	C++	s--	no	macro definition
 -	name	yes	C++	s--	no	aliased names
 -	properties	no	C++	s--	no	properties (static, inline, mutable,...)
 -	template	no	C++	s--	no	template parameters
 -	macrodef	no	CPreProcessor	s--	no	macro definition
+-	macrodef	no	CUDA	s--	no	macro definition
 -	properties	no	CUDA	s--	no	properties (static, inline, mutable,...)
 -	access	yes	Elixir	s--	no	access
 -	howImported	no	Go	s--	no	how the package is imported ("inline" for `.' or "init" for `_')

--- a/Units/parser-c.r/macrodef.d/args.ctags
+++ b/Units/parser-c.r/macrodef.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--fields-C=+{macrodef}
+--fields=+Sl

--- a/Units/parser-c.r/macrodef.d/expected.tags
+++ b/Units/parser-c.r/macrodef.d/expected.tags
@@ -1,0 +1,13 @@
+INT	input.c	/^#define INT /;"	d	language:C	file:	macrodef:1
+STR	input.c	/^#define STR /;"	d	language:C	file:	macrodef:"bar"
+CHR	input.c	/^#define CHR /;"	d	language:C	file:	macrodef:''
+HEX	input.c	/^#define HEX /;"	d	language:C	file:	macrodef:0xff01
+OCT	input.c	/^#define OCT /;"	d	language:C	file:	macrodef:0644
+SYSCALL_METADATA	input.c	/^#define SYSCALL_METADATA(/;"	d	language:C	file:	signature:(sname,nb,...)	macrodef:
+SYSCALL_DEFINE2	input.c	/^#define SYSCALL_DEFINE2(/;"	d	language:C	file:	signature:(name,...)	macrodef:SYSCALL_DEFINEx(2, _##name, __VA_ARGS__)
+SYSCALL_DEFINEx	input.c	/^#define SYSCALL_DEFINEx(/;"	d	language:C	file:	signature:(x,sname,...)	macrodef:SYSCALL_METADATA(sname, x, __VA_ARGS__) __SYSCALL_DEFINEx(x, sname, __VA_ARGS__)
+__SYSCALL_DEFINEx	input.c	/^#define __SYSCALL_DEFINEx(/;"	d	language:C	file:	signature:(x,name,...)	macrodef:__diag_push(); __diag_ignore(GCC, 8, "-Wattribute-alias", "Type aliasing is used to sanitize syscall arguments"); asmlinkage long sys##name(__MAP(x,__SC_DECL,__VA_ARGS__)) __attribute__((alias(__stringify(__se_sys##name)))); ALLOW_ERROR_INJECTION(sys##name, ERRNO); static inline long __do_sys##name(__MAP(x,__SC_DECL,__VA_ARGS__)); asmlinkage long __se_sys##name(__MAP(x,__SC_LONG,__VA_ARGS__)); asmlinkage long __se_sys##name(__MAP(x,__SC_LONG,__VA_ARGS__)) { long ret = __do_sys##name(__MAP(x,__SC_CAST,__VA_ARGS__)); __MAP(x,__SC_TEST,__VA_ARGS__); __PROTECT(x, ret,__MAP(x,__SC_ARGS,__VA_ARGS__)); return ret; } __diag_pop(); static inline long __do_sys##name(__MAP(x,__SC_DECL,__VA_ARGS__))
+__MAP1	input.c	/^#define __MAP1(/;"	d	language:C	file:	signature:(m,t,a,...)	macrodef:m(t,a)
+__MAP2	input.c	/^#define __MAP2(/;"	d	language:C	file:	signature:(m,t,a,...)	macrodef:m(t,a), __MAP1(m,__VA_ARGS__)
+__MAP	input.c	/^#define __MAP(/;"	d	language:C	file:	signature:(n,...)	macrodef:__MAP##n(__VA_ARGS__)
+__SC_DECL	input.c	/^#define __SC_DECL(/;"	d	language:C	file:	signature:(t,a)	macrodef:t a

--- a/Units/parser-c.r/macrodef.d/input.c
+++ b/Units/parser-c.r/macrodef.d/input.c
@@ -42,22 +42,9 @@
 #define __MAP(n,...) __MAP##n(__VA_ARGS__)
 
 #define __SC_DECL(t, a)	t a
-
+#if 0
 SYSCALL_DEFINE2(setregid16, old_gid_t, rgid, old_gid_t, egid)
 {
 	return __sys_setregid(low2highgid(rgid), low2highgid(egid));
 }
-
-#define slash_fn(t) t fn (t i, t j) {			\
-	return i / j;								\
-}
-
-#define question_fn(t) t fn (t i, t j) {		\
-	return (i < j)? i: j;						\
-}
-
-#define finally(X) \
-	int fin_##X(void) { return 0; } \
-\
-	\
-\
+#endif

--- a/Units/parser-cpreprocessor.r/macrodef.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/macrodef.d/args.ctags
@@ -1,0 +1,4 @@
+--language-force=CPreProcessor
+--sort=no
+--fields-CPreProcessor=+{macrodef}
+--fields=+Sl

--- a/Units/parser-cpreprocessor.r/macrodef.d/expected.tags
+++ b/Units/parser-cpreprocessor.r/macrodef.d/expected.tags
@@ -1,0 +1,13 @@
+INT	input.h	/^#define INT /;"	d	language:CPreProcessor	macrodef:1
+STR	input.h	/^#define STR /;"	d	language:CPreProcessor	macrodef:"bar"
+CHR	input.h	/^#define CHR /;"	d	language:CPreProcessor	macrodef:''
+HEX	input.h	/^#define HEX /;"	d	language:CPreProcessor	macrodef:0xff01
+OCT	input.h	/^#define OCT /;"	d	language:CPreProcessor	macrodef:0644
+SYSCALL_METADATA	input.h	/^#define SYSCALL_METADATA(/;"	d	language:CPreProcessor	signature:(sname,nb,...)	macrodef:
+SYSCALL_DEFINE2	input.h	/^#define SYSCALL_DEFINE2(/;"	d	language:CPreProcessor	signature:(name,...)	macrodef:SYSCALL_DEFINEx(2, _##name, __VA_ARGS__)
+SYSCALL_DEFINEx	input.h	/^#define SYSCALL_DEFINEx(/;"	d	language:CPreProcessor	signature:(x,sname,...)	macrodef:SYSCALL_METADATA(sname, x, __VA_ARGS__) __SYSCALL_DEFINEx(x, sname, __VA_ARGS__)
+__SYSCALL_DEFINEx	input.h	/^#define __SYSCALL_DEFINEx(/;"	d	language:CPreProcessor	signature:(x,name,...)	macrodef:__diag_push(); __diag_ignore(GCC, 8, "-Wattribute-alias", "Type aliasing is used to sanitize syscall arguments"); asmlinkage long sys##name(__MAP(x,__SC_DECL,__VA_ARGS__)) __attribute__((alias(__stringify(__se_sys##name)))); ALLOW_ERROR_INJECTION(sys##name, ERRNO); static inline long __do_sys##name(__MAP(x,__SC_DECL,__VA_ARGS__)); asmlinkage long __se_sys##name(__MAP(x,__SC_LONG,__VA_ARGS__)); asmlinkage long __se_sys##name(__MAP(x,__SC_LONG,__VA_ARGS__)) { long ret = __do_sys##name(__MAP(x,__SC_CAST,__VA_ARGS__)); __MAP(x,__SC_TEST,__VA_ARGS__); __PROTECT(x, ret,__MAP(x,__SC_ARGS,__VA_ARGS__)); return ret; } __diag_pop(); static inline long __do_sys##name(__MAP(x,__SC_DECL,__VA_ARGS__))
+__MAP1	input.h	/^#define __MAP1(/;"	d	language:CPreProcessor	signature:(m,t,a,...)	macrodef:m(t,a)
+__MAP2	input.h	/^#define __MAP2(/;"	d	language:CPreProcessor	signature:(m,t,a,...)	macrodef:m(t,a), __MAP1(m,__VA_ARGS__)
+__MAP	input.h	/^#define __MAP(/;"	d	language:CPreProcessor	signature:(n,...)	macrodef:__MAP##n(__VA_ARGS__)
+__SC_DECL	input.h	/^#define __SC_DECL(/;"	d	language:CPreProcessor	signature:(t,a)	macrodef:t a

--- a/Units/parser-cpreprocessor.r/macrodef.d/expected.tags
+++ b/Units/parser-cpreprocessor.r/macrodef.d/expected.tags
@@ -11,3 +11,6 @@ __MAP1	input.h	/^#define __MAP1(/;"	d	language:CPreProcessor	signature:(m,t,a,..
 __MAP2	input.h	/^#define __MAP2(/;"	d	language:CPreProcessor	signature:(m,t,a,...)	macrodef:m(t,a), __MAP1(m,__VA_ARGS__)
 __MAP	input.h	/^#define __MAP(/;"	d	language:CPreProcessor	signature:(n,...)	macrodef:__MAP##n(__VA_ARGS__)
 __SC_DECL	input.h	/^#define __SC_DECL(/;"	d	language:CPreProcessor	signature:(t,a)	macrodef:t a
+slash_fn	input.h	/^#define slash_fn(/;"	d	language:CPreProcessor	signature:(t)	macrodef:t fn (t i, t j) { return i / j; }
+question_fn	input.h	/^#define question_fn(/;"	d	language:CPreProcessor	signature:(t)	macrodef:t fn (t i, t j) { return (i < j)? i: j; }
+finally	input.h	/^#define finally(/;"	d	language:CPreProcessor	signature:(X)	macrodef:int fin_##X(void) { return 0; } 

--- a/Units/parser-cpreprocessor.r/macrodef.d/input.h
+++ b/Units/parser-cpreprocessor.r/macrodef.d/input.h
@@ -1,0 +1,49 @@
+#define INT 1
+#define STR "bar"
+#define CHR 'b'
+#define HEX 0xff01
+#define OCT 0644
+
+/*
+ * Taken from linux kernel
+ */
+#define SYSCALL_METADATA(sname, nb, ...)
+#define SYSCALL_DEFINE2(name, ...) SYSCALL_DEFINEx(2, _##name, __VA_ARGS__)
+#define SYSCALL_DEFINEx(x, sname, ...)				\
+	SYSCALL_METADATA(sname, x, __VA_ARGS__)			\
+	__SYSCALL_DEFINEx(x, sname, __VA_ARGS__)
+
+/*
+ * The asmlinkage stub is aliased to a function named __se_sys_*() which
+ * sign-extends 32-bit ints to longs whenever needed. The actual work is
+ * done within __do_sys_*().
+ */
+#define __SYSCALL_DEFINEx(x, name, ...)					\
+	__diag_push();							\
+	__diag_ignore(GCC, 8, "-Wattribute-alias",			\
+		      "Type aliasing is used to sanitize syscall arguments");\
+	asmlinkage long sys##name(__MAP(x,__SC_DECL,__VA_ARGS__))	\
+		__attribute__((alias(__stringify(__se_sys##name))));	\
+	ALLOW_ERROR_INJECTION(sys##name, ERRNO);			\
+	static inline long __do_sys##name(__MAP(x,__SC_DECL,__VA_ARGS__));\
+	asmlinkage long __se_sys##name(__MAP(x,__SC_LONG,__VA_ARGS__));	\
+	asmlinkage long __se_sys##name(__MAP(x,__SC_LONG,__VA_ARGS__))	\
+	{								\
+		long ret = __do_sys##name(__MAP(x,__SC_CAST,__VA_ARGS__));\
+		__MAP(x,__SC_TEST,__VA_ARGS__);				\
+		__PROTECT(x, ret,__MAP(x,__SC_ARGS,__VA_ARGS__));	\
+		return ret;						\
+	}								\
+	__diag_pop();							\
+	static inline long __do_sys##name(__MAP(x,__SC_DECL,__VA_ARGS__))
+
+#define __MAP1(m,t,a,...) m(t,a)
+#define __MAP2(m,t,a,...) m(t,a), __MAP1(m,__VA_ARGS__)
+#define __MAP(n,...) __MAP##n(__VA_ARGS__)
+
+#define __SC_DECL(t, a)	t a
+
+SYSCALL_DEFINE2(setregid16, old_gid_t, rgid, old_gid_t, egid)
+{
+	return __sys_setregid(low2highgid(rgid), low2highgid(egid));
+}

--- a/main/entry.h
+++ b/main/entry.h
@@ -143,6 +143,14 @@ size_t        countEntryInCorkQueue (void);
 extern void    markTagExtraBit     (tagEntryInfo *const tag, xtagType extra);
 extern bool isTagExtraBitMarked (const tagEntryInfo *const tag, xtagType extra);
 
+/* Attaching parser speicificc fields
+ *
+ * If your parser doesn't use Cork API, use attachParserField().
+ * If your parser use Cork API, use attachParserFieldToCorkEntry(),
+ *
+ * Calling either one, the caller owns VALUE. If the parser allocates VALUE
+ * dynamically, the parser must free it.
+ */
 extern void attachParserField (tagEntryInfo *const tag, fieldType ftype, const char* value);
 extern void attachParserFieldToCorkEntry (int index, fieldType ftype, const char* value);
 

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -312,7 +312,8 @@ static void findAsmTags (void)
 	const unsigned char *line;
 
 	cppInit (false, false, false, false,
-			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX, KIND_GHOST_INDEX, 0, 0);
+			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX, KIND_GHOST_INDEX, 0, 0,
+			 FIELD_UNKNOWN);
 
 	unsigned int lastMacroCorkIndex = CORK_NIL;
 

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3501,7 +3501,8 @@ static rescanReason findCTags (const unsigned int passCount)
 	cppInit ((bool) (passCount > 1), isInputLanguage (Lang_csharp), isInputLanguage(Lang_cpp),
 		 isInputLanguage(Lang_vera),
 		 kind_for_define, role_for_macro_undef, kind_for_param,
-		 kind_for_header, role_for_header_system, role_for_header_local);
+		 kind_for_header, role_for_header_system, role_for_header_local,
+		 FIELD_UNKNOWN);
 
 	Signature = vStringNew ();
 

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -317,7 +317,7 @@ extern void cppInit (const bool state, const bool hasAtLiteralStrings,
 		     int defineMacroKindIndex,
 		     int macroUndefRoleIndex,
 		     int macroParamKindIndex,
-			 int headerKindIndex,
+		     int headerKindIndex,
 		     int headerSystemRoleIndex, int headerLocalRoleIndex)
 {
 	langType client = getInputLanguage ();
@@ -325,7 +325,8 @@ extern void cppInit (const bool state, const bool hasAtLiteralStrings,
 	cppInitCommon (client, state, hasAtLiteralStrings,
 				   hasCxxRawLiteralStrings, hasSingleQuoteLiteralNumbers,
 				   defineMacroKindIndex, macroUndefRoleIndex, macroParamKindIndex,
-				   headerKindIndex, headerSystemRoleIndex, headerLocalRoleIndex);
+				   headerKindIndex, headerSystemRoleIndex, headerLocalRoleIndex,
+				   macrodefFieldIndex);
 }
 
 extern void cppTerminate (void)
@@ -2016,6 +2017,9 @@ extern parserDefinition* CPreProParser (void)
 	def->kindCount  = ARRAY_SIZE (CPreProKinds);
 	def->initialize = initializeCpp;
 	def->parser     = findCppTags;
+
+	def->fieldTable = CPreProFields;
+	def->fieldCount = ARRAY_SIZE (CPreProFields);
 
 	def->parameterHandlerTable = CpreProParameterHandlerTable;
 	def->parameterHandlerCount = ARRAY_SIZE(CpreProParameterHandlerTable);

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -98,6 +98,8 @@ typedef struct sCppState {
 	int headerSystemRoleIndex;
 	int headerLocalRoleIndex;
 
+	int macrodefFieldIndex;
+
 	struct sDirective {
 		enum eState state;       /* current directive being processed */
 		bool	accept;          /* is a directive syntactically permitted? */
@@ -138,6 +140,17 @@ static kindDefinition CPreProKinds [] = {
 	{ true, 'h', "header",     "included header files",
 	  .referenceOnly = true, ATTACH_ROLES(CPREPROHeaderRoles)},
 	{ false, 'D', "parameter", "macro parameters", },
+};
+
+typedef enum {
+	F_MACRODEF,
+	COUNT_FIELD
+} cPreProField;
+
+static fieldDefinition CPreProFields[COUNT_FIELD] = {
+	{ .name = "macrodef",
+	  .description = "macro definition",
+	  .enabled = false },
 };
 
 /*
@@ -190,6 +203,7 @@ static cppState Cpp = {
 	.headerKindIndex = CPREPRO_HEADER,
 	.headerSystemRoleIndex = CPREPRO_HEADER_KIND_SYSTEM_ROLE,
 	.headerLocalRoleIndex = CPREPRO_HEADER_KIND_LOCAL_ROLE,
+	.macrodefFieldIndex = FIELD_UNKNOWN,
 	.directive = {
 		.state = DRCTV_NONE,
 		.accept = false,
@@ -228,7 +242,8 @@ static void cppInitCommon(langType clientLang,
 		     int macroUndefRoleIndex,
 		     int macroParamKindIndex,
 		     int headerKindIndex,
-		     int headerSystemRoleIndex, int headerLocalRoleIndex)
+		     int headerSystemRoleIndex, int headerLocalRoleIndex,
+		     int macrodefFieldIndex)
 {
 	BraceFormat = state;
 
@@ -262,6 +277,7 @@ static void cppInitCommon(langType clientLang,
 		Cpp.useClientLangDefineMacroKindIndex = true;
 
 		Cpp.macroUndefRoleIndex = macroUndefRoleIndex;
+		Cpp.macrodefFieldIndex = macrodefFieldIndex;
 	}
 	else
 	{
@@ -269,6 +285,7 @@ static void cppInitCommon(langType clientLang,
 		Cpp.useClientLangDefineMacroKindIndex = false;
 
 		Cpp.macroUndefRoleIndex = CPREPRO_MACRO_KIND_UNDEF_ROLE;
+		Cpp.macrodefFieldIndex = CPreProFields [F_MACRODEF].ftype;
 	}
 
 	if (macroParamKindIndex != KIND_GHOST_INDEX)
@@ -318,7 +335,8 @@ extern void cppInit (const bool state, const bool hasAtLiteralStrings,
 		     int macroUndefRoleIndex,
 		     int macroParamKindIndex,
 		     int headerKindIndex,
-		     int headerSystemRoleIndex, int headerLocalRoleIndex)
+		     int headerSystemRoleIndex, int headerLocalRoleIndex,
+		     int macrodefFieldIndex)
 {
 	langType client = getInputLanguage ();
 
@@ -1494,7 +1512,8 @@ static void findCppTags (void)
 {
 	cppInitCommon (Cpp.lang, 0, false, false, false,
 				   KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX,
-				   KIND_GHOST_INDEX, 0, 0);
+				   KIND_GHOST_INDEX, 0, 0,
+				   FIELD_UNKNOWN);
 
 	findRegexTagsMainloop (cppGetc);
 

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1278,9 +1278,9 @@ process:
 			case NEWLINE:
 				if (directive  &&  ! ignore)
 				{
+					directive = false;
 					attachEndFieldMaybe (macroCorkIndex);
 					macroCorkIndex = CORK_NIL;
-					directive = false;
 				}
 				Cpp.directive.accept = true;
 				break;

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1233,12 +1233,12 @@ static int skipToEndOfChar ()
 	return CHAR_SYMBOL;  /* symbolic representation of character */
 }
 
-static void attachEndField (int macroCorkIndex)
+static void attachFields (int macroCorkIndex, unsigned long endLine)
 {
 	tagEntryInfo *tag;
 
 	tag = getEntryInCorkQueue (macroCorkIndex);
-	tag->extensionFields.endLine = getInputLineNumber ();
+	tag->extensionFields.endLine = endLine;
 }
 
 
@@ -1266,7 +1266,8 @@ process:
 				directive = false;
 				if (macroCorkIndex != CORK_NIL)
 				{
-					attachEndFieldMaybe (macroCorkIndex);
+					attachFields (macroCorkIndex,
+								  getInputLineNumber());
 					macroCorkIndex = CORK_NIL;
 				}
 				break;
@@ -1281,7 +1282,8 @@ process:
 					directive = false;
 					if (macroCorkIndex != CORK_NIL)
 					{
-						attachEndFieldMaybe (macroCorkIndex);
+						attachFields (macroCorkIndex,
+									  getInputLineNumber());
 						macroCorkIndex = CORK_NIL;
 					}
 				}

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1233,15 +1233,12 @@ static int skipToEndOfChar ()
 	return CHAR_SYMBOL;  /* symbolic representation of character */
 }
 
-static void attachEndFieldMaybe (int macroCorkIndex)
+static void attachEndField (int macroCorkIndex)
 {
-	if (macroCorkIndex != CORK_NIL)
-	{
-		tagEntryInfo *tag;
+	tagEntryInfo *tag;
 
-		tag = getEntryInCorkQueue (macroCorkIndex);
-		tag->extensionFields.endLine = getInputLineNumber ();
-	}
+	tag = getEntryInCorkQueue (macroCorkIndex);
+	tag->extensionFields.endLine = getInputLineNumber ();
 }
 
 
@@ -1267,8 +1264,11 @@ process:
 			case EOF:
 				ignore    = false;
 				directive = false;
-				attachEndFieldMaybe (macroCorkIndex);
-				macroCorkIndex = CORK_NIL;
+				if (macroCorkIndex != CORK_NIL)
+				{
+					attachEndFieldMaybe (macroCorkIndex);
+					macroCorkIndex = CORK_NIL;
+				}
 				break;
 
 			case TAB:
@@ -1279,8 +1279,11 @@ process:
 				if (directive  &&  ! ignore)
 				{
 					directive = false;
-					attachEndFieldMaybe (macroCorkIndex);
-					macroCorkIndex = CORK_NIL;
+					if (macroCorkIndex != CORK_NIL)
+					{
+						attachEndFieldMaybe (macroCorkIndex);
+						macroCorkIndex = CORK_NIL;
+					}
 				}
 				Cpp.directive.accept = true;
 				break;

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1235,9 +1235,9 @@ static int skipToEndOfChar ()
 
 static void attachFields (int macroCorkIndex, unsigned long endLine)
 {
-	tagEntryInfo *tag;
+	tagEntryInfo *tag = getEntryInCorkQueue (macroCorkIndex);
+	Assert(tag);
 
-	tag = getEntryInCorkQueue (macroCorkIndex);
 	tag->extensionFields.endLine = endLine;
 }
 

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -78,11 +78,11 @@ extern void cppInit (const bool state,
 		     const bool hasAtLiteralStrings,
 		     const bool hasCxxRawLiteralStrings,
 		     const bool hasSingleQuoteLiteralNumbers,
-			 int defineMacroKindIndex,
+		     int defineMacroKindIndex,
 		     int macroUndefRoleIndex,
 		     int headerKindIndex,
 		     int headerSystemRoleIndex, int headerLocalRoleIndex,
-			 int macroParamKindIndex);
+		     int macroParamKindIndex);
 
 extern void cppTerminate (void);
 extern void cppBeginStatement (void);

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -82,7 +82,8 @@ extern void cppInit (const bool state,
 		     int macroUndefRoleIndex,
 		     int headerKindIndex,
 		     int headerSystemRoleIndex, int headerLocalRoleIndex,
-		     int macroParamKindIndex);
+		     int macroParamKindIndex,
+		     int macrodefFieldIndex);
 
 extern void cppTerminate (void);
 extern void cppBeginStatement (void);

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1830,7 +1830,8 @@ static rescanReason cxxParserMain(const unsigned int passCount)
 			kind_for_macro_param,
 			kind_for_header,
 			role_for_header_system,
-			role_for_header_local
+			role_for_header_local,
+			FIELD_UNKNOWN
 		);
 
 	g_cxx.iChar = ' ';

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1831,7 +1831,7 @@ static rescanReason cxxParserMain(const unsigned int passCount)
 			kind_for_header,
 			role_for_header_system,
 			role_for_header_local,
-			FIELD_UNKNOWN
+			g_cxx.pFieldOptions[CXXTagFieldMacrodef].ftype
 		);
 
 	g_cxx.iChar = ' ';

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -93,6 +93,10 @@ static const char * g_aCXXAccessStrings [] = {
 		.name = "properties", \
 		.description = "properties (static, inline, mutable,...)", \
 		.enabled = false \
+	}, { \
+		.name = "macrodef", \
+		.description = "macro definition", \
+			.enabled = false \
 	}
 
 static fieldDefinition g_aCXXCFields [] = {

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -53,6 +53,7 @@ enum CXXTagCPPKind
 enum CXXTagCommonField
 {
 	CXXTagFieldProperties,
+	CXXTagFieldMacrodef,
 
 	CXXTagCommonFieldCount
 };

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -12,6 +12,7 @@
 */
 #include "general.h"
 #include "cpreprocessor.h"
+#include "field.h"
 #include "kind.h"
 #include "parse.h"
 #include "routines.h"
@@ -39,7 +40,8 @@ static void runCppGetc (void)
 {
 	cppInit (false, false, false, false,
 			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX,
-			 KIND_GHOST_INDEX, 0, 0);
+			 KIND_GHOST_INDEX, 0, 0,
+			 FIELD_UNKNOWN);
 
 	findRegexTagsMainloop (cppGetc);
 

--- a/parsers/ldscript.c
+++ b/parsers/ldscript.c
@@ -695,7 +695,8 @@ static void findLdScriptTags (void)
 
 	cppInit (false, false, false, false,
 			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX,
-			 KIND_GHOST_INDEX, 0, 0);
+			 KIND_GHOST_INDEX, 0, 0,
+			 FIELD_UNKNOWN);
 
 	do {
 		tokenRead (token);

--- a/parsers/protobuf.c
+++ b/parsers/protobuf.c
@@ -246,7 +246,8 @@ static void findProtobufTags (void)
 {
 	cppInit (false, false, false, false,
 			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX,
-			 KIND_GHOST_INDEX, 0, 0);
+			 KIND_GHOST_INDEX, 0, 0,
+			 FIELD_UNKNOWN);
 	token.value = vStringNew ();
 
 	nextToken ();


### PR DESCRIPTION
Currently, saveMacro feature can be used from command line (-D option).
I'm thinking about using it from CPreProcessor parser itself.
This is the first step to implement the idea.
With this patch, entries for macros can have "signature" and "macrodef" fields.
It is enough to make arguments passed to saveMacro.
