### PR TITLE
systemd: fix the list of file name extensions

### DIFF
--- a/parsers/systemdunit.c
+++ b/parsers/systemdunit.c
@@ -117,11 +117,10 @@ static void findSystemdUnitTags (void)
 
 extern parserDefinition* SystemdUnitParser (void)
 {
-	static const char *const extensions [] = { "unit", "service", "socket", "device",
+	static const char *const extensions [] = { "service", "socket", "device",
 											   "mount", "automount", "swap", "target",
-											   "path", "timer", "snapshot", "scope",
-											   "slice", "time", /* ... */
-											   NULL };
+											   "path", "timer", "snapshot",
+											   "slice", NULL };
 	static iniconfSubparser systemdUnitSubparser = {
 		.subparser = {
 			.direction = SUBPARSER_SUB_RUNS_BASE,


### PR DESCRIPTION
A ".scope" is always generated dynamically.
There is no unit file for it.

".time" may be a typo. No such unit.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>