### PR TITLE
travis: force make command to run update-docs target of man/Makefile

### DIFF
--- a/misc/travis-check.sh
+++ b/misc/travis-check.sh
@@ -61,7 +61,7 @@ if [ "$TARGET" = "Unix" ]; then
         )
 
     else
-		make -C man QUICK=1 update-docs
+		make -B -C man QUICK=1 update-docs
 		if ! git diff --exit-code docs/man; then
 			echo "Files under docs/man/ are not up to date."
 			echo "Please execute 'make -C man QUICK=1 update-docs' and commit them."


### PR DESCRIPTION
On a file system with low resolution of timestamp, the code verifying
rst files under docs/man are commited doesn't work well. On the such
file system, "make -C man QUICK=1 update-docs" does nothing in some
cases. I inspected this issue in #2367.

Suggested by @k-takata in #2376.