### PR TITLE
main: Update help for --use-slash-as-filename-separator

### DIFF
--- a/main/options.c
+++ b/main/options.c
@@ -699,7 +699,6 @@ extern void freeList (stringList** const pList)
 }
 
 extern void setDefaultTagFileName (void)
-
 {
 	if (Option.filter || Option.interactive)
 		return;

--- a/main/options.c
+++ b/main/options.c
@@ -419,7 +419,7 @@ static optionDescription LongOptionDescription [] = {
  {1,"  --totals=[yes|no|extra]"},
  {1,"       Print statistics about input and tag files [no]."},
 #ifdef WIN32
- {1,"  --use-slash-as-filename-separator"},
+ {1,"  --use-slash-as-filename-separator=[yes|no]"},
  {1,"       Use slash as filename separator [yes] for u-ctags output format."},
 #endif
  {1,"  --verbose=[yes|no]"},


### PR DESCRIPTION
`--use-slash-as-filename-separator` has a parameter (yes or no).
Also remove unnecessary empty line.