### PR TITLE
CPreProcessor: macro expansion in a file

### DIFF
--- a/Tmain/list-params.d/stdout-expected.txt
+++ b/Tmain/list-params.d/stdout-expected.txt
@@ -1,36 +1,42 @@
 # ALL
-#LANGUAGE      NAME   DESCRIPTION
-CPreProcessor  define define replacement for an identifier (name(params,...)=definition)
-CPreProcessor  if0    examine code within "#if 0" branch (true or [false])
-CPreProcessor  ignore a token to be specially handled
-Fypp           guest  parser run after Fypp parser parses the original input ("NONE" or a parser name [Fortran])
+#LANGUAGE      NAME    DESCRIPTION
+CPreProcessor  _expand expand macro definitions found in input file (true or [false])
+CPreProcessor  define  define replacement for an identifier (name(params,...)=definition)
+CPreProcessor  if0     examine code within "#if 0" branch (true or [false])
+CPreProcessor  ignore  a token to be specially handled
+Fypp           guest   parser run after Fypp parser parses the original input ("NONE" or a parser name [Fortran])
 
 # ALL MACHINABLE
 #LANGUAGE	NAME	DESCRIPTION
+CPreProcessor	_expand	expand macro definitions found in input file (true or [false])
 CPreProcessor	define	define replacement for an identifier (name(params,...)=definition)
 CPreProcessor	if0	examine code within "#if 0" branch (true or [false])
 CPreProcessor	ignore	a token to be specially handled
 Fypp	guest	parser run after Fypp parser parses the original input ("NONE" or a parser name [Fortran])
 
 # ALL MACHINABLE NOHEADER
+CPreProcessor	_expand	expand macro definitions found in input file (true or [false])
 CPreProcessor	define	define replacement for an identifier (name(params,...)=definition)
 CPreProcessor	if0	examine code within "#if 0" branch (true or [false])
 CPreProcessor	ignore	a token to be specially handled
 Fypp	guest	parser run after Fypp parser parses the original input ("NONE" or a parser name [Fortran])
 
 # CPP
-#NAME   DESCRIPTION
-define  define replacement for an identifier (name(params,...)=definition)
-if0     examine code within "#if 0" branch (true or [false])
-ignore  a token to be specially handled
+#NAME    DESCRIPTION
+_expand  expand macro definitions found in input file (true or [false])
+define   define replacement for an identifier (name(params,...)=definition)
+if0      examine code within "#if 0" branch (true or [false])
+ignore   a token to be specially handled
 
 # CPP MACHINABLE
 #NAME	DESCRIPTION
+_expand	expand macro definitions found in input file (true or [false])
 define	define replacement for an identifier (name(params,...)=definition)
 if0	examine code within "#if 0" branch (true or [false])
 ignore	a token to be specially handled
 
 # CPP MACHINABLE NOHEADER
+_expand	expand macro definitions found in input file (true or [false])
 define	define replacement for an identifier (name(params,...)=definition)
 if0	examine code within "#if 0" branch (true or [false])
 ignore	a token to be specially handled

--- a/Tmain/list-params.d/stdout-expected.txt
+++ b/Tmain/list-params.d/stdout-expected.txt
@@ -1,37 +1,37 @@
 # ALL
 #LANGUAGE      NAME   DESCRIPTION
-CPreProcessor  define define replacement for an identifier
+CPreProcessor  define define replacement for an identifier (name(params,...)=definition)
 CPreProcessor  if0    examine code within "#if 0" branch (true or [false])
 CPreProcessor  ignore a token to be specially handled
 Fypp           guest  parser run after Fypp parser parses the original input ("NONE" or a parser name [Fortran])
 
 # ALL MACHINABLE
 #LANGUAGE	NAME	DESCRIPTION
-CPreProcessor	define	define replacement for an identifier
+CPreProcessor	define	define replacement for an identifier (name(params,...)=definition)
 CPreProcessor	if0	examine code within "#if 0" branch (true or [false])
 CPreProcessor	ignore	a token to be specially handled
 Fypp	guest	parser run after Fypp parser parses the original input ("NONE" or a parser name [Fortran])
 
 # ALL MACHINABLE NOHEADER
-CPreProcessor	define	define replacement for an identifier
+CPreProcessor	define	define replacement for an identifier (name(params,...)=definition)
 CPreProcessor	if0	examine code within "#if 0" branch (true or [false])
 CPreProcessor	ignore	a token to be specially handled
 Fypp	guest	parser run after Fypp parser parses the original input ("NONE" or a parser name [Fortran])
 
 # CPP
 #NAME   DESCRIPTION
-define  define replacement for an identifier
+define  define replacement for an identifier (name(params,...)=definition)
 if0     examine code within "#if 0" branch (true or [false])
 ignore  a token to be specially handled
 
 # CPP MACHINABLE
 #NAME	DESCRIPTION
-define	define replacement for an identifier
+define	define replacement for an identifier (name(params,...)=definition)
 if0	examine code within "#if 0" branch (true or [false])
 ignore	a token to be specially handled
 
 # CPP MACHINABLE NOHEADER
-define	define replacement for an identifier
+define	define replacement for an identifier (name(params,...)=definition)
 if0	examine code within "#if 0" branch (true or [false])
 ignore	a token to be specially handled
 

--- a/Units/parser-cpreprocessor.r/macroexpand.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/macroexpand.d/args.ctags
@@ -1,0 +1,4 @@
+--param-CPreProcessor:_expand=1
+--fields-C=+{macrodef}
+--fields=+Ss
+--sort=no

--- a/Units/parser-cpreprocessor.r/macroexpand.d/expected.tags
+++ b/Units/parser-cpreprocessor.r/macroexpand.d/expected.tags
@@ -1,0 +1,14 @@
+defStruct	input.c	/^#define defStruct(/;"	d	file:	signature:(PREFIX,X)	macrodef:struct PREFIX##X
+begin	input.c	/^#define begin /;"	d	file:	macrodef:{
+defField	input.c	/^#define defField(/;"	d	file:	signature:(PREFIX,T,F)	macrodef:T PREFIX##F;
+endf	input.c	/^#define endf /;"	d	file:	macrodef:;
+ends	input.c	/^#define ends /;"	d	file:	macrodef:};
+mydefs	input.c	/^#define mydefs(/;"	d	file:	signature:(X)	macrodef:defStruct(my_,X)
+mydeff	input.c	/^#define mydeff(/;"	d	file:	signature:(T,Y)	macrodef:defField(my_,T,Y)
+your_point	input.c	/^defStruct(your_,point) begin$/;"	s	file:
+your_x	input.c	/^  defField(your_,int, x) endf$/;"	m	struct:your_point	typeref:typename:int	file:
+your_y	input.c	/^  defField(your_,int, y) endf$/;"	m	struct:your_point	typeref:typename:int	file:
+my_point3d	input.c	/^mydefs(point3d) begin$/;"	s	file:
+my_x	input.c	/^  mydeff(int, x) endf$/;"	m	struct:my_point3d	typeref:typename:int	file:
+my_y	input.c	/^  mydeff(int, y) endf$/;"	m	struct:my_point3d	typeref:typename:int	file:
+my_z	input.c	/^  mydeff(int, z) endf$/;"	m	struct:my_point3d	typeref:typename:int	file:

--- a/Units/parser-cpreprocessor.r/macroexpand.d/input.c
+++ b/Units/parser-cpreprocessor.r/macroexpand.d/input.c
@@ -1,0 +1,19 @@
+#define defStruct(PREFIX,X) struct PREFIX##X
+#define begin {
+#define defField(PREFIX,T, F) T PREFIX##F;
+#define endf ;
+#define ends };
+
+#define mydefs(X) defStruct(my_,X)
+#define mydeff(T,Y) defField(my_,T,Y)
+
+defStruct(your_,point) begin
+  defField(your_,int, x) endf
+  defField(your_,int, y) endf
+ends
+
+mydefs(point3d) begin
+  mydeff(int, x) endf
+  mydeff(int, y) endf
+  mydeff(int, z) endf
+ends

--- a/main/entry.c
+++ b/main/entry.c
@@ -1916,16 +1916,18 @@ extern void invalidatePatternCache(void)
 	TagFile.patternCacheValid = false;
 }
 
-extern void tagFilePosition (MIOPos *p)
+extern int tagFilePosition (MIOPos *p)
 {
 	if (TagFile.mio)
-		mio_getpos (TagFile.mio, p);
+		return mio_getpos (TagFile.mio, p);
+	return -2;
 }
 
-extern void setTagFilePosition (MIOPos *p)
+extern int setTagFilePosition (MIOPos *p)
 {
 	if (TagFile.mio)
-		mio_setpos (TagFile.mio, p);
+		return mio_setpos (TagFile.mio, p);
+	return -2;
 }
 
 extern const char* getTagFileDirectory (void)

--- a/main/entry.c
+++ b/main/entry.c
@@ -1013,6 +1013,17 @@ extern const tagField* getParserFieldForIndex (const tagEntryInfo * tag, int ind
 	}
 }
 
+extern const char* getParserFieldValueForType (tagEntryInfo *const tag, fieldType ftype)
+{
+	for (int i = 0; i < tag->usedParserFields; i++)
+	{
+		const tagField *f = getParserFieldForIndex (tag, i);
+		if (f && f->ftype == ftype)
+			return f->value;
+	}
+	return NULL;
+}
+
 static void copyParserFields (const tagEntryInfo *const tag, tagEntryInfo* slot)
 {
 	unsigned int i;

--- a/main/entry.c
+++ b/main/entry.c
@@ -388,20 +388,13 @@ extern void openTagFile (void)
 	 */
 	if (TagsToStdout)
 	{
-		if (Option.sorted == SO_UNSORTED)
+		if (Option.interactive == INTERACTIVE_SANDBOX)
 		{
-			/* Passing NULL for keeping stdout open.
-			   stdout can be used for debugging purpose.*/
-			TagFile.mio = mio_new_fp(stdout, NULL);
-			TagFile.name = eStrdup ("/dev/stdout");
+			TagFile.mio = mio_new_memory (NULL, 0, eRealloc, free);
+			TagFile.name = NULL;
 		}
 		else
-		{
-			/* Open a tempfile with read and write mode. Read mode is used when
-			 * write the result to stdout. */
 			TagFile.mio = tempFile ("w+", &TagFile.name);
-		}
-
 		if (isXtagEnabled (XTAG_PSEUDO_TAGS))
 			addCommonPseudoTags ();
 	}
@@ -563,6 +556,12 @@ static void resizeTagFile (const long newSize)
 {
 	int result;
 
+	if (!TagFile.name)
+	{
+		mio_try_resize (TagFile.mio, newSize);
+		return;
+	}
+
 #ifdef USE_REPLACEMENT_TRUNCATE
 	result = replacementTruncate (TagFile.name, newSize);
 #else
@@ -611,13 +610,6 @@ extern void closeTagFile (const bool resize)
 		writeEtagsIncludes (TagFile.mio);
 	mio_flush (TagFile.mio);
 
-	if ((TagsToStdout && (Option.sorted == SO_UNSORTED)))
-	{
-		if (mio_unref (TagFile.mio) != 0)
-			error (FATAL | PERROR, "cannot close tag file");
-		goto out;
-	}
-
 	abort_if_ferror (TagFile.mio);
 	desiredSize = mio_tell (TagFile.mio);
 	mio_seek (TagFile.mio, 0L, SEEK_END);
@@ -631,7 +623,7 @@ extern void closeTagFile (const bool resize)
 	{
 		DebugStatement (
 			debugPrintf (DEBUG_STATUS, "shrinking %s from %ld to %ld bytes\n",
-				TagFile.name, size, desiredSize); )
+				TagFile.name? TagFile.name: "<mio>", size, desiredSize); )
 		resizeTagFile (desiredSize);
 	}
 	sortTagFile ();
@@ -639,11 +631,13 @@ extern void closeTagFile (const bool resize)
 	{
 		if (mio_unref (TagFile.mio) != 0)
 			error (FATAL | PERROR, "cannot close tag file");
-		remove (tagFileName ());  /* remove temporary file */
+		if (TagFile.name)
+			remove (TagFile.name);  /* remove temporary file */
 	}
 
- out:
-	eFree (TagFile.name);
+	TagFile.mio = NULL;
+	if (TagFile.name)
+		eFree (TagFile.name);
 	TagFile.name = NULL;
 }
 

--- a/main/entry.h
+++ b/main/entry.h
@@ -198,6 +198,7 @@ extern bool isTagExtra (const tagEntryInfo *const tag);
  */
 extern void attachParserField (tagEntryInfo *const tag, bool inCorkQueue, fieldType ftype, const char* value);
 extern void attachParserFieldToCorkEntry (int index, fieldType ftype, const char* value);
+extern const char* getParserFieldValueForType (tagEntryInfo *const tag, fieldType ftype);
 
 extern int makePlaceholder (const char *const name);
 

--- a/main/entry_p.h
+++ b/main/entry_p.h
@@ -38,8 +38,8 @@ extern void setNumTagsAdded (unsigned long nadded);
 extern unsigned long numTagsTotal(void);
 extern unsigned long maxTagsLine(void);
 extern void invalidatePatternCache(void);
-extern void tagFilePosition (MIOPos *p);
-extern void setTagFilePosition (MIOPos *p);
+extern int tagFilePosition (MIOPos *p);
+extern int setTagFilePosition (MIOPos *p);
 extern const char* getTagFileDirectory (void);
 extern void getTagScopeInformation (tagEntryInfo *const tag,
 				    const char **kind, const char **name);

--- a/main/main.c
+++ b/main/main.c
@@ -456,6 +456,7 @@ void interactiveLoop (cookedArgs *args CTAGS_ATTR_UNUSED, void *user)
 				if (iargs->sandbox) {
 					error (FATAL,
 						   "invalid request in sandbox submode: reading file contents from a file is limited");
+					closeTagFile (false);
 					goto next;
 				}
 

--- a/main/mio.c
+++ b/main/mio.c
@@ -813,7 +813,7 @@ int mio_vprintf (MIO *mio, const char *format, va_list ap)
 		old_size = mio->impl.mem.size;
 		va_copy (ap_copy, ap);
 		/* compute the size we will need into the buffer */
-		n = vsnprintf (&dummy, 1, format, ap_copy);
+		n = vsnprintf (&dummy, 1, format, ap_copy) + 1;
 		va_end (ap_copy);
 		if (mem_try_ensure_space (mio, n))
 		{

--- a/main/mio.c
+++ b/main/mio.c
@@ -648,6 +648,11 @@ static int mem_try_resize (MIO *mio, size_t new_size)
 	return success;
 }
 
+int mio_try_resize (MIO *mio, size_t new_size)
+{
+	return mem_try_resize (mio, new_size);
+}
+
 /*
  * mem_try_ensure_space:
  * @mio: A #MIO object

--- a/main/mio.h
+++ b/main/mio.h
@@ -159,4 +159,6 @@ int mio_flush (MIO *mio);
 void  mio_attach_user_data (MIO *mio, void *user_data, MIODestroyNotify user_data_free_func);
 void *mio_get_user_data (MIO *mio);
 
+int mio_try_resize (MIO *mio, size_t new_size);
+
 #endif /* MIO_H */

--- a/main/parse.c
+++ b/main/parse.c
@@ -3449,7 +3449,15 @@ static bool createTagsWithFallback1 (const langType language,
 
 	addParserPseudoTags (language);
 	initializeParserStats (parser);
-	tagFilePosition (&tagfpos);
+	switch (tagFilePosition (&tagfpos))
+	{
+	case -1:
+		error (FATAL|PERROR, "failed in tagFilePosition\n");
+		break;
+	case -2:
+		error (FATAL, "failed in tagFilePosition\n");
+		break;
+	}
 
 	anonResetMaybe (parser);
 
@@ -3468,7 +3476,16 @@ static bool createTagsWithFallback1 (const langType language,
 		{
 			/*  Restore prior state of tag file.
 			*/
-			setTagFilePosition (&tagfpos);
+			switch (setTagFilePosition (&tagfpos))
+			{
+			case -1:
+				error (FATAL|PERROR, "failed in setTagFilePosition\n");
+				break;
+			case -2:
+				error (FATAL, "failed in setTagFilePosition\n");
+				break;
+			}
+
 			setNumTagsAdded (numTags);
 			writerRescanFailed (numTags);
 			tagFileResized = true;

--- a/main/writer-etags.c
+++ b/main/writer-etags.c
@@ -70,6 +70,7 @@ static bool endEtagsFile (tagWriter *writer,
 	struct sEtags *etags = writer->private;
 
 	mio_printf (mainfp, "\f\n%s,%ld\n", filename, (long) etags->byteCount);
+	setNumTagsAdded (numTagsAdded () + 1);
 	abort_if_ferror (mainfp);
 
 	if (etags->mio != NULL)

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -107,6 +107,9 @@ typedef struct sCppState {
 		unsigned int nestLevel;  /* level 0 is not used */
 		conditionalInfo ifdef [MaxCppNestingLevel];
 	} directive;
+
+	hashTable * fileMacroTable;
+
 } cppState;
 
 
@@ -158,6 +161,7 @@ static fieldDefinition CPreProFields[COUNT_FIELD] = {
 */
 
 static bool doesExaminCodeWithInIf0Branch;
+static bool doesExpandMacros;
 
 /*
 * CXX parser state. This is stored at the beginning of a conditional.
@@ -219,6 +223,13 @@ static cppState Cpp = {
 		}
 	}  /* directive */
 };
+
+/*
+*   FUNCTION DECLARATIONS
+*/
+
+static hashTable *makeMacroTable (void);
+static cppMacroInfo * saveMacro(hashTable *table, const char * macro);
 
 /*
 *   FUNCTION DEFINITIONS
@@ -326,6 +337,11 @@ static void cppInitCommon(langType clientLang,
 	Cpp.directive.ifdef [0].ignoring     = false;
 
 	Cpp.directive.name = vStringNewOrClear (Cpp.directive.name);
+
+	Cpp.fileMacroTable =
+		doesExpandMacros && isFieldEnabled (FIELD_SIGNATURE) && isFieldEnabled (Cpp.macrodefFieldIndex)
+		? makeMacroTable ()
+		: NULL;
 }
 
 extern void cppInit (const bool state, const bool hasAtLiteralStrings,
@@ -368,6 +384,12 @@ extern void cppTerminate (void)
 	}
 
 	Cpp.clientLang = LANG_IGNORE;
+
+	if (Cpp.fileMacroTable)
+	{
+		hashTableDelete (Cpp.fileMacroTable);
+		Cpp.fileMacroTable = NULL;
+	}
 }
 
 extern void cppBeginStatement (void)
@@ -892,6 +914,9 @@ static int directiveDefine (const int c, bool undef)
 		}
 	}
 	Cpp.directive.state = DRCTV_NONE;
+
+	if (r != CORK_NIL && Cpp.fileMacroTable)
+		registerEntry (r);
 	return r;
 }
 
@@ -1627,14 +1652,66 @@ static void findCppTags (void)
 
 static hashTable * cmdlineMacroTable;
 
+
+static bool buildMacroInfoFromTagEntry (int corkIndex,
+										tagEntryInfo * entry,
+										void * data)
+{
+	cppMacroInfo **info = data;
+
+	if (entry->langType == Cpp.clientLang
+		&& entry->kindIndex == Cpp.defineMacroKindIndex
+		&& isRoleAssigned (entry, ROLE_DEFINITION_INDEX))
+	{
+		vString *macrodef = vStringNewInit (entry->name);
+		if (entry->extensionFields.signature)
+			vStringCatS (macrodef, entry->extensionFields.signature);
+		vStringPut (macrodef, '=');
+
+		const char *val = getParserFieldValueForType (entry, Cpp.macrodefFieldIndex);
+		if (val)
+			vStringCatS (macrodef, val);
+
+		*info = saveMacro (Cpp.fileMacroTable, vStringValue (macrodef));
+		vStringDelete (macrodef);
+
+		return false;
+	}
+	return true;
+}
+
+extern cppMacroInfo * cppFindMacroFromSymtab (const char *const name)
+{
+	cppMacroInfo *info = NULL;
+	foreachEntriesInScope (CORK_NIL, name, buildMacroInfoFromTagEntry, &info);
+
+	return info;
+}
+
 /*  Determines whether or not "name" should be ignored, per the ignore list.
  */
-extern const cppMacroInfo * cppFindMacro(const char *const name)
+extern const cppMacroInfo * cppFindMacro (const char *const name)
 {
-	if(!cmdlineMacroTable)
-		return NULL;
+	cppMacroInfo *info;
 
-	return (const cppMacroInfo *)hashTableGetItem(cmdlineMacroTable,(char *)name);
+	if (cmdlineMacroTable)
+	{
+		info = (cppMacroInfo *)hashTableGetItem (cmdlineMacroTable,(char *)name);
+		if (info)
+			return info;
+	}
+
+	if (Cpp.fileMacroTable)
+	{
+		info = (cppMacroInfo *)hashTableGetItem (Cpp.fileMacroTable,(char *)name);
+		if (info)
+			return info;
+
+		info = cppFindMacroFromSymtab(name);
+		if (info)
+			return info;
+	}
+	return NULL;
 }
 
 extern vString * cppBuildMacroReplacement(
@@ -2083,6 +2160,12 @@ static void initializeCpp (const langType language)
 	DEFAULT_TRASH_BOX(cmdlineMacroTable,hashTableDelete);
 }
 
+static void CpreProExpandMacrosInInput (const langType language CTAGS_ATTR_UNUSED, const char *name, const char *arg)
+{
+	doesExpandMacros = paramParserBool (arg, doesExpandMacros,
+										name, "parameter");
+}
+
 static void CpreProInstallIgnoreToken (const langType language CTAGS_ATTR_UNUSED, const char *optname CTAGS_ATTR_UNUSED, const char *arg)
 {
 	if (arg == NULL || arg[0] == '\0')
@@ -2129,6 +2212,10 @@ static parameterHandlerTable CpreProParameterHandlerTable [] = {
 	  .desc = "define replacement for an identifier (name(params,...)=definition)",
 	  .handleParameter = CpreProInstallMacroToken,
 	},
+	{ .name = "_expand",
+	  .desc = "expand macro definitions found in input file (true or [false])",
+	  .handleParameter = CpreProExpandMacrosInInput,
+	}
 };
 
 extern parserDefinition* CPreProParser (void)
@@ -2145,6 +2232,6 @@ extern parserDefinition* CPreProParser (void)
 	def->parameterHandlerTable = CpreProParameterHandlerTable;
 	def->parameterHandlerCount = ARRAY_SIZE(CpreProParameterHandlerTable);
 
-	def->useCork = CORK_QUEUE;
+	def->useCork = CORK_QUEUE | CORK_SYMTAB;
 	return def;
 }

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1625,16 +1625,16 @@ static void findCppTags (void)
  *  Token ignore processing
  */
 
-static hashTable * defineMacroTable;
+static hashTable * cmdlineMacroTable;
 
 /*  Determines whether or not "name" should be ignored, per the ignore list.
  */
 extern const cppMacroInfo * cppFindMacro(const char *const name)
 {
-	if(!defineMacroTable)
+	if(!cmdlineMacroTable)
 		return NULL;
 
-	return (const cppMacroInfo *)hashTableGetItem(defineMacroTable,(char *)name);
+	return (const cppMacroInfo *)hashTableGetItem(cmdlineMacroTable,(char *)name);
 }
 
 extern vString * cppBuildMacroReplacement(
@@ -1694,7 +1694,7 @@ static void saveIgnoreToken(const char * ignoreToken)
 	if(!ignoreToken)
 		return;
 
-	Assert (defineMacroTable);
+	Assert (cmdlineMacroTable);
 
 	const char * c = ignoreToken;
 	char cc = *c;
@@ -1749,7 +1749,7 @@ static void saveIgnoreToken(const char * ignoreToken)
 		info->replacements = NULL;
 	}
 
-	hashTablePutItem(defineMacroTable,eStrndup(tokenBegin,tokenEnd - tokenBegin),info);
+	hashTablePutItem(cmdlineMacroTable,eStrndup(tokenBegin,tokenEnd - tokenBegin),info);
 
 	verbose ("    ignore token: %s\n", ignoreToken);
 }
@@ -1761,7 +1761,7 @@ static void saveMacro(const char * macro)
 	if(!macro)
 		return;
 
-	Assert (defineMacroTable);
+	Assert (cmdlineMacroTable);
 
 	const char * c = macro;
 
@@ -2042,7 +2042,7 @@ static void saveMacro(const char * macro)
 			ADD_CONSTANT_REPLACEMENT(begin,c - begin);
 	}
 
-	hashTablePutItem(defineMacroTable,eStrndup(identifierBegin,identifierEnd - identifierBegin),info);
+	hashTablePutItem(cmdlineMacroTable,eStrndup(identifierBegin,identifierEnd - identifierBegin),info);
 	CXX_DEBUG_LEAVE();
 }
 
@@ -2077,18 +2077,18 @@ static void initializeCpp (const langType language)
 {
 	Cpp.lang = language;
 
-	defineMacroTable = makeMacroTable ();
-	DEFAULT_TRASH_BOX(defineMacroTable,hashTableDelete);
+	cmdlineMacroTable = makeMacroTable ();
+	DEFAULT_TRASH_BOX(cmdlineMacroTable,hashTableDelete);
 }
 
 static void CpreProInstallIgnoreToken (const langType language CTAGS_ATTR_UNUSED, const char *optname CTAGS_ATTR_UNUSED, const char *arg)
 {
 	if (arg == NULL || arg[0] == '\0')
 	{
-		DEFAULT_TRASH_BOX_TAKE_BACK(defineMacroTable);
-		hashTableDelete(defineMacroTable);
-		defineMacroTable = makeMacroTable ();
-		DEFAULT_TRASH_BOX(defineMacroTable,hashTableDelete);
+		DEFAULT_TRASH_BOX_TAKE_BACK(cmdlineMacroTable);
+		hashTableDelete(cmdlineMacroTable);
+		cmdlineMacroTable = makeMacroTable ();
+		DEFAULT_TRASH_BOX(cmdlineMacroTable,hashTableDelete);
 
 		verbose ("    clearing list\n");
 	} else {
@@ -2100,8 +2100,8 @@ static void CpreProInstallMacroToken (const langType language CTAGS_ATTR_UNUSED,
 {
 	if (arg == NULL || arg[0] == '\0')
 	{
-		hashTableDelete(defineMacroTable);
-		defineMacroTable = makeMacroTable ();
+		hashTableDelete(cmdlineMacroTable);
+		cmdlineMacroTable = makeMacroTable ();
 		verbose ("    clearing list\n");
 	} else {
 		saveMacro(arg);

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -2126,7 +2126,7 @@ static parameterHandlerTable CpreProParameterHandlerTable [] = {
 	  .handleParameter = CpreProInstallIgnoreToken,
 	},
 	{ .name = "define",
-	  .desc = "define replacement for an identifier",
+	  .desc = "define replacement for an identifier (name(params,...)=definition)",
 	  .handleParameter = CpreProInstallMacroToken,
 	},
 };

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1754,12 +1754,12 @@ static void saveIgnoreToken(const char * ignoreToken)
 	verbose ("    ignore token: %s\n", ignoreToken);
 }
 
-static void saveMacro(const char * macro)
+static cppMacroInfo * saveMacro(hashTable *table, const char * macro)
 {
 	CXX_DEBUG_ENTER_TEXT("Save macro %s",macro);
 
 	if(!macro)
-		return;
+		return NULL;
 
 	Assert (cmdlineMacroTable);
 
@@ -1772,13 +1772,13 @@ static void saveMacro(const char * macro)
 	if(!*c)
 	{
 		CXX_DEBUG_LEAVE_TEXT("Bad empty macro definition");
-		return;
+		return NULL;
 	}
 
 	if(!(isalpha(*c) || (*c == '_' || (*c == '$') )))
 	{
 		CXX_DEBUG_LEAVE_TEXT("Macro does not start with an alphanumeric character");
-		return; // must be a sequence of letters and digits
+		return NULL; // must be a sequence of letters and digits
 	}
 
 	const char * identifierBegin = c;
@@ -2042,8 +2042,10 @@ static void saveMacro(const char * macro)
 			ADD_CONSTANT_REPLACEMENT(begin,c - begin);
 	}
 
-	hashTablePutItem(cmdlineMacroTable,eStrndup(identifierBegin,identifierEnd - identifierBegin),info);
+	hashTablePutItem(table,eStrndup(identifierBegin,identifierEnd - identifierBegin),info);
 	CXX_DEBUG_LEAVE();
+
+	return info;
 }
 
 static void freeMacroInfo(cppMacroInfo * info)
@@ -2104,7 +2106,7 @@ static void CpreProInstallMacroToken (const langType language CTAGS_ATTR_UNUSED,
 		cmdlineMacroTable = makeMacroTable ();
 		verbose ("    clearing list\n");
 	} else {
-		saveMacro(arg);
+		saveMacro(cmdlineMacroTable, arg);
 	}
 }
 

--- a/parsers/cxx/cxx.c
+++ b/parsers/cxx/cxx.c
@@ -93,7 +93,7 @@ parserDefinition * CParser (void)
 	def->initialize = cxxCParserInitialize;
 	def->finalize = cxxParserCleanup;
 	def->selectLanguage = selectors;
-	def->useCork = CORK_QUEUE; // We use corking to block output until the end of file
+	def->useCork = CORK_QUEUE|CORK_SYMTAB; // We use corking to block output until the end of file
 
 	return def;
 }
@@ -128,7 +128,7 @@ parserDefinition * CppParser (void)
 	def->initialize = cxxCppParserInitialize;
 	def->finalize = cxxParserCleanup;
 	def->selectLanguage = selectors;
-	def->useCork = CORK_QUEUE; // We use corking to block output until the end of file
+	def->useCork = CORK_QUEUE|CORK_SYMTAB; // We use corking to block output until the end of file
 
 	return def;
 }
@@ -157,7 +157,7 @@ parserDefinition * CUDAParser (void)
 	def->initialize = cxxCUDAParserInitialize;
 	def->finalize = cxxParserCleanup;
 	def->selectLanguage = NULL;
-	def->useCork = CORK_QUEUE; // We use corking to block output until the end of file
+	def->useCork = CORK_QUEUE|CORK_SYMTAB; // We use corking to block output until the end of file
 
 	return def;
 }


### PR DESCRIPTION
Close #2413.

```
[jet@localhost]~/var/ctags% cat /tmp/foo.sv
typedef bit[31:0] int32_t;
module mod(
  input bit clk,
  input int32_t a
);
endmodule
[jet@localhost]~/var/ctags% ./ctags --extras=+q  -o - /tmp/input.sv 
a	/tmp/input.sv	/^  input int32_t a$/;"	p	module:mod
clk	/tmp/input.sv	/^  input bit clk,$/;"	p	module:mod
int32_t	/tmp/input.sv	/^typedef bit[31:0] int32_t;$/;"	T
mod	/tmp/input.sv	/^module mod($/;"	m
mod.a	/tmp/input.sv	/^  input int32_t a$/;"	p	module:mod
mod.clk	/tmp/input.sv	/^  input bit clk,$/;"	p	module:mod
```

----

hashtable related changes are proposed separately in #2449.
The rbtree based symbol table is proposed separately in #2450.

----

This pull request still can be converted to smaller pull requests.

1. a pull request dealing with etags output, temporary file, and file position rewinding.
2. pull requests that make parsers use the symbol tables.

The original SystemVerilog issue will be partially fixed (mitigated) in 2.

