### PR TITLE
Update version

### DIFF
--- a/Tmain/input-encoding-option.d/tags-expected.txt
+++ b/Tmain/input-encoding-option.d/tags-expected.txt
@@ -6,7 +6,7 @@
 !_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
 !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/
-!_TAG_PROGRAM_VERSION	0.0.0	//
+!_TAG_PROGRAM_VERSION	5.9.0	//
 Foo	input.java	/^	public Foo() { \/\/ コンストラクタ$/;"	m	class:Foo
 Foo	input.java	/^class Foo { \/\/ Fooクラス$/;"	c
 a	input.js	/^var a = 1; \/\/ 変数初期化$/;"	v

--- a/Tmain/interactive-mode.d/stdout-expected.txt
+++ b/Tmain/interactive-mode.d/stdout-expected.txt
@@ -1,26 +1,26 @@
 identification message on startup
 =======================================
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 
 error on invalid command
 =======================================
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 {"_type": "error", "message": "unknown command name", "fatal": true}
 
 error on missing arguments
 =======================================
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 {"_type": "error", "message": "invalid generate-tags request", "fatal": true}
 
 error on invalid file
 =======================================
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 {"_type": "error", "message": "cannot open input file \"test.foo\"", "warning": true, "errno": 2, "perror": "No such file or directory"}
 {"_type": "completed", "command": "generate-tags"}
 
 generate tags from file
 =======================================
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 {"_type": "tag", "name": "Test", "path": "test.rb", "pattern": "/^class Test$/", "kind": "class"}
 {"_type": "tag", "name": "foobar", "path": "test.rb", "pattern": "/^  def foobar$/", "kind": "method", "scope": "Test", "scopeKind": "class"}
 {"_type": "tag", "name": "baz", "path": "test.rb", "pattern": "/^  def baz(a=1)$/", "kind": "method", "scope": "Test", "scopeKind": "class"}
@@ -28,7 +28,7 @@ generate tags from file
 
 process multiple commands
 =======================================
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 {"_type": "tag", "name": "Test", "path": "test.rb", "pattern": "/^class Test$/", "kind": "class"}
 {"_type": "tag", "name": "foobar", "path": "test.rb", "pattern": "/^  def foobar$/", "kind": "method", "scope": "Test", "scopeKind": "class"}
 {"_type": "tag", "name": "baz", "path": "test.rb", "pattern": "/^  def baz(a=1)$/", "kind": "method", "scope": "Test", "scopeKind": "class"}
@@ -39,7 +39,7 @@ process multiple commands
 
 generate tags from data
 =======================================
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 {"_type": "tag", "name": "Test", "path": "foobar.rb", "pattern": "/^class Test$/", "kind": "class"}
 {"_type": "tag", "name": "foobar", "path": "foobar.rb", "pattern": "/^  def foobar$/", "kind": "method", "scope": "Test", "scopeKind": "class"}
 {"_type": "tag", "name": "baz", "path": "foobar.rb", "pattern": "/^  def baz(a=1)$/", "kind": "method", "scope": "Test", "scopeKind": "class"}

--- a/Tmain/interactive-option-write-to-file.d/stdout-expected.txt
+++ b/Tmain/interactive-option-write-to-file.d/stdout-expected.txt
@@ -1,4 +1,4 @@
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 {"_type": "tag", "name": "Test", "path": "test.rb", "pattern": "/^class Test$/", "kind": "class"}
 {"_type": "tag", "name": "foobar", "path": "test.rb", "pattern": "/^  def foobar$/", "kind": "method", "scope": "Test", "scopeKind": "class"}
 {"_type": "tag", "name": "baz", "path": "test.rb", "pattern": "/^  def baz(a=1)$/", "kind": "method", "scope": "Test", "scopeKind": "class"}

--- a/Tmain/output-encoding-option.d/tags-expected.txt
+++ b/Tmain/output-encoding-option.d/tags-expected.txt
@@ -6,7 +6,7 @@
 !_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
 !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/
-!_TAG_PROGRAM_VERSION	0.0.0	//
+!_TAG_PROGRAM_VERSION	5.9.0	//
 Foo	input.java	/^	public Foo() { \/\/ コンストラクタ$/;"	m	class:Foo
 Foo	input.java	/^class Foo { \/\/ Fooクラス$/;"	c
 a	input.js	/^var a = 1; \/\/ 変数初期化$/;"	v

--- a/Tmain/sandbox-default-req.d/stdout-expected.txt
+++ b/Tmain/sandbox-default-req.d/stdout-expected.txt
@@ -1,4 +1,4 @@
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 {"_type": "error", "message": "invalid request in sandbox submode: reading file contents from a file is limited", "fatal": true}
 {"_type": "tag", "name": "foo", "path": "input.el", "pattern": "/^(defun foo () 0)/", "kind": "function"}
 {"_type": "completed", "command": "generate-tags"}

--- a/Tmain/sandbox-no-eager-guessing.d/stdout-expected.txt
+++ b/Tmain/sandbox-no-eager-guessing.d/stdout-expected.txt
@@ -1,2 +1,2 @@
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 {"_type": "completed", "command": "generate-tags"}

--- a/Tmain/sandbox-with-eager-guessing.d/stdout-expected.txt
+++ b/Tmain/sandbox-with-eager-guessing.d/stdout-expected.txt
@@ -1,3 +1,3 @@
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 {"_type": "tag", "name": "main", "path": "input.unknown", "pattern": "/^\\/* -*- c -*- *\\/ int main(void) { return 0; }/", "typeref": "typename:int", "kind": "function"}
 {"_type": "completed", "command": "generate-tags"}

--- a/Tmain/sandbox.d/stdout-expected.txt
+++ b/Tmain/sandbox.d/stdout-expected.txt
@@ -1,3 +1,3 @@
-{"_type": "program", "name": "Universal Ctags", "version": "0.0.0"}
+{"_type": "program", "name": "Universal Ctags", "version": "5.9.0"}
 {"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^int main(void) { return 0; }/", "typeref": "typename:int", "kind": "function"}
 {"_type": "completed", "command": "generate-tags"}

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@
 #	Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.59])
-AC_INIT([universal-ctags],[0.0.0])
+AC_INIT([universal-ctags],[5.9.0])
 
 if ! test -e "${srcdir}/config.h.in"; then
    echo "---"


### PR DESCRIPTION
Related with #2361

This reveals that versioning break test suite (which doesn't m takes sense).

We need a test suite able to avoid tag comments that breaks test suite or preprocess test fixtures to allow version on it (which seems overengineered)