### PR TITLE
main: display pseudo tags in xref output if requested

### DIFF
--- a/Tmain/xref-ptag-in-list-extras.d/stdout-expected.txt
+++ b/Tmain/xref-ptag-in-list-extras.d/stdout-expected.txt
@@ -5,8 +5,8 @@ p       pseudo            no      NONE     no    Include pseudo tags
 # tags NOTHING
 p       pseudo            yes     NONE     no    Include pseudo tags
 # xref regular file
-p       pseudo            no      NONE     yes   Include pseudo tags
+p       pseudo            no      NONE     no    Include pseudo tags
 # xref -
-p       pseudo            no      NONE     yes   Include pseudo tags
+p       pseudo            no      NONE     no    Include pseudo tags
 # xref NOTHING
-p       pseudo            no      NONE     yes   Include pseudo tags
+p       pseudo            no      NONE     no    Include pseudo tags

--- a/Units/ptag-xref.d/args.ctags
+++ b/Units/ptag-xref.d/args.ctags
@@ -1,0 +1,2 @@
+--extras=+p
+--pseudo-tags=-TAG_PROGRAM_VERSION

--- a/Units/ptag-xref.d/expected.tags-x
+++ b/Units/ptag-xref.d/expected.tags-x
@@ -1,0 +1,8 @@
+!_TAG_FILE_FORMAT ptag          0 2                extended format; --format=1 will not append ;" to lines
+!_TAG_FILE_SORTED ptag          0 1                0=unsorted, 1=sorted, 2=foldcase
+!_TAG_OUTPUT_FILESEP ptag          0 slash            slash or backslash
+!_TAG_OUTPUT_MODE ptag          0                  u-ctags or e-ctags
+!_TAG_PROGRAM_AUTHOR ptag          0 Universal Ctags Team 
+!_TAG_PROGRAM_NAME ptag          0 Universal Ctags  Derived from Exuberant Ctags
+!_TAG_PROGRAM_URL ptag          0 https://ctags.io/ official site
+main             function      1 input.c int main (void)

--- a/Units/ptag-xref.d/input.c
+++ b/Units/ptag-xref.d/input.c
@@ -1,0 +1,4 @@
+int main (void)
+{
+	return 0;
+}

--- a/main/entry.h
+++ b/main/entry.h
@@ -50,6 +50,8 @@ struct sTagEntryInfo {
 					    don't print it to tags file. */
 	unsigned int skipAutoFQEmission:1; /* If a parser makes a fq tag for the
 										  current tag by itself, set this. */
+	unsigned int isPseudoTag:1;	/* Used only in xref output.
+								   If a tag is a pseudo, set this. */
 
 	unsigned long lineNumber;     /* line number of tag */
 	const char* pattern;	      /* pattern for locating input line

--- a/main/field.c
+++ b/main/field.c
@@ -398,7 +398,7 @@ static const char *renderEscapedName (const bool isTagName,
 {
 	int unexpected_byte = 0;
 
-	if (isTagName && (*s == ' ' || *s == '!'))
+	if (isTagName && (!tag->isPseudoTag) &&  (*s == ' ' || *s == '!'))
 	{
 		/* Don't allow a leading space or exclamation mark as it conflicts with
 		 * pseudo-tags when sorting.  Anything with a lower byte value is
@@ -658,6 +658,12 @@ static const char *renderFieldCompactInputLine (const tagEntryInfo *const tag,
 {
 	const char *line;
 	static vString *tmp;
+
+	if (tag->isPseudoTag)
+	{
+		Assert (tag->pattern);
+		return tag->pattern;
+	}
 
 	tmp = vStringNewOrClearWithAutoRelease (tmp);
 

--- a/main/parse.c
+++ b/main/parse.c
@@ -122,11 +122,13 @@ static void uninstallTagXpathTable (const langType language);
 /*
 *   DATA DEFINITIONS
 */
+static parserDefinition *CTagsParser (void);
 static parserDefinition *CTagsSelfTestParser (void);
 static parserDefinitionFunc* BuiltInParsers[] = {
 #ifdef EXTERNAL_PARSER_LIST
 	EXTERNAL_PARSER_LIST
 #else  /* ! EXTERNAL_PARSER_LIST */
+	CTagsParser,				/* This must be first entry. */
 	CTagsSelfTestParser,
 	PARSER_LIST,
 	XML_PARSER_LIST
@@ -4488,6 +4490,28 @@ extern bool processPretendOption (const char *const option, const char *const pa
 	enableLanguage (old_language, false);
 
 	return true;
+}
+
+/*
+ * A dummy parser for printing pseudo tags in xref output
+ */
+static void dontFindTags (void)
+{
+}
+
+static kindDefinition CtagsKinds[] = {
+	{true, 'p', "ptag", "pseudo tags"},
+};
+
+static parserDefinition *CTagsParser (void)
+{
+	parserDefinition *const def = parserNew ("UniversalCtags");
+	def->extensions = NULL;
+	def->kindTable = CtagsKinds;
+	def->kindCount = ARRAY_SIZE(CtagsKinds);
+	def->parser = dontFindTags;
+	def->invisible = true;
+	return def;
 }
 
 /*

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -46,6 +46,7 @@ struct rejection {
 tagWriter uCtagsWriter = {
 	.writeEntry = writeCtagsEntry,
 	.writePtagEntry = writeCtagsPtagEntry,
+	.printPtagByDefault = true,
 	.preWriteEntry = NULL,
 	.postWriteEntry = NULL,
 	.rescanFailedEntry = NULL,
@@ -86,6 +87,7 @@ static enum filenameSepOp overrideFilenameSeparator (enum filenameSepOp currentS
 tagWriter eCtagsWriter = {
 	.writeEntry = writeCtagsEntry,
 	.writePtagEntry = writeCtagsPtagEntry,
+	.printPtagByDefault = true,
 	.preWriteEntry = beginECtagsFile,
 	.postWriteEntry = endECTagsFile,
 	.rescanFailedEntry = NULL,

--- a/main/writer-json.c
+++ b/main/writer-json.c
@@ -44,6 +44,7 @@ static int writeJsonPtagEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 tagWriter jsonWriter = {
 	.writeEntry = writeJsonEntry,
 	.writePtagEntry = writeJsonPtagEntry,
+	.printPtagByDefault = true,
 	.preWriteEntry = NULL,
 	.postWriteEntry = NULL,
 	.rescanFailedEntry = NULL,

--- a/main/writer.c
+++ b/main/writer.c
@@ -147,3 +147,8 @@ extern void writerCheckOptions (void)
 	if (writer->checkOptions)
 		writer->checkOptions (writer);
 }
+
+extern bool writerPrintPtagByDefault (void)
+{
+	return writer->printPtagByDefault;
+}

--- a/main/writer_p.h
+++ b/main/writer_p.h
@@ -40,6 +40,7 @@ struct sTagWriter {
 							const char *const pattern,
 							const char *const parserName,
 							void *clientData);
+	bool printPtagByDefault;
 	void * (* preWriteEntry) (tagWriter *writer, MIO * mio,
 							  void *clientData);
 
@@ -96,6 +97,7 @@ extern bool writerCanPrintPtag (void);
 extern bool writerDoesTreatFieldAsFixed (int fieldType);
 
 extern void writerCheckOptions (void);
+extern bool writerPrintPtagByDefault (void);
 
 #ifdef WIN32
 extern enum filenameSepOp getFilenameSeparator (enum filenameSepOp currentSetting);

--- a/main/xtag.c
+++ b/main/xtag.c
@@ -35,6 +35,8 @@ static bool isPseudoTagsEnabled (xtagDefinition *pdef CTAGS_ATTR_UNUSED)
 {
 	if (!writerCanPrintPtag())
 		return false;
+	if (!writerPrintPtagByDefault())
+		return false;
 
 	return ! isDestinationStdout ();
 }


### PR DESCRIPTION
```
  $ u-ctags --extras=+p -x input.c
  !_TAG_FILE_FORMAT ptag          0 2                extended format; --format=1 will not append ;" to lines
  !_TAG_FILE_SORTED ptag          0 1                0=unsorted, 1=sorted, 2=foldcase
  !_TAG_OUTPUT_FILESEP ptag          0 slash            slash or backslash
  !_TAG_OUTPUT_MODE ptag          0                  u-ctags or e-ctags
  !_TAG_PROGRAM_AUTHOR ptag          0 Universal Ctags Team
  !_TAG_PROGRAM_NAME ptag          0 Universal Ctags  Derived from Exuberant Ctags
  !_TAG_PROGRAM_URL ptag          0 https://ctags.io/ official site
  !_TAG_PROGRAM_VERSION ptag          0 0.0.0            da9919d2
  main             function      1 input.c          int main (void)
```

Suggested by @amerlyq in #2407.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>