### PR TITLE
[INCOMPATIBLE in Python] Limit the characters that can be used in a role name

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -2,138 +2,138 @@
 #
 #
 #
-#LANGUAGE      KIND(L/N)         NAME                ENABLED DESCRIPTION
-Asm            s/section         placement           on      placement where the assembled code goes
-AutoIt         S/script          local               on      local include
-AutoIt         S/script          system              on      system include
-Automake       c/condition       branched            on      used for branching
-Automake       d/directory       data                on      directory for DATA primary
-Automake       d/directory       library             on      directory for LIBRARIES primary
-Automake       d/directory       ltlibrary           on      directory for LTLIBRARIES primary
-Automake       d/directory       man                 on      directory for MANS primary
-Automake       d/directory       program             on      directory for PROGRAMS primary
-Automake       d/directory       script              on      directory for SCRIPTS primary
-C              d/macro           undef               on      undefined
-C              h/header          local               on      local header
-C              h/header          system              on      system header
-C++            d/macro           undef               on      undefined
-C++            h/header          local               on      local header
-C++            h/header          system              on      system header
-CPreProcessor  d/macro           undef               on      undefined
-CPreProcessor  h/header          local               on      local header
-CPreProcessor  h/header          system              on      system header
-CUDA           d/macro           undef               on      undefined
-CUDA           h/header          local               on      local header
-CUDA           h/header          system              on      system header
-Cobol          S/sourcefile      copied              on      copied in source file
-DTD            e/element         attOwner            on      attributes owner
-DTD            p/parameterEntity condition           on      conditions
-DTD            p/parameterEntity elementName         on      element names
-DTD            p/parameterEntity partOfAttDef        on      part of attribute definition
-Elm            m/module          imported            on      imported module
-Flex           I/import          import              on      imports
-Go             p/package         imported            on      imported package
-Go             u/unknown         receiverType        on      receiver type
-HTML           C/stylesheet      extFile             on      referenced as external files
-HTML           J/script          extFile             on      referenced as external files
-HTML           c/class           attribute           on      assigned as attributes
-Java           p/package         imported            on      imported package
-LdScript       i/inputSection    discarded           on      discarded when linking
-LdScript       i/inputSection    mapped              on      mapped to output section
-LdScript       s/symbol          entrypoint          on      entry points
-M4             I/macrofile       included            on      included macro
-M4             I/macrofile       sincluded           on      silently included macro
-M4             d/macro           undef               on      undefined
-Make           I/makefile        included            on      included
-Make           I/makefile        optional            on      optionally included
-NSIS           i/script          included            on      included with !include
-Perl           M/module          unused              on      specified in `no' built-in function
-Perl           M/module          used                on      specified in `use' built-in function
-Python         i/module          imported            on      imported modules
-Python         i/module          indirectly-imported on      module imported in alternative name
-Python         i/module          namespace           on      namespace from where classes/variables/functions are imported
-Python         x/unknown         imported            on      imported from the other module
-Python         x/unknown         indirectly-imported on      classes/variables/functions/modules imported in alternative name
-RpmSpec        m/macro           undef               on      undefined
-Sh             h/heredoc         endmarker           on      end marker
-Sh             s/script          loaded              on      loaded
-SystemdUnit    u/unit            After               on      referred in After key
-SystemdUnit    u/unit            Before              on      referred in Before key
-SystemdUnit    u/unit            RequiredBy          on      referred in RequiredBy key
-SystemdUnit    u/unit            Requires            on      referred in Requires key
-SystemdUnit    u/unit            WantedBy            on      referred in WantedBy key
-SystemdUnit    u/unit            Wants               on      referred in Wants key
-Vera           d/macro           undef               on      undefined
-Vera           h/header          local               on      local header
-Vera           h/header          system              on      system header
+#LANGUAGE      KIND(L/N)         NAME               ENABLED DESCRIPTION
+Asm            s/section         placement          on      placement where the assembled code goes
+AutoIt         S/script          local              on      local include
+AutoIt         S/script          system             on      system include
+Automake       c/condition       branched           on      used for branching
+Automake       d/directory       data               on      directory for DATA primary
+Automake       d/directory       library            on      directory for LIBRARIES primary
+Automake       d/directory       ltlibrary          on      directory for LTLIBRARIES primary
+Automake       d/directory       man                on      directory for MANS primary
+Automake       d/directory       program            on      directory for PROGRAMS primary
+Automake       d/directory       script             on      directory for SCRIPTS primary
+C              d/macro           undef              on      undefined
+C              h/header          local              on      local header
+C              h/header          system             on      system header
+C++            d/macro           undef              on      undefined
+C++            h/header          local              on      local header
+C++            h/header          system             on      system header
+CPreProcessor  d/macro           undef              on      undefined
+CPreProcessor  h/header          local              on      local header
+CPreProcessor  h/header          system             on      system header
+CUDA           d/macro           undef              on      undefined
+CUDA           h/header          local              on      local header
+CUDA           h/header          system             on      system header
+Cobol          S/sourcefile      copied             on      copied in source file
+DTD            e/element         attOwner           on      attributes owner
+DTD            p/parameterEntity condition          on      conditions
+DTD            p/parameterEntity elementName        on      element names
+DTD            p/parameterEntity partOfAttDef       on      part of attribute definition
+Elm            m/module          imported           on      imported module
+Flex           I/import          import             on      imports
+Go             p/package         imported           on      imported package
+Go             u/unknown         receiverType       on      receiver type
+HTML           C/stylesheet      extFile            on      referenced as external files
+HTML           J/script          extFile            on      referenced as external files
+HTML           c/class           attribute          on      assigned as attributes
+Java           p/package         imported           on      imported package
+LdScript       i/inputSection    discarded          on      discarded when linking
+LdScript       i/inputSection    mapped             on      mapped to output section
+LdScript       s/symbol          entrypoint         on      entry points
+M4             I/macrofile       included           on      included macro
+M4             I/macrofile       sincluded          on      silently included macro
+M4             d/macro           undef              on      undefined
+Make           I/makefile        included           on      included
+Make           I/makefile        optional           on      optionally included
+NSIS           i/script          included           on      included with !include
+Perl           M/module          unused             on      specified in `no' built-in function
+Perl           M/module          used               on      specified in `use' built-in function
+Python         i/module          imported           on      imported modules
+Python         i/module          indirectlyImported on      module imported in alternative name
+Python         i/module          namespace          on      namespace from where classes/variables/functions are imported
+Python         x/unknown         imported           on      imported from the other module
+Python         x/unknown         indirectlyImported on      classes/variables/functions/modules imported in alternative name
+RpmSpec        m/macro           undef              on      undefined
+Sh             h/heredoc         endmarker          on      end marker
+Sh             s/script          loaded             on      loaded
+SystemdUnit    u/unit            After              on      referred in After key
+SystemdUnit    u/unit            Before             on      referred in Before key
+SystemdUnit    u/unit            RequiredBy         on      referred in RequiredBy key
+SystemdUnit    u/unit            Requires           on      referred in Requires key
+SystemdUnit    u/unit            WantedBy           on      referred in WantedBy key
+SystemdUnit    u/unit            Wants              on      referred in Wants key
+Vera           d/macro           undef              on      undefined
+Vera           h/header          local              on      local header
+Vera           h/header          system             on      system header
 
 #
 # all.*
 #
-#LANGUAGE      KIND(L/N)         NAME                ENABLED DESCRIPTION
-Asm            s/section         placement           on      placement where the assembled code goes
-AutoIt         S/script          local               on      local include
-AutoIt         S/script          system              on      system include
-Automake       c/condition       branched            on      used for branching
-Automake       d/directory       data                on      directory for DATA primary
-Automake       d/directory       library             on      directory for LIBRARIES primary
-Automake       d/directory       ltlibrary           on      directory for LTLIBRARIES primary
-Automake       d/directory       man                 on      directory for MANS primary
-Automake       d/directory       program             on      directory for PROGRAMS primary
-Automake       d/directory       script              on      directory for SCRIPTS primary
-C              d/macro           undef               on      undefined
-C              h/header          local               on      local header
-C              h/header          system              on      system header
-C++            d/macro           undef               on      undefined
-C++            h/header          local               on      local header
-C++            h/header          system              on      system header
-CPreProcessor  d/macro           undef               on      undefined
-CPreProcessor  h/header          local               on      local header
-CPreProcessor  h/header          system              on      system header
-CUDA           d/macro           undef               on      undefined
-CUDA           h/header          local               on      local header
-CUDA           h/header          system              on      system header
-Cobol          S/sourcefile      copied              on      copied in source file
-DTD            e/element         attOwner            on      attributes owner
-DTD            p/parameterEntity condition           on      conditions
-DTD            p/parameterEntity elementName         on      element names
-DTD            p/parameterEntity partOfAttDef        on      part of attribute definition
-Elm            m/module          imported            on      imported module
-Flex           I/import          import              on      imports
-Go             p/package         imported            on      imported package
-Go             u/unknown         receiverType        on      receiver type
-HTML           C/stylesheet      extFile             on      referenced as external files
-HTML           J/script          extFile             on      referenced as external files
-HTML           c/class           attribute           on      assigned as attributes
-Java           p/package         imported            on      imported package
-LdScript       i/inputSection    discarded           on      discarded when linking
-LdScript       i/inputSection    mapped              on      mapped to output section
-LdScript       s/symbol          entrypoint          on      entry points
-M4             I/macrofile       included            on      included macro
-M4             I/macrofile       sincluded           on      silently included macro
-M4             d/macro           undef               on      undefined
-Make           I/makefile        included            on      included
-Make           I/makefile        optional            on      optionally included
-NSIS           i/script          included            on      included with !include
-Perl           M/module          unused              on      specified in `no' built-in function
-Perl           M/module          used                on      specified in `use' built-in function
-Python         i/module          imported            on      imported modules
-Python         i/module          indirectly-imported on      module imported in alternative name
-Python         i/module          namespace           on      namespace from where classes/variables/functions are imported
-Python         x/unknown         imported            on      imported from the other module
-Python         x/unknown         indirectly-imported on      classes/variables/functions/modules imported in alternative name
-RpmSpec        m/macro           undef               on      undefined
-Sh             h/heredoc         endmarker           on      end marker
-Sh             s/script          loaded              on      loaded
-SystemdUnit    u/unit            After               on      referred in After key
-SystemdUnit    u/unit            Before              on      referred in Before key
-SystemdUnit    u/unit            RequiredBy          on      referred in RequiredBy key
-SystemdUnit    u/unit            Requires            on      referred in Requires key
-SystemdUnit    u/unit            WantedBy            on      referred in WantedBy key
-SystemdUnit    u/unit            Wants               on      referred in Wants key
-Vera           d/macro           undef               on      undefined
-Vera           h/header          local               on      local header
-Vera           h/header          system              on      system header
+#LANGUAGE      KIND(L/N)         NAME               ENABLED DESCRIPTION
+Asm            s/section         placement          on      placement where the assembled code goes
+AutoIt         S/script          local              on      local include
+AutoIt         S/script          system             on      system include
+Automake       c/condition       branched           on      used for branching
+Automake       d/directory       data               on      directory for DATA primary
+Automake       d/directory       library            on      directory for LIBRARIES primary
+Automake       d/directory       ltlibrary          on      directory for LTLIBRARIES primary
+Automake       d/directory       man                on      directory for MANS primary
+Automake       d/directory       program            on      directory for PROGRAMS primary
+Automake       d/directory       script             on      directory for SCRIPTS primary
+C              d/macro           undef              on      undefined
+C              h/header          local              on      local header
+C              h/header          system             on      system header
+C++            d/macro           undef              on      undefined
+C++            h/header          local              on      local header
+C++            h/header          system             on      system header
+CPreProcessor  d/macro           undef              on      undefined
+CPreProcessor  h/header          local              on      local header
+CPreProcessor  h/header          system             on      system header
+CUDA           d/macro           undef              on      undefined
+CUDA           h/header          local              on      local header
+CUDA           h/header          system             on      system header
+Cobol          S/sourcefile      copied             on      copied in source file
+DTD            e/element         attOwner           on      attributes owner
+DTD            p/parameterEntity condition          on      conditions
+DTD            p/parameterEntity elementName        on      element names
+DTD            p/parameterEntity partOfAttDef       on      part of attribute definition
+Elm            m/module          imported           on      imported module
+Flex           I/import          import             on      imports
+Go             p/package         imported           on      imported package
+Go             u/unknown         receiverType       on      receiver type
+HTML           C/stylesheet      extFile            on      referenced as external files
+HTML           J/script          extFile            on      referenced as external files
+HTML           c/class           attribute          on      assigned as attributes
+Java           p/package         imported           on      imported package
+LdScript       i/inputSection    discarded          on      discarded when linking
+LdScript       i/inputSection    mapped             on      mapped to output section
+LdScript       s/symbol          entrypoint         on      entry points
+M4             I/macrofile       included           on      included macro
+M4             I/macrofile       sincluded          on      silently included macro
+M4             d/macro           undef              on      undefined
+Make           I/makefile        included           on      included
+Make           I/makefile        optional           on      optionally included
+NSIS           i/script          included           on      included with !include
+Perl           M/module          unused             on      specified in `no' built-in function
+Perl           M/module          used               on      specified in `use' built-in function
+Python         i/module          imported           on      imported modules
+Python         i/module          indirectlyImported on      module imported in alternative name
+Python         i/module          namespace          on      namespace from where classes/variables/functions are imported
+Python         x/unknown         imported           on      imported from the other module
+Python         x/unknown         indirectlyImported on      classes/variables/functions/modules imported in alternative name
+RpmSpec        m/macro           undef              on      undefined
+Sh             h/heredoc         endmarker          on      end marker
+Sh             s/script          loaded             on      loaded
+SystemdUnit    u/unit            After              on      referred in After key
+SystemdUnit    u/unit            Before             on      referred in Before key
+SystemdUnit    u/unit            RequiredBy         on      referred in RequiredBy key
+SystemdUnit    u/unit            Requires           on      referred in Requires key
+SystemdUnit    u/unit            WantedBy           on      referred in WantedBy key
+SystemdUnit    u/unit            Wants              on      referred in Wants key
+Vera           d/macro           undef              on      undefined
+Vera           h/header          local              on      local header
+Vera           h/header          system             on      system header
 
 #
 # C.*

--- a/Units/parser-python.r/python-dot-in-import.d/expected.tags
+++ b/Units/parser-python.r/python-dot-in-import.d/expected.tags
@@ -1,5 +1,5 @@
 A.B	input.py	/^from A.B import C as D$/;"	i	roles:namespace
-C	input.py	/^from A.B import C as D$/;"	x	roles:indirectly-imported
+C	input.py	/^from A.B import C as D$/;"	x	roles:indirectlyImported
 D	input.py	/^from A.B import C as D$/;"	x	roles:def
 .	input.py	/^from . import E$/;"	i	roles:namespace
 E	input.py	/^from . import E$/;"	x	roles:imported

--- a/Units/parser-python.r/python-import.d/expected.tags
+++ b/Units/parser-python.r/python-import.d/expected.tags
@@ -11,29 +11,29 @@ i	input.py	/^from g import h, i$/;"	unknown	roles:imported
 g.i	input.py	/^from g import h, i$/;"	unknown	roles:imported
 j	input.py	/^from j import *$/;"	module	roles:namespace
 k	input.py	/^from k import l as m$/;"	module	roles:namespace
-l	input.py	/^from k import l as m$/;"	unknown	roles:indirectly-imported
-k.l	input.py	/^from k import l as m$/;"	unknown	roles:indirectly-imported
+l	input.py	/^from k import l as m$/;"	unknown	roles:indirectlyImported
+k.l	input.py	/^from k import l as m$/;"	unknown	roles:indirectlyImported
 m	input.py	/^from k import l as m$/;"	unknown	roles:def
-n	input.py	/^import n as o$/;"	module	roles:indirectly-imported
+n	input.py	/^import n as o$/;"	module	roles:indirectlyImported
 o	input.py	/^import n as o$/;"	namespace	roles:def
 a1	input.py	/^import a1, a2 as a3, a4, a5$/;"	module	roles:imported
-a2	input.py	/^import a1, a2 as a3, a4, a5$/;"	module	roles:indirectly-imported
+a2	input.py	/^import a1, a2 as a3, a4, a5$/;"	module	roles:indirectlyImported
 a3	input.py	/^import a1, a2 as a3, a4, a5$/;"	namespace	roles:def
 a4	input.py	/^import a1, a2 as a3, a4, a5$/;"	module	roles:imported
 a5	input.py	/^import a1, a2 as a3, a4, a5$/;"	module	roles:imported
 p	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	module	roles:namespace
 b1	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	unknown	roles:imported
 p.b1	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	unknown	roles:imported
-b2	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	unknown	roles:indirectly-imported
-p.b2	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	unknown	roles:indirectly-imported
+b2	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	unknown	roles:indirectlyImported
+p.b2	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	unknown	roles:indirectlyImported
 b3	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	unknown	roles:def
 b4	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	unknown	roles:imported
 p.b4	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	unknown	roles:imported
 b5	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	unknown	roles:imported
 p.b5	input.py	/^from p import b1, b2 as b3, b4, b5$/;"	unknown	roles:imported
 x	input.py	/^from x import (y as z1, z2,$/;"	module	roles:namespace
-y	input.py	/^from x import (y as z1, z2,$/;"	unknown	roles:indirectly-imported
-x.y	input.py	/^from x import (y as z1, z2,$/;"	unknown	roles:indirectly-imported
+y	input.py	/^from x import (y as z1, z2,$/;"	unknown	roles:indirectlyImported
+x.y	input.py	/^from x import (y as z1, z2,$/;"	unknown	roles:indirectlyImported
 z1	input.py	/^from x import (y as z1, z2,$/;"	unknown	roles:def
 z2	input.py	/^from x import (y as z1, z2,$/;"	unknown	roles:imported
 x.z2	input.py	/^from x import (y as z1, z2,$/;"	unknown	roles:imported

--- a/main/kind.c
+++ b/main/kind.c
@@ -80,6 +80,13 @@ extern void enableKind (kindDefinition *kind, bool enable)
 	}
 }
 
+static void initRoleObject (roleObject *robj, roleDefinition *rdef, freeRoleDefFunc freefunc, int roleId)
+{
+	robj->def = rdef;
+	robj->free = freefunc;
+	robj->def->id = roleId;
+}
+
 static struct roleControlBlock* allocRoleControlBlock (kindObject *kind)
 {
 	unsigned int j;
@@ -90,12 +97,7 @@ static struct roleControlBlock* allocRoleControlBlock (kindObject *kind)
 	rcb->owner = kind->def->id;
 	rcb->role = xMalloc(rcb->count, roleObject);
 	for (j = 0; j < rcb->count; j++)
-	{
-		roleObject *role = rcb->role + j;
-		role->def = kind->def->roles + j;
-		role->free = NULL;
-		role->def->id = j;
-	}
+		initRoleObject (rcb->role + j, kind->def->roles + j, NULL, j);
 
 	return rcb;
 }
@@ -189,7 +191,6 @@ extern int defineRole (struct kindControlBlock* kcb, int kindIndex,
 {
 	struct roleControlBlock *rcb = kcb->kind[kindIndex].rcb;
 	int roleIndex = rcb->count++;
-	roleObject *role;
 
 	if (roleIndex == ROLE_MAX_COUNT)
 	{
@@ -201,10 +202,8 @@ extern int defineRole (struct kindControlBlock* kcb, int kindIndex,
 	}
 
 	rcb->role = xRealloc (rcb->role, rcb->count, roleObject);
-	role = rcb->role + roleIndex;
-	role->def = def;
-	role->free = freeRoleDef;
-	role->def->id = roleIndex;
+	initRoleObject (rcb->role + roleIndex, def, freeRoleDef, roleIndex);
+
 	return roleIndex;
 }
 

--- a/main/kind.c
+++ b/main/kind.c
@@ -12,6 +12,7 @@
 
 #include "general.h"
 
+#include <ctype.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -82,6 +83,11 @@ extern void enableKind (kindDefinition *kind, bool enable)
 
 static void initRoleObject (roleObject *robj, roleDefinition *rdef, freeRoleDefFunc freefunc, int roleId)
 {
+#ifdef DEBUG
+	size_t len = strlen (rdef->name);
+	for (int i = 0; i < len; i++)
+		Assert (isalnum (rdef->name [i]));
+#endif
 	robj->def = rdef;
 	robj->free = freefunc;
 	robj->def->id = roleId;

--- a/main/options.c
+++ b/main/options.c
@@ -2199,7 +2199,8 @@ static void processListRolesOptions (const char *const option CTAGS_ATTR_UNUSED,
 
 	kindspecs = sep + 1;
 	if (strncmp (parameter, "all.", 4) == 0
-	    || strncmp (parameter, "*.", 1) == 0
+		/* Handle the case if no language is specified.
+		 * This case is not documented. */
 	    || strncmp (parameter, ".", 1) == 0)
 		lang = LANG_AUTO;
 	else

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -114,7 +114,7 @@ my $options =
 
 	 push @{$_[0]->{'fielddefs'}}, { name => $name, desc => $desc };
        } ],
-     [ qr/^--_roledef-(.*)=([a-zA-Z])\.([a-zA-Z][a-zA-Z0-9]*),([^\{]+)/, sub {
+     [ qr/^--_roledef-(.*)=([a-zA-Z])\.([a-zA-Z0-9]+),([^\{]+)/, sub {
 	   die "Don't use --_roledef-<LANG>=+ option before defining the language"
 	     if (! defined $_[0]->{'langdef'});
 	   die "Adding a field is allowed only to the language specified with --langdef: $1"

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -98,7 +98,7 @@ typedef enum {
  * ==========================
  * import X              X = (kind:module, role:imported)
  *
- * import X as Y         X = (kind:module, role:indirectly-imported),
+ * import X as Y         X = (kind:module, role:indirectlyImported),
  *                       Y = (kind:namespace, [nameref:X])
  *                       ------------------------------------------------
  *                       Don't confuse with namespace role of module kind.
@@ -109,7 +109,7 @@ typedef enum {
  *                       Y = (kind:unknown, role:imported, [scope:X])
  *
  * from X import Y as Z  X = (kind:module,  role:namespace),
- *                       Y = (kind:unknown, role:indirectly-imported, [scope:X])
+ *                       Y = (kind:unknown, role:indirectlyImported, [scope:X])
  *                       Z = (kind:unknown, [nameref:X.Y]) */
 
 static roleDefinition PythonModuleRoles [] = {
@@ -117,13 +117,13 @@ static roleDefinition PythonModuleRoles [] = {
 	  "imported modules" },
 	{ true, "namespace",
 	  "namespace from where classes/variables/functions are imported" },
-	{ true, "indirectly-imported",
+	{ true, "indirectlyImported",
 	  "module imported in alternative name" },
 };
 
 static roleDefinition PythonUnknownRoles [] = {
 	{ true, "imported",   "imported from the other module" },
-	{ true, "indirectly-imported",
+	{ true, "indirectlyImported",
 	  "classes/variables/functions/modules imported in alternative name" },
 };
 
@@ -990,7 +990,7 @@ static bool parseImport (tokenInfo *const token)
 							/* from x import Y as Z
 							 * ----------------------------
 							 * x = (kind:module,  role:namespace),
-							 * Y = (kind:unknown, role:indirectly-imported),
+							 * Y = (kind:unknown, role:indirectlyImported),
 							 * Z = (kind:unknown) */
 
 							/* Y */
@@ -1015,7 +1015,7 @@ static bool parseImport (tokenInfo *const token)
 						{
 							/* import x as Y
 							 * ----------------------------
-							 * X = (kind:module, role:indirectly-imported)
+							 * X = (kind:module, role:indirectlyImported)
 							 * Y = (kind:namespace)*/
 							/* X */
 							makeSimplePythonRefTag (name, NULL, K_MODULE,


### PR DESCRIPTION
Close #1711.

An assert macro is introduced for the purpose.
Python had a role name "indirectly-imported". This violated the new limitation.
So I renamed it to "indirectlyImported".