### PR TITLE
travis: Revise build process

### DIFF
--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -27,18 +27,6 @@ if [ "$TARGET" = "Unix" ]; then
     BUILDDIR0="$TRAVIS_OS_NAME"-"$CC"
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CC" = "gcc" ]; then
 
-        BUILDDIR=${BUILDDIR0}
-        mkdir -p "${BUILDDIR}"
-        (
-            cd "${BUILDDIR}"
-            ${CONFIGURE_CMDLINE}
-            make -j2
-            echo 'Run "make tmain (sandbox only)" without gcov'
-            make tmain TRAVIS=1 UNITS=${SANDBOX_CASES}
-
-            make clean
-        )
-
         BUILDDIR=${BUILDDIR0}-gcov
         mkdir -p "${BUILDDIR}"
         (
@@ -53,8 +41,17 @@ if [ "$TARGET" = "Unix" ]; then
 			tar zxvf universal-ctags*tar.gz
 			(
 				cd universal-ctags*[0-9]
-				./configure
-				make -j2
+				BUILDDIR=${BUILDDIR0}
+				mkdir -p "${BUILDDIR}"
+				(
+					cd "${BUILDDIR}"
+					${CONFIGURE_CMDLINE}
+					make -j2
+					echo 'Run "make tmain (sandbox only)" without gcov'
+					make tmain TRAVIS=1 UNITS=${SANDBOX_CASES}
+
+					make clean
+				)
 			)
         )
 

--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -34,7 +34,7 @@ if [ "$TARGET" = "Unix" ]; then
             ${CONFIGURE_CMDLINE}
             make -j2
             echo 'Run "make tmain (sandbox only)" without gcov'
-            make -j2 tmain TRAVIS=1 UNITS=${SANDBOX_CASES}
+            make tmain TRAVIS=1 UNITS=${SANDBOX_CASES}
 
             make clean
         )
@@ -48,13 +48,13 @@ if [ "$TARGET" = "Unix" ]; then
             echo 'List features'
             ./ctags --list-features
             echo 'Run "make check" with gcov'
-            make -j2 check roundtrip TRAVIS=1
+            make check roundtrip TRAVIS=1
 			make dist
 			tar zxvf universal-ctags*tar.gz
 			(
 				cd universal-ctags*[0-9]
 				./configure
-				make
+				make -j2
 			)
         )
 
@@ -68,7 +68,7 @@ if [ "$TARGET" = "Unix" ]; then
             echo 'List features'
             ./ctags --list-features
             echo 'Run "make check" (without gcov)'
-            make -j2 check roundtrip TRAVIS=1
+            make check roundtrip TRAVIS=1
         )
     fi
 


### PR DESCRIPTION
Derived from #2240.

* Stop using -j2 for make check. This makes the log readable.
* Reduce configure and make from 3 times to 2 times. This makes the CI about 30 seconds faster.
