### PR TITLE
fuzz: extend the timeout of execution to 10 secs

### DIFF
--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -46,7 +46,7 @@ fuzz: $(CTAGS_TEST)
 		--ctags=$(CTAGS_TEST) \
 		--languages=$(LANGUAGES) \
 		$${VALGRIND} --run-shrink \
-		--with-timeout=$(TIMEOUT)"; \
+		--with-timeout=`expr $(TIMEOUT) '*' 10`"; \
 	$(SHELL) $${c} $(srcdir)/Units
 
 #


### PR DESCRIPTION
1 second is too short for mtable parsers tagging long input.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>