### PR TITLE
buildsys: Add some files to EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,13 +7,15 @@ EXTRA_DIST   = README.md autogen.sh \
 	       .indent.pro .uncrustify.cfg \
 	       gnu_regex/README.txt gnu_regex/regcomp.c gnu_regex/regexec.c \
 	       gnu_regex/regex_internal.c gnu_regex/regex_internal.h \
+	       misc/packcc/.gitignore misc/packcc/LICENSE.txt \
+	       misc/packcc/README.md \
 	       $(WIN32_HEADS) $(WIN32_SRCS) mk_mingw.mak mk_mvc.mak \
 	       win32/mkstemp/COPYING.MinGW-w64-runtime.txt \
 	       win32/ctags_vs2013.sln \
 	       win32/ctags_vs2013.vcxproj win32/ctags_vs2013.vcxproj.filters \
 	       win32/gen-repoinfo.bat \
-	       man/tags.5.rst \
-		$(PEG_INPUT) $(OPTLIB2C_INPUT)
+	       man/Makefile man/README man/tags.5.rst \
+	       $(PEG_INPUT) $(OPTLIB2C_INPUT)
 
 bin_PROGRAMS = ctags
 noinst_LIBRARIES = libctags.a


### PR DESCRIPTION
Packcc's documents were not included in the distribution.
Some files in man/ were also missing.