### PR TITLE
Protobuf,D,C#,Vera: use cork

### DIFF
--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3583,6 +3583,9 @@ extern parserDefinition* OldCParser (void)
 	def->parser2    = findCTags;
 	def->initialize = initializeCParser;
 	def->enabled = 0;
+
+	/* cpreprocessor wants corkQueue. */
+	def->useCork    = true;
 	return def;
 }
 
@@ -3596,7 +3599,9 @@ extern parserDefinition* DParser (void)
 	def->parser2    = findCTags;
 	def->initialize = initializeDParser;
 	// end: field is not tested.
-	// def->useCork    = true;
+
+	/* cpreprocessor wants corkQueue. */
+	def->useCork    = true;
 	return def;
 }
 
@@ -3621,6 +3626,9 @@ extern parserDefinition* OldCppParser (void)
 	def->initialize = initializeCppParser;
 	def->selectLanguage = selectors;
 	def->enabled = 0;
+
+	/* cpreprocessor wants corkQueue. */
+	def->useCork    = true;
 	return def;
 }
 
@@ -3636,7 +3644,9 @@ extern parserDefinition* CsharpParser (void)
 	def->parser2    = findCTags;
 	def->initialize = initializeCsharpParser;
 	// end: field is not tested.
-	// def->useCork    = true;
+
+	/* cpreprocessor wants corkQueue. */
+	def->useCork    = true;
 	return def;
 }
 
@@ -3663,6 +3673,9 @@ extern parserDefinition* VeraParser (void)
 	def->parser2    = findCTags;
 	def->initialize = initializeVeraParser;
 	// end: field is not tested.
-	// def->useCork    = true;
+
+	/* cpreprocessor wants corkQueue. */
+	def->useCork    = true;
+
 	return def;
 }

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -74,6 +74,9 @@
 extern bool cppIsBraceFormat (void);
 extern unsigned int cppGetDirectiveNestLevel (void);
 
+/* Don't forget to set useCort true if your parser.
+ * The corkQueue is needed to capture macro parameters
+ */
 extern void cppInit (const bool state,
 		     const bool hasAtLiteralStrings,
 		     const bool hasCxxRawLiteralStrings,

--- a/parsers/protobuf.c
+++ b/parsers/protobuf.c
@@ -293,5 +293,8 @@ extern parserDefinition* ProtobufParser (void)
 	def->keywordTable = ProtobufKeywordTable;
 	def->keywordCount = ARRAY_SIZE (ProtobufKeywordTable);
 
+	/* cpreprocessor wants corkQueue. */
+	def->useCork    = true;
+
 	return def;
 }


### PR DESCRIPTION
These parsers themselves don't need the corkQueue directly.
However, they call cpreproparser parser that needs the corkQueue for
capturing macro arguments. So this change sets useCork field of callers

Without setting the field, the parsers may crash with input, "#define foo(x)",
when capturing `x`. "make fuzz" can reproduce the crash.

Ideally, the setting for the parsers is done automatically.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>