### PR TITLE
lregex: fix lang_set to avoid core dump

### DIFF
--- a/main/lregex.c
+++ b/main/lregex.c
@@ -1646,8 +1646,10 @@ static bool fillGuestRequest (const char *start,
 		int size = pmatch [guest_spec->lang.spec.patternGroup].rm_eo
 			- pmatch [guest_spec->lang.spec.patternGroup].rm_so;
 		if (size > 0)
+		{
 			guest_req->lang = getNamedLanguage (name, size);
-		guest_req->lang_set = true;
+			guest_req->lang_set = true;
+		}
 	}
 	else if (guest_spec->lang.type == GUEST_LANG_PTN_GROUP_FOR_FILEMAP)
 	{
@@ -1659,9 +1661,9 @@ static bool fillGuestRequest (const char *start,
 		if (fname)
 		{
 			guest_req->lang = getLanguageForFilename (fname, LANG_AUTO);
+			guest_req->lang_set = true;
 			eFree (fname);
 		}
-		guest_req->lang_set = true;
 	}
 
 	for (int i = 0; i < 2; i++)


### PR DESCRIPTION
Markdown regex based parser used `guest` flag.
This fix the bug of guest flag implementation.

Markdown parser runs a guest parser for the area surrounded with
```...```. If the language for the area is specified explicitly
like the following example, ctags works fine:

	```C
	int main(void) { return 0; }
	```

"C" is specified in the example.

However, if the language is not specified explicitly like the following
example, a core dump may occur because referring a wrongly set value:

	 ```
	 int main(void) { return 0; }
	 ```

Even if the core dump doesn't occur on a platform, valgrind reports
a wrong memory access.

(Based on #2261, @masatake wrote this commit log.)