### PR TITLE
CXX: Handle non-pointer function typedefs

### DIFF
--- a/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
@@ -15,6 +15,8 @@ T305	input.cpp	/^typedef struct AStruct (T305)(int);$/;"	t	typeref:struct:AStruc
 T306	input.cpp	/^typedef union AUnion & (T306)(int);$/;"	t	typeref:union:AUnion & ()(int)	file:
 T307	input.cpp	/^typedef AClass (T307)(int);$/;"	t	typeref:typename:AClass ()(int)	file:
 T308	input.cpp	/^typedef enum AEnum (T308)(int);$/;"	t	typeref:enum:AEnum ()(int)	file:
+T309	input.cpp	/^typedef int T309(int);$/;"	t	file:
+T310	input.cpp	/^typedef int T310(AUnion *);$/;"	t	file:
 T401	input.cpp	/^typedef int T401 [ 10];$/;"	t	typeref:typename:int[10]	file:
 T501	input.cpp	/^typedef ATemplate1<int > T501;$/;"	t	typeref:typename:ATemplate1<int>	file:
 T502	input.cpp	/^typedef ATemplate1< unsigned short int> T502;$/;"	t	typeref:typename:ATemplate1<unsigned short int>	file:

--- a/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/typedefs.cpp.d/expected.tags
@@ -15,8 +15,8 @@ T305	input.cpp	/^typedef struct AStruct (T305)(int);$/;"	t	typeref:struct:AStruc
 T306	input.cpp	/^typedef union AUnion & (T306)(int);$/;"	t	typeref:union:AUnion & ()(int)	file:
 T307	input.cpp	/^typedef AClass (T307)(int);$/;"	t	typeref:typename:AClass ()(int)	file:
 T308	input.cpp	/^typedef enum AEnum (T308)(int);$/;"	t	typeref:enum:AEnum ()(int)	file:
-T309	input.cpp	/^typedef int T309(int);$/;"	t	file:
-T310	input.cpp	/^typedef int T310(AUnion *);$/;"	t	file:
+T309	input.cpp	/^typedef int T309(int);$/;"	t	typeref:typename:int ()(int)	file:
+T310	input.cpp	/^typedef int T310(AUnion *);$/;"	t	typeref:typename:int ()(AUnion *)	file:
 T401	input.cpp	/^typedef int T401 [ 10];$/;"	t	typeref:typename:int[10]	file:
 T501	input.cpp	/^typedef ATemplate1<int > T501;$/;"	t	typeref:typename:ATemplate1<int>	file:
 T502	input.cpp	/^typedef ATemplate1< unsigned short int> T502;$/;"	t	typeref:typename:ATemplate1<unsigned short int>	file:

--- a/Units/parser-cxx.r/typedefs.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/typedefs.cpp.d/input.cpp
@@ -34,6 +34,10 @@ typedef AClass (T307)(int);
 typedef enum AEnum (T308)(int);
 typedef int T309(int);
 typedef int T310(AUnion *);
+#if 0
+	// broken input (to make coveralls happy)
+	typedef int int(int);
+#endif
 
 // arrays
 typedef int T401 [ 10];

--- a/Units/parser-cxx.r/typedefs.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/typedefs.cpp.d/input.cpp
@@ -32,6 +32,8 @@ typedef struct AStruct (T305)(int);
 typedef union AUnion & (T306)(int);
 typedef AClass (T307)(int);
 typedef enum AEnum (T308)(int);
+typedef int T309(int);
+typedef int T310(AUnion *);
 
 // arrays
 typedef int T401 [ 10];

--- a/parsers/cxx/cxx_parser_typedef.c
+++ b/parsers/cxx/cxx_parser_typedef.c
@@ -107,6 +107,9 @@ bool cxxParserParseGenericTypedef(void)
 //    [typedef] int (x)(void)
 //        x = int ()(void) <--- function type (not a pointer!)
 //
+//    [typedef] int x(void)
+//        x = int ()(void) <--- still function type
+//
 //    [typedef] int (MACRO *x)(void);
 //        x = int (MACRO *)(void) <--- function pointer
 //    (WINAPI is an example of MACRO.)
@@ -275,16 +278,54 @@ skip_to_comma_or_end:
 			pTParentChain = pChain;
 		} else if(pFirstParenthesis)
 		{
-			// look for the last nested identifier in here
-			// e.g.
-			// typedef void (WINAPI *func_t) (void);
-			// We expect func_t we want to capture is at the end of parenthesis chain.
 			CXX_DEBUG_PRINT("Identifier not at end, but got parenthesis chain");
-			t = cxxTokenChainLastPossiblyNestedTokenOfType(
-					pFirstParenthesis->pChain,
-					CXXTokenTypeIdentifier,
-					&pTParentChain
-				);
+			//
+			// Possibly function pointer or function type definition.
+			//
+			//    typedef blah (*(foo))(baz)
+			//    typedef blah (*foo)(baz)
+			//    typedef blah (*foo)[...]
+			//    typedef blah (foo)(baz)
+			//    typedef blah ((foo))(baz)
+			//    typedef blah foo(baz)
+			//
+			// So we have two cases: either there are at least two parentheses at the
+			// top level or there is only one. If there are at least two then
+			// we expect foo we want to capture to be at the end of the first nested
+			// parenthesis chain. If there is only one then we expect it to be the
+			// last identifier before the parenthesis.
+			//
+			if(
+					pFirstParenthesis->pNext &&
+					cxxTokenTypeIsOneOf(
+							pFirstParenthesis->pNext,
+							CXXTokenTypeParenthesisChain |
+								CXXTokenTypeSquareParenthesisChain
+						)
+				)
+			{
+				CXX_DEBUG_PRINT("There are two parenthesis chains. Looking in the first one");
+				t = cxxTokenChainLastPossiblyNestedTokenOfType(
+						pFirstParenthesis->pChain,
+						CXXTokenTypeIdentifier,
+						&pTParentChain
+					);
+			} else {
+				CXX_DEBUG_PRINT("There is one parenthesis chain. Looking just before");
+
+				if(
+					pFirstParenthesis->pPrev &&
+					cxxTokenTypeIs(pFirstParenthesis->pPrev,CXXTokenTypeIdentifier)
+				)
+				{
+					// Nasty "typedef blah foo(baz)" case.
+					t = pFirstParenthesis->pPrev;
+					pTParentChain = pChain;
+				} else {
+					CXX_DEBUG_LEAVE_TEXT("Parenthesis but no identifier: no clue");
+					return;
+				}
+			}
 		} else {
 			// just scan backwards to the last identifier
 			CXX_DEBUG_PRINT("No identifier and no parenthesis chain, trying to scan backwards");

--- a/parsers/cxx/cxx_parser_typedef.c
+++ b/parsers/cxx/cxx_parser_typedef.c
@@ -320,7 +320,43 @@ skip_to_comma_or_end:
 				{
 					// Nasty "typedef blah foo(baz)" case.
 					t = pFirstParenthesis->pPrev;
-					pTParentChain = pChain;
+
+					// Let's have a consistent typeref too. We correct user
+					// input so it becomes "typedef blah (foo)(baz)".
+
+					pTParentChain = cxxTokenChainCreate();
+
+					CXXToken * par = cxxTokenCreate();
+					par->eType = CXXTokenTypeOpeningParenthesis;
+					par->iLineNumber = t->iLineNumber;
+					par->oFilePosition = t->oFilePosition;
+					vStringPut(par->pszWord,'(');
+					par->pChain = NULL;
+					cxxTokenChainAppend(pTParentChain,par);
+
+					par = cxxTokenCreate();
+					par->eType = CXXTokenTypeIdentifier;
+					par->iLineNumber = t->iLineNumber;
+					par->oFilePosition = t->oFilePosition;
+					vStringCopy(par->pszWord,t->pszWord);
+					par->pChain = NULL;
+					cxxTokenChainAppend(pTParentChain,par);
+
+					t->eType = CXXTokenTypeParenthesisChain;
+					t->pChain = pTParentChain;
+					vStringClear(t->pszWord);
+
+					pFirstParenthesis = t;
+					t = par;
+
+					par = cxxTokenCreate();
+					par->eType = CXXTokenTypeClosingParenthesis;
+					par->iLineNumber = t->iLineNumber;
+					par->oFilePosition = t->oFilePosition;
+					vStringPut(par->pszWord,')');
+					par->pChain = NULL;
+					cxxTokenChainAppend(pTParentChain,par);
+
 				} else {
 					CXX_DEBUG_LEAVE_TEXT("Parenthesis but no identifier: no clue");
 					return;


### PR DESCRIPTION
Fixes #2394 .
typeref is currently missing. Not sure if it's worth to add it as it would require some bits of complexity.