### PR TITLE
Tmain: Speed up filter_by_column_index

### DIFF
--- a/Tmain/utils.sh
+++ b/Tmain/utils.sh
@@ -116,15 +116,19 @@ filter_by_column_index()
 	local column
 	local tmp
 
-	while read line; do
-		tmp=0
-		for column in $line; do
-			if [ $tmp = $index ]; then
-				echo $column
-			fi
-			tmp=$(expr $tmp + 1)
+	if type awk > /dev/null; then
+		awk '{print $'$(expr $index + 1)'}'
+	else
+		while read line; do
+			tmp=0
+			for column in $line; do
+				if [ $tmp = $index ]; then
+					echo $column
+				fi
+				tmp=$(expr $tmp + 1)
+			done
 		done
-	done
+	fi
 }
 
 echo2()

--- a/Tmain/utils.sh
+++ b/Tmain/utils.sh
@@ -112,23 +112,7 @@ filter_by_column_index()
 {
 	local index=$1
 
-	local line
-	local column
-	local tmp
-
-	if type awk > /dev/null; then
-		awk '{print $'$(expr $index + 1)'}'
-	else
-		while read line; do
-			tmp=0
-			for column in $line; do
-				if [ $tmp = $index ]; then
-					echo $column
-				fi
-				tmp=$(expr $tmp + 1)
-			done
-		done
-	fi
+	awk '{print $'$(expr $index + 1)'}'
 }
 
 echo2()

--- a/misc/units
+++ b/misc/units
@@ -2256,6 +2256,9 @@ action_tmain ()
 	ERROR 1 "unexpected option argument for --colorized-output: ${COLORIZED_OUTPUT}"
     fi
 
+    check_availability awk
+    check_availability diff
+
     tmain_run ${tmain_dir} ${build_dir} ${UNITS}
     return $?
 }


### PR DESCRIPTION
`filter_by_column_index` function is really slow on Cygwin/MSYS2.  This
is used by the test `option-extras-enabling-all` and it takes about 15
seconds in my environment.  Use awk if available.  Now it takes less
than 2 seconds.