### PR TITLE
buildsys: Suppress messages from type command

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,8 +2,8 @@
 
 set -xe
 
-type autoreconf || exit 1
-type pkg-config || exit 1
+type autoreconf > /dev/null || exit 1
+type pkg-config > /dev/null || exit 1
 
 if [ -z "${MAKE}" ]; then
 	if type make > /dev/null; then


### PR DESCRIPTION
They are redundant.