### PR TITLE
docs(web): Don't transform `--` into an en-dash

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,6 +95,10 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 #keep_warnings = False
 
+# Customizes the Smart Quotes transform. The default 'qDe' educates normal
+# quote characters ", ', em- and en-Dashes ---, --, and ellipses ....
+smartquotes_action = 'qe'  # Exclude dashes transform for cmdline options.
+
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
`--` is used for command line options. Sphinx transforms it to an en-dash (U+2013) which is incorrect. Disable the transformation.

See:
https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-smartquotes_action