### PR TITLE
CXX: Handle C++11 attributes. Fixes bug #2364

### DIFF
--- a/Units/parser-cxx.r/cxx11-attributes.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/cxx11-attributes.cpp.d/args.ctags
@@ -1,0 +1,4 @@
+--kinds-c++=*
+--fields-C++=+{properties}
+--fields=+tS
+--sort=no

--- a/Units/parser-cxx.r/cxx11-attributes.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-attributes.cpp.d/expected.tags
@@ -1,0 +1,14 @@
+f	input.cpp	/^inline int f(); \/\/ declare f with four attributes$/;"	p	typeref:typename:int	file:	signature:()	properties:inline
+g	input.cpp	/^int g(); \/\/ same as above, but uses a single attr specifier that contains four attributes$/;"	p	typeref:typename:int	file:	signature:()	properties:inline
+h	input.cpp	/^int h[[gnu::always_inline]](); \/\/ an attribute may appear in multiple specifiers$/;"	p	typeref:typename:int	file:	signature:()	properties:inline
+i	input.cpp	/^int i() { return 0; }$/;"	f	typeref:typename:int	signature:()
+j	input.cpp	/^[ [ deprecated ] ] int j(int k) {$/;"	f	typeref:typename:int	signature:(int k)	properties:deprecated
+k	input.cpp	/^[ [ deprecated ] ] int j(int k) {$/;"	z	function:j	typeref:typename:int	file:
+v1	input.cpp	/^	int v1;$/;"	l	function:j	typeref:typename:int	file:
+foo	input.cpp	/^void foo();$/;"	p	typeref:typename:void	file:	signature:()
+main	input.cpp	/^int main([[maybe_unused]]int argc, [[maybe_unused]]char *argv[]) {$/;"	f	typeref:typename:int	signature:(int argc,char * argv[])
+argc	input.cpp	/^int main([[maybe_unused]]int argc, [[maybe_unused]]char *argv[]) {$/;"	z	function:main	typeref:typename:int	file:
+argv	input.cpp	/^int main([[maybe_unused]]int argc, [[maybe_unused]]char *argv[]) {$/;"	z	function:main	typeref:typename:char * []	file:
+alpha	input.cpp	/^  int alpha;$/;"	l	function:main	typeref:typename:int	file:
+bravo	input.cpp	/^  int bravo;$/;"	l	function:main	typeref:typename:int	file:
+charlie	input.cpp	/^  int charlie;$/;"	l	function:main	typeref:typename:int	file:

--- a/Units/parser-cxx.r/cxx11-attributes.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/cxx11-attributes.cpp.d/input.cpp
@@ -1,0 +1,39 @@
+// Tkane from https://en.cppreference.com/w/cpp/language/attributes
+[[gnu::always_inline]] [[gnu::hot]] [[gnu::const]] [[nodiscard]]
+inline int f(); // declare f with four attributes
+
+[[gnu::always_inline, gnu::const, gnu::hot, nodiscard]]
+int g(); // same as above, but uses a single attr specifier that contains four attributes
+
+// C++17:
+[[using gnu : const, always_inline, hot]] [[nodiscard]]
+int h[[gnu::always_inline]](); // an attribute may appear in multiple specifiers
+
+int i() { return 0; }
+
+[ [ deprecated ] ] int j(int k) {
+	switch(k)
+	{
+		case 1:
+			[[fallthrough]];
+		case 2:
+			[[likely]]
+			return 3;
+	}
+	
+	int v1;
+	
+	return -1;
+}
+
+/* Taken from issue #2364 opened by andrejlevkovitch. */
+
+void foo();
+
+int main([[maybe_unused]]int argc, [[maybe_unused]]char *argv[]) {
+  int alpha;
+  int bravo;
+  int charlie;
+
+  return 0;
+}


### PR DESCRIPTION
Second attempt based on @Masatake's idea.
We skip C++11 attributes at tokenizer level so they don't bother the parser at all.
By the way we decode a couple of them just like in the __attribute__(()) case.