### PR TITLE
docs,man: Fix markup

### DIFF
--- a/docs/man/ctags-optlib.7.rst
+++ b/docs/man/ctags-optlib.7.rst
@@ -196,10 +196,10 @@ OPTION ITEMS
 	initial in a kind name.
 
 	*description* comes from any printable ASCII characters. The
-	exception is "{" and "\". "{" is reserved for adding flags
-	this option in the future. So put "\" before "{" to include
-	"{" to a description. To include "\" itself to a description,
-	put "\" before "\".
+	exception is ``{`` and ``\``. ``{`` is reserved for adding flags
+	this option in the future. So put ``\`` before ``{`` to include
+	``{`` to a description. To include ``\`` itself to a description,
+	put ``\`` before ``\``.
 
 	Both *letter*, *name* and their combination must be unique in
 	a *<LANG>*.
@@ -231,14 +231,14 @@ OPTION ITEMS
 	or user-defined language). The regular expression, regexp, defines
 	an extended regular expression (roughly that used by egrep(1)),
 	which is used to locate a single source line containing a tag and
-	may specify tab characters using \t. When a matching line is
+	may specify tab characters using ``\t``. When a matching line is
 	found, a tag will be generated for the name defined by
 	*replacement*, which generally will contain the special
-	back-references \1 through \9 to refer to matching sub-expression
-	groups within regexp.  The '/' separator characters shown in the
+	back-references ``\1`` through ``\9`` to refer to matching sub-expression
+	groups within regexp.  The ``/`` separator characters shown in the
 	parameter to the option can actually be replaced by any
 	character. Note that whichever separator character is used will
-	have to be escaped with a backslash ('\') character wherever it is
+	have to be escaped with a backslash (``\``) character wherever it is
 	used in the parameter as something other than a separator. The
 	regular expression defined by this option is added to the current
 	list of regular expressions for the specified language unless the

--- a/docs/man/tags.5.rst
+++ b/docs/man/tags.5.rst
@@ -269,10 +269,10 @@ A tagfield has a name, a colon, and a value: "name:value".
 * The value may be empty.
   It cannot contain a <Tab>.
 
-  - When a value contains a "\\t", this stands for a <Tab>.
-  - When a value contains a "\\r", this stands for a <CR>.
-  - When a value contains a "\\n", this stands for a <NL>.
-  - When a value contains a "\\\\", this stands for a single '\\' character.
+  - When a value contains a ``\t``, this stands for a <Tab>.
+  - When a value contains a ``\r``, this stands for a <CR>.
+  - When a value contains a ``\n``, this stands for a <NL>.
+  - When a value contains a ``\\``, this stands for a single ``\`` character.
 
   Other use of the backslash character is reserved for future expansion.
   Warning: When a tagfield value holds an MS-DOS file name, the backslashes
@@ -280,12 +280,12 @@ A tagfield has a name, a colon, and a value: "name:value".
 
   EXCEPTION: Universal-ctags introduces more conversion rules.
 
-  - When a value contains a "\\a", this stands for a <BEL> (0x07).
-  - When a value contains a "\\b", this stands for a <BS> (0x08).
-  - When a value contains a "\\v", this stands for a <VT> (0x0b).
-  - When a value contains a "\\f", this stands for a <FF> (0x0c).
+  - When a value contains a ``\a``, this stands for a <BEL> (0x07).
+  - When a value contains a ``\b``, this stands for a <BS> (0x08).
+  - When a value contains a ``\v``, this stands for a <VT> (0x0b).
+  - When a value contains a ``\f``, this stands for a <FF> (0x0c).
   - The characters in range 0x01 to 0x1F included, 0x7F, and leading space
-    (0x20) and '!' (0x21) are converted to \x prefixed hexadecimal number if
+    (0x20) and ``!`` (0x21) are converted to ``\x`` prefixed hexadecimal number if
     the characters are not handled in the above "value" rules.
 
 Proposed tagfield names:
@@ -415,9 +415,9 @@ compatibility.  However, all known programs that generate tags use a single
 
 There is a problem for using file names with embedded white space in the
 tagfile field.  To work around this, the same special characters could be used
-as in the new fields, for example "\\s".  But, unfortunately, in MS-DOS the
+as in the new fields, for example ``\s``.  But, unfortunately, in MS-DOS the
 backslash character is used to separate file names.  The file name
-"c:\\vim\\sap" contains "\\s", but this is not a <Space>.  The number of
+``c:\vim\sap`` contains ``\s``, but this is not a <Space>.  The number of
 backslashes could be doubled, but that will add a lot of characters, and make
 parsing the tags file slower and clumsy.
 

--- a/man/ctags-optlib.7.rst.in
+++ b/man/ctags-optlib.7.rst.in
@@ -196,10 +196,10 @@ OPTION ITEMS
 	initial in a kind name.
 
 	*description* comes from any printable ASCII characters. The
-	exception is "{" and "\". "{" is reserved for adding flags
-	this option in the future. So put "\" before "{" to include
-	"{" to a description. To include "\" itself to a description,
-	put "\" before "\".
+	exception is ``{`` and ``\``. ``{`` is reserved for adding flags
+	this option in the future. So put ``\`` before ``{`` to include
+	``{`` to a description. To include ``\`` itself to a description,
+	put ``\`` before ``\``.
 
 	Both *letter*, *name* and their combination must be unique in
 	a *<LANG>*.
@@ -231,14 +231,14 @@ OPTION ITEMS
 	or user-defined language). The regular expression, regexp, defines
 	an extended regular expression (roughly that used by egrep(1)),
 	which is used to locate a single source line containing a tag and
-	may specify tab characters using \t. When a matching line is
+	may specify tab characters using ``\t``. When a matching line is
 	found, a tag will be generated for the name defined by
 	*replacement*, which generally will contain the special
-	back-references \1 through \9 to refer to matching sub-expression
-	groups within regexp.  The '/' separator characters shown in the
+	back-references ``\1`` through ``\9`` to refer to matching sub-expression
+	groups within regexp.  The ``/`` separator characters shown in the
 	parameter to the option can actually be replaced by any
 	character. Note that whichever separator character is used will
-	have to be escaped with a backslash ('\') character wherever it is
+	have to be escaped with a backslash (``\``) character wherever it is
 	used in the parameter as something other than a separator. The
 	regular expression defined by this option is added to the current
 	list of regular expressions for the specified language unless the

--- a/man/tags.5.rst
+++ b/man/tags.5.rst
@@ -269,10 +269,10 @@ A tagfield has a name, a colon, and a value: "name:value".
 * The value may be empty.
   It cannot contain a <Tab>.
 
-  - When a value contains a "\\t", this stands for a <Tab>.
-  - When a value contains a "\\r", this stands for a <CR>.
-  - When a value contains a "\\n", this stands for a <NL>.
-  - When a value contains a "\\\\", this stands for a single '\\' character.
+  - When a value contains a ``\t``, this stands for a <Tab>.
+  - When a value contains a ``\r``, this stands for a <CR>.
+  - When a value contains a ``\n``, this stands for a <NL>.
+  - When a value contains a ``\\``, this stands for a single ``\`` character.
 
   Other use of the backslash character is reserved for future expansion.
   Warning: When a tagfield value holds an MS-DOS file name, the backslashes
@@ -280,12 +280,12 @@ A tagfield has a name, a colon, and a value: "name:value".
 
   EXCEPTION: Universal-ctags introduces more conversion rules.
 
-  - When a value contains a "\\a", this stands for a <BEL> (0x07).
-  - When a value contains a "\\b", this stands for a <BS> (0x08).
-  - When a value contains a "\\v", this stands for a <VT> (0x0b).
-  - When a value contains a "\\f", this stands for a <FF> (0x0c).
+  - When a value contains a ``\a``, this stands for a <BEL> (0x07).
+  - When a value contains a ``\b``, this stands for a <BS> (0x08).
+  - When a value contains a ``\v``, this stands for a <VT> (0x0b).
+  - When a value contains a ``\f``, this stands for a <FF> (0x0c).
   - The characters in range 0x01 to 0x1F included, 0x7F, and leading space
-    (0x20) and '!' (0x21) are converted to \x prefixed hexadecimal number if
+    (0x20) and ``!`` (0x21) are converted to ``\x`` prefixed hexadecimal number if
     the characters are not handled in the above "value" rules.
 
 Proposed tagfield names:
@@ -415,9 +415,9 @@ compatibility.  However, all known programs that generate tags use a single
 
 There is a problem for using file names with embedded white space in the
 tagfile field.  To work around this, the same special characters could be used
-as in the new fields, for example "\\s".  But, unfortunately, in MS-DOS the
+as in the new fields, for example ``\s``.  But, unfortunately, in MS-DOS the
 backslash character is used to separate file names.  The file name
-"c:\\vim\\sap" contains "\\s", but this is not a <Space>.  The number of
+``c:\vim\sap`` contains ``\s``, but this is not a <Space>.  The number of
 backslashes could be doubled, but that will add a lot of characters, and make
 parsing the tags file slower and clumsy.
 


### PR DESCRIPTION
Use double backquotes to quote a backslash to avoid incorrect markup.