### PR TITLE
man: Fix error after #2259

### DIFF
--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -1449,8 +1449,7 @@ are not listed here. They are experimental or for debugging purpose.
 ``--print-language``
 	Just prints the language parsers for specified source files, and then exits.
 
-``--pseudo-tags=[+|-]ptag``
-``--pseudo-tags=*``
+``--pseudo-tags=[+|-]ptag``, ``--pseudo-tags=*``
 	Enable/disable emitting pseudo tag named ptag.
 	if \* is given, enable emitting all pseudo tags.
 

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -1449,8 +1449,7 @@ are not listed here. They are experimental or for debugging purpose.
 ``--print-language``
 	Just prints the language parsers for specified source files, and then exits.
 
-``--pseudo-tags=[+|-]ptag``
-``--pseudo-tags=*``
+``--pseudo-tags=[+|-]ptag``, ``--pseudo-tags=*``
 	Enable/disable emitting pseudo tag named ptag.
 	if \* is given, enable emitting all pseudo tags.
 


### PR DESCRIPTION
Fix the following error:

```
RST2MAN   man/ctags.1
man/ctags.1.rst:1454: (ERROR/3) Unexpected indentation.
```