### PR TITLE
buildsys: Show program name and version on top of configure command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,9 +8,7 @@
 
 AC_PREREQ([2.59])
 AC_INIT([universal-ctags],[0.0.0])
-AM_INIT_AUTOMAKE([foreign subdir-objects tar-ustar])
-AM_SILENT_RULES([yes])
-AC_CONFIG_HEADERS([config.h])
+
 if ! test -e "${srcdir}/config.h.in"; then
    echo "---"
    echo "--- ${srcdir}/config.h.in WAS NOT FOUND." 1>&2
@@ -19,6 +17,17 @@ if ! test -e "${srcdir}/config.h.in"; then
    echo "---"
    exit 1
 fi
+
+# Report system info
+# ------------------
+program_name=[`grep 'PROGRAM_NAME  *"' $srcdir/main/ctags.h | sed -e 's/.*"\([^"]*\)".*/\1/'`]
+program_version=[`grep 'PROGRAM_VERSION  *"' $srcdir/main/ctags.h | sed -e 's/.*"\([^"]*\)".*/\1/'`]
+echo "$program_name, version $program_version"
+uname -mrsv 2>/dev/null
+
+AM_INIT_AUTOMAKE([foreign subdir-objects tar-ustar])
+AM_SILENT_RULES([yes])
+AC_CONFIG_HEADERS([config.h])
 
 AC_CANONICAL_BUILD
 AC_CANONICAL_HOST
@@ -85,13 +94,6 @@ AH_TEMPLATE([MSDOS_STYLE_PATH],
 AH_TEMPLATE([ENABLE_GCOV],
 	[Define to 1 if gcov is instrumented.])
 
-
-# Report system info
-# ------------------
-program_name=[`grep 'PROGRAM_NAME  *"' $srcdir/main/ctags.h | sed -e 's/.*"\([^"]*\)".*/\1/'`]
-program_version=[`grep 'PROGRAM_VERSION  *"' $srcdir/main/ctags.h | sed -e 's/.*"\([^"]*\)".*/\1/'`]
-echo "$program_name, version $program_version"
-uname -mrsv 2>/dev/null
 
 # Define convenience macros
 # -------------------------


### PR DESCRIPTION
Program name and version were shown on top of configure command a few
years ago. (Maybe, before #497.)
Bring them to the top again.

E.g.

Before:

	$ ./configure
	checking for a BSD-compatible install... /usr/bin/install -c
	checking whether build environment is sane... yes
	checking for a thread-safe mkdir -p... /usr/bin/mkdir -p
	checking for gawk... gawk
	checking whether make sets $(MAKE)... yes
	checking whether make supports nested variables... yes
	checking whether UID '197609' is supported by ustar format... yes
	checking whether GID '197609' is supported by ustar format... yes
	checking how to create a ustar tar archive... gnutar
	checking whether make supports nested variables... (cached) yes
	checking build system type... x86_64-pc-cygwin
	checking host system type... x86_64-pc-cygwin
	Universal Ctags, version 0.0.0
	CYGWIN_NT-10.0 3.0.7(0.338/5/3) 2019-04-30 18:08 x86_64
	...

After:

	$ ./configure
	Universal Ctags, version 0.0.0
	CYGWIN_NT-10.0 3.0.7(0.338/5/3) 2019-04-30 18:08 x86_64
	checking for a BSD-compatible install... /usr/bin/install -c
	checking whether build environment is sane... yes
	...