### PR TITLE
Fix unexpected regex kind in list kinds

### DIFF
--- a/Tmain/lregex-unexpected-regex-kind.d/X.ctags
+++ b/Tmain/lregex-unexpected-regex-kind.d/X.ctags
@@ -1,0 +1,7 @@
+--langdef=X
+--kinddef-X=f,foo,foobars
+--_tabledef-X=main
+--_tabledef-X=sharp
+--_mtable-regex-X=main/^#///{tjump=sharp}{_advanceTo=0start}
+--_mtable-regex-X=sharp/^[^\n]+[\n]//{tjump=main}
+--mline-regex-X=/^#.*//{_guest=C,0start,0end}

--- a/Tmain/lregex-unexpected-regex-kind.d/Y-r-regex-with-kinddef.ctags
+++ b/Tmain/lregex-unexpected-regex-kind.d/Y-r-regex-with-kinddef.ctags
@@ -1,0 +1,4 @@
+--langdef=Y3
+--map-Y3=.yyy
+--kinddef-Y3=r,regex,captured by regex patterns
+--regex-Y3=/^block//r/{_anonymous=yyy}

--- a/Tmain/lregex-unexpected-regex-kind.d/Y-r-regex.ctags
+++ b/Tmain/lregex-unexpected-regex-kind.d/Y-r-regex.ctags
@@ -1,0 +1,3 @@
+--langdef=Y2
+--map-Y2=.yyy
+--regex-Y2=/^block//r,regex/{_anonymous=yyy}

--- a/Tmain/lregex-unexpected-regex-kind.d/Y-r.ctags
+++ b/Tmain/lregex-unexpected-regex-kind.d/Y-r.ctags
@@ -1,0 +1,3 @@
+--langdef=Y1
+--map-Y1=.yyy
+--regex-Y1=/^block//r/{_anonymous=yyy}

--- a/Tmain/lregex-unexpected-regex-kind.d/Y-regex.ctags
+++ b/Tmain/lregex-unexpected-regex-kind.d/Y-regex.ctags
@@ -1,0 +1,3 @@
+--langdef=Y2
+--map-Y2=.yyy
+--regex-Y2=/^block//,regex/{_anonymous=yyy}

--- a/Tmain/lregex-unexpected-regex-kind.d/Yempty1.ctags
+++ b/Tmain/lregex-unexpected-regex-kind.d/Yempty1.ctags
@@ -1,0 +1,3 @@
+--langdef=Ye0
+--map-Ye0=.yyy
+--regex-Ye0=/^block//,/{_anonymous=yyy}

--- a/Tmain/lregex-unexpected-regex-kind.d/Yempty2.ctags
+++ b/Tmain/lregex-unexpected-regex-kind.d/Yempty2.ctags
@@ -1,0 +1,3 @@
+--langdef=Ye1
+--map-Ye1=.yyy
+--regex-Ye1=/^block//,,/{_anonymous=yyy}

--- a/Tmain/lregex-unexpected-regex-kind.d/Ynokind.ctags
+++ b/Tmain/lregex-unexpected-regex-kind.d/Ynokind.ctags
@@ -1,0 +1,3 @@
+--langdef=Y0
+--map-Y0=.yyy
+--regex-Y0=/^block///{_anonymous=yyy}

--- a/Tmain/lregex-unexpected-regex-kind.d/input.yyy
+++ b/Tmain/lregex-unexpected-regex-kind.d/input.yyy
@@ -1,0 +1,3 @@
+block
+end
+

--- a/Tmain/lregex-unexpected-regex-kind.d/run.sh
+++ b/Tmain/lregex-unexpected-regex-kind.d/run.sh
@@ -1,0 +1,27 @@
+# Copyright: 2019 Masatake YAMATO
+# License: GPL-2
+
+CTAGS="$1 --quiet --options=NONE"
+
+$CTAGS --options=X.ctags --list-kinds=X
+
+echo "# no kind is specified" 1>&2
+$CTAGS --options=Ynokind.ctags input.yyy
+
+echo "# no kind (empty,) is specified" 1>&2
+$CTAGS --options=Yempty1.ctags input.yyy
+
+echo "# no kind (empty,,) is specified" 1>&2
+$CTAGS --options=Yempty2.ctags input.yyy
+
+echo "# (r/) kind is specified inline" 1>&2
+$CTAGS --options=Y-r.ctags input.yyy
+
+echo "# (/regex) kind is specified inline" 1>&2
+$CTAGS --options=Y-regex.ctags input.yyy
+
+echo "# (r/regex) kind is specified inline" 1>&2
+$CTAGS --options=Y-r-regex.ctags input.yyy
+
+echo "# (r/regex) kind defined with --kinddef-<LANG> option" 1>&2
+$CTAGS --options=Y-r-regex-with-kinddef.ctags input.yyy

--- a/Tmain/lregex-unexpected-regex-kind.d/stderr-expected.txt
+++ b/Tmain/lregex-unexpected-regex-kind.d/stderr-expected.txt
@@ -1,0 +1,16 @@
+# no kind is specified
+ctags: Warning: use "_anonymous" regex flag only with an explicitly defined kind
+ctags: Warning: ^block: regexp missing name pattern
+ctags: Warning: input.yyy:1: null expansion of name pattern ""
+# no kind (empty,) is specified
+ctags: Warning: use "_anonymous" regex flag only with an explicitly defined kind
+ctags: Warning: ^block: regexp missing name pattern
+ctags: Warning: input.yyy:1: null expansion of name pattern ""
+# no kind (empty,,) is specified
+ctags: Warning: use "_anonymous" regex flag only with an explicitly defined kind
+ctags: Warning: ^block: regexp missing name pattern
+ctags: Warning: input.yyy:1: null expansion of name pattern ""
+# (r/) kind is specified inline
+# (/regex) kind is specified inline
+# (r/regex) kind is specified inline
+# (r/regex) kind defined with --kinddef-<LANG> option

--- a/Tmain/lregex-unexpected-regex-kind.d/stdout-expected.txt
+++ b/Tmain/lregex-unexpected-regex-kind.d/stdout-expected.txt
@@ -1,0 +1,1 @@
+f  foobars

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -1325,7 +1325,8 @@ static regex_t* compileRegex (enum regexParserType regptype,
 }
 
 
-static void parseKinds (
+/* If a letter and/or a name are defined in kindSpec, return true. */
+static bool parseKinds (
 		const char* const kindSpec, char* const kindLetter, char** const kindName,
 		char **description)
 {
@@ -1335,13 +1336,18 @@ static void parseKinds (
 	{
 		*kindLetter = KIND_REGEX_DEFAULT_LETTER;
 		*kindName = eStrdup (KIND_REGEX_DEFAULT_NAME);
+		return false;
 	}
 	else
 	{
+		bool explicitly_defined = false;
 		const char* k = kindSpec;
 
 		if (k [0] != ','  &&  (k [1] == ','  ||  k [1] == '\0'))
+		{
 			*kindLetter = *k++;
+			explicitly_defined = true;
+		}
 		else
 			*kindLetter = KIND_REGEX_DEFAULT_LETTER;
 
@@ -1355,15 +1361,30 @@ static void parseKinds (
 			const char *const comma = strchr (k, ',');
 
 			if (comma == NULL)
-				*kindName = eStrdup (k);
+			{
+				if (strlen (k) == 0)
+					*kindName = eStrdup (KIND_REGEX_DEFAULT_NAME);
+				else
+				{
+					*kindName = eStrdup (k);
+					explicitly_defined = true;
+				}
+			}
 			else
 			{
-				*kindName = eStrndup (k, comma - k );
+				if (comma - k == 0)
+					*kindName = eStrdup (KIND_REGEX_DEFAULT_NAME);
+				else
+				{
+					*kindName = eStrndup (k, comma - k );
+					explicitly_defined = true;
+				}
 				k = comma + 1;
 				if (k [0] != '\0')
 					*description = eStrdup (k);
 			}
 		}
+		return explicitly_defined;
 	}
 }
 

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -1020,7 +1020,7 @@ static void common_flag_role_long (const char* const s, const char* const v, voi
 	ptrn->u.tag.roleBits |= makeRoleBit(role->id);
 }
 
-static void common_flag_anonymous_long (const char* const s CTAGS_ATTR_UNUSED, const char* const v, void* data)
+static void common_flag_anonymous_long (const char* const s, const char* const v, void* data)
 {
 	struct commonFlagData * cdata = data;
 	regexPattern *ptrn = cdata->ptrn;
@@ -1039,6 +1039,12 @@ static void common_flag_anonymous_long (const char* const s CTAGS_ATTR_UNUSED, c
 	{
 		error (WARNING, "no PREFIX for anonymous regex flag is given (pattern == %s)",
 			   ptrn->pattern_string? ptrn->pattern_string: "");
+		return;
+	}
+
+	if (ptrn->u.tag.kindIndex == KIND_GHOST_INDEX)
+	{
+		error (WARNING, "use \"%s\" regex flag only with an explicitly defined kind", s);
 		return;
 	}
 

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -1208,11 +1208,10 @@ static regexPattern *addCompiledTagPattern (struct lregexControlBlock *lcb,
 	ptrn->u.tag.name_pattern = eStrdup (name);
 	ptrn->disabled = disabled;
 
-	/* need to check for exclusive before setting the kind */
+	setKind(ptrn, lcb->owner, kindLetter, kindName, description);
+
 	if (regptype == REG_PARSER_SINGLE_LINE)
 		flagsEval (flags, prePtrnFlagDef, ARRAY_SIZE(prePtrnFlagDef), &ptrn->exclusive);
-
-	setKind(ptrn, lcb->owner, kindLetter, kindName, description);
 
 	flagsEval (flags, commonSpecFlagDef, ARRAY_SIZE(commonSpecFlagDef), &commonFlagData);
 

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -1160,7 +1160,6 @@ static void setKind(regexPattern * ptrn, const langType owner,
 	Assert (kindName);
 
 	if (*ptrn->u.tag.name_pattern == '\0' &&
-		ptrn->exclusive &&
 		kindLetter == KIND_REGEX_DEFAULT_LETTER)
 	{
 		ptrn->u.tag.kindIndex = KIND_GHOST_INDEX;

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -1188,27 +1188,16 @@ static void setKind(regexPattern * ptrn, const langType owner,
 	}
 }
 
-
-static regexPattern *addCompiledTagPattern (struct lregexControlBlock *lcb,
-											int table_index,
-											enum regexParserType regptype, regex_t* const pattern,
-					    const char* const name, char kindLetter, const char* kindName,
-					    char *const description, const char* flags,
-					    bool *disabled)
+static void patternEvalFlags (struct lregexControlBlock *lcb,
+							  regexPattern * ptrn,
+							  enum regexParserType regptype,
+							  const char* flags)
 {
-	regexPattern * ptrn = addCompiledTagCommon(lcb, table_index, pattern, regptype);
-
 	struct commonFlagData commonFlagData = {
 		.owner = lcb->owner,
 		.lcb = lcb,
 		.ptrn = ptrn
 	};
-
-	ptrn->type = PTRN_TAG;
-	ptrn->u.tag.name_pattern = eStrdup (name);
-	ptrn->disabled = disabled;
-
-	setKind(ptrn, lcb->owner, kindLetter, kindName, description);
 
 	if (regptype == REG_PARSER_SINGLE_LINE)
 		flagsEval (flags, prePtrnFlagDef, ARRAY_SIZE(prePtrnFlagDef), &ptrn->exclusive);
@@ -1233,6 +1222,23 @@ static regexPattern *addCompiledTagPattern (struct lregexControlBlock *lcb,
 
 	if (regptype == REG_PARSER_MULTI_TABLE)
 		flagsEval (flags, multitablePtrnFlagDef, ARRAY_SIZE(multitablePtrnFlagDef), &commonFlagData);
+}
+
+static regexPattern *addCompiledTagPattern (struct lregexControlBlock *lcb,
+											int table_index,
+											enum regexParserType regptype, regex_t* const pattern,
+					    const char* const name, char kindLetter, const char* kindName,
+					    char *const description, const char* flags,
+					    bool *disabled)
+{
+	regexPattern * ptrn = addCompiledTagCommon(lcb, table_index, pattern, regptype);
+
+	ptrn->type = PTRN_TAG;
+	ptrn->u.tag.name_pattern = eStrdup (name);
+	ptrn->disabled = disabled;
+
+	setKind(ptrn, lcb->owner, kindLetter, kindName, description);
+	patternEvalFlags (lcb, ptrn, regptype, flags);
 
 	return ptrn;
 }


### PR DESCRIPTION
Close #2202.

If a kind is not specified explicitly in --regex-<LANG> option, r/regex kind is used.
This feature comes from Exuberant-ctags.

Universal-ctags extends the option heavily. As the result, the way to handling r/regex in u-ctags had various inconsistencies.

This PR revises the code related to the fallback r/regex kind feature.
