### PR TITLE
appveyor: Enable jansson, libxml2 and libyaml on Cygwin

### DIFF
--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -244,7 +244,7 @@ goto :eof
 :: ----------------------------------------------------------------------
 :: Using Cygwin, iconv enabled
 @echo on
-c:\cygwin64\setup-x86_64.exe -qnNdO -P dos2unix,libiconv-devel
+c:\cygwin64\setup-x86_64.exe -qnNdO -P dos2unix,libiconv-devel,libjansson-devel,libxml2-devel,libyaml-devel
 PATH c:\cygwin64\bin;%PATH%
 set CHERE_INVOKING=yes
 bash -lc "./autogen.sh"


### PR DESCRIPTION
Currently, these features are not enabled. Enable them.