### PR TITLE
win32: Use copyright mark on properties dialog box

### DIFF
--- a/win32/ctags.rc
+++ b/win32/ctags.rc
@@ -78,7 +78,7 @@ BEGIN
             VALUE "FileDescription", "Universal Ctags"
             VALUE "FileVersion", "0.0.0.0"
             VALUE "InternalName", "ctags.exe"
-            VALUE "LegalCopyright", "Copyright (C) 2015 Universal Ctags Team"
+            VALUE "LegalCopyright", "Copyright \251 2015 Universal Ctags Team"
             VALUE "OriginalFilename", "ctags.exe"
             VALUE "ProductName", "Universal Ctags"
             VALUE "ProductVersion", "0.0.0.0"


### PR DESCRIPTION
Just a cosmetic change. Use copyright mark © instead of (C) in the properties dialog box.

Before this fix:
![ctags-prop1](https://user-images.githubusercontent.com/840186/70533906-5c440b00-1b9d-11ea-8784-53df1cd0e3ce.png)

After this fix:
![ctags-prop2](https://user-images.githubusercontent.com/840186/70533944-6bc35400-1b9d-11ea-833a-f24413a95535.png)