### PR TITLE
buildsys: Fix `make distcheck`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,7 +87,7 @@ endif
 PARSER_SRCS += $(PEG_SRCS)
 PARSER_HEADS += $(PEG_HEADS) $(PEG_EXTRA_HEADS)
 
-libctags_a_CPPFLAGS = -I. -I$(srcdir) -I$(srcdir)/main -DHAVE_PACKCC
+libctags_a_CPPFLAGS = -I. -I$(srcdir) -I$(srcdir)/main -I$(srcdir)/peg -DHAVE_PACKCC
 if ENABLE_DEBUGGING
 libctags_a_CPPFLAGS+= $(DEBUG_CPPFLAGS)
 endif
@@ -145,12 +145,12 @@ packcc_verbose_0 = @echo PACKCC "    $@";
 PACKCC = $(top_builddir)/packcc$(EXEEXT)
 SUFFIXES += .peg
 .peg.c:
-	$(packcc_verbose)$(PACKCC) $<
+	$(packcc_verbose)$(PACKCC) -o $(top_builddir)/peg/$(*F) $<
 .peg.h:
-	$(packcc_verbose)$(PACKCC) $<
+	$(packcc_verbose)$(PACKCC) -o $(top_builddir)/peg/$(*F) $<
 # You cannot use $(PACKCC) as a target name here.
-$(PEG_INPUT): packcc$(EXEEXT) Makefile
 $(PEG_HEADS): packcc$(EXEEXT) Makefile
+$(PEG_SRCS): packcc$(EXEEXT) Makefile
 dist_libctags_a_SOURCES = $(ALL_LIB_HEADS) $(ALL_LIB_SRCS)
 
 ctags_CPPFLAGS = $(libctags_a_CPPFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,11 @@ EXTRA_DIST   = README.md autogen.sh \
 	       man/Makefile man/README man/tags.5.rst \
 	       $(PEG_INPUT) $(OPTLIB2C_INPUT)
 
+clean-local:
+	@if test "$(top_srcdir)" != "$(top_builddir)"; then \
+		rm -rf $(OPTLIB2C_SRCS); \
+	fi
+
 bin_PROGRAMS = ctags
 noinst_LIBRARIES = libctags.a
 
@@ -109,9 +114,9 @@ libctags_a_CFLAGS  += $(LIBYAML_CFLAGS)
 libctags_a_CFLAGS  += $(ASPELL_CFLAGS)
 libctags_a_CFLAGS  += $(SECCOMP_CFLAGS)
 
-nodist_libctags_a_SOURCES = $(REPOINFO_HEADS)
+nodist_libctags_a_SOURCES = $(REPOINFO_HEADS) $(PEG_SRCS) $(PEG_HEADS)
 BUILT_SOURCES = $(REPOINFO_HEADS)
-CLEANFILES = $(REPOINFO_HEADS)
+CLEANFILES = $(REPOINFO_HEADS) $(PEG_SRCS) $(PEG_HEADS)
 $(REPOINFO_OBJS): $(REPOINFO_SRCS) $(REPOINFO_HEADS)
 repoinfo_verbose = $(repoinfo_verbose_@AM_V@)
 repoinfo_verbose_ = $(repoinfo_verbose_@AM_DEFAULT_V@)

--- a/circle.yml
+++ b/circle.yml
@@ -26,6 +26,31 @@ jobs:
            command: |
              MAKE=bmake bmake validate-input check roundtrip codecheck CIRCLECI=1
 
+   fedora_distcheck:
+     working_directory: ~/universal-ctags
+     docker:
+       - image: docker.io/fedora:latest
+     steps:
+       - run:
+           name: Install Git and Gdb
+           command: |
+             dnf -y install git gdb
+       - checkout
+       - run:
+           name: Install build tools
+           command: |
+             dnf -y install gcc automake autoconf pkgconfig make aspell-devel aspell-en libseccomp-devel libxml2-devel jansson-devel libyaml-devel findutils diffutils
+             dnf -y install jq puppet
+       - run:
+           name: Build
+           command: |
+             bash ./autogen.sh
+             ./configure
+       - run:
+           name: Test
+           command: |
+             make distcheck
+
    centos_make:
      working_directory: ~/universal-ctags
      docker:
@@ -57,4 +82,5 @@ workflows:
   build_and_test:
     jobs:
       - fedora30_bmake
+      - fedora_distcheck
       - centos_make


### PR DESCRIPTION
This is an additional PR to #2297.

This fixes:

* Failed to update peg/varlink.[ch]. Generate them in the builddir instead.
* The generated peg/*.[ch] files were distributed. No need to distribute them.
* optlib/*.c were left behind after `make (dist)clean`. Delete them with `make clean`.
* Use fedora:latest to check `make distcheck`.
