### PR TITLE
units: Fix SameFileError on Cygwin

### DIFF
--- a/misc/units.py
+++ b/misc/units.py
@@ -471,7 +471,7 @@ def run_tcase(finput, t, name, tclass, category, build_t, extra_inputs):
 
     clean_tcase(o, obundles)
     os.makedirs(o, exist_ok=True)
-    if os.path.realpath(o) != os.path.realpath(t):
+    if not os.path.samefile(o, t):
         prepare_bundles(t, o, obundles)
 
 


### PR DESCRIPTION
Cygwin python cannot handle "c:/path" style path in os.path.realpath().
This causes `SameFileError` when try to copy bundle files.
Use os.path.samefile() to check if two directories are the same.