### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,12 @@ indent_size = 4
 indent_style = tab
 trim_trailing_whitespace = true
 
+[fnmatch/*.{c,h}]
+tab_width = 8
+
+[gnu_regex/*.{c,h}]
+tab_width = 8
+
 [win32/*]
 end_of_line = crlf
 


### PR DESCRIPTION
GNU source's tab width is 8. It is different from indent size.

(Should indent size be 2 for GNU style?)