### PR TITLE
CXX: Handle C++11 attributes. Fixes bug #2364.

### DIFF
--- a/Units/parser-cxx.r/cxx11-attributes.d/args.ctags
+++ b/Units/parser-cxx.r/cxx11-attributes.d/args.ctags
@@ -1,0 +1,5 @@
+--sort=no
+--extras=+q
+--kinds-c++=*
+--fields-C++=+{properties}
+--fields=+tS

--- a/Units/parser-cxx.r/cxx11-attributes.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-attributes.d/expected.tags
@@ -1,0 +1,8 @@
+deprecated	input.cpp	/^[[deprecated("does nothing")]] [[gnu::always_inline, noreturn]] void deprecated()$/;"	f	typeref:typename:void	signature:()
+main	input.cpp	/^int main([[maybe_unused]] int argc,[[maybe_unused]] char ** argv)$/;"	f	typeref:typename:int	signature:(int argc,char ** argv)
+argc	input.cpp	/^int main([[maybe_unused]] int argc,[[maybe_unused]] char ** argv)$/;"	z	function:main	typeref:typename:int	file:
+argv	input.cpp	/^int main([[maybe_unused]] int argc,[[maybe_unused]] char ** argv)$/;"	z	function:main	typeref:typename:char **	file:
+v1	input.cpp	/^	int v1;$/;"	l	function:main	typeref:typename:int	file:
+v2	input.cpp	/^		int v2;$/;"	l	function:main	typeref:typename:int	file:
+v3	input.cpp	/^			int v3;$/;"	l	function:main	typeref:typename:int	file:
+v4	input.cpp	/^			int v4;$/;"	l	function:main	typeref:typename:int	file:

--- a/Units/parser-cxx.r/cxx11-attributes.d/input.cpp
+++ b/Units/parser-cxx.r/cxx11-attributes.d/input.cpp
@@ -1,0 +1,35 @@
+
+
+[[deprecated("does nothing")]] [[gnu::always_inline, noreturn]] void deprecated()
+{
+	
+}
+
+int main([[maybe_unused]] int argc,[[maybe_unused]] char ** argv)
+{
+	int v1;
+	
+	if(1)
+	{
+		[[likely]];
+		int v2;
+	}
+	
+	switch(argc)
+	{
+		case 1:
+			[[fallthrough]];
+		[[likely]] case 2:
+		{
+			int v3;
+			return 1;
+		}
+		[[unlikely]] case 3:
+		{
+			int v4;
+			return 2;
+		}
+	}
+
+	return 0;
+}

--- a/parsers/cxx/cxx_debug_type.c
+++ b/parsers/cxx/cxx_debug_type.c
@@ -48,6 +48,7 @@ const char * cxxDebugTypeDecode (enum CXXTokenType eType)
 	if (eType & CXXTokenTypeParenthesisChain) a = append (buf, "ParenthesisChain", a);
 	if (eType & CXXTokenTypeSquareParenthesisChain) a = append (buf, "SquareParenthesisChain", a);
 	if (eType & CXXTokenTypeAngleBracketChain) a = append (buf, "AngleBracketChain", a);
+	if (eType & CXXTokenTypeAttributeChain) a = append (buf, "AttributeChain", a);
 	if (vStringLength(buf) == 0) vStringCatS(buf, "REALLY-UNKNOWN");
 	return vStringValue (buf);
 }

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -1552,7 +1552,7 @@ int cxxParserEmitFunctionTags(
 			}
 		}
 
-		vString * pszSignature = cxxTokenChainJoin(pInfo->pParenthesis->pChain,NULL,0);
+		vString * pszSignature = cxxTokenChainJoinFiltered(pInfo->pParenthesis->pChain,CXXTokenTypeAttributeChain,0);
 		if(pInfo->pSignatureConst)
 		{
 			vStringPut (pszSignature, ' ');
@@ -1893,12 +1893,14 @@ bool cxxParserTokenChainLooksLikeFunctionParameterList(
 		if(!cxxTokenTypeIsOneOf(
 				t,
 				CXXTokenTypeIdentifier | CXXTokenTypeKeyword |
-					CXXTokenTypeMultipleDots | CXXTokenTypeMultipleColons
+					CXXTokenTypeMultipleDots | CXXTokenTypeMultipleColons |
+					CXXTokenTypeAttributeChain
 			))
 		{
 			CXX_DEBUG_LEAVE_TEXT(
-					"Token '%s' is something that is not a identifier, keyword, :: or ...",
-					vStringValue(t->pszWord)
+					"Token '%s' of type %s is something that is not a identifier, keyword, :: or ...",
+					vStringValue(t->pszWord),
+					cxxDebugTypeDecode(t->eType)
 				);
 			return false;
 		}

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -437,20 +437,24 @@ CXXToken * cxxTagCheckAndSetTypeField(
 	// allowed by C++ for unqualified types. However I haven't been able
 	// to come up with something better... so "typename" it is for now.
 
-	// FIXME: The typeRef forma with two fields should be dropped.
+	// FIXME: The typeRef form with two fields should be dropped.
 	//        It has been created with specific use cases in mind
 	//        and we are pushing it way beyond them.
 	//        We should have a plain "type" field instead.
 
 	static const char * szTypename = "typename";
 
-	// Filter out initial keywords that need to be excluded from typenames
+	// Filter out initial keywords and attribute chains that need to be excluded
+	// from typenames
 	for(;;)
 	{
-		if(!cxxTokenTypeIs(pTypeStart,CXXTokenTypeKeyword))
-			break;
-		if(!cxxKeywordExcludeFromTypeNames(pTypeStart->eKeyword))
-			break;
+		if(!cxxTokenTypeIs(pTypeStart,CXXTokenTypeAttributeChain))
+		{
+			if(!cxxTokenTypeIs(pTypeStart,CXXTokenTypeKeyword))
+				break;
+			if(!cxxKeywordExcludeFromTypeNames(pTypeStart->eKeyword))
+				break;
+		}
 		// must be excluded
 		if(pTypeStart == pTypeEnd)
 		{

--- a/parsers/cxx/cxx_token.c
+++ b/parsers/cxx/cxx_token.c
@@ -145,6 +145,7 @@ void cxxTokenAppendToString(vString * s,CXXToken * t)
 		case CXXTokenTypeSquareParenthesisChain:
 		case CXXTokenTypeBracketChain:
 		case CXXTokenTypeAngleBracketChain:
+		case CXXTokenTypeAttributeChain:
 			CXX_DEBUG_ASSERT(t->pChain,"This token should have a nested chain!");
 			cxxTokenChainJoinInString(t->pChain,s,NULL,0);
 		break;

--- a/parsers/cxx/cxx_token.h
+++ b/parsers/cxx/cxx_token.h
@@ -59,6 +59,13 @@ enum CXXTokenType
 	CXXTokenTypeParenthesisChain = (1 << 28), // (...)
 	CXXTokenTypeSquareParenthesisChain = (1 << 29), // [...]
 	CXXTokenTypeAngleBracketChain = (1 << 30), // <...>
+
+	// A special chain that really has no opening/closing marker.
+	// It is generated as a special case when condensing a square parenthesis
+	// chain. The reason is that two consecutive closing square parentheses
+	// are ambiguous and can't be always treated as a closing ]] token.
+	// There must be a matching [[ at the same chain level.
+	CXXTokenTypeAttributeChain = (1 << 31), // [[...]]
 };
 
 // Forward decl

--- a/parsers/cxx/cxx_token_chain.h
+++ b/parsers/cxx/cxx_token_chain.h
@@ -185,6 +185,18 @@ vString * cxxTokenChainJoin(
 		unsigned int uFlags
 	);
 
+void cxxTokenChainJoinFilteredInString(
+		CXXTokenChain * tc,
+		vString * s,
+		unsigned int uFilterTokenTypes,
+		unsigned int uFlags
+	);
+vString * cxxTokenChainJoinFiltered(
+		CXXTokenChain * tc,
+		unsigned int uFilterTokenTypes,
+		unsigned int uFlags
+	);
+
 void cxxTokenChainJoinRangeInString(
 		CXXToken * from,
 		CXXToken * to,


### PR DESCRIPTION
Don't let C++11 [[attributes]] fool the parser.