### PR TITLE
man(web): Add links to each man page on the Web site

### DIFF
--- a/docs/man/ctags-incompatibilities.7.rst
+++ b/docs/man/ctags-incompatibilities.7.rst
@@ -77,7 +77,7 @@ Language name defined with ``--langdef=name`` option
 ....................................................................................
 
 The characters you can use are more restricted than Exuberant-ctags.
-For more details, see the description of ``--langdef=name`` in ctags-optlib(7).
+For more details, see the description of ``--langdef=name`` in :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
 
 Obsoleting ``--<LANG>-kinds`` option
 ....................................................................................
@@ -175,7 +175,7 @@ Option files loading at starting up time (preload files)
 
 File paths for preload files are changed.
 Universal-ctags doesn't load "~/.ctags" at starting up time.
-See "FILES" section of ctags(1).
+See "FILES" section of :ref:`ctags(1) <ctags(1)>`.
 
 Kind letters and names
 -------------------------------------------------------------
@@ -194,4 +194,4 @@ to follow the above rule.
 
 SEE ALSO
 --------
-ctags(1), ctags-optlib(7), and tags(5).
+:ref:`ctags(1) <ctags(1)>`, :ref:`ctags-optlib(7) <ctags-optlib(7)>`, and :ref:`tags(5) <tags(5)>`.

--- a/docs/man/ctags-optlib.7.rst
+++ b/docs/man/ctags-optlib.7.rst
@@ -26,7 +26,7 @@ combination of command line options. "lib" intends an optlib parser
 can be more than ad-hoc personal configuration.
 
 This man page is for people who wants to define an optlib parser. The
-reader should read ctags(1) of Universal-ctags first. Following
+reader should read :ref:`ctags(1) <ctags(1)>` of Universal-ctags first. Following
 options are for defining (or customizing) a parser:
 
 * ``--langdef=``
@@ -65,15 +65,15 @@ want to type the same command line each time when you need the parser.
 You can store options for defining a parser into a file.
 
 ctags loads files (preload files) listed in "FILES"
-section of ctags(1) at program starting up. You can put your parser
+section of :ref:`ctags(1) <ctags(1)>` at program starting up. You can put your parser
 definition needed usually to the files.
 
 ``--options=pathname``, ``--options-maybe=pathname``, and
 ``--optlib-dir=[+]directory`` are for loading optlib files you need
-occasionally. See "COMMAND LINE INTERFACE" section of ctags(1) for
+occasionally. See "COMMAND LINE INTERFACE" section of :ref:`ctags(1) <ctags(1)>` for
 these options.
 
-As explained in FILES section of ctags(1), options for defining a
+As explained in FILES section of :ref:`ctags(1) <ctags(1)>`, options for defining a
 parser listed line by line in an optlib file. Prefixed white spaces are
 ignored. A line starting with '#' is treated as a comment.  Escaping
 shell meta character is not needed.
@@ -93,7 +93,7 @@ Overview for defining a parser
 
    You need know both the target language and the ctags'
    concepts (definition, reference, kind, role, field, extra). About
-   the concepts, ctags(1) of Universal-ctags may help you.
+   the concepts, :ref:`ctags(1) <ctags(1)>` of Universal-ctags may help you.
 
 2. Give a name to the parser
 
@@ -158,7 +158,7 @@ OPTION ITEMS
 
 	 "all" is an exception.  "all" as *name* is not acceptable. It is
 	 a reserved word. See the description of
-	 ``--kinds-<LANG>=[+|-]kinds|*`` option in ctags(1) about how the
+	 ``--kinds-<LANG>=[+|-]kinds|*`` option in :ref:`ctags(1) <ctags(1)>` about how the
 	 reserved word is used.
 
 	The names of built-in parsers are capitalized. When
@@ -250,7 +250,7 @@ OPTION ITEMS
 	message will be reported unless ``{placeholder}`` regex flag is
 	specified. An optional kind specifier for tags matching regexp may
 	follow *replacement*, which will determine what kind of tag is
-	reported in the "kind" extension field (see tags(5)).
+	reported in the "kind" extension field (see :ref:`tags(5) <tags(5)>`).
 
 	*kind-spec* has two forms: letter only form and full form.  The
 	letter form assumes using ``--regex-<LANG>`` option with
@@ -433,14 +433,14 @@ The official Universal-ctags web site at:
 
 https://ctags.io/
 
-ctags(1), tags(5), regex(5,7), egrep(1)
+:ref:`ctags(1) <ctags(1)>`, :ref:`tags(5) <tags(5)>`, regex(5,7), egrep(1)
 
 AUTHOR
 ------
 
 Universal-ctags project
 https://ctags.io/
-(This man page partially derived from ctags(1) of
+(This man page partially derived from :ref:`ctags(1) <ctags(1)>` of
 Executable-ctags)
 
 Darren Hiebert <dhiebert@users.sourceforge.net>

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -46,11 +46,11 @@ options.
 This man page describes **Universal-ctags**, an implementation of ctags
 derived from **Exuberant-ctags**. The major incompatible changes between
 Universal-ctags and Exuberant-ctags are enumerated in
-ctags-incompatibilities(7).
+:ref:`ctags-incompatibilities(7) <ctags-incompatibilities(7)>`.
 
 One of the advantages of Exuberant-ctags is that it allows a user to
 define a new parser from the command line. Extending this capability is one
-of the major features of Universal-ctags. ctags-optlib(7)
+of the major features of Universal-ctags. :ref:`ctags-optlib(7) <ctags-optlib(7)>`
 describes how the capability is extended.
 
 Newly introduced experimental features are not explained here. If you
@@ -761,7 +761,7 @@ are not listed here. They are experimental or for debugging purpose.
 		Note: Using backslash characters as separators forming
 		qualified name in PHP. However, in tags output of
 		Universal-ctags, a backslash character in a name is escaped
-		with a backslash character. See tags(5) about the escaping.
+		with a backslash character. See :ref:`tags(5) <tags(5)>` about the escaping.
 
 	r/reference
 		Include reference tags. See "TAG ENTRIES" about reference tags.
@@ -897,7 +897,7 @@ are not listed here. They are experimental or for debugging purpose.
 	Universal-ctags provides an alternative way to control this option,
 	with the "F/fileScope" extra, and recommends users to use the
 	extra. However, this extra can cause issues.
-	See ctags-incompatibilities(7).
+	See :ref:`ctags-incompatibilities(7) <ctags-incompatibilities(7)>`.
 
 ``--filter[=yes|no]``
 	Makes ctags behave as a filter, reading source
@@ -963,7 +963,7 @@ are not listed here. They are experimental or for debugging purpose.
 	default value given with ``--input-encoding``.
 
 ``--kinddef-<LANG>=letter,name,description``
-	See ctags-optlib(7).
+	See :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
 	Be not confused this with ``--kinds-<LANG>``.
 
 ``--kinds-<LANG>=[+|-]kinds|*``
@@ -998,7 +998,7 @@ are not listed here. They are experimental or for debugging purpose.
 	This option is obsolete. Use ``--kinds-<LANG>=...`` instead.
 
 ``--langdef=name``
-	See ctags-optlib(7).
+	See :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
 
 ``--langmap=map[,map[...]]``
 	Controls how file names are mapped to languages (see the ``--list-maps``
@@ -1044,7 +1044,7 @@ are not listed here. They are experimental or for debugging purpose.
 
 	Note that file name patterns are tested before file extensions when inferring
 	the language of a file. This order of Universal-ctags is different from
-	Exuberant-ctags. See ctags-incompatibilities(7) for the background of
+	Exuberant-ctags. See :ref:`ctags-incompatibilities(7) <ctags-incompatibilities(7)>` for the background of
 	this incompatible change.
 
 ``--language-force=language``
@@ -1331,7 +1331,7 @@ are not listed here. They are experimental or for debugging purpose.
 	Output list of pseudo tags.
 
 ``--list-regex-flags``
-	See ctags-optlib(7).
+	See :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
 
 ``--list-roles[=language|all[.kinds]]``
 	List the roles for either the specified language or "all"
@@ -1428,7 +1428,7 @@ are not listed here. They are experimental or for debugging purpose.
 
 ``--output-format=u-ctags|e-ctags|etags|xref|json``
 	Specify the output format. The default is "u-ctags".
-	See tags(5) for "u-ctags" and "e-ctags".
+	See :ref:`tags(5) <tags(5)>` for "u-ctags" and "e-ctags".
 	See ``-e`` for "etags", and ``-x`` for "xref".
 	"json" is experimental format, and available only if
 	the ctags executable is built with libjansson.
@@ -1471,7 +1471,7 @@ are not listed here. They are experimental or for debugging purpose.
 	recursion.
 
 ``--regex-<LANG>=/regexp/replacement/[kind-spec/][flags]``
-	See ctags-optlib(7).
+	See :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
 
 ``--sort[=yes|no|foldcase]``
 	Indicates whether the tag file should be sorted on the tag name
@@ -1863,10 +1863,10 @@ TAGS
 SEE ALSO
 --------
 
-See ctags-optlib(7) for defining (or extending) a parser
+See :ref:`ctags-optlib(7) <ctags-optlib(7)>` for defining (or extending) a parser
 in a configuration file.
 
-See tags(5) for the format of tag files.
+See :ref:`tags(5) <tags(5)>` for the format of tag files.
 
 The official Universal-ctags web site at:
 

--- a/docs/man/tags.5.rst
+++ b/docs/man/tags.5.rst
@@ -515,4 +515,4 @@ used when ctags generating tags file.
 
 SEE ALSO
 --------
-ctags(1), ctags-incompatibilities(7)
+:ref:`ctags(1) <ctags(1)>`, :ref:`ctags-incompatibilities(7) <ctags-incompatibilities(7)>`

--- a/man/Makefile
+++ b/man/Makefile
@@ -56,6 +56,7 @@ rst_files  = $(gen_rst_files) $(SOURCE_FILES)
 man_pages  = $(basename $(rst_files))
 html_pages = $(addsuffix .html,$(man_pages))
 pdf_pages  = $(addsuffix .pdf,$(man_pages))
+doc_files = $(addprefix ../docs/man/,$(rst_files))
 
 all: man html pdf
 
@@ -63,8 +64,15 @@ man: $(man_pages)
 html: $(html_pages)
 pdf: $(pdf_pages)
 
-update-docs: $(rst_files)
-	cp $(rst_files) ../docs/man
+update-docs: $(doc_files)
+
+../docs/man/%.rst: %.rst
+	sed \
+		-e 's/\<ctags(1)/:ref:`& <&>`/g' \
+		-e 's/\<ctags-incompatibilities(7)/:ref:`& <&>`/g' \
+		-e 's/\<ctags-optlib(7)/:ref:`& <&>`/g' \
+		-e 's/\<tags(5)/:ref:`& <&>`/g' \
+	< $< > $@
 
 %.rst: %.rst.in
 ifeq ($(QUICK),)


### PR DESCRIPTION
Add links to ctags(1), ctags-incompatibilities(7), ctags-optlib(7) and
tags(5). This is only useful on ./docs/man/, not useful on ./man/, so convert them
when running `make update-docs`.