### PR TITLE
buildsys: Don't make Makefiles for each *.d directory

### DIFF
--- a/misc/dist-test-cases
+++ b/misc/dist-test-cases
@@ -60,9 +60,15 @@ make_am_with_git ()
     cd "${git_top}"
     for top_d in $(git ls-tree --name-only HEAD | sort); do
 	if [ -d "${top_d}" ]; then
-	    echo "DIST_SUBDIRS +=" "${top_d}"
-	    make_am_sub_with_git ${top_d} > ${top_d}/Makefile.am
-	    echo "AC_CONFIG_FILES([${git_top}/${top_d}/Makefile])" >> dist.m4
+	    if [ "${top_d##*.}" = "r" ]; then
+		echo "DIST_SUBDIRS +=" "${top_d}"
+		make_am_sub_with_git ${top_d} > ${top_d}/Makefile.am
+		echo "AC_CONFIG_FILES([${git_top}/${top_d}/Makefile])" >> dist.m4
+	    else
+		for sub_f in $(git ls-files ${top_d}); do
+		    echo "EXTRA_DIST   +=" "${sub_f}"
+		done
+	    fi
 	else
 	    echo "EXTRA_DIST   +=" "${top_d}"
 	fi


### PR DESCRIPTION
Creating many Makefiles slows down `./configure` especially on Cygwin/MSYS2.
Reduce the number of Makefiles to avoid it. Create only in `*.r` directories.

This has a potential risk that it may cause #1952 again.
I don't know how many files are accepted in one Makefile.