### PR TITLE
lregex: fix meaningless type mismatching between unsigned int and unsigned long

### DIFF
--- a/main/lregex.c
+++ b/main/lregex.c
@@ -478,7 +478,7 @@ static flagDefinition prePtrnFlagDef[] = {
 static void scope_ptrn_flag_eval (const char* const f  CTAGS_ATTR_UNUSED,
 				  const char* const v, void* data)
 {
-	unsigned long *bfields = data;
+	unsigned int *bfields = data;
 
 	if (strcmp (v, "ref") == 0)
 		*bfields |= SCOPE_REF;
@@ -497,7 +497,7 @@ static void scope_ptrn_flag_eval (const char* const f  CTAGS_ATTR_UNUSED,
 static void placeholder_ptrn_flag_eval (const char* const f  CTAGS_ATTR_UNUSED,
 				     const char* const v  CTAGS_ATTR_UNUSED, void* data)
 {
-	unsigned long *bfields = data;
+	unsigned int *bfields = data;
 	*bfields |= SCOPE_PLACEHOLDER;
 }
 


### PR DESCRIPTION
Partially close #2369.

A pointer to unsigned int variable is passed to functions expecting
a pointer to unsigned long variable.

This didn't cause a trouble because the sizes of the types are the
same on x86_64, the most popular platform. However, on s390x, they
are different, and cause a trouble as reported in #2369.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>