### PR TITLE
Fix typo in units python script

### DIFF
--- a/misc/units.py
+++ b/misc/units.py
@@ -268,7 +268,7 @@ def run_shrink(cmdline_template, finput, foutput, lang):
 
     print('Shrinking ' + finput + ' as ' + lang)
     # fallback to the shell script version
-    subproces.run([SHELL, script, 'shrink',
+    subprocess.run([SHELL, script, 'shrink',
         '--timeout=1', '--foreground',
         cmdline_template, finput, foutput])
 


### PR DESCRIPTION
@k-takata I found this problem trying the new vala parser.

I guess is related with a buggy implementation as vala parser actually SIGSEV.