### PR TITLE
scheme: Add racket support to scheme parser

### DIFF
--- a/parsers/scheme.c
+++ b/parsers/scheme.c
@@ -111,10 +111,10 @@ static void findSchemeTags (void)
 extern parserDefinition* SchemeParser (void)
 {
 	static const char *const extensions [] = {
-		"SCM", "SM", "sch", "scheme", "scm", "sm", NULL
+		"SCM", "SM", "sch", "scheme", "scm", "sm", "rkt", NULL
 	};
 	static const char *const aliases [] = {
-		"gosh", "guile", NULL
+		"gosh", "guile", "racket", NULL
 	};
 	parserDefinition* def = parserNew ("Scheme");
 	def->kindTable      = SchemeKinds;


### PR DESCRIPTION
Addressing #1877 by adding support for the `.rkt` extensions. Change is simple because syntax is the same. Tested locally on some Racket source.