### PR TITLE
units: Don't test parser-cxx.r/cxx-keywords-as-c-identifiers twice

### DIFF
--- a/Units/parser-cxx.r/cxx-keywords-as-c-identifiers.b/input.c
+++ b/Units/parser-cxx.r/cxx-keywords-as-c-identifiers.b/input.c
@@ -1,1 +1,0 @@
-#include "input.h"


### PR DESCRIPTION
`parser-cxx.r/cxx-keywords-as-c-identifiers` had two input files: `input.c` and `input.h`.
This causes the test being executed twice. Actually, `input.c` is not used. So, delete it.

(Found while implementing #2240.)