### PR TITLE
buildsys: Add --enable-static option to ./configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -198,6 +198,10 @@ AC_ARG_ENABLE([debugging],
 	[AS_HELP_STRING([--enable-debugging],
 		[enable debugging features])])
 
+AC_ARG_ENABLE([static],
+	[AS_HELP_STRING([--enable-static],
+		[enable static linking (mainly for MinGW)])])
+
 AC_ARG_PROGRAM
 
 # Process configuration options
@@ -449,6 +453,10 @@ AC_C_CONST
 AC_OBJEXT
 AC_EXEEXT
 
+if test "${enable_static}" = "yes"; then
+	LDFLAGS="$LDFLAGS -static"
+fi
+
 # Check for host type
 case "$host" in
   i?86-*-mingw* | x86_64-*-mingw*)
@@ -592,6 +600,12 @@ AC_CHECK_FUNCS(scandir,have_scandir=yes)
 have_dirent_h=no
 AC_CHECK_HEADERS(dirent.h,have_dirent_h=yes)
 
+dnl Dummy check for setting $PKG_CONFIG.
+PKG_CHECK_EXISTS([dummy])
+if test "${enable_static}" = "yes"; then
+	PKG_CONFIG="$PKG_CONFIG --static"
+fi
+
 AC_ARG_ENABLE([xml],
 	[AS_HELP_STRING([--disable-xml],
 		[disable xml support])])
@@ -608,6 +622,15 @@ AS_IF([test "x$enable_xml" != "xno"], [
 			           AC_MSG_ERROR([libxml2 not found])])])
 ])
 AM_CONDITIONAL(HAVE_LIBXML, test "x$have_libxml" = xyes)
+
+if test "${enable_static}" = "yes"; then
+	if test "${have_libxml}" = "yes"; then
+		if test "${host_mingw}" = "yes"; then
+			dnl -DLIBXML_STATIC needs to be added manually.
+			LIBXML_CFLAGS="$LIBXML_CFLAGS -DLIBXML_STATIC"
+		fi
+	fi
+fi
 
 AC_ARG_ENABLE([json],
 	[AS_HELP_STRING([--disable-json],

--- a/docs/windows.rst
+++ b/docs/windows.rst
@@ -106,7 +106,7 @@ If you want to build a single static-linked binary, you can use the following co
 .. code-block:: bash
 
         ./autogen.sh
-        ./configure --disable-external-sort EXTRA_CFLAGS=-DLIBXML_STATIC LDFLAGS=-static LIBS='-lz -llzma -lws2_32'
+        ./configure --disable-external-sort --enable-static
         make
 
 ``--disable-external-sort`` is a recommended option for Windows builds.

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -155,7 +155,7 @@ bash -lc "for i in {1..3}; do pacman --noconfirm --noprogressbar -S --needed min
 
 bash -lc "./autogen.sh"
 :: Use static link.
-bash -lc "./configure --enable-iconv --disable-external-sort EXTRA_CFLAGS=-DLIBXML_STATIC LDFLAGS=-static LIBS='-lz -llzma -lws2_32' && make"
+bash -lc "./configure --disable-external-sort --enable-static && make"
 
 @echo off
 goto :eof


### PR DESCRIPTION
Support static linking on MinGW.

Actually, we can enable static linking even without this PR, however, many options are needed for that.
This PR makes it easy.
