### PR TITLE
 buildsys,travis: verify code genereated by optlib2c is added to commits 

### DIFF
--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -26,6 +26,11 @@ if [ "$TARGET" = "Unix" ]; then
 
     BUILDDIR0="$TRAVIS_OS_NAME"-"$CC"
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$CC" = "gcc" ]; then
+		if ! git diff --exit-code optlib; then
+			echo "Files under optlib are not up to date."
+			echo "If you change optlib/foo.ctags, don't forget to add optlib/foo.c to your commit."
+			exit 1
+		fi
 
         BUILDDIR=${BUILDDIR0}-gcov
         mkdir -p "${BUILDDIR}"


### PR DESCRIPTION
Like docs/man/\*.[0-9], code genereated by optlib2c must be added to our
git repository. This allows building ctags where optlib2c written in
perl cannot to be run. To avoid merging commits including only changes
for optlib/\*.ctags, this change introduces code for verifying
optlib/\*.c is also included in the commits.

Close #2358.
See also #2355.
