### PR TITLE
buildsys: Stop checking C90 standard headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -359,57 +359,21 @@ fi
 # Checks for header files
 # -----------------------
 
-AC_CHECK_HEADERS([direct.h])
-AC_CHECK_HEADERS([dirent.h errno.h fcntl.h io.h limits.h stat.h stdlib.h string.h])
-AC_CHECK_HEADERS([time.h types.h unistd.h])
-AC_CHECK_HEADERS([sys/dir.h sys/stat.h sys/times.h sys/types.h sys/wait.h])
+AC_CHECK_HEADERS([direct.h dirent.h fcntl.h io.h stat.h types.h unistd.h])
+AC_CHECK_HEADERS([sys/dir.h sys/stat.h sys/types.h sys/wait.h])
 
 # Checks for header file macros
 # -----------------------------
 
 CHECK_HEADER_DEFINE(L_tmpnam, [stdio.h],, AC_DEFINE(L_tmpnam, 20))
 
-CHECK_HEADER_DEFINE(INT_MAX, [limits.h],,
-	CHECK_HEADER_DEFINE(MAXINT, [limits.h],
-		AC_DEFINE(INT_MAX, MAXINT), AC_DEFINE(INT_MAX, 32767)))
-
 
 # Checks for typedefs and types
 # -----------------------------
 
-AC_TYPE_SIZE_T
 AC_TYPE_OFF_T
 
-AC_MSG_CHECKING(for fpos_t)
-AC_EGREP_HEADER(fpos_t, stdio.h, AC_MSG_RESULT(yes),
-[
-	AC_MSG_RESULT(no)
-	AC_DEFINE(fpos_t, long)
-])
-
-AC_MSG_CHECKING(for clock_t)
-AC_EGREP_HEADER(clock_t, time.h, AC_MSG_RESULT(yes),
-[
-	AC_MSG_RESULT(no)
-	AC_DEFINE(clock_t, long)
-])
-
-AC_CHECK_HEADERS([stdbool.h],
-[
-	AH_TEMPLATE([HAVE_STDBOOL_H], [whether or not to use <stdbool.h>.])
-	AC_DEFINE([HAVE_STDBOOL_H])
-],
-[
-	AH_TEMPLATE([bool],  [type for 'bool' if <stdbool.h> is missing or broken.])
-	AH_TEMPLATE([true],  [value of 'true' if <stdbool.h> is missing or broken.])
-	AH_TEMPLATE([false], [value of 'false' if <stdbool.h> is missing or broken.])
-
-	AC_CHECK_TYPES([_Bool],
-		       [AC_DEFINE([bool], [_Bool])],
-		       [AC_DEFINE([bool], [int])])
-	AC_DEFINE([true],  [1])
-	AC_DEFINE([false], [0])
-])
+AC_CHECK_HEADERS([stdbool.h])
 
 AC_MSG_CHECKING(if "%zu" in printf works)
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
@@ -450,8 +414,6 @@ AM_CONDITIONAL([USE_ULONGLONG_FORMATTER_FOR_SIZE_T], [test "x${use_ulonglong_for
 # Checks for compiler characteristics
 # -----------------------------------
 
-# AC_CYGWIN
-# AC_MINGW32
 AC_C_CONST
 AC_OBJEXT
 AC_EXEEXT
@@ -512,7 +474,6 @@ AC_CHECK_FUNCS(asprintf)
 AC_CHECK_FUNCS(strstr)
 AC_CHECK_FUNCS(strcasecmp stricmp, break)
 AC_CHECK_FUNCS(strncasecmp strnicmp, break)
-AC_CHECK_FUNCS(fgetpos, have_fgetpos=yes)
 
 AC_CHECK_FUNCS(mkstemp, have_mkstemp=yes)
 if test "$have_mkstemp" != yes ; then
@@ -527,9 +488,6 @@ fi
 
 AC_CHECK_FUNCS(opendir findfirst _findfirst, break)
 AC_CHECK_FUNCS(strerror)
-AC_CHECK_FUNCS(clock times, break)
-AC_CHECK_FUNCS(remove, have_remove=yes,
-	CHECK_HEADER_DEFINE(remove, unistd.h,, AC_DEFINE(remove, unlink)))
 
 AC_CHECK_FUNCS(truncate, have_truncate=yes)
 # === Cannot nest AC_CHECK_FUNCS() calls
@@ -700,18 +658,8 @@ AS_IF([test "x$enable_aspell" != "xno"], [
 # -----------------------------
 AC_MSG_NOTICE(checking for new missing prototypes)
 
-if test "$have_remove" = yes ; then
-	CHECK_PROTO(remove, stdio.h)
-else
-	CHECK_PROTO(unlink,	unistd.h)
-fi
-CHECK_PROTO(malloc,	stdlib.h)
-CHECK_PROTO(getenv,	stdlib.h)
 CHECK_PROTO(stat,	sys/stat.h)
 CHECK_PROTO(lstat,	sys/stat.h)
-if test "$have_fgetpos" = yes ; then
-	CHECK_PROTO(fgetpos, stdio.h)
-fi
 if test "$have_truncate" = yes ; then
 	CHECK_PROTO(truncate, unistd.h)
 fi

--- a/main/e_msoft.h
+++ b/main/e_msoft.h
@@ -14,15 +14,10 @@
 #define MSDOS_STYLE_PATH 1
 #define HAVE_FCNTL_H 1
 #define HAVE_IO_H 1
-#define HAVE_LIMITS_H 1
-#define HAVE_STDLIB_H 1
 #define HAVE_SYS_STAT_H 1
 #define HAVE_SYS_TYPES_H 1
-#define HAVE_TIME_H 1
-#define HAVE_CLOCK 1
 #define HAVE_CHSIZE 1
 #define HAVE_DIRECT_H 1
-#define HAVE_FGETPOS 1
 #define HAVE_STRICMP 1
 #define HAVE_STRNICMP 1
 #define HAVE_STRSTR 1

--- a/main/general.h
+++ b/main/general.h
@@ -18,19 +18,9 @@
 # include "e_msoft.h"
 #endif
 
-/*  To provide timings features if available.
+/*  To provide timings features.
  */
-#ifdef HAVE_CLOCK
-# ifdef HAVE_TIME_H
-#  include <time.h>
-# endif
-#else
-# ifdef HAVE_TIMES
-#  ifdef HAVE_SYS_TIMES_H
-#   include <sys/times.h>
-#  endif
-# endif
-#endif
+#include <time.h>
 
 /*
 *   MACROS
@@ -65,22 +55,6 @@
 #endif
 
 /*
-*   FUNCTION PROTOTYPES
-*/
-
-#if defined (NEED_PROTO_REMOVE) && defined (HAVE_REMOVE)
-extern int remove (const char *);
-#endif
-
-#if defined (NEED_PROTO_UNLINK) && ! defined (HAVE_REMOVE)
-extern void *unlink (const char *);
-#endif
-
-#ifdef NEED_PROTO_GETENV
-extern char *getenv (const char *);
-#endif
-
-/*
 *   HACK for #1610.
 */
 
@@ -88,28 +62,6 @@ extern char *getenv (const char *);
 #define iconv libiconv
 #define iconv_open libiconv_open
 #define iconv_close libiconv_close
-#endif
-
-/*
-*  Prepare clock() and its related macros
-*/
-#if defined (HAVE_CLOCK)
-# define CLOCK_AVAILABLE
-# ifndef CLOCKS_PER_SEC
-#  define CLOCKS_PER_SEC		1000000
-# endif
-#elif defined (HAVE_TIMES)
-# define CLOCK_AVAILABLE
-# define CLOCKS_PER_SEC	60
-static clock_t clock (void)
-{
-	struct tms buf;
-
-	times (&buf);
-	return (buf.tms_utime + buf.tms_stime);
-}
-#else
-# define clock()  (clock_t)0
 #endif
 
 #endif  /* CTAGS_MAIN_GENERAL_H */

--- a/main/routines.c
+++ b/main/routines.c
@@ -12,9 +12,7 @@
 */
 #include "general.h"  /* must always come first */
 
-#ifdef HAVE_STDLIB_H
-# include <stdlib.h>  /* to declare malloc (), realloc (), mbcs() */
-#endif
+#include <stdlib.h>  /* to declare malloc (), realloc (), mbcs() */
 #include <ctype.h>
 #include <string.h>
 #include <stdio.h>  /* to declare tempnam(), and SEEK_SET (hopefully) */
@@ -26,9 +24,7 @@
 # include <unistd.h>  /* to declare mkstemp () */
 #endif
 
-#ifdef HAVE_LIMITS_H
-# include <limits.h>  /* to declare MB_LEN_MAX */
-#endif
+#include <limits.h>  /* to declare MB_LEN_MAX */
 #ifndef MB_LEN_MAX
 # define MB_LEN_MAX 6
 #endif
@@ -59,9 +55,7 @@
 #include "debug.h"
 #include "routines.h"
 #include "routines_p.h"
-#ifdef HAVE_ERRNO_H
-# include <errno.h>
-#endif
+#include <errno.h>
 
 #include "vstring.h"
 

--- a/main/sort.c
+++ b/main/sort.c
@@ -15,9 +15,7 @@
 #if defined (HAVE_IO_H)
 # include <io.h>
 #endif
-#if defined (HAVE_STDLIB_H)
-# include <stdlib.h>  /* to declare malloc () */
-#endif
+#include <stdlib.h>  /* to declare malloc () */
 #if defined (HAVE_UNISTD_H)
 # include <unistd.h>
 #endif

--- a/main/stats.c
+++ b/main/stats.c
@@ -53,17 +53,15 @@ extern void printTotals (const clock_t *const timeStamps, bool append, sortType 
 			Totals.files, plural (Totals.files),
 			Totals.lines, plural (Totals.lines),
 			Totals.bytes/1024L);
-#ifdef CLOCK_AVAILABLE
-	{
-		const double interval = ((double) (timeStamps [1] - timeStamps [0])) /
-								CLOCKS_PER_SEC;
 
-		fprintf (stderr, " in %.01f seconds", interval);
-		if (interval != (double) 0.0)
-			fprintf (stderr, " (%lu kB/s)",
-					(unsigned long) (Totals.bytes / interval) / 1024L);
-	}
-#endif
+	const double interval = ((double) (timeStamps [1] - timeStamps [0])) /
+							CLOCKS_PER_SEC;
+
+	fprintf (stderr, " in %.01f seconds", interval);
+	if (interval != (double) 0.0)
+		fprintf (stderr, " (%lu kB/s)",
+				(unsigned long) (Totals.bytes / interval) / 1024L);
+
 	fputc ('\n', stderr);
 
 	fprintf (stderr, "%lu tag%s added to tag file",
@@ -75,10 +73,8 @@ extern void printTotals (const clock_t *const timeStamps, bool append, sortType 
 	if (totalTags > 0  &&  sorted != SO_UNSORTED)
 	{
 		fprintf (stderr, "%lu tag%s sorted", totalTags, plural (totalTags));
-#ifdef CLOCK_AVAILABLE
 		fprintf (stderr, " in %.02f seconds",
 				((double) (timeStamps [2] - timeStamps [1])) / CLOCKS_PER_SEC);
-#endif
 		fputc ('\n', stderr);
 	}
 

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -14,9 +14,7 @@
 */
 #include "general.h"  /* must always come first */
 
-#if defined(HAVE_STDLIB_H)
-# include <stdlib.h>  /* to define size_t */
-#endif
+#include <stdlib.h>  /* to define size_t */
 
 #include <stdio.h>
 


### PR DESCRIPTION
We already use C99. We can assume that C90 standard headers, macros and functions are always available.

Stop checking:
* errno.h, limits.h, stdlib.h, string.h, time.h.
  Also stop checking sys/times.h because we can use time.h.
* INT_MAX from limits.h, fpos_t from stdio.h, clock_t from time.h,
  size_t from stddef.h.
* fgetpos() from stdio.h, clock() from time.h, malloc() from stdlib.h,
  getenv() from stdlib.h, remove() from stdio.h.
* Also remove out dated comments: AC_CYGWIN, AC_MINGW32.

Still keep checking stdbool.h (C99), because HAVE_STDBOOL_H is used in gnu_regex.