### PR TITLE
main: allow to specify F/file kind as an argument for --kinds-all option

### DIFF
--- a/Tmain/kinds-all-with-spec.d/input.c
+++ b/Tmain/kinds-all-with-spec.d/input.c
@@ -1,0 +1,1 @@
+int main(void) {return 0;}

--- a/Tmain/kinds-all-with-spec.d/run.sh
+++ b/Tmain/kinds-all-with-spec.d/run.sh
@@ -5,6 +5,105 @@
 
 CTAGS=$1
 
+t ()
+{
+	echo '#' "--all-kinds=$1" 1>&2
+	$CTAGS --quiet --options=NONE -o - --all-kinds="$1" input.c
+	echo '#' "--kinds-all=$1" 1>&2
+	$CTAGS --quiet --options=NONE -o - --kinds-all="$1" input.c
+}
+
+echo '#' 1>&2
+echo '# unexpected flags after operators ([+-])' 1>&2
+echo '#' 1>&2
+t '*-a'
+t '*-{abc}'
+t '*+a'
+t '*+{abc}'
+
+t 'F-a'
+t 'F-{abc}'
+t 'F+a'
+t 'F+{abc}'
+
+t '{file}-a'
+t '{file}-{abc}'
+t '{file}+a'
+t '{file}+{abc}'
+
+t '+F-a'
+t '+F-{abc}'
+t '+F+a'
+t '+F+{abc}'
+
+t '+{file}-a'
+t '+{file}-{abc}'
+t '+{file}+a'
+t '+{file}+{abc}'
+
+echo '#' 1>&2
+echo '# repeaed operators ([+-])' 1>&2
+echo '#' 1>&2
+t '*--{file}'
+t '*--F'
+t '*++{file}'
+t '*++F'
+t '*+-{file}'
+t '*+-F'
+t '*-+{file}'
+t '*-+F'
+
+t '{file}--F'
+t '{file}++F'
+t '{file}-+F'
+t '{file}+-F'
+
+t '{file}--{file}'
+t '{file}++{file}'
+t '{file}-+{file}'
+t '{file}+-{file}'
+
+t 'F--{file}'
+t 'F++{file}'
+t 'F-+{file}'
+t 'F+-{file}'
+
+t 'F--F'
+t 'F++F'
+t 'F-+F'
+t 'F+-F'
+
+echo '#' 1>&2
+echo '# redundant * usage' 1>&2
+echo '#' 1>&2
+t '-*'
+t '+*'
+t 'F-*'
+t 'F+*'
+t '{file}-*'
+t '{file}+*'
+t '+F-*'
+t '-F+*'
+t '+{file}-*'
+t '-{file}+*'
+
+echo '#' 1>&2
+echo '# Just print the parsed file name' 1>&2
+echo '#' 1>&2
+
+$CTAGS --quiet --options=NONE -o- --all-kinds=F --extras=+f input.c
+$CTAGS --quiet --options=NONE -o- --all-kinds=FF --extras=+f input.c
+$CTAGS --quiet --options=NONE -o- --all-kinds=-F+F --extras=+f input.c
+$CTAGS --quiet --options=NONE -o- --all-kinds='*' --all-kinds=F --extras=+f input.c
+
+$CTAGS --quiet --options=NONE -o- --kinds-all=F --extras=+f input.c
+$CTAGS --quiet --options=NONE -o- --kinds-all=FF --extras=+f input.c
+$CTAGS --quiet --options=NONE -o- --kinds-all=-F+F --extras=+f input.c
+$CTAGS --quiet --options=NONE -o- --kinds-all='*' --kinds-all=F --extras=+f input.c
+
+echo '#' 1>&2
+echo '# The original test cases' 1>&2
+echo '#' 1>&2
 if ! $CTAGS --quiet --options=NONE --kinds-all=xyz --_force-quit=0; then
 	$CTAGS --quiet --options=NONE --all-kinds=abc --_force-quit=0
 else

--- a/Tmain/kinds-all-with-spec.d/stderr-expected.txt
+++ b/Tmain/kinds-all-with-spec.d/stderr-expected.txt
@@ -1,3 +1,293 @@
-ctags: only '*' is acceptable as kind letter for --kinds-all
+#
+# unexpected flags after operators ([+-])
+#
+# --all-kinds=*-a
 ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
-ctags: only '*' is acceptable as kind letter for --all-kinds
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=*-a
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=*-{abc}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=*-{abc}
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=*+a
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=*+a
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=*+{abc}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=*+{abc}
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=F-a
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=F-a
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=F-{abc}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=F-{abc}
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=F+a
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=F+a
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=F+{abc}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=F+{abc}
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds={file}-a
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all={file}-a
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds={file}-{abc}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all={file}-{abc}
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds={file}+a
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all={file}+a
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds={file}+{abc}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all={file}+{abc}
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=+F-a
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=+F-a
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=+F-{abc}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=+F-{abc}
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=+F+a
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=+F+a
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=+F+{abc}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=+F+{abc}
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=+{file}-a
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=+{file}-a
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=+{file}-{abc}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=+{file}-{abc}
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=+{file}+a
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=+{file}+a
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+# --all-kinds=+{file}+{abc}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds
+# --kinds-all=+{file}+{abc}
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+#
+# repeaed operators ([+-])
+#
+# --all-kinds=*--{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=*--{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=*--F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=*--F
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=*++{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=*++{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=*++F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=*++F
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=*+-{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=*+-{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=*+-F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=*+-F
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=*-+{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=*-+{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=*-+F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=*-+F
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds={file}--F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all={file}--F
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds={file}++F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all={file}++F
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds={file}-+F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all={file}-+F
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds={file}+-F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all={file}+-F
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds={file}--{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all={file}--{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds={file}++{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all={file}++{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds={file}-+{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all={file}-+{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds={file}+-{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all={file}+-{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=F--{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=F--{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=F++{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=F++{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=F-+{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=F-+{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=F+-{file}
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=F+-{file}
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=F--F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=F--F
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=F++F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=F++F
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=F-+F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=F-+F
+ctags: don't repeat + (nor -) in --kinds-all option
+# --all-kinds=F+-F
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't repeat + (nor -) in --all-kinds option
+# --kinds-all=F+-F
+ctags: don't repeat + (nor -) in --kinds-all option
+#
+# redundant * usage
+#
+# --all-kinds=-*
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't use '*' after + (nor -) in --all-kinds option
+# --kinds-all=-*
+ctags: don't use '*' after + (nor -) in --kinds-all option
+# --all-kinds=+*
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't use '*' after + (nor -) in --all-kinds option
+# --kinds-all=+*
+ctags: don't use '*' after + (nor -) in --kinds-all option
+# --all-kinds=F-*
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't use '*' after + (nor -) in --all-kinds option
+# --kinds-all=F-*
+ctags: don't use '*' after + (nor -) in --kinds-all option
+# --all-kinds=F+*
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't use '*' after + (nor -) in --all-kinds option
+# --kinds-all=F+*
+ctags: don't use '*' after + (nor -) in --kinds-all option
+# --all-kinds={file}-*
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't use '*' after + (nor -) in --all-kinds option
+# --kinds-all={file}-*
+ctags: don't use '*' after + (nor -) in --kinds-all option
+# --all-kinds={file}+*
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't use '*' after + (nor -) in --all-kinds option
+# --kinds-all={file}+*
+ctags: don't use '*' after + (nor -) in --kinds-all option
+# --all-kinds=+F-*
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't use '*' after + (nor -) in --all-kinds option
+# --kinds-all=+F-*
+ctags: don't use '*' after + (nor -) in --kinds-all option
+# --all-kinds=-F+*
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't use '*' after + (nor -) in --all-kinds option
+# --kinds-all=-F+*
+ctags: don't use '*' after + (nor -) in --kinds-all option
+# --all-kinds=+{file}-*
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't use '*' after + (nor -) in --all-kinds option
+# --kinds-all=+{file}-*
+ctags: don't use '*' after + (nor -) in --kinds-all option
+# --all-kinds=-{file}+*
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: don't use '*' after + (nor -) in --all-kinds option
+# --kinds-all=-{file}+*
+ctags: don't use '*' after + (nor -) in --kinds-all option
+#
+# Just print the parsed file name
+#
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+#
+# The original test cases
+#
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --kinds-all
+ctags: Warning: "--all-kinds" option is obsolete; use "--kinds-all" instead
+ctags: only '*', 'F', "{file}" or their combination is acceptable as kind letter for --all-kinds

--- a/Tmain/kinds-all-with-spec.d/stdout-expected.txt
+++ b/Tmain/kinds-all-with-spec.d/stdout-expected.txt
@@ -1,0 +1,10 @@
+input.c	input.c	1;"	F
+input.c	input.c	1;"	F
+input.c	input.c	1;"	F
+main	input.c	/^int main(void) {return 0;}$/;"	f	typeref:typename:int
+input.c	input.c	1;"	F
+input.c	input.c	1;"	F
+input.c	input.c	1;"	F
+input.c	input.c	1;"	F
+main	input.c	/^int main(void) {return 0;}$/;"	f	typeref:typename:int
+input.c	input.c	1;"	F

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -712,8 +712,8 @@ are not listed here. They are experimental or for debugging purpose.
 	Specify '*' as the parameter to include all kinds implemented
 	in <LANG> in the output. Furthermore if "all" is given as <LANG>,
 	specification of the parameter kinds affects all languages defined
-	in ctags. Giving "all" makes sense only when '*' is
-	given as the parameter kinds.
+	in ctags. Giving "all" makes sense only when '*' or
+	'F' is given as the parameter kinds.
 
 	As an example for the C language, in order to add prototypes and
 	external variable declarations to the default set of tag kinds,

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -712,8 +712,8 @@ are not listed here. They are experimental or for debugging purpose.
 	Specify '*' as the parameter to include all kinds implemented
 	in <LANG> in the output. Furthermore if "all" is given as <LANG>,
 	specification of the parameter kinds affects all languages defined
-	in @CTAGS_NAME_EXECUTABLE@. Giving "all" makes sense only when '*' is
-	given as the parameter kinds.
+	in @CTAGS_NAME_EXECUTABLE@. Giving "all" makes sense only when '*' or
+	'F' is given as the parameter kinds.
 
 	As an example for the C language, in order to add prototypes and
 	external variable declarations to the default set of tag kinds,


### PR DESCRIPTION
The option accepted only '*'.
With this change, you can print all parser files like:

    $ ./u-ctags --kinds-all=F --extras=+f -o - -R ./
    .dir-locals.el	./.dir-locals.el	1;"	F	language:Lisp
    .dir-locals.el	./cxx-token-based-backtrack/.dir-locals.el	1;"	F	language:Lisp
    .gdbinit	./.gdbinit	1;"	F	language:Gdbinit
    ...

Signed-off-by: Masatake YAMATO <yamato@redhat.com>