### PR TITLE
units: store regex pattern to variable

### DIFF
--- a/misc/units
+++ b/misc/units
@@ -767,9 +767,10 @@ failure_in_globing ()
 {
     # skip if globing failed, also ignore backup files
     local file=$1
+    local pat='~$|\*'
     # use [[ if it is available in the shell implementation.
     if type '[[' > /dev/null 2>&1; then
-	if [[ "$file" =~ ~$|\* ]]; then
+	if [[ "$file" =~ $pat ]]; then
 	    return 0
 	fi
     else


### PR DESCRIPTION
NOTE: units.py may come in soon, this change for the original units shell script is not so meaningful.

zsh expects the operand of =~ operator inside [[ ... ]] to be quoted.
bash doesn't.

To fill the gap between zsh and bash, this change stores the
regex pattern to a variable, and refers the variable as
the operand.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>