### PR TITLE
win32: Add version resource and manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ tags.test
 test.*.diff
 tg
 tinst-root
+win32/*.aps
 win32/*.opensdf
 win32/*.sdf
 win32/*.suo

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,5 @@
 include $(top_srcdir)/source.mak
 
-# Test cases are added to EXTRA_DIST by makefiles under Tmain and Units
-# Documents are added to EXTRA_DIST by makefiles/docs.mak
 EXTRA_DIST   = README.md autogen.sh \
 	       makefiles/list-optlib2c-input.mak misc/optlib2c \
 	       .ctags.d/exclusion.ctags .dir-locals.el .editorconfig .gdbinit .gitignore \
@@ -18,6 +16,7 @@ EXTRA_DIST   = README.md autogen.sh \
 	       misc/validators/validator-puppet \
 	       $(WIN32_HEADS) $(WIN32_SRCS) mk_mingw.mak mk_mvc.mak \
 	       win32/mkstemp/COPYING.MinGW-w64-runtime.txt \
+	       win32/ctags.rc win32/ctags.exe.manifest win32/resource.h \
 	       win32/ctags_vs2013.sln \
 	       win32/ctags_vs2013.vcxproj win32/ctags_vs2013.vcxproj.filters \
 	       win32/gen-repoinfo.bat \
@@ -166,6 +165,16 @@ ctags_LDADD += $(LIBYAML_LIBS)
 ctags_LDADD += $(SECCOMP_LIBS)
 ctags_LDADD += $(ICONV_LIBS)
 dist_ctags_SOURCES = $(CMDLINE_HEADS) $(CMDLINE_SRCS)
+
+if HOST_MINGW
+WINDRES = windres
+RES_OBJ = win32/ctags.res.o
+ctags_LDADD += $(RES_OBJ)
+$(RES_OBJ): win32/ctags.rc win32/ctags.exe.manifest win32/resource.h
+	mkdir -p $(builddir)/win32
+	$(WINDRES) -o $@ -O coff $<
+MOSTLYCLEANFILES = $(RES_OBJ)
+endif
 
 mini_geany_CPPFLAGS = $(libctags_a_CPPFLAGS)
 mini_geany_CFLAGS = $(libctags_a_CFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -170,9 +170,12 @@ if HOST_MINGW
 WINDRES = windres
 RES_OBJ = win32/ctags.res.o
 ctags_LDADD += $(RES_OBJ)
+windres_verbose = $(windres_verbose_@AM_V@)
+windres_verbose_ = $(windres_verbose_@AM_DEFAULT_V@)
+windres_verbose_0 = @echo WINDRES "   $@";
 $(RES_OBJ): win32/ctags.rc win32/ctags.exe.manifest win32/resource.h
-	mkdir -p $(builddir)/win32
-	$(WINDRES) -o $@ -O coff $<
+	@mkdir -p $(builddir)/win32
+	$(windres_verbose)$(WINDRES) -o $@ -O coff $<
 MOSTLYCLEANFILES = $(RES_OBJ)
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,9 @@ EXTRA_DIST   = README.md autogen.sh \
 	       $(PEG_INPUT) $(OPTLIB2C_INPUT) \
 	       docs Tmain Units
 
+CLEANFILES =
+MOSTLYCLEANFILES =
+
 clean-local:
 	@if test "$(top_srcdir)" != "$(top_builddir)"; then \
 		rm -rf $(OPTLIB2C_SRCS); \
@@ -115,7 +118,7 @@ libctags_a_CFLAGS  += $(SECCOMP_CFLAGS)
 
 nodist_libctags_a_SOURCES = $(REPOINFO_HEADS) $(PEG_SRCS) $(PEG_HEADS)
 BUILT_SOURCES = $(REPOINFO_HEADS)
-CLEANFILES = $(REPOINFO_HEADS) $(PEG_SRCS) $(PEG_HEADS)
+CLEANFILES += $(REPOINFO_HEADS) $(PEG_SRCS) $(PEG_HEADS)
 $(REPOINFO_OBJS): $(REPOINFO_SRCS) $(REPOINFO_HEADS)
 repoinfo_verbose = $(repoinfo_verbose_@AM_V@)
 repoinfo_verbose_ = $(repoinfo_verbose_@AM_DEFAULT_V@)
@@ -176,7 +179,7 @@ windres_verbose_0 = @echo WINDRES "   $@";
 $(RES_OBJ): win32/ctags.rc win32/ctags.exe.manifest win32/resource.h
 	@mkdir -p $(builddir)/win32
 	$(windres_verbose)$(WINDRES) -o $@ -O coff $<
-MOSTLYCLEANFILES = $(RES_OBJ)
+MOSTLYCLEANFILES += $(RES_OBJ)
 endif
 
 mini_geany_CPPFLAGS = $(libctags_a_CPPFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -429,6 +429,7 @@ case "$host" in
 	AC_DEFINE(MSDOS_STYLE_PATH)
 	;;
 esac
+AM_CONDITIONAL([HOST_MINGW], [test "x${host_mingw}" = "xyes"])
 
 # Check if struct stat contains st_ino.
 # MinGW has st_ino, but it doesn't work.

--- a/misc/src-check
+++ b/misc/src-check
@@ -95,10 +95,11 @@ check_eof_chars_in_vcxproj()
     local r=2
     local f
 
+    # *.vcxproj* should not have the last CRLF.
     for f in win32/ctags_vs2013.vcxproj win32/ctags_vs2013.vcxproj.filters; do
 	header "Check the EOF characters of $f"
-	local s=$(od -t c  -j $(expr $(stat -c %s $f) - 3) $f)
-	if echo "$s" | grep -q '>  \\r  \\n'; then
+	local s=$(od -t c  -j $(expr $(stat -c %s $f) - 1) $f)
+	if echo "$s" | grep -q '>$'; then
 	    r=$(expr $r - 1)
 	else
 	    echo "unexpected chars: $s"

--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -78,7 +78,7 @@ if [ "$TARGET" = "Unix" ]; then
 
 elif [ "$TARGET" = "Mingw32" ]; then
     # Don't run test units in Mingw32 target.
-    make -j2 CC=i686-w64-mingw32-gcc CC_FOR_PACKCC=gcc -f mk_mingw.mak
+    make -j2 CC=i686-w64-mingw32-gcc WINDRES=i686-w64-mingw32-windres CC_FOR_PACKCC=gcc -f mk_mingw.mak
 
 else
     echo "Invalid TARGET value: $TARGET" 1>&2

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -11,13 +11,16 @@ COMMON_DEFINES=-DUSE_SYSTEM_STRNLEN
 DEFINES = -DWIN32 $(REGEX_DEFINES) -DHAVE_PACKCC $(COMMON_DEFINES)
 INCLUDES = -I. -Imain -Ignu_regex -Ifnmatch -Iparsers
 CC = gcc
+WINDRES = windres
 OPTLIB2C = ./misc/optlib2c
 PACKCC   = ./packcc.exe
 OBJEXT = o
+RES_OBJ = win32/ctags.res.o
 ALL_OBJS += $(REGEX_OBJS)
 ALL_OBJS += $(FNMATCH_OBJS)
 ALL_OBJS += $(WIN32_OBJS)
 ALL_OBJS += $(PEG_OBJS)
+ALL_OBJS += $(RES_OBJ)
 VPATH = . ./main ./parsers ./optlib ./read ./win32
 
 ifeq (yes, $(WITH_ICONV))
@@ -82,6 +85,9 @@ $(PACKCC): $(PACKCC_OBJS)
 ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(PEG_HEADS) $(PEG_EXTRA_HEADS) $(REGEX_HEADS) $(FNMATCH_HEADS) $(WIN32_HEADS)
 	$(V_CC) $(CC) $(OPT) $(CFLAGS) $(LDFLAGS) $(DEFINES) $(INCLUDES) -o $@ $(ALL_OBJS) $(LIBS)
 
+$(RES_OBJ): win32/ctags.rc win32/ctags.exe.manifest win32/resource.h
+	$(WINDRES) -o $@ -O coff $<
+
 read/%.o: read/%.c
 	$(V_CC) $(CC) -c $(OPT) $(CFLAGS) -DWIN32 -Iread -o $@ $<
 
@@ -92,4 +98,4 @@ clean:
 	$(SILENT) echo Cleaning
 	$(SILENT) rm -f ctags.exe readtags.exe $(PACKCC)
 	$(SILENT) rm -f tags
-	$(SILENT) rm -f main/*.o optlib/*.o parsers/*.o parsers/cxx/*.o gnu_regex/*.o fnmatch/*.o misc/packcc/*.o peg/*.o read/*.o win32/mkstemp/*.o
+	$(SILENT) rm -f main/*.o optlib/*.o parsers/*.o parsers/cxx/*.o gnu_regex/*.o fnmatch/*.o misc/packcc/*.o peg/*.o read/*.o win32/*.o win32/mkstemp/*.o

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -62,6 +62,10 @@ V_PACKCC   = $(V_PACKCC_$(V))
 V_PACKCC_0 = @echo [PACKCC] $@;
 V_PACKCC_1 =
 
+V_WINDRES   = $(V_WINDRES_$(V))
+V_WINDRES_0 = @echo [WINDRES] $@;
+V_WINDRES_1 =
+
 
 .c.o:
 	$(V_CC) $(CC) -c $(OPT) $(CFLAGS) $(DEFINES) $(INCLUDES) -o $@ $<
@@ -86,7 +90,7 @@ ctags.exe: $(ALL_OBJS) $(ALL_HEADS) $(PEG_HEADS) $(PEG_EXTRA_HEADS) $(REGEX_HEAD
 	$(V_CC) $(CC) $(OPT) $(CFLAGS) $(LDFLAGS) $(DEFINES) $(INCLUDES) -o $@ $(ALL_OBJS) $(LIBS)
 
 $(RES_OBJ): win32/ctags.rc win32/ctags.exe.manifest win32/resource.h
-	$(WINDRES) -o $@ -O coff $<
+	$(V_WINDRES) $(WINDRES) -o $@ -O coff $<
 
 read/%.o: read/%.c
 	$(V_CC) $(CC) -c $(OPT) $(CFLAGS) -DWIN32 -Iread -o $@ $<

--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -23,7 +23,8 @@ FNMATCH_OBJS = $(FNMATCH_SRCS:.c=.obj)
 WIN32_OBJS = $(WIN32_SRCS:.c=.obj)
 PEG_OBJS = $(PEG_SRCS:.c=.obj)
 PACKCC_OBJS = $(PACKCC_SRCS:.c=.obj)
-ALL_OBJS = $(ALL_SRCS:.c=.obj) $(REGEX_OBJS) $(FNMATCH_OBJS) $(WIN32_OBJS) $(PEG_OBJS)
+RES_OBJ = win32/ctags.res
+ALL_OBJS = $(ALL_SRCS:.c=.obj) $(REGEX_OBJS) $(FNMATCH_OBJS) $(WIN32_OBJS) $(PEG_OBJS) $(RES_OBJ)
 READTAGS_OBJS = $(READTAGS_SRCS:.c=.obj)
 
 !if "$(WITH_ICONV)" == "yes"
@@ -93,8 +94,11 @@ main\repoinfo.obj: main\repoinfo.c main\repoinfo.h
 
 peg\varlink.c peg\varlink.h: peg\varlink.peg $(PACKCC)
 
+$(RES_OBJ): win32/ctags.rc win32/ctags.exe.manifest win32/resource.h
+	$(RC) /nologo /l 0x409 /Fo$@ $*.rc
+
 
 clean:
-	- del *.obj main\*.obj optlib\*.obj parsers\*.obj parsers\cxx\*.obj gnu_regex\*.obj fnmatch\*.obj misc\packcc\*.obj peg\*.obj read\*.obj win32\mkstemp\*.obj main\repoinfo.h
+	- del *.obj main\*.obj optlib\*.obj parsers\*.obj parsers\cxx\*.obj gnu_regex\*.obj fnmatch\*.obj misc\packcc\*.obj peg\*.obj read\*.obj win32\mkstemp\*.obj win32\*.res main\repoinfo.h
 	- del ctags.exe readtags.exe $(PACKCC)
 	- del tags

--- a/win32/ctags.exe.manifest
+++ b/win32/ctags.exe.manifest
@@ -13,4 +13,18 @@
       <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
     </windowsSettings>
   </application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!--The ID below indicates application support for Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!--The ID below indicates application support for Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!--The ID below indicates application support for Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!--The ID below indicates application support for Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!--The ID below indicates application support for Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
 </assembly>

--- a/win32/ctags.exe.manifest
+++ b/win32/ctags.exe.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity type="win32" name="Universal Ctags" version="0.0.0.0" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <application>
+    <windowsSettings>
+      <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/win32/ctags.rc
+++ b/win32/ctags.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "winres.h"
+#include "winresrc.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS

--- a/win32/ctags.rc
+++ b/win32/ctags.rc
@@ -1,0 +1,107 @@
+// Microsoft Visual C++ generated resource script.
+//
+#include "resource.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 2 resource.
+//
+#include "winres.h"
+
+/////////////////////////////////////////////////////////////////////////////
+#undef APSTUDIO_READONLY_SYMBOLS
+
+/////////////////////////////////////////////////////////////////////////////
+// English (United States) resources
+
+#if !defined(AFX_RESOURCE_DLL) || defined(AFX_TARG_ENU)
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+#ifdef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// TEXTINCLUDE
+//
+
+1 TEXTINCLUDE 
+BEGIN
+    "resource.h\0"
+END
+
+2 TEXTINCLUDE 
+BEGIN
+    "#include ""winres.h""\r\n"
+    "\0"
+END
+
+3 TEXTINCLUDE 
+BEGIN
+    "\r\n"
+    "\0"
+END
+
+#endif    // APSTUDIO_INVOKED
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// RT_MANIFEST
+//
+
+1                       RT_MANIFEST             "ctags.exe.manifest"
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 0,0,0,0
+ PRODUCTVERSION 0,0,0,0
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x40004L
+ FILETYPE 0x1L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "Universal Ctags Team"
+            VALUE "FileDescription", "Universal Ctags"
+            VALUE "FileVersion", "0.0.0.0"
+            VALUE "InternalName", "ctags.exe"
+            VALUE "LegalCopyright", "Copyright (C) 2015 Universal Ctags Team"
+            VALUE "OriginalFilename", "ctags.exe"
+            VALUE "ProductName", "Universal Ctags"
+            VALUE "ProductVersion", "0.0.0.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+#endif    // English (United States) resources
+/////////////////////////////////////////////////////////////////////////////
+
+
+
+#ifndef APSTUDIO_INVOKED
+/////////////////////////////////////////////////////////////////////////////
+//
+// Generated from the TEXTINCLUDE 3 resource.
+//
+
+
+/////////////////////////////////////////////////////////////////////////////
+#endif    // not APSTUDIO_INVOKED
+

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -53,6 +53,12 @@
     <CodeAnalysisRules Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
     <CodeAnalysisRuleAssemblies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <EmbedManifest>false</EmbedManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <EmbedManifest>false</EmbedManifest>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -338,6 +344,10 @@
     <ClInclude Include="..\parsers\make.h" />
     <ClInclude Include="..\parsers\perl.h" />
     <ClInclude Include="..\parsers\tcl.h" />
+    <ClInclude Include="resource.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="ctags.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -144,7 +144,7 @@
     <ClCompile Include="..\main\sort.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
-    <ClCompile Include="..\main\stat.c">
+    <ClCompile Include="..\main\stats.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
     <ClCompile Include="..\main\strlist.c">
@@ -159,7 +159,7 @@
     <ClCompile Include="..\main\vstring.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
-    <ClCompile Include="..\main\uwindi.c">
+    <ClCompile Include="..\main\unwindi.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
     <ClCompile Include="..\main\writer-ctags.c">
@@ -566,9 +566,6 @@
     <ClInclude Include="..\main\flags_p.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\main\fmt.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="..\main\fmt_p.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -641,7 +638,7 @@
     <ClInclude Include="..\main\parse.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\main\parse_.h">
+    <ClInclude Include="..\main\parse_p.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\parsers_p.h">
@@ -767,5 +764,13 @@
     <ClInclude Include="..\parsers\tcl.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="ctags.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/win32/resource.h
+++ b/win32/resource.h
@@ -1,0 +1,14 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by ctags.rc
+
+// Next default values for new objects
+//
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_COMMAND_VALUE         40001
+#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_SYMED_VALUE           101
+#endif
+#endif


### PR DESCRIPTION
This adds version resource and application manifest to the win32 executable file.
`win32/ctags.rc` and `win32/resource.h` are created by VS2013 and edited manually.

The application manifest should fix the issue #1837 on Windows 10 version 1903 or later.
See: https://docs.microsoft.com/en-us/windows/uwp/design/globalizing/use-utf8-code-page
This is a relatively new feature in Windows and it might not be matured enough, but at least I confirmed that ctags.exe can handle Unicode file names on Windows 10 1909.

NOTE: the version number needs to be updated manually.
We have version numbers in several files: `configure.ac`, `docs/conf.py`, `main/ctags.h`, `win32/ctags.exe.manifest` and `win32/ctags.rc`. (The last two files are added in this PR.)
We need to update all of them, when we release a new version.