### PR TITLE
travis: sed command line for macos

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -78,7 +78,12 @@ cites := ${subst .,(,${addsuffix ),${man_pages}}}
 # ctags(1) tags(5) ...
 # => -e 's/\<ctags(1)/:ref:`& <&>`/g' -e 's/\<ctags(5)/:ref:`& <&>`/g' ...
 #
+is_gnu_sed := $(shell sed --version | grep -q GNU && echo 1)
+ifeq ($(is_gnu_sed),1)
 reppat := $(foreach m,$(cites),-e 's/\<$(m)/:ref:`& <&>`/g')
+else
+reppat := $(foreach m,$(cites),-e 's/[[:<:]]$(m)/:ref:`& <&>`/g')
+endif
 
 update-docs: $(doc_files)
 

--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -61,7 +61,7 @@ if [ "$TARGET" = "Unix" ]; then
         )
 
     else
-		make -C man QUICK=1 update-docs
+		make -B -C man QUICK=1 update-docs
 		if ! git diff --exit-code docs/man; then
 			echo "Files under docs/man/ are not up to date."
 			echo "Please execute 'make -C man QUICK=1 update-docs' and commit them."


### PR DESCRIPTION
We tracked the strange result about the code verifying the rst files under docs/man are committed.
fc7e236 is for fixing the issue.

Without fc7e236,  in some cases, "make -C man QUICK=1 update-docs" does nothing.
As the result, the code using "git diff --exit-code docs/man" reports "o.k." though it is not o.k.
I guess it is related to low resolution of timestamp of the file system. (This never happens on GNU/Linux.)

This behaviour hides '\<' used in sed command line is not portable.

c6b9a4c defines an alternative regular expression that can be used in BSD sed.


TODO: We should drop the support for BSD make. We already use enough GNU make features. We cannot go back. We can utilize autotools for fixing part of issues. However, it is impossible to put our man pages to our web site with autotools. GNU make is needed to run "make -C man QUICK=1 update-docs".