### PR TITLE
parser: Remove dead increments

### DIFF
--- a/parsers/asp.c
+++ b/parsers/asp.c
@@ -77,13 +77,11 @@ static void findAspTags (void)
 
 					if (strncasecmp ((const char*) cp, "function", (size_t) 8) == 0)
 					{
-						cp+=8;
 						break;
 					}
 
 					else if (strncasecmp ((const char*) cp, "sub", (size_t) 3) == 0)
 					{
-						cp+=3;
 						break;
 					}
 				}
@@ -100,13 +98,11 @@ static void findAspTags (void)
 
 					if (strncasecmp ((const char*) cp, "function", (size_t) 8) == 0)
 					{
-						cp+=8;
 						break;
 					}
 
 					else if (strncasecmp ((const char*) cp, "sub", (size_t) 3) == 0)
 					{
-						cp+=3;
 						break;
 					}
 				}

--- a/parsers/nsis.c
+++ b/parsers/nsis.c
@@ -291,7 +291,6 @@ static void findNsisTags (void)
 		}
 		else if (lineStartingWith (cp, "sectiongroupend", true))
 		{
-			cp += 15;
 			sectionGroupIndex = CORK_NIL;
 		}
 		/* sections */


### PR DESCRIPTION
Detected by clang scan-build