### PR TITLE
build-sys,docs(man): check whether --syntax-highlight option of rst2man is available or not

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -228,8 +228,6 @@ rst2man_verbose = $(rst2man_verbose_@AM_V@)
 rst2man_verbose_ = $(rst2man_verbose_@AM_DEFAULT_V@)
 rst2man_verbose_0 = @echo RST2MAN "   $@";
 SUFFIXES += .1.rst .1 .5.rst .5 .7.rst .7
-# See man/Makefile
-RST2MAN_OPTIONS=--syntax-highlight=none
 .1.rst.1:
 	$(rst2man_verbose)$(RST2MAN) $(RST2MAN_OPTIONS) $< $@
 .5.rst.5:

--- a/configure.ac
+++ b/configure.ac
@@ -271,6 +271,19 @@ AM_CONDITIONAL([RUN_OPTLIB2C], [test "${perl_found}" = "yes"])
 AC_PATH_PROGS(RST2MAN, [rst2man rst2man.py rst2man3 rst2man3.py], [no])
 AM_CONDITIONAL([HAVE_RST2MAN], [test "x$RST2MAN" != "xno"])
 
+RST2MAN_OPTIONS=
+if ! test "x$RST2MAN" = "xno"; then
+   RST2MAN_SUPPORTING_SYNTAX_HIGHLIGHT_OPTION=no
+   AC_MSG_CHECKING(whether rst2mn has --syntax-highlight option)
+   if $RST2MAN --help | grep -q -e --syntax-highlight; then
+      RST2MAN_SUPPORTING_SYNTAX_HIGHLIGHT_OPTION=yes
+      dnl See man/Makefile about the option
+      RST2MAN_OPTIONS=--syntax-highlight=none
+   fi
+   AC_MSG_RESULT($RST2MAN_SUPPORTING_SYNTAX_HIGHLIGHT_OPTION)
+fi
+AC_SUBST(RST2MAN_OPTIONS)
+
 # Checks for operating environment
 # --------------------------------
 in_git_repo=no


### PR DESCRIPTION
This change is similar to 7cf97016d7e5b0b4e9cec9511fa7a60e5f76c7d1.
7cf97016d7e5b0b4e9cec9511fa7a60e5f76c7d1 is for 'make -C man QUICK=1'.

This one handles the case for QUICK != 1.

Suggested by @songouyang in #2374

Close #2374 again.