### PR TITLE
main,win32: Work around that sometimes mkstemp() fails

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -28,7 +28,9 @@
 #include <crt_externs.h>
 #endif
 
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 /*  To provide directory searching for recursion feature.
  */
@@ -546,6 +548,11 @@ static void sanitizeEnviron (void)
 extern int ctags_cli_main (int argc CTAGS_ATTR_UNUSED, char **argv)
 {
 	cookedArgs *args;
+
+#if defined(WIN32) && defined(HAVE_MKSTEMP)
+	/* MinGW-w64's mkstemp() uses rand() for generating temporary files. */
+	srand ((unsigned int) clock ());
+#endif
 
 	initDefaultTrashBox ();
 

--- a/main/routines.c
+++ b/main/routines.c
@@ -914,6 +914,19 @@ extern MIO *tempFile (const char *const mode, char **const pName)
 	name = xMalloc (strlen (tmpdir) + 1 + strlen (pattern) + 1, char);
 	sprintf (name, "%s%c%s", tmpdir, OUTPUT_PATH_SEPARATOR, pattern);
 	fd = mkstemp (name);
+# ifdef WIN32
+	if (fd == -1)
+	{
+		/* mkstemp() sometimes fails with unknown reasons.
+		 * Retry a few times. */
+		int i;
+		for (i = 0; i < 5 && fd == -1; i++)
+		{
+			sprintf (name, "%s%c%s", tmpdir, OUTPUT_PATH_SEPARATOR, pattern);
+			fd = mkstemp (name);
+		}
+	}
+# endif
 	eStatFree (file);
 #elif defined(HAVE_TEMPNAM)
 	const char *tmpdir = NULL;


### PR DESCRIPTION
It seems that mkstemp() (from MinGW-w64) sometimes fails with permission
error or some other reasons, especially when running multiple commands
in parallel.

mkstemp() uses rand() but srand() was not called in our code.
Initialize srand() and retry mkstemp() several times as a workaround.

See https://github.com/universal-ctags/ctags/pull/2240#issuecomment-544528511.