### PR TITLE
[WIP] C++:  make tags for type parameters

### DIFF
--- a/Units/parser-cxx.r/bug-github-2263.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug-github-2263.cpp.d/expected.tags
@@ -1,24 +1,41 @@
+T	input.cc	/^template <class T> class C0 {$/;"	Z
 C0	input.cc	/^template <class T> class C0 {$/;"	c	file:
 t	input.cc	/^  T t;$/;"	m	class:C0	typeref:typename:T	file:
+T	input.cc	/^template <class T, typename T0 = C0<const T>> class C1 {$/;"	Z
+T0	input.cc	/^template <class T, typename T0 = C0<const T>> class C1 {$/;"	Z
 C1	input.cc	/^template <class T, typename T0 = C0<const T>> class C1 {$/;"	c	file:
 t0	input.cc	/^  T0 t0;$/;"	m	class:C1	typeref:typename:T0	file:
 c1rehash	input.cc	/^  void c1rehash() {}$/;"	f	class:C1	typeref:typename:void	file:
+T	input.cc	/^template <class T, typename T1 = C0<C0<const T>>> class C2 {$/;"	Z
+T1	input.cc	/^template <class T, typename T1 = C0<C0<const T>>> class C2 {$/;"	Z
 C2	input.cc	/^template <class T, typename T1 = C0<C0<const T>>> class C2 {$/;"	c	file:
 t1	input.cc	/^  T1 t1;$/;"	m	class:C2	typeref:typename:T1	file:
 c2rehash	input.cc	/^  void c2rehash() {}$/;"	f	class:C2	typeref:typename:void	file:
+T	input.cc	/^template <class T, typename T2 = C0<C0<C0<const T>>>> class C3 {$/;"	Z
+T2	input.cc	/^template <class T, typename T2 = C0<C0<C0<const T>>>> class C3 {$/;"	Z
 C3	input.cc	/^template <class T, typename T2 = C0<C0<C0<const T>>>> class C3 {$/;"	c	file:
 t2	input.cc	/^  T2 t2;$/;"	m	class:C3	typeref:typename:T2	file:
 c3rehash	input.cc	/^  void c3rehash() {}$/;"	f	class:C3	typeref:typename:void	file:
+T	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>> class C4 {$/;"	Z
+T3	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>> class C4 {$/;"	Z
 C4	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>> class C4 {$/;"	c	file:
 t3	input.cc	/^  T3 t3;$/;"	m	class:C4	typeref:typename:T3	file:
 c4rehash	input.cc	/^  void c4rehash() {}$/;"	f	class:C4	typeref:typename:void	file:
+T	input.cc	/^template <class T, typename T4 = C0<C0<C0<C0<C0<const T>>>>>> class C5 {$/;"	Z
+T4	input.cc	/^template <class T, typename T4 = C0<C0<C0<C0<C0<const T>>>>>> class C5 {$/;"	Z
 C5	input.cc	/^template <class T, typename T4 = C0<C0<C0<C0<C0<const T>>>>>> class C5 {$/;"	c	file:
 t4	input.cc	/^  T4 t4;$/;"	m	class:C5	typeref:typename:T4	file:
 c5rehash	input.cc	/^  void c5rehash() {}$/;"	f	class:C5	typeref:typename:void	file:
+T	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = int> class C4x1 {$/;"	Z
+T3	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = int> class C4x1 {$/;"	Z
+S	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = int> class C4x1 {$/;"	Z
 C4x1	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = int> class C4x1 {$/;"	c	file:
 t3	input.cc	/^  T3 t3;$/;"	m	class:C4x1	typeref:typename:T3	file:
 s	input.cc	/^  S  s;$/;"	m	class:C4x1	typeref:typename:S	file:
 c4x1rehash	input.cc	/^  void c4x1rehash() {}$/;"	f	class:C4x1	typeref:typename:void	file:
+T	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = C0<const T>> class C4x2 {$/;"	Z
+T3	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = C0<const T>> class C4x2 {$/;"	Z
+S	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = C0<const T>> class C4x2 {$/;"	Z
 C4x2	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = C0<const T>> class C4x2 {$/;"	c	file:
 t3	input.cc	/^  T3 t3;$/;"	m	class:C4x2	typeref:typename:T3	file:
 s	input.cc	/^  S  s;$/;"	m	class:C4x2	typeref:typename:S	file:

--- a/Units/parser-cxx.r/bug-github-2263.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug-github-2263.cpp.d/expected.tags
@@ -1,41 +1,41 @@
-T	input.cc	/^template <class T> class C0 {$/;"	Z
+T	input.cc	/^template <class T> class C0 {$/;"	Z	class:C0
 C0	input.cc	/^template <class T> class C0 {$/;"	c	file:
 t	input.cc	/^  T t;$/;"	m	class:C0	typeref:typename:T	file:
-T	input.cc	/^template <class T, typename T0 = C0<const T>> class C1 {$/;"	Z
-T0	input.cc	/^template <class T, typename T0 = C0<const T>> class C1 {$/;"	Z
+T	input.cc	/^template <class T, typename T0 = C0<const T>> class C1 {$/;"	Z	class:C1
+T0	input.cc	/^template <class T, typename T0 = C0<const T>> class C1 {$/;"	Z	class:C1
 C1	input.cc	/^template <class T, typename T0 = C0<const T>> class C1 {$/;"	c	file:
 t0	input.cc	/^  T0 t0;$/;"	m	class:C1	typeref:typename:T0	file:
 c1rehash	input.cc	/^  void c1rehash() {}$/;"	f	class:C1	typeref:typename:void	file:
-T	input.cc	/^template <class T, typename T1 = C0<C0<const T>>> class C2 {$/;"	Z
-T1	input.cc	/^template <class T, typename T1 = C0<C0<const T>>> class C2 {$/;"	Z
+T	input.cc	/^template <class T, typename T1 = C0<C0<const T>>> class C2 {$/;"	Z	class:C2
+T1	input.cc	/^template <class T, typename T1 = C0<C0<const T>>> class C2 {$/;"	Z	class:C2
 C2	input.cc	/^template <class T, typename T1 = C0<C0<const T>>> class C2 {$/;"	c	file:
 t1	input.cc	/^  T1 t1;$/;"	m	class:C2	typeref:typename:T1	file:
 c2rehash	input.cc	/^  void c2rehash() {}$/;"	f	class:C2	typeref:typename:void	file:
-T	input.cc	/^template <class T, typename T2 = C0<C0<C0<const T>>>> class C3 {$/;"	Z
-T2	input.cc	/^template <class T, typename T2 = C0<C0<C0<const T>>>> class C3 {$/;"	Z
+T	input.cc	/^template <class T, typename T2 = C0<C0<C0<const T>>>> class C3 {$/;"	Z	class:C3
+T2	input.cc	/^template <class T, typename T2 = C0<C0<C0<const T>>>> class C3 {$/;"	Z	class:C3
 C3	input.cc	/^template <class T, typename T2 = C0<C0<C0<const T>>>> class C3 {$/;"	c	file:
 t2	input.cc	/^  T2 t2;$/;"	m	class:C3	typeref:typename:T2	file:
 c3rehash	input.cc	/^  void c3rehash() {}$/;"	f	class:C3	typeref:typename:void	file:
-T	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>> class C4 {$/;"	Z
-T3	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>> class C4 {$/;"	Z
+T	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>> class C4 {$/;"	Z	class:C4
+T3	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>> class C4 {$/;"	Z	class:C4
 C4	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>> class C4 {$/;"	c	file:
 t3	input.cc	/^  T3 t3;$/;"	m	class:C4	typeref:typename:T3	file:
 c4rehash	input.cc	/^  void c4rehash() {}$/;"	f	class:C4	typeref:typename:void	file:
-T	input.cc	/^template <class T, typename T4 = C0<C0<C0<C0<C0<const T>>>>>> class C5 {$/;"	Z
-T4	input.cc	/^template <class T, typename T4 = C0<C0<C0<C0<C0<const T>>>>>> class C5 {$/;"	Z
+T	input.cc	/^template <class T, typename T4 = C0<C0<C0<C0<C0<const T>>>>>> class C5 {$/;"	Z	class:C5
+T4	input.cc	/^template <class T, typename T4 = C0<C0<C0<C0<C0<const T>>>>>> class C5 {$/;"	Z	class:C5
 C5	input.cc	/^template <class T, typename T4 = C0<C0<C0<C0<C0<const T>>>>>> class C5 {$/;"	c	file:
 t4	input.cc	/^  T4 t4;$/;"	m	class:C5	typeref:typename:T4	file:
 c5rehash	input.cc	/^  void c5rehash() {}$/;"	f	class:C5	typeref:typename:void	file:
-T	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = int> class C4x1 {$/;"	Z
-T3	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = int> class C4x1 {$/;"	Z
-S	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = int> class C4x1 {$/;"	Z
+T	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = int> class C4x1 {$/;"	Z	class:C4x1
+T3	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = int> class C4x1 {$/;"	Z	class:C4x1
+S	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = int> class C4x1 {$/;"	Z	class:C4x1
 C4x1	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = int> class C4x1 {$/;"	c	file:
 t3	input.cc	/^  T3 t3;$/;"	m	class:C4x1	typeref:typename:T3	file:
 s	input.cc	/^  S  s;$/;"	m	class:C4x1	typeref:typename:S	file:
 c4x1rehash	input.cc	/^  void c4x1rehash() {}$/;"	f	class:C4x1	typeref:typename:void	file:
-T	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = C0<const T>> class C4x2 {$/;"	Z
-T3	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = C0<const T>> class C4x2 {$/;"	Z
-S	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = C0<const T>> class C4x2 {$/;"	Z
+T	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = C0<const T>> class C4x2 {$/;"	Z	class:C4x2
+T3	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = C0<const T>> class C4x2 {$/;"	Z	class:C4x2
+S	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = C0<const T>> class C4x2 {$/;"	Z	class:C4x2
 C4x2	input.cc	/^template <class T, typename T3 = C0<C0<C0<C0<const T>>>>, class S = C0<const T>> class C4x2 {$/;"	c	file:
 t3	input.cc	/^  T3 t3;$/;"	m	class:C4x2	typeref:typename:T3	file:
 s	input.cc	/^  S  s;$/;"	m	class:C4x2	typeref:typename:S	file:

--- a/Units/parser-cxx.r/bug1563476.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1563476.cpp.d/expected.tags
@@ -1,3 +1,6 @@
 g	input.cpp	/^int g() {$/;"	f	typeref:typename:int
+Accessor	input.cpp	/^template< typename Accessor, typename bEnable = void >$/;"	Z
+bEnable	input.cpp	/^template< typename Accessor, typename bEnable = void >$/;"	Z
+Accessor	input.cpp	/^template< typename Accessor >$/;"	Z
 IntroduceBitDef	input.cpp	/^struct IntroduceBitDef< Accessor, typename$/;"	s	file:
 f	input.cpp	/^ int f() { }$/;"	f	struct:IntroduceBitDef	typeref:typename:int	file:

--- a/Units/parser-cxx.r/template-specializations.d/expected.tags
+++ b/Units/parser-cxx.r/template-specializations.d/expected.tags
@@ -1,14 +1,21 @@
+T	input.cpp	/^template<typename T>$/;"	Z
 A	input.cpp	/^struct A {$/;"	s	file:	template:<typename T>
 f	input.cpp	/^    void f(T); \/\/ member, declared in the primary template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T)
 h	input.cpp	/^    void h(T) {} \/\/ member, defined in the primary template$/;"	f	struct:A	typeref:typename:void	file:	signature:(T)
+X1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	Z	struct:A
 g1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T,X1)	template:<class X1>
+X2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	Z	struct:A
 g2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T,X2)	template:<class X2>
 f	input.cpp	/^template<> void A<int>::f(int);$/;"	p	class:A	typeref:typename:void	file:	signature:(int)	template:<>	properties:scopespecialization,specialization
 h	input.cpp	/^template<> void A<int>::h(int) {}$/;"	f	class:A	typeref:typename:void	signature:(int)	template:<>	properties:scopespecialization,specialization
+T	input.cpp	/^template<class T>$/;"	Z
+X1	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	Z
 g1	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	f	class:A	typeref:typename:void	signature:(T,X1)	template:<class X1>	properties:scopespecialization,specialization
+X1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	Z
 g1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	p	class:A	typeref:typename:void	file:	signature:(int,X1)	template:<class X1>	properties:scopespecialization,specialization
 g2	input.cpp	/^template<> void A<int>::g2<char>(int, char); \/\/ for X2 = char$/;"	p	class:A	typeref:typename:void	file:	signature:(int,char)	template:<>	properties:scopespecialization,specialization
 g1	input.cpp	/^template<> void A<int>::g1(int, char);$/;"	p	class:A	typeref:typename:void	file:	signature:(int,char)	template:<>	properties:scopespecialization,specialization
+X	input.cpp	/^template<typename X> void m(X)$/;"	Z
 m	input.cpp	/^template<typename X> void m(X)$/;"	f	typeref:typename:void	signature:(X)	template:<typename X>
 m	input.cpp	/^template<> void m<int>(int)$/;"	f	typeref:typename:void	signature:(int)	template:<>	properties:specialization
 m	input.cpp	/^template<> void m<A>(A)$/;"	f	typeref:typename:void	signature:(A)	template:<>	properties:specialization

--- a/Units/parser-cxx.r/template-type-params.d/args.ctags
+++ b/Units/parser-cxx.r/template-type-params.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-C++=+Z

--- a/Units/parser-cxx.r/template-type-params.d/expected.tags
+++ b/Units/parser-cxx.r/template-type-params.d/expected.tags
@@ -1,0 +1,10 @@
+T	input.cpp	/^template <typename T, typename S>$/;"	Z
+S	input.cpp	/^template <typename T, typename S>$/;"	Z
+f	input.cpp	/^S f (T a, T b)$/;"	f	typeref:typename:S
+f	input.cpp	/^int f (int a, int b)$/;"	f	typeref:typename:int
+T	input.cpp	/^template <typename T>$/;"	Z
+klass	input.cpp	/^class klass$/;"	c	file:
+v	input.cpp	/^  T v;$/;"	m	class:klass	typeref:typename:T	file:
+g	input.cpp	/^  T g (T a)$/;"	f	class:klass	typeref:typename:T	file:
+T	input.cpp	/^template <class T>$/;"	Z
+c	input.cpp	/^using c = klass<T>;$/;"	t	typeref:typename:klass<T>	file:

--- a/Units/parser-cxx.r/template-type-params.d/expected.tags
+++ b/Units/parser-cxx.r/template-type-params.d/expected.tags
@@ -1,8 +1,8 @@
-T	input.cpp	/^template <typename T, typename S>$/;"	Z
-S	input.cpp	/^template <typename T, typename S>$/;"	Z
+T	input.cpp	/^template <typename T, typename S>$/;"	Z	function:f
+S	input.cpp	/^template <typename T, typename S>$/;"	Z	function:f
 f	input.cpp	/^S f (T a, T b)$/;"	f	typeref:typename:S
 f	input.cpp	/^int f (int a, int b)$/;"	f	typeref:typename:int
-T	input.cpp	/^template <typename T>$/;"	Z
+T	input.cpp	/^template <typename T>$/;"	Z	class:klass
 klass	input.cpp	/^class klass$/;"	c	file:
 v	input.cpp	/^  T v;$/;"	m	class:klass	typeref:typename:T	file:
 g	input.cpp	/^  T g (T a)$/;"	f	class:klass	typeref:typename:T	file:

--- a/Units/parser-cxx.r/template-type-params.d/input.cpp
+++ b/Units/parser-cxx.r/template-type-params.d/input.cpp
@@ -1,0 +1,25 @@
+template <typename T, typename S>
+S f (T a, T b)
+{
+  return (S) (a + b);
+}
+
+template <>
+int f (int a, int b)
+{
+  return a + b;
+}
+
+template <typename T>
+class klass
+{
+public:
+  T v;
+  T g (T a)
+  {
+    return f<T>(a, v);
+  }
+};
+
+template <class T>
+using c = klass<T>;

--- a/Units/parser-cxx.r/templates.d/expected.tags
+++ b/Units/parser-cxx.r/templates.d/expected.tags
@@ -1,9 +1,12 @@
+T	input.cpp	/^template <typename T> int $/;"	Z
 zero	input.cpp	/^zero (const T &v1, const T &v2)$/;"	f	typeref:typename:int	template:<typename T>
 v1	input.cpp	/^zero (const T &v1, const T &v2)$/;"	z	function:zero	typeref:typename:const T &	file:
 v2	input.cpp	/^zero (const T &v1, const T &v2)$/;"	z	function:zero	typeref:typename:const T &	file:
+T	input.cpp	/^template <typename T> inline T $/;"	Z
 min	input.cpp	/^min(const T&v1, const T&v2)$/;"	f	typeref:typename:T	template:<typename T>
 v1	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:typename:const T &	file:
 v2	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:typename:const T &	file:
+Type	input.cpp	/^template <class Type> $/;"	Z
 Item	input.cpp	/^class Item$/;"	c	file:	template:<class Type>
 Item	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	f	class:Item	file:
 Item::Item	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	f	class:Item	file:

--- a/Units/parser-cxx.r/templates.d/expected.tags
+++ b/Units/parser-cxx.r/templates.d/expected.tags
@@ -1,12 +1,12 @@
-T	input.cpp	/^template <typename T> int $/;"	Z
+T	input.cpp	/^template <typename T> int $/;"	Z	function:zero
 zero	input.cpp	/^zero (const T &v1, const T &v2)$/;"	f	typeref:typename:int	template:<typename T>
 v1	input.cpp	/^zero (const T &v1, const T &v2)$/;"	z	function:zero	typeref:typename:const T &	file:
 v2	input.cpp	/^zero (const T &v1, const T &v2)$/;"	z	function:zero	typeref:typename:const T &	file:
-T	input.cpp	/^template <typename T> inline T $/;"	Z
+T	input.cpp	/^template <typename T> inline T $/;"	Z	function:min
 min	input.cpp	/^min(const T&v1, const T&v2)$/;"	f	typeref:typename:T	template:<typename T>
 v1	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:typename:const T &	file:
 v2	input.cpp	/^min(const T&v1, const T&v2)$/;"	z	function:min	typeref:typename:const T &	file:
-Type	input.cpp	/^template <class Type> $/;"	Z
+Type	input.cpp	/^template <class Type> $/;"	Z	class:Item
 Item	input.cpp	/^class Item$/;"	c	file:	template:<class Type>
 Item	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	f	class:Item	file:
 Item::Item	input.cpp	/^  Item(const Type &t) : item (t), next (0) { }$/;"	f	class:Item	file:

--- a/Units/parser-cxx.r/templates2.d/expected.tags
+++ b/Units/parser-cxx.r/templates2.d/expected.tags
@@ -1,10 +1,10 @@
-Container	input.cpp	/^template<template<class...> class Container, class Elem>$/;"	Z
-Elem	input.cpp	/^template<template<class...> class Container, class Elem>$/;"	Z
+Container	input.cpp	/^template<template<class...> class Container, class Elem>$/;"	Z	function:foo1
+Elem	input.cpp	/^template<template<class...> class Container, class Elem>$/;"	Z	function:foo1
 foo1	input.cpp	/^auto foo1(const Container<Elem> & p_container)$/;"	f	typeref:typename:auto	template:<template<class...> class Container,class Elem>
 p_container	input.cpp	/^auto foo1(const Container<Elem> & p_container)$/;"	z	function:foo1	typeref:typename:const Container<Elem> &	file:
-Container	input.cpp	/^template<template<class...> class Container, class Key, class Elem>$/;"	Z
-Key	input.cpp	/^template<template<class...> class Container, class Key, class Elem>$/;"	Z
-Elem	input.cpp	/^template<template<class...> class Container, class Key, class Elem>$/;"	Z
+Container	input.cpp	/^template<template<class...> class Container, class Key, class Elem>$/;"	Z	function:foo2
+Key	input.cpp	/^template<template<class...> class Container, class Key, class Elem>$/;"	Z	function:foo2
+Elem	input.cpp	/^template<template<class...> class Container, class Key, class Elem>$/;"	Z	function:foo2
 foo2	input.cpp	/^auto foo2(const Container<Key,Elem> & p_container)$/;"	f	typeref:typename:auto	template:<template<class...> class Container,class Key,class Elem>
 p_container	input.cpp	/^auto foo2(const Container<Key,Elem> & p_container)$/;"	z	function:foo2	typeref:typename:const Container<Key,Elem> &	file:
 bar	input.cpp	/^void bar()$/;"	f	typeref:typename:void

--- a/Units/parser-cxx.r/templates2.d/expected.tags
+++ b/Units/parser-cxx.r/templates2.d/expected.tags
@@ -1,5 +1,10 @@
+Container	input.cpp	/^template<template<class...> class Container, class Elem>$/;"	Z
+Elem	input.cpp	/^template<template<class...> class Container, class Elem>$/;"	Z
 foo1	input.cpp	/^auto foo1(const Container<Elem> & p_container)$/;"	f	typeref:typename:auto	template:<template<class...> class Container,class Elem>
 p_container	input.cpp	/^auto foo1(const Container<Elem> & p_container)$/;"	z	function:foo1	typeref:typename:const Container<Elem> &	file:
+Container	input.cpp	/^template<template<class...> class Container, class Key, class Elem>$/;"	Z
+Key	input.cpp	/^template<template<class...> class Container, class Key, class Elem>$/;"	Z
+Elem	input.cpp	/^template<template<class...> class Container, class Key, class Elem>$/;"	Z
 foo2	input.cpp	/^auto foo2(const Container<Key,Elem> & p_container)$/;"	f	typeref:typename:auto	template:<template<class...> class Container,class Key,class Elem>
 p_container	input.cpp	/^auto foo2(const Container<Key,Elem> & p_container)$/;"	z	function:foo2	typeref:typename:const Container<Key,Elem> &	file:
 bar	input.cpp	/^void bar()$/;"	f	typeref:typename:void

--- a/Units/parser-cxx.r/templates3.d/expected.tags
+++ b/Units/parser-cxx.r/templates3.d/expected.tags
@@ -1,3 +1,6 @@
+ValueType	input.cpp	/^template <typename ValueType, int N, typename SizeType>$/;"	Z
+N	input.cpp	/^template <typename ValueType, int N, typename SizeType>$/;"	Z
+SizeType	input.cpp	/^template <typename ValueType, int N, typename SizeType>$/;"	Z
 makeArrayRef	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	f	typeref:typename:boost::disable_if_c<N==1,ArrayRef<ValueType,SizeType>>::type	template:<typename ValueType,int N,typename SizeType>
 p_data	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	z	function:makeArrayRef	typeref:typename:ValueType (&)[N]	file:
 p_size	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	z	function:makeArrayRef	typeref:typename:SizeType &	file:

--- a/Units/parser-cxx.r/templates3.d/expected.tags
+++ b/Units/parser-cxx.r/templates3.d/expected.tags
@@ -1,6 +1,6 @@
-ValueType	input.cpp	/^template <typename ValueType, int N, typename SizeType>$/;"	Z
-N	input.cpp	/^template <typename ValueType, int N, typename SizeType>$/;"	Z
-SizeType	input.cpp	/^template <typename ValueType, int N, typename SizeType>$/;"	Z
+ValueType	input.cpp	/^template <typename ValueType, int N, typename SizeType>$/;"	Z	function:makeArrayRef
+N	input.cpp	/^template <typename ValueType, int N, typename SizeType>$/;"	Z	function:makeArrayRef
+SizeType	input.cpp	/^template <typename ValueType, int N, typename SizeType>$/;"	Z	function:makeArrayRef
 makeArrayRef	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	f	typeref:typename:boost::disable_if_c<N==1,ArrayRef<ValueType,SizeType>>::type	template:<typename ValueType,int N,typename SizeType>
 p_data	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	z	function:makeArrayRef	typeref:typename:ValueType (&)[N]	file:
 p_size	input.cpp	/^makeArrayRef(ValueType (&p_data)[N], SizeType& p_size)$/;"	z	function:makeArrayRef	typeref:typename:SizeType &	file:

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1005,7 +1005,7 @@ static bool cxxParserParseClassStructOrUnionInternal(
 		// FIXME: Should we add the specialisation arguments somewhere?
 		//        Maybe as a separate field?
 
-		bRet = cxxParserParseTemplateAngleBracketsToSeparateChain();
+		bRet = cxxParserParseTemplateAngleBracketsToSeparateChain(false);
 
 		if(!bRet)
 		{

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -10,6 +10,7 @@
 */
 
 #include "general.h"
+#include "numarray.h"
 
 #include "parse.h"
 
@@ -42,7 +43,7 @@ bool cxxParserHandleLambda(CXXToken * pParenthesis);
 
 // cxx_parser_block.c
 bool cxxParserParseBlock(bool bExpectClosingBracket);
-bool cxxParserParseBlockHandleOpeningBracket(void);
+bool cxxParserParseBlockHandleOpeningBracket(intArray *piaTypeParamCorks);
 
 enum CXXExtractVariableDeclarationsFlags
 {
@@ -215,7 +216,8 @@ bool cxxParserParseEnum(void);
 bool cxxParserParseClassStructOrUnion(
 		CXXKeyword eKeyword,
 		unsigned int uTagKind,
-		unsigned int uScopeType
+		unsigned int uScopeType,
+		intArray *piaTypeParamCorks
 	);
 bool cxxParserParseAndCondenseCurrentSubchain(
 		unsigned int uInitialSubchainMarkerTypes,
@@ -225,8 +227,8 @@ bool cxxParserParseAndCondenseCurrentSubchain(
 bool cxxParserParseUpToOneOf(unsigned int uTokenTypes,
 							 bool bCanReduceInnerElements);
 bool cxxParserParseIfForWhileSwitchCatchParenthesis(void);
-bool cxxParserParseTemplatePrefix(void);
-bool cxxParserParseTemplateAngleBracketsToSeparateChain(bool bCaptureTypeParams);
+bool cxxParserParseTemplatePrefix(intArray *piaTypeParamCorks);
+bool cxxParserParseTemplateAngleBracketsToSeparateChain(intArray *piaTypeParamCorks);
 bool cxxParserParseUsingClause(void);
 bool cxxParserParseAccessSpecifier(void);
 void cxxParserAnalyzeOtherStatement(void);

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -226,7 +226,7 @@ bool cxxParserParseUpToOneOf(unsigned int uTokenTypes,
 							 bool bCanReduceInnerElements);
 bool cxxParserParseIfForWhileSwitchCatchParenthesis(void);
 bool cxxParserParseTemplatePrefix(void);
-bool cxxParserParseTemplateAngleBracketsToSeparateChain(void);
+bool cxxParserParseTemplateAngleBracketsToSeparateChain(bool bCaptureTypeParams);
 bool cxxParserParseUsingClause(void);
 bool cxxParserParseAccessSpecifier(void);
 void cxxParserAnalyzeOtherStatement(void);

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -328,7 +328,9 @@ evaluate_current_token:
 											 CXXKeywordTYPENAME|CXXKeywordCLASS)
 						 &&
 						 g_cxx.pToken->pPrev &&
+						 // CXXTokenTypeGreaterThanSign is for T in "template<template<class...> class T,"
 						 cxxTokenTypeIsOneOf(g_cxx.pToken->pPrev,
+											 CXXTokenTypeGreaterThanSign|
 											 CXXTokenTypeSmallerThanSign|CXXTokenTypeComma))
 				{
 					/* < typename X , class Y> */

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -617,8 +617,12 @@ int cxxTagCommit(void)
 	return iCorkQueueIndex;
 }
 
-void cxxTag(unsigned int uKind,CXXToken * pToken)
+int cxxTag(unsigned int uKind,CXXToken * pToken)
 {
+	int iCorkQueueIndex = CORK_NIL;
+
 	if(cxxTagBegin(uKind,pToken) != NULL)
-		cxxTagCommit();
+		iCorkQueueIndex = cxxTagCommit();
+
+	return iCorkQueueIndex;
 }

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -75,6 +75,7 @@ static kindDefinition g_aCXXCPPKinds [] = {
 	{ false, 'N', "name",       "names imported via using scope::symbol" },
 	{ false, 'U', "using",      "using namespace statements",
 			.referenceOnly = true },
+	{ false, 'Z', "typeparam",  "type parameters in templates" },
 };
 
 static kindDefinition g_aCXXCUDAKinds [] = {

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -176,7 +176,7 @@ void cxxTagSetCorkQueueField(
 int cxxTagCommit(void);
 
 // Same as cxxTagBegin() eventually followed by cxxTagCommit()
-void cxxTag(unsigned int uKind,CXXToken * pToken);
+int cxxTag(unsigned int uKind,CXXToken * pToken);
 
 typedef enum {
 	CR_MACRO_UNDEF,

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -46,7 +46,8 @@ enum CXXTagCPPKind
 	CXXTagCPPKindNAMESPACE,
 	CXXTagCPPKindALIAS,
 	CXXTagCPPKindNAME,
-	CXXTagCPPKindUSING
+	CXXTagCPPKindUSING,
+	CXXTagKindTYPEPARAM,
 };
 
 // The fields common to all (sub)languages this parser supports.


### PR DESCRIPTION
See #2264.

@pragmaware, this is my version that is for capturing type parameters in template prefix.
I used corkIndex to track type parameters unlike your idea: tracking by CXXToken.
cork indexes for type parameters are stored to intArray.
To avoid memory leak, trashbox is used for the intArray object.

I'm thinking about introducing a symbol table by extending the cork queue.
So I think using cork inde for tracking type parameters is quite natutal.

I still get unexpected results for some test cases. So I marked [WIP] on this pull request.