### PR TITLE
Tmain: Fix `make distcheck`

### DIFF
--- a/Tmain/abnormal-output-file-names.d/run.sh
+++ b/Tmain/abnormal-output-file-names.d/run.sh
@@ -2,42 +2,43 @@
 # License: GPL-2
 
 CTAGS=$1
+BUILDDIR=$2
 
 . ../utils.sh
 
 exit_if_win32 "$CTAGS"
 
-rm -f ./"'"
-rm -f ./'"'
-rm -f ./'$(ls)'
-rm -f ./'a b'
+rm -f $BUILDDIR/"'"
+rm -f $BUILDDIR/'"'
+rm -f $BUILDDIR/'$(ls)'
+rm -f $BUILDDIR/'a b'
 
-${CTAGS} --quiet --options=NONE -o ./"'" --extras=-pF input.c
-${CTAGS} --quiet --options=NONE -o ./'"' --extras=-pF input.c
-${CTAGS} --quiet --options=NONE -o ./'$(ls)' --extras=-pF input.c
-${CTAGS} --quiet --options=NONE -o ./'a b' --extras=-pF input.c
+${CTAGS} --quiet --options=NONE -o $BUILDDIR/"'" --extras=-pF input.c
+${CTAGS} --quiet --options=NONE -o $BUILDDIR/'"' --extras=-pF input.c
+${CTAGS} --quiet --options=NONE -o $BUILDDIR/'$(ls)' --extras=-pF input.c
+${CTAGS} --quiet --options=NONE -o $BUILDDIR/'a b' --extras=-pF input.c
 
 echo '#' SINGLE QUOTE
-if [ -e "'" ]; then
-	cat "'"
+if [ -e $BUILDDIR/"'" ]; then
+	cat $BUILDDIR/"'"
 fi
 
 echo '#' DOUBLE QUOTES
-if [ -e '"' ]; then
-	cat '"'
+if [ -e $BUILDDIR/'"' ]; then
+	cat $BUILDDIR/'"'
 fi
 
 echo '#' PROCESS SUBSTITUTION
-if [ -e '$(ls)' ]; then
-	cat '$(ls)'
+if [ -e $BUILDDIR/'$(ls)' ]; then
+	cat $BUILDDIR/'$(ls)'
 fi
 
 echo '#' SPACE
-if [ -e 'a b' ]; then
-	cat 'a b'
+if [ -e $BUILDDIR/'a b' ]; then
+	cat $BUILDDIR/'a b'
 fi
 
-rm -f ./"'"
-rm -f ./'"'
-rm -f ./'$(ls)'
-rm -f ./'a b'
+rm -f $BUILDDIR/"'"
+rm -f $BUILDDIR/'"'
+rm -f $BUILDDIR/'$(ls)'
+rm -f $BUILDDIR/'a b'

--- a/Tmain/c-anon-counter.d/run.sh
+++ b/Tmain/c-anon-counter.d/run.sh
@@ -2,16 +2,17 @@
 # License: GPL-2
 
 CTAGS=$1
+BUILDDIR=$2
 
-${CTAGS} --quiet --options=NONE -o - input1.c input2.c > ./12.tmp
-${CTAGS} --quiet --options=NONE -o - input2.c input1.c > ./21.tmp
+${CTAGS} --quiet --options=NONE -o - input1.c input2.c > $BUILDDIR/12.tmp
+${CTAGS} --quiet --options=NONE -o - input2.c input1.c > $BUILDDIR/21.tmp
 
-diff ./12.tmp ./21.tmp
+diff $BUILDDIR/12.tmp $BUILDDIR/21.tmp
 s=$?
 
 if [ "$s" = 0 ]; then
-    rm -f ./12.tmp
-    rm -f ./21.tmp
+    rm -f $BUILDDIR/12.tmp
+    rm -f $BUILDDIR/21.tmp
 fi
 
 exit $s

--- a/Tmain/e-ctags-output.d/run.sh
+++ b/Tmain/e-ctags-output.d/run.sh
@@ -27,7 +27,7 @@ run()
 				   -o - \
 				   "${tmp}" \
 				   input_tab.rst input_space.rst
-		rm "${tmp}"
+		rm -f "${tmp}"
 
 		echo "# WITH SCOPE"
 		"${CTAGS}" --quiet --options=NONE ${1} --output-format=e-ctags \
@@ -42,7 +42,7 @@ run()
 				   input_scope.rst
 
 		if [ "$copied" = "yes" ]; then
-			rm input_*.rst
+			rm -f input_*.rst
 		fi
 	)
 }

--- a/Tmain/e-ctags-output.d/run.sh
+++ b/Tmain/e-ctags-output.d/run.sh
@@ -3,6 +3,9 @@
 # The original bug is reported by @elecalion in #2014.
 
 CTAGS=$1
+BUILDDIR=$2
+
+. ../utils.sh
 
 tmp="input file.cc"
 
@@ -12,25 +15,36 @@ run()
 	echo '#' with $1
 	echo '#'
 
-	cp input_file.cc "${tmp}"
-	"${CTAGS}" --quiet --options=NONE ${1} --output-format=e-ctags \
-			   --kinds-c++=+p --fields=+iaSs \
-			   -o - \
-			   "${tmp}" \
-			   input_tab.rst input_space.rst
-	rm "${tmp}"
+	cp input_file.cc $BUILDDIR/"${tmp}"
+	if ! direq $BUILDDIR .; then
+		cp input_*.rst $BUILDDIR
+		copied=yes
+	fi
+	(
+		cd $BUILDDIR
+		"${CTAGS}" --quiet --options=NONE ${1} --output-format=e-ctags \
+				   --kinds-c++=+p --fields=+iaSs \
+				   -o - \
+				   "${tmp}" \
+				   input_tab.rst input_space.rst
+		rm "${tmp}"
 
-	echo "# WITH SCOPE"
-	"${CTAGS}" --quiet --options=NONE ${1} --output-format=e-ctags \
-			   --fields=+s \
-			   -o - \
-			   input_scope.rst
+		echo "# WITH SCOPE"
+		"${CTAGS}" --quiet --options=NONE ${1} --output-format=e-ctags \
+				   --fields=+s \
+				   -o - \
+				   input_scope.rst
 
-	echo "# WITHOUT SCOPE"
-	"${CTAGS}" --quiet --options=NONE ${1} --output-format=e-ctags \
-			   --fields=-s \
-			   -o - \
-			   input_scope.rst
+		echo "# WITHOUT SCOPE"
+		"${CTAGS}" --quiet --options=NONE ${1} --output-format=e-ctags \
+				   --fields=-s \
+				   -o - \
+				   input_scope.rst
+
+		if [ "$copied" = "yes" ]; then
+			rm input_*.rst
+		fi
+	)
 }
 
 run "--sort=yes"

--- a/Tmain/interactive-resource-management.d/run.sh
+++ b/Tmain/interactive-resource-management.d/run.sh
@@ -2,12 +2,13 @@
 # License: GPL-2
 
 CTAGS=$1
+BUILDDIR=$2
 
 . ../utils.sh
 
 if is_feature_available ${CTAGS} json; then
-	exit_status_for_input_c $CTAGS NONE      --output-format=json -o -         --sort=no
-	exit_status_for_input_c $CTAGS tags.json --output-format=json -o tags.json --sort=no
-	exit_status_for_input_c $CTAGS tags.json --output-format=json -o tags.json
-	exit_status_for_input_c $CTAGS NONE      --output-format=json -o -
+	exit_status_for_input_c $CTAGS NONE                --output-format=json -o -                   --sort=no
+	exit_status_for_input_c $CTAGS $BUILDDIR/tags.json --output-format=json -o $BUILDDIR/tags.json --sort=no
+	exit_status_for_input_c $CTAGS $BUILDDIR/tags.json --output-format=json -o $BUILDDIR/tags.json
+	exit_status_for_input_c $CTAGS NONE                --output-format=json -o -
 fi

--- a/Tmain/invalid-encoding-option.d/run.sh
+++ b/Tmain/invalid-encoding-option.d/run.sh
@@ -8,7 +8,7 @@ CTAGS=$1
 . ../utils.sh
 
 if ${CTAGS} --quiet --options=NONE --list-features | grep -q iconv; then
-  ${CTAGS} --quiet --options=NONE --input-encoding-java=invalid	--input-encoding-javascript=euc-jp input.js input.java
+  ${CTAGS} --quiet --options=NONE --input-encoding-java=invalid	--input-encoding-javascript=euc-jp -o - input.js input.java
   exit $?
 else
   skip "iconv feature is not available"

--- a/Tmain/languages-and-language-force-options.d/run.sh
+++ b/Tmain/languages-and-language-force-options.d/run.sh
@@ -2,4 +2,4 @@
 # License: GPL-2
 CTAGS=$1
 
-${CTAGS} --quiet --options=NONE --language-force=C --languages=-C input.c
+${CTAGS} --quiet --options=NONE --language-force=C --languages=-C -o - input.c

--- a/Tmain/lregex-unexpected-regex-kind.d/run.sh
+++ b/Tmain/lregex-unexpected-regex-kind.d/run.sh
@@ -2,26 +2,27 @@
 # License: GPL-2
 
 CTAGS="$1 --quiet --options=NONE"
+BUILDDIR=$2
 
 $CTAGS --options=X.ctags --list-kinds=X
 
 echo "# no kind is specified" 1>&2
-$CTAGS --options=Ynokind.ctags input.yyy
+$CTAGS --options=Ynokind.ctags -o $BUILDDIR/tags input.yyy
 
 echo "# no kind (empty,) is specified" 1>&2
-$CTAGS --options=Yempty1.ctags input.yyy
+$CTAGS --options=Yempty1.ctags -o $BUILDDIR/tags input.yyy
 
 echo "# no kind (empty,,) is specified" 1>&2
-$CTAGS --options=Yempty2.ctags input.yyy
+$CTAGS --options=Yempty2.ctags -o $BUILDDIR/tags input.yyy
 
 echo "# (r/) kind is specified inline" 1>&2
-$CTAGS --options=Y-r.ctags input.yyy
+$CTAGS --options=Y-r.ctags -o $BUILDDIR/tags input.yyy
 
 echo "# (/regex) kind is specified inline" 1>&2
-$CTAGS --options=Y-regex.ctags input.yyy
+$CTAGS --options=Y-regex.ctags -o $BUILDDIR/tags input.yyy
 
 echo "# (r/regex) kind is specified inline" 1>&2
-$CTAGS --options=Y-r-regex.ctags input.yyy
+$CTAGS --options=Y-r-regex.ctags -o $BUILDDIR/tags input.yyy
 
 echo "# (r/regex) kind defined with --kinddef-<LANG> option" 1>&2
-$CTAGS --options=Y-r-regex-with-kinddef.ctags input.yyy
+$CTAGS --options=Y-r-regex-with-kinddef.ctags -o $BUILDDIR/tags input.yyy

--- a/Tmain/no-input-encoding-option.d/run.sh
+++ b/Tmain/no-input-encoding-option.d/run.sh
@@ -3,11 +3,12 @@
 # License: GPL-2
 
 CTAGS=$1
+BUILDDIR=$2
 
 . ../utils.sh
 
 if ${CTAGS} --quiet --options=NONE --list-features | grep -q iconv; then
-  ${CTAGS} --quiet --options=NONE --output-encoding=utf-8	input.js input.java
+  ${CTAGS} --quiet --options=NONE --output-encoding=utf-8 -o $BUILDDIR/tags input.js input.java
   exit $?
 else
   skip "iconv feature is not available"

--- a/Tmain/output-file-resource-management.d/run.sh
+++ b/Tmain/output-file-resource-management.d/run.sh
@@ -2,20 +2,21 @@
 # License: GPL-2
 
 CTAGS=$1
+BUILDDIR=$2
 
 . ../utils.sh
 
-exit_status_for_input_c $CTAGS NONE -o - --sort=no
-exit_status_for_input_c $CTAGS tags      --sort=no
-exit_status_for_input_c $CTAGS tags
-exit_status_for_input_c $CTAGS NONE -o -
+exit_status_for_input_c $CTAGS NONE           -o -              --sort=no
+exit_status_for_input_c $CTAGS $BUILDDIR/tags -o $BUILDDIR/tags --sort=no
+exit_status_for_input_c $CTAGS $BUILDDIR/tags -o $BUILDDIR/tags
+exit_status_for_input_c $CTAGS NONE           -o -
 
-exit_status_for_input_c $CTAGS NONE -e -o - --sort=no
-exit_status_for_input_c $CTAGS TAGS -e      --sort=no
-exit_status_for_input_c $CTAGS TAGS -e
-exit_status_for_input_c $CTAGS NONE -e -o -
+exit_status_for_input_c $CTAGS NONE           -e -o -              --sort=no
+exit_status_for_input_c $CTAGS $BUILDDIR/TAGS -e -o $BUILDDIR/TAGS --sort=no
+exit_status_for_input_c $CTAGS $BUILDDIR/TAGS -e -o $BUILDDIR/TAGS
+exit_status_for_input_c $CTAGS NONE           -e -o -
 
-exit_status_for_input_c $CTAGS NONE   -x -o -      --sort=no
-exit_status_for_input_c $CTAGS tags-x -x -o tags-x --sort=no
-exit_status_for_input_c $CTAGS tags-x -x -o tags-x
-exit_status_for_input_c $CTAGS NONE   -x -o -
+exit_status_for_input_c $CTAGS NONE             -x -o -                --sort=no
+exit_status_for_input_c $CTAGS $BUILDDIR/tags-x -x -o $BUILDDIR/tags-x --sort=no
+exit_status_for_input_c $CTAGS $BUILDDIR/tags-x -x -o $BUILDDIR/tags-x
+exit_status_for_input_c $CTAGS NONE             -x -o -

--- a/Tmain/output-file-resource-management.d/stdout-expected.txt
+++ b/Tmain/output-file-resource-management.d/stdout-expected.txt
@@ -1,10 +1,10 @@
 -o - --sort=no => ok
---sort=no => ok
- => ok
+-o tags --sort=no => ok
+-o tags => ok
 -o - => ok
 -e -o - --sort=no => ok
--e --sort=no => ok
--e => ok
+-e -o TAGS --sort=no => ok
+-e -o TAGS => ok
 -e -o - => ok
 -x -o - --sort=no => ok
 -x -o tags-x --sort=no => ok

--- a/Tmain/sorted-help-message.d/run.sh
+++ b/Tmain/sorted-help-message.d/run.sh
@@ -2,6 +2,7 @@
 # License: GPL-2
 
 CTAGS=$1
+BUILDDIR=$2
 
 . ../utils.sh
 
@@ -40,12 +41,12 @@ extract_debug_options()
 
 gdiff()
 {
-    print_help | extract_$1_options > ./$1.tmp
-    print_help | extract_$1_options | opt_sort > ./sorted-$1.tmp
+    print_help | extract_$1_options > $BUILDDIR/$1.tmp
+    print_help | extract_$1_options | opt_sort > $BUILDDIR/sorted-$1.tmp
 
-    diff -ruN ./$1.tmp ./sorted-$1.tmp
+    diff -ruN $BUILDDIR/$1.tmp $BUILDDIR/sorted-$1.tmp
     r=$?
-    rm ./$1.tmp ./sorted-$1.tmp
+    rm $BUILDDIR/$1.tmp $BUILDDIR/sorted-$1.tmp
 
     return $r
 }

--- a/Tmain/sorted-list-languages.d/run.sh
+++ b/Tmain/sorted-list-languages.d/run.sh
@@ -1,6 +1,7 @@
 # Copyright: 2016 Masatake YAMATO
 # License: GPL-2
 CTAGS=$1
+BUILDDIR=$2
 
 . ../utils.sh
 
@@ -13,9 +14,9 @@ list_languages()
     ${CTAGS} --quiet --options=NONE --list-languages
 }
 
-list_languages > ./ll.tmp
-list_languages | sort --ignore-case > ./sorted-ll.tmp
-diff -uN ./ll.tmp ./sorted-ll.tmp
+list_languages > $BUILDDIR/ll.tmp
+list_languages | sort --ignore-case > $BUILDDIR/sorted-ll.tmp
+diff -uN $BUILDDIR/ll.tmp $BUILDDIR/sorted-ll.tmp
 r=$?
-rm ./ll.tmp ./sorted-ll.tmp
+rm $BUILDDIR/ll.tmp $BUILDDIR/sorted-ll.tmp
 exit $r

--- a/Tmain/tag-relative-option-in-etags.d/run.sh
+++ b/Tmain/tag-relative-option-in-etags.d/run.sh
@@ -2,15 +2,22 @@
 # License: GPL-2
 
 CTAGS=$1
+BUILDDIR=$2
 ARGS="--quiet --options=NONE"
 O=TAGS.TMP
 
+. ../utils.sh
+
 for x in no yes default; do
-    touch ${x}-$O
+    touch $BUILDDIR/${x}-$O
 done
 
+if ! direq $BUILDDIR .; then
+	cp -r indirect $BUILDDIR
+	copied=yes
+fi
 (
-    cd indirect
+    cd $BUILDDIR/indirect
 
     ${CTAGS} ${ARGS} -e  -o ../no-${O}      --tag-relative=no  src/input.c
     ${CTAGS} ${ARGS} -e  -o ../yes-${O}     --tag-relative=yes src/input.c
@@ -20,8 +27,13 @@ done
 for x in no yes default; do
     echo '#' ${x}
     # convert path separators in the output
-    sed -e 's|\\|/|g' ${x}-$O
-    rm ${x}-$O
+    sed -e 's|\\|/|g' $BUILDDIR/${x}-$O
+    rm $BUILDDIR/${x}-$O
 done
+
+if [ "$copied" = "yes" ]; then
+	chmod -R u+w $BUILDDIR/indirect
+	rm -rf $BUILDDIR/indirect
+fi
 
 exit $?

--- a/Tmain/utils.sh
+++ b/Tmain/utils.sh
@@ -74,7 +74,7 @@ exit_status_for_input_c()
 	local remove_file=$1
 	shift
 
-	printf "%s => " "$*"
+	printf "%s => " "$(echo "$*" | sed -e 's#[^ ][^ ]*/\([^ ]*\)#\1#g')"
 	${ctags} --quiet --options=NONE "$@" input.c > /dev/null
 	local result_local=$?
 
@@ -121,4 +121,10 @@ echo2()
 	# built-in echo suppresses \1.
 	/bin/echo "$@"
 	/bin/echo "$@" 1>&2
+}
+
+direq ()
+{
+    [ "$(cd ${1} && pwd)" = "$(cd ${2} && pwd)" ]
+    return $?
 }

--- a/misc/tlib
+++ b/misc/tlib
@@ -39,6 +39,6 @@ test "$N" -gt 0
 sed -i -e '/^Number of all parsers is: [0-9]*$/d' ${actual}
 
 echo "comparing with expected output:"
-diff -uN --strip-trailing-cr ${expected} ${actual}
+diff -uN --strip-trailing-cr ${expected} ${actual} && rm ${actual}
 
 exit 0


### PR DESCRIPTION
`make distcheck` sets the source directories readonly. So, temporary files or output files should be written in $BUILDDIR. Otherwise, tests will fail with permission errors.

`make distcheck` is important when we create a release.