### PR TITLE
buildsys: Align the output of make

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -226,7 +226,7 @@ man_MANS = \
 	$(NULL)
 rst2man_verbose = $(rst2man_verbose_@AM_V@)
 rst2man_verbose_ = $(rst2man_verbose_@AM_DEFAULT_V@)
-rst2man_verbose_0 = @echo RST2MAN "  $@";
+rst2man_verbose_0 = @echo RST2MAN "   $@";
 SUFFIXES += .1.rst .1 .5.rst .5 .7.rst .7
 # See man/Makefile
 RST2MAN_OPTIONS=--syntax-highlight=none


### PR DESCRIPTION
The RST2MAN lines in the output of make were not well aligned:

```
  CC       peg/libctags_a-varlink.o
  AR       libctags.a
WINDRES    win32/ctags.res.o
  CCLD     ctags.exe
  CCLD     mini-geany.exe
RST2MAN   man/ctags.1
RST2MAN   man/ctags-incompatibilities.7
          ^
```

This should be:

```
  CC       peg/libctags_a-varlink.o
  AR       libctags.a
WINDRES    win32/ctags.res.o
  CCLD     ctags.exe
  CCLD     mini-geany.exe
RST2MAN    man/ctags.1
RST2MAN    man/ctags-incompatibilities.7
```