### PR TITLE
buildsys: Fix that packcc may fail on MSYS2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -151,9 +151,9 @@ packcc_verbose_0 = @echo PACKCC "    $@";
 PACKCC = $(top_builddir)/packcc$(EXEEXT)
 SUFFIXES += .peg
 .peg.c:
-	$(packcc_verbose)$(PACKCC) -o $(top_builddir)/peg/$(*F) $<
+	$(packcc_verbose)$(PACKCC) -o $(top_builddir)/peg/$(*F) "$<"
 .peg.h:
-	$(packcc_verbose)$(PACKCC) -o $(top_builddir)/peg/$(*F) $<
+	$(packcc_verbose)$(PACKCC) -o $(top_builddir)/peg/$(*F) "$<"
 # You cannot use $(PACKCC) as a target name here.
 $(PEG_HEADS): packcc$(EXEEXT) Makefile
 $(PEG_SRCS): packcc$(EXEEXT) Makefile


### PR DESCRIPTION
When shadow builds are used on MSYS2, packcc fails to read *.peg file.
It seems that MSYS's make uses `\` for directory separator on some
conditions. In such situation, a command `./packcc ..\peg\varlink.peg`
is executed, and `\` is considered as an escape character. Then the
command is interpreted as `./packcc ..pegvarlink.peg`, and it fails.

(Derived from #2302.)