### PR TITLE
circleci: temporary disable fedora:latest and bmake combination

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,9 @@
 version: 2
 jobs:
-   fedora_bmake:
+   fedora30_bmake:
      working_directory: ~/universal-ctags
      docker:
-       - image: docker.io/fedora:latest
+       - image: docker.io/fedora:30
      steps:
        - run:
            name: Install Git and Gdb
@@ -56,5 +56,5 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - fedora_bmake
+      - fedora30_bmake
       - centos_make

--- a/misc/units
+++ b/misc/units
@@ -2749,7 +2749,7 @@ validate_dir ()
     local has_expected_tags=no
     for f in "${base_dir}"/expected.tags*; do
 	[ -r "$f" ] || continue
-	unwanted_file "$f" && continue
+	failure_in_globing "$f" && continue
 	has_expected_tags=yes
 	break
     done
@@ -2759,7 +2759,7 @@ validate_dir ()
     # doesn't exit.
     inputs0=$(for f in "${base_dir}"/input.*; do
 		  [ -r "$f" ] || continue
-		  unwanted_file "$f" && continue
+		  failure_in_globing "$f" && continue
 		  echo $f
 	      done | sort)
     v0=$(resolve_validator "${base_dir}"/validator \
@@ -2795,7 +2795,7 @@ validate_dir ()
     inputs=$(for f in "${base_dir}"/input[-_][0-9].* \
 		      "${base_dir}"/input[-_][0-9][-_]*.*; do
 		 [ -r "$f" ] || continue
-		 unwanted_file "$f" && continue
+		 failure_in_globing "$f" && continue
 		 echo $f
 	     done | sort)
 


### PR DESCRIPTION
Use older Fedora instead.

It seems that mk-files package required by bmake package
is not available in the latest Fedora dnf/yum repository.
We always got following error message:

    dnf -y install gcc automake autoconf pkgconfig bmake aspell-devel aspell-en libseccomp-devel libxml2-devel jansson-devel libyaml-devel findutils
    dnf -y install jq puppet

    Last metadata expiration check: 0:00:53 ago on Wed Oct 30 14:38:43 2019.
    Package gcc-9.2.1-1.fc31.x86_64 is already installed.
    Package pkgconf-pkg-config-1.6.3-2.fc31.x86_64 is already installed.
    Error:
     Problem: conflicting requests
      - nothing provides mk-files needed by bmake-20180512-4.fc31.x86_64
    (try to add '--skip-broken' to skip uninstallable packages)
    Exited with code 1

Signed-off-by: Masatake YAMATO <yamato@redhat.com>