### PR TITLE
docs(web), docs(man): don't use '\|' in a pattern for sed when making hyperlinks

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -64,14 +64,26 @@ man: $(man_pages)
 html: $(html_pages)
 pdf: $(pdf_pages)
 
-empty :=
-space := $(empty) $(empty)
-reppat := \<\(${subst ${space},\|,${subst .,(,${addsuffix ),${man_pages}}}}\)
+#
+# Convert the names of man page files (without suffix) to man page citations.
+#
+# ctags.1 tags.5 ...
+# => ctags(1) tags(5) ...
+#
+cites := ${subst .,(,${addsuffix ),${man_pages}}}
+
+#
+# Convert the man page citations to sed patterns for making hyperlinks.
+#
+# ctags(1) tags(5) ...
+# => -e 's/\<ctags(1)/:ref:`& <&>`/g' -e 's/\<ctags(5)/:ref:`& <&>`/g' ...
+#
+reppat := $(foreach m,$(cites),-e 's/\<$(m)/:ref:`& <&>`/g')
 
 update-docs: $(doc_files)
 
 ../docs/man/%.rst: %.rst
-	sed -e 's/$(reppat)/:ref:`& <&>`/g' < $< > $@
+	sed $(reppat) < $< > $@
 
 %.rst: %.rst.in
 ifeq ($(QUICK),)


### PR DESCRIPTION
sed implementation in MacOS doesn't understand '\|'.
To avoid using '\|', this change expands 'A\|B' to "-e A -e B".

Signed-off-by: Masatake YAMATO <yamato@redhat.com>