### PR TITLE
Reject more non alnum chars in langdef

### DIFF
--- a/Tmain/broken-langdef.d/input.c
+++ b/Tmain/broken-langdef.d/input.c
@@ -1,0 +1,1 @@
+int f(void) { return 0; }

--- a/Tmain/broken-langdef.d/run.sh
+++ b/Tmain/broken-langdef.d/run.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Copyright: 2019 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+run_ctags()
+{
+	echo '#' "$1" 1>&2
+	${CTAGS} --quiet --options=NONE --langdef="$1" --kinddef-"$1"=f,func,functions --_force-quit=0 -o - input.c
+}
+
+run_ctags ""
+run_ctags all
+for c in '!' '"' '$' '%' '&' "'" '(' ')' '*' ',' '-' '.' '/' ':' ';' '<' '=' '>' '?' '@' '[' '\' ']' '^' '`' '|' '~'; do
+	run_ctags "C$c"
+done

--- a/Tmain/broken-langdef.d/stderr-expected.txt
+++ b/Tmain/broken-langdef.d/stderr-expected.txt
@@ -1,0 +1,58 @@
+# 
+ctags: No language specified for "langdef" option
+# all
+ctags: "all" is reserved; don't use it as the name for defining a new language
+# C!
+ctags: don't use `!' in a language name (C!)
+# C"
+ctags: don't use `"' in a language name (C")
+# C$
+ctags: don't use `$' in a language name (C$)
+# C%
+ctags: don't use `%' in a language name (C%)
+# C&
+ctags: don't use `&' in a language name (C&)
+# C'
+ctags: don't use "'" in a language name (C')
+# C(
+ctags: don't use `(' in a language name (C()
+# C)
+ctags: don't use `)' in a language name (C))
+# C*
+ctags: don't use `*' in a language name (C*)
+# C,
+ctags: don't use `,' in a language name (C,)
+# C-
+ctags: don't use `-' in a language name (C-)
+# C.
+ctags: don't use `.' in a language name (C.)
+# C/
+ctags: don't use `/' in a language name (C/)
+# C:
+ctags: don't use `:' in a language name (C:)
+# C;
+ctags: don't use `;' in a language name (C;)
+# C<
+ctags: don't use `<' in a language name (C<)
+# C=
+ctags: don't use `=' in a language name (C=)
+# C>
+ctags: don't use `>' in a language name (C>)
+# C?
+ctags: don't use `?' in a language name (C?)
+# C@
+ctags: don't use `@' in a language name (C@)
+# C[
+ctags: don't use `[' in a language name (C[)
+# C\
+ctags: don't use `\' in a language name (C\)
+# C]
+ctags: don't use `]' in a language name (C])
+# C^
+ctags: don't use `^' in a language name (C^)
+# C`
+ctags: don't use "`" in a language name (C`)
+# C|
+ctags: don't use `|' in a language name (C|)
+# C~
+ctags: don't use `~' in a language name (C~)

--- a/docs/man/ctags-incompatibilities.7.rst
+++ b/docs/man/ctags-incompatibilities.7.rst
@@ -70,8 +70,14 @@ q/qualified". Unexpectedly the command line becomes as if
 
 In this case, the user should set "--extras=+q" instead of "--extras=q".
 
-Kind definitions
+Language and kind definitions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Language name defined with ``--langdef=name`` option
+....................................................................................
+
+The characters you can use are more restricted than Exuberant-ctags.
+For more details, see the description of ``--langdef=name`` in ctags-optlib(7).
 
 Obsoleting ``--<LANG>-kinds`` option
 ....................................................................................
@@ -188,4 +194,4 @@ to follow the above rule.
 
 SEE ALSO
 --------
-ctags(1) and tags(5).
+ctags(1), ctags-optlib(7), and tags(5).

--- a/docs/man/ctags-optlib.7.rst
+++ b/docs/man/ctags-optlib.7.rst
@@ -149,9 +149,17 @@ OPTION ITEMS
 	expressions. Once defined, name may be used in other options taking
 	language names.
 
-	"all" as *name* is not acceptable. It is a reserved word. See
-	the description of ``--kinds-<LANG>=[+|-]kinds|*`` option in ctags(1)
-	about how the reserved word is used.
+	*name* must consist of alphanumeric characters, "#", or "+"
+	 ('[a-zA-Z0-9#+]+'). The graph characters other than "#" and
+	 "+" are disallowed (or reserved). Some of them ('[-=:{]') are
+	 disallowed because they can make the command line parser of
+	 ctags confused. The rest of them are just
+	 reserved for future extending ctags.
+
+	 "all" is an exception.  "all" as *name* is not acceptable. It is
+	 a reserved word. See the description of
+	 ``--kinds-<LANG>=[+|-]kinds|*`` option in ctags(1) about how the
+	 reserved word is used.
 
 	The names of built-in parsers are capitalized. When
 	ctags evaluates an option in a command line, and

--- a/main/parse.c
+++ b/main/parse.c
@@ -1918,24 +1918,17 @@ extern void initializeParsing (void)
 		parserDefinition* const def = (*BuiltInParsers [i]) ();
 		if (def != NULL)
 		{
-			bool accepted = false;
-			if (def->name == NULL  ||  def->name[0] == '\0')
-				error (FATAL, "parser definition must contain name\n");
-			else if (strcmp (def->name, RSV_LANG_ALL) == 0)
-				error (FATAL, "\"all\" is reserved; don't use it as the name for defining a new language");
-			else if (def->method & METHOD_NOT_CRAFTED)
-			{
+			Assert (def->name);
+			Assert (def->name[0] != '\0');
+			Assert (strcmp (def->name, RSV_LANG_ALL));
+
+			if (def->method & METHOD_NOT_CRAFTED)
 				def->parser = findRegexTags;
-				accepted = true;
-			}
-			else if ((!def->invisible) && (((!!def->parser) + (!!def->parser2)) != 1))
-				error (FATAL,
-		"%s parser definition must define one and only one parsing routine\n",
-					   def->name);
 			else
-				accepted = true;
-			if (accepted)
-				initializeParsingCommon (def, true);
+				/* parser definition must define one and only one parsing routine */
+				Assert ((!!def->parser) + (!!def->parser2) == 1);
+
+			initializeParsingCommon (def, true);
 		}
 	}
 	verbose ("\n");

--- a/main/parse.c
+++ b/main/parse.c
@@ -2157,8 +2157,8 @@ extern void processLanguageDefineOption (
 	}
 	else if (getNamedLanguage (name, 0) != LANG_IGNORE)
 	{
-		eFree (name);
-		error (FATAL, "Language \"%s\" already defined", parameter);
+		/* name cannot be freed because it is used in the FATAL message. */
+		error (FATAL, "Language \"%s\" already defined", name);
 	}
 	else if (strcmp(name, RSV_LANG_ALL) == 0)
 	{

--- a/main/parse.c
+++ b/main/parse.c
@@ -1921,6 +1921,7 @@ extern void initializeParsing (void)
 			Assert (def->name);
 			Assert (def->name[0] != '\0');
 			Assert (strcmp (def->name, RSV_LANG_ALL));
+			Assert (strpbrk (def->name, "!\"$%&'()*,-./:;<=>?@[\\]^`|~") == NULL);
 
 			if (def->method & METHOD_NOT_CRAFTED)
 				def->parser = findRegexTags;
@@ -2143,6 +2144,7 @@ extern void processLanguageDefineOption (
 		name = eStrdup (parameter);
 
 	/* Veirfy that the name of new language is acceptable or not. */
+	char *unacceptable;
 	if (name [0] == '\0')
 	{
 		eFree (name);
@@ -2157,6 +2159,19 @@ extern void processLanguageDefineOption (
 	{
 		eFree (name);
 		error (FATAL, "\"all\" is reserved; don't use it as the name for defining a new language");
+	}
+	else if ((unacceptable = strpbrk (name, "!\"$%&'()*,-./:;<=>?@[\\]^`|~")))
+	{
+		char c = *unacceptable;
+
+		/* name cannot be freed because it is used in the FATAL message. */
+		/* We accept '_'.
+		 * We accept # and + because they are already used in C# parser and C++ parser.
+		 * {... is already trimmed at the beginning of this function. */
+		if ((c == '`') || (c == '\''))
+			error (FATAL, "don't use \"%c\" in a language name (%s)", c, name);
+		else
+			error (FATAL, "don't use `%c' in a language name (%s)", c, name);
 	}
 
 	LanguageTable = xRealloc (LanguageTable, LanguageCount + 1, parserObject);

--- a/man/ctags-incompatibilities.7.rst.in
+++ b/man/ctags-incompatibilities.7.rst.in
@@ -70,8 +70,14 @@ q/qualified". Unexpectedly the command line becomes as if
 
 In this case, the user should set "--extras=+q" instead of "--extras=q".
 
-Kind definitions
+Language and kind definitions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Language name defined with ``--langdef=name`` option
+....................................................................................
+
+The characters you can use are more restricted than Exuberant-ctags.
+For more details, see the description of ``--langdef=name`` in ctags-optlib(7).
 
 Obsoleting ``--<LANG>-kinds`` option
 ....................................................................................
@@ -188,4 +194,4 @@ to follow the above rule.
 
 SEE ALSO
 --------
-ctags(1) and tags(5).
+ctags(1), ctags-optlib(7), and tags(5).

--- a/man/ctags-optlib.7.rst.in
+++ b/man/ctags-optlib.7.rst.in
@@ -149,9 +149,17 @@ OPTION ITEMS
 	expressions. Once defined, name may be used in other options taking
 	language names.
 
-	"all" as *name* is not acceptable. It is a reserved word. See
-	the description of ``--kinds-<LANG>=[+|-]kinds|*`` option in ctags(1)
-	about how the reserved word is used.
+	*name* must consist of alphanumeric characters, "#", or "+"
+	 ('[a-zA-Z0-9#+]+'). The graph characters other than "#" and
+	 "+" are disallowed (or reserved). Some of them ('[-=:{]') are
+	 disallowed because they can make the command line parser of
+	 @CTAGS_NAME_EXECUTABLE@ confused. The rest of them are just
+	 reserved for future extending @CTAGS_NAME_EXECUTABLE@.
+
+	 "all" is an exception.  "all" as *name* is not acceptable. It is
+	 a reserved word. See the description of
+	 ``--kinds-<LANG>=[+|-]kinds|*`` option in ctags(1) about how the
+	 reserved word is used.
 
 	The names of built-in parsers are capitalized. When
 	@CTAGS_NAME_EXECUTABLE@ evaluates an option in a command line, and

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -51,10 +51,14 @@ my $options =
 	       if (defined $_[0]->{'langdef'});
 	   die "Don't use \"all\" as a language name. It is reserved word."
 	       if ($1 eq "all");
+
 	   $_[0]->{'langdef'} = $1;
 	   $_[0]->{'base'} = $5 if defined $5;
 	   $_[0]->{'direction'} = $7 if defined $7;
 	   $_[0]->{'autoFQTag'} = (defined $8)? 1: 0;
+
+	   die "Don't use a character as a language name other than alphanumeric, # and +."
+	       unless ($_[0]->{'langdef'} =~ /^[a-zA-Z#+]+$/);
        } ],
      [ qr/^--kinddef-(.*)=([^,]),([^,]+),([^\{]+)(\{_refonly\})?/, sub {
 	 die "Don't use --kinddef-<LANG>=+ option before defining the language"


### PR DESCRIPTION
All changes about --langdef option.

The main change is for rejecting characters like @, $, % as a parser name.