### PR TITLE
Extend tokeninfo API

### DIFF
--- a/main/tokeninfo.h
+++ b/main/tokeninfo.h
@@ -76,6 +76,7 @@ void tokenCopy       (tokenInfo *dest, tokenInfo *src);
 /* Helper macro & functions */
 
 #define tokenIsType(TKN,T)     ((TKN)->type == TOKEN_##T)
+#define tokenIsTypeVal(TKN,TV)   ((TKN)->type == (TV))
 #define tokenIsKeyword(TKN,K)  ((TKN)->type == TKN->klass->typeForKeyword \
 									&& (TKN)->keyword == KEYWORD_##K)
 #define tokenIsEOF(TKN)      ((TKN)->type == (TKN)->klass->typeForEOF)

--- a/main/tokeninfo.h
+++ b/main/tokeninfo.h
@@ -82,6 +82,8 @@ void tokenCopy       (tokenInfo *dest, tokenInfo *src);
 
 #define tokenString(TKN)	   (vStringValue ((TKN)->string))
 #define tokenPutc(TKN,C)      (vStringPut ((TKN)->string, C))
+#define tokenCat(TKN,VS)       (vStringCat ((TKN)->string, VS))
+#define tokenLast(TKN)         (vStringIsEmpty((TKN)->string)? '\0': vStringLast((TKN)->string))
 
 /* return true if t is found. In that case token holds an
    language object type t.

--- a/parsers/tcloo.c
+++ b/parsers/tcloo.c
@@ -42,7 +42,7 @@ static void parseMethod (tokenInfo *token, int owner)
 	{
 		tagEntryInfo e;
 
-		initTagEntry(&e, vStringValue (token->string), K_METHOD);
+		initTagEntry(&e, tokenString (token), K_METHOD);
 		e.extensionFields.scopeIndex = owner;
 		makeTagEntry (&e);
 	}
@@ -83,7 +83,7 @@ static int parseClass (tclSubparser *s CTAGS_ATTR_UNUSED, int parentIndex,
 		{
 			tagEntryInfo e;
 
-			initTagEntry(&e, vStringValue (token->string), K_CLASS);
+			initTagEntry(&e, tokenString (token), K_CLASS);
 			e.extensionFields.scopeIndex = parentIndex;
 			r = makeTagEntry (&e);
 		}


### PR DESCRIPTION
Define some new macros accessing fields of tokenInfo data type.
I found they were useful when prototyping a vala parser with tokenInfo in #621.