### PR TITLE
main,CPreProcessor: don't include extra tags to macro signature field

### DIFF
--- a/Units/parser-cpreprocessor.r/macro-signature-with-subword-extra.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/macro-signature-with-subword-extra.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=*-{inputFile}{pseudo}
+--fields=+{signature}{extras}

--- a/Units/parser-cpreprocessor.r/macro-signature-with-subword-extra.d/expected.tags
+++ b/Units/parser-cpreprocessor.r/macro-signature-with-subword-extra.d/expected.tags
@@ -1,0 +1,2 @@
+m	input.h	/^#define m(/;"	d	signature:(_argument_)
+m	input.h	/^#define m(/;"	d	signature:(_argument_)	extras:subword

--- a/Units/parser-cpreprocessor.r/macro-signature-with-subword-extra.d/input.h
+++ b/Units/parser-cpreprocessor.r/macro-signature-with-subword-extra.d/input.h
@@ -1,0 +1,1 @@
+#define m(_argument_) 50

--- a/main/entry.c
+++ b/main/entry.c
@@ -1658,6 +1658,14 @@ extern bool isTagExtraBitMarked (const tagEntryInfo *const tag, xtagType extra)
 	return !! ((slot [ index ]) & (1 << offset));
 }
 
+extern bool isTagExtra (const tagEntryInfo *const tag)
+{
+	for (unsigned int i = 0; i < XTAG_COUNT; i++)
+		if (isTagExtraBitMarked (tag, i))
+			return true;
+	return false;
+}
+
 static void assignRoleFull(tagEntryInfo *const e, int roleIndex, bool assign)
 {
 	if (roleIndex == ROLE_DEFINITION_INDEX)

--- a/main/entry.h
+++ b/main/entry.h
@@ -143,6 +143,9 @@ size_t        countEntryInCorkQueue (void);
 extern void    markTagExtraBit     (tagEntryInfo *const tag, xtagType extra);
 extern bool isTagExtraBitMarked (const tagEntryInfo *const tag, xtagType extra);
 
+/* If any extra bit is on, return true. */
+extern bool isTagExtra (const tagEntryInfo *const tag);
+
 /* Attaching parser speicificc fields
  *
  * If your parser doesn't use Cork API, use attachParserField().

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -802,11 +802,14 @@ static void regenreateSignatureFromParameters (vString * buffer, int from, int t
 	for (int pindex = from; pindex < to; pindex++)
 	{
 		tagEntryInfo *e = getEntryInCorkQueue (pindex);
-		if (e)
+		if (e && !isTagExtra (e))
+		{
 			vStringCatS (buffer, e->name);
-		if (pindex != (to - 1))
 			vStringPut (buffer, ',');
+		}
 	}
+	if (vStringLast (buffer) == ',')
+		vStringChop (buffer);
 	vStringPut (buffer, ')');
 }
 


### PR DESCRIPTION
Close #2275.

During gathering macro parameters for making the signature field of
macro, ctags can emit tags for subword extra. These subword extra tags
make the signature field broken.

Only non-extra tags should be gathered for making the signature field.
isTagExtra helper function is introduced to filter non-extra tags
from the cork queue.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>