### PR TITLE
C++: skip C++ attributes

### DIFF
--- a/Units/parser-cxx.r/cxx11-attribute.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/cxx11-attribute.cpp.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-C++=+pz

--- a/Units/parser-cxx.r/cxx11-attribute.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-attribute.cpp.d/expected.tags
@@ -1,0 +1,8 @@
+f	input.cpp	/^inline int f(); \/\/ declare f with four attributes$/;"	p	typeref:typename:int	file:
+g	input.cpp	/^int g(); \/\/ same as above, but uses a single attr specifier that contains four attributes$/;"	p	typeref:typename:int	file:
+h	input.cpp	/^int h[[gnu::always_inline]](); \/\/ an attribute may appear in multiple specifiers$/;"	p	typeref:typename:int	file:
+i	input.cpp	/^int i() { return 0; }$/;"	f	typeref:typename:int
+foo	input.cpp	/^void foo();$/;"	p	typeref:typename:void	file:
+main	input.cpp	/^int main([[maybe_unused]]int argc, [[maybe_unused]]char *argv[]) {$/;"	f	typeref:typename:int
+argc	input.cpp	/^int main([[maybe_unused]]int argc, [[maybe_unused]]char *argv[]) {$/;"	z	function:main	typeref:typename:int	file:
+argv	input.cpp	/^int main([[maybe_unused]]int argc, [[maybe_unused]]char *argv[]) {$/;"	z	function:main	typeref:typename:char * []	file:

--- a/Units/parser-cxx.r/cxx11-attribute.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/cxx11-attribute.cpp.d/input.cpp
@@ -1,0 +1,28 @@
+// Tkane from https://en.cppreference.com/w/cpp/language/attributes
+[[gnu::always_inline]] [[gnu::hot]] [[gnu::const]] [[nodiscard]]
+inline int f(); // declare f with four attributes
+ 
+[[gnu::always_inline, gnu::const, gnu::hot, nodiscard]]
+int g(); // same as above, but uses a single attr specifier that contains four attributes
+ 
+// C++17:
+[[using gnu : const, always_inline, hot]] [[nodiscard]]
+int h[[gnu::always_inline]](); // an attribute may appear in multiple specifiers
+ 
+int i() { return 0; }
+ 
+
+/* Taken from issue #2364 opened by andrejlevkovitch. */
+// main.cpp
+#include <cstdlib>
+#include <iostream>
+
+void foo();
+
+int main([[maybe_unused]]int argc, [[maybe_unused]]char *argv[]) {
+  int alpha;
+  int bravo;
+  int charlie;
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Skip [[foo]] as we do for __attribute__(("foo")).
[[foo]] style attribute notation is introduced in C++11.

Close #2364.

NOTE: This may make implementing ObjectiveC++ parser handler.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>