### PR TITLE
circleci: enable AppStream repository when buindling on CentOS8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -40,7 +40,7 @@ jobs:
            name: Install build tools
            # TODO: enable spell checker
            command: |
-              yum -y install gcc automake autoconf pkgconfig make libxml2-devel jansson-devel libyaml-devel findutils
+              yum -y --enablerepo=PowerTools install gcc automake autoconf pkgconfig make libxml2-devel jansson-devel libyaml-devel findutils diffutils
        - run:
            name: Build
            command: |


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>