### PR TITLE
packcc: add EXTRA_CFLAGS to packcc_CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,8 @@ noinst_PROGRAMS += packcc
 noinst_PROGRAMS += mini-geany
 
 packcc_CPPFLAGS =
-packcc_CFLAGS =
+packcc_CFLAGS  =
+packcc_CFLAGS += $(EXTRA_CFLAGS)
 dist_packcc_SOURCES = $(PACKCC_SRCS)
 
 if HAVE_STRNLEN


### PR DESCRIPTION
packcc includes initial declarations in for loops, but does not inherit EXTRA_CFLAGS (and notably -std=gnu99) as found by autotools, unlike ctags.

As such, if the compiler uses a C<99 standard by default, [packcc's build breaks](http://build-failures.rhaalovely.net/sparc64/2019-11-07/devel/universal-ctags.log)

I'm just proposing to add EXTRA_CFLAGS to packcc_CFLAGS.