### PR TITLE
main,win32: Suppress MinGW warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -350,6 +350,7 @@ fi
 # Checks for header files
 # -----------------------
 
+AC_CHECK_HEADERS([direct.h])
 AC_CHECK_HEADERS([dirent.h errno.h fcntl.h io.h limits.h stat.h stdlib.h string.h])
 AC_CHECK_HEADERS([time.h types.h unistd.h])
 AC_CHECK_HEADERS([sys/dir.h sys/stat.h sys/times.h sys/types.h sys/wait.h])

--- a/gnu_regex/regex_internal.c
+++ b/gnu_regex/regex_internal.c
@@ -674,10 +674,10 @@ re_string_reconstruct (re_string_t *pstr, int idx, int eflags)
 	}
       else
 	{
+#ifdef RE_ENABLE_I18N
 	  /* No, skip all characters until IDX.  */
 	  int prev_valid_len = pstr->valid_len;
 
-#ifdef RE_ENABLE_I18N
 	  if (BE (pstr->offsets_needed, 0))
 	    {
 	      pstr->len = pstr->raw_len - idx + offset;
@@ -1396,7 +1396,9 @@ static int
 internal_function
 re_dfa_add_node (re_dfa_t *dfa, re_token_t token)
 {
+#ifdef RE_ENABLE_I18N
   int type = token.type;
+#endif
   if (BE (dfa->nodes_len >= dfa->nodes_alloc, 0))
     {
       size_t new_nodes_alloc = dfa->nodes_alloc * 2;

--- a/gnu_regex/regexec.c
+++ b/gnu_regex/regexec.c
@@ -227,7 +227,9 @@ regexec (preg, string, nmatch, pmatch, eflags)
 {
   reg_errcode_t err;
   int start, length;
+#ifdef _LIBC
   re_dfa_t *dfa = (re_dfa_t *) preg->buffer;
+#endif
 
   if (eflags & ~(REG_NOTBOL | REG_NOTEOL | REG_STARTEND))
     return REG_BADPAT;
@@ -418,7 +420,9 @@ re_search_stub (bufp, string, length, start, range, stop, regs, ret_len)
   regmatch_t *pmatch;
   int nregs, rval;
   int eflags = 0;
+#ifdef _LIBC
   re_dfa_t *dfa = (re_dfa_t *) bufp->buffer;
+#endif
 
   /* Check for out-of-range.  */
   if (BE (start < 0 || start > length, 0))
@@ -3037,7 +3041,9 @@ check_arrival_add_next_nodes (re_match_context_t *mctx, int str_idx,
   const re_dfa_t *const dfa = mctx->dfa;
   int result;
   int cur_idx;
+#ifdef RE_ENABLE_I18N
   reg_errcode_t err = REG_NOERROR;
+#endif
   re_node_set union_set;
   re_node_set_init_empty (&union_set);
   for (cur_idx = 0; cur_idx < cur_nodes->nelem; ++cur_idx)

--- a/main/e_msoft.h
+++ b/main/e_msoft.h
@@ -21,12 +21,15 @@
 #define HAVE_TIME_H 1
 #define HAVE_CLOCK 1
 #define HAVE_CHSIZE 1
+#define HAVE_DIRECT_H 1
 #define HAVE_FGETPOS 1
 #define HAVE_STRICMP 1
 #define HAVE_STRNICMP 1
 #define HAVE_STRSTR 1
 #define HAVE_STRERROR 1
+#define HAVE__FINDFIRST 1
 #define HAVE_FINDNEXT 1
+#define findfirst_t intptr_t
 #define HAVE_MKSTEMP 1
 #define HAVE_FNMATCH 1
 #define HAVE_FNMATCH_H 1
@@ -37,12 +40,9 @@ int mkstemp (char *template_name);
 
 #ifdef _MSC_VER
 
-# define HAVE__FINDFIRST 1
-# define HAVE_DIRECT_H 1
 # if _MSC_VER < 1900
 #  define snprintf _snprintf
 # endif
-# define findfirst_t intptr_t
 
 #if (_MSC_VER >= 1800) // Visual Studio 2013 or newer
 #define HAVE_STDBOOL_H 1
@@ -60,8 +60,6 @@ typedef enum { false, true } bool;
 # include <_mingw.h>
 # define HAVE_STDBOOL_H 1
 # define HAVE_DIRENT_H 1
-# define HAVE__FINDFIRST 1
-# define findfirst_t long
 # define ffblk _finddata_t
 # define FA_DIREC _A_SUBDIR
 # define ff_name name

--- a/main/gcc-attr.h
+++ b/main/gcc-attr.h
@@ -14,11 +14,7 @@
 
 /*  Prevent warnings about unused variables in GCC. */
 #if defined (__GNUC__) && !defined (__GNUG__)
-# ifdef __MINGW32__
-#  define CTAGS_ATTR_UNUSED
-# else
-#  define CTAGS_ATTR_UNUSED __attribute__((unused))
-# endif
+# define CTAGS_ATTR_UNUSED __attribute__((unused))
 # define CTAGS_ATTR_PRINTF(s,f)  __attribute__((format (printf, s, f)))
 # define attr__noreturn __attribute__((__noreturn__))
 #else

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -25,6 +25,8 @@
 #endif
 #include <regex.h>
 
+#include <inttypes.h>
+
 #include "debug.h"
 #include "colprint_p.h"
 #include "entry_p.h"
@@ -2753,10 +2755,10 @@ static void   guestRequestSubmit (struct guestRequest *r)
 {
 	const char *langName = getLanguageName (r->lang);
 	verbose ("guestRequestSubmit: %s; "
-			 "range: %lld - %lld\n",
+			 "range: %"PRId64" - %"PRId64"\n",
 			 langName,
-			 (long long)r->boundary[BOUNDARY_START].offset,
-			 (long long)r->boundary[BOUNDARY_END].offset);
+			 (int64_t)r->boundary[BOUNDARY_START].offset,
+			 (int64_t)r->boundary[BOUNDARY_END].offset);
 	makePromiseForAreaSpecifiedWithOffsets (langName,
 											r->boundary[BOUNDARY_START].offset,
 											r->boundary[BOUNDARY_END].offset);

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -25,6 +25,8 @@
 #endif
 #include <regex.h>
 
+#include <inttypes.h>
+
 #include "debug.h"
 #include "colprint_p.h"
 #include "entry_p.h"
@@ -2753,7 +2755,7 @@ static void   guestRequestSubmit (struct guestRequest *r)
 {
 	const char *langName = getLanguageName (r->lang);
 	verbose ("guestRequestSubmit: %s; "
-			 "range: %ld - %ld\n",
+			 "range: %"PRIdPTR" - %"PRIdPTR"\n",
 			 langName,
 			 r->boundary[BOUNDARY_START].offset,
 			 r->boundary[BOUNDARY_END].offset);

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -25,8 +25,6 @@
 #endif
 #include <regex.h>
 
-#include <inttypes.h>
-
 #include "debug.h"
 #include "colprint_p.h"
 #include "entry_p.h"
@@ -2755,10 +2753,10 @@ static void   guestRequestSubmit (struct guestRequest *r)
 {
 	const char *langName = getLanguageName (r->lang);
 	verbose ("guestRequestSubmit: %s; "
-			 "range: %"PRIdPTR" - %"PRIdPTR"\n",
+			 "range: %lld - %lld\n",
 			 langName,
-			 r->boundary[BOUNDARY_START].offset,
-			 r->boundary[BOUNDARY_END].offset);
+			 (long long)r->boundary[BOUNDARY_START].offset,
+			 (long long)r->boundary[BOUNDARY_END].offset);
 	makePromiseForAreaSpecifiedWithOffsets (langName,
 											r->boundary[BOUNDARY_START].offset,
 											r->boundary[BOUNDARY_END].offset);

--- a/main/routines.c
+++ b/main/routines.c
@@ -129,7 +129,9 @@
  */
 #if defined (WIN32)
 # if defined (_MSC_VER) || defined (__MINGW32__)
-#  define stat    _stat
+#  ifndef stat
+#   define stat    _stat
+#  endif
 #  define getcwd  _getcwd
 #  define currentdrive() (_getdrive() + 'A' - 1)
 # else


### PR DESCRIPTION
There are several warnings when compiled with MinGW:
https://ci.appveyor.com/project/universalctags/ctags/builds/27959476/job/7xggnuxg5wf97wqh#L673

This suppress some of the warnings.

* Check the existence of direct.h for `_getdrive()`.
* Don't redefine `stat`.
* Use proper size for printf format string.