### PR TITLE
Go: don't check whether kinds is enabled or no at the parser side

### DIFF
--- a/Units/parser-go.r/github-issue-2430.d/README
+++ b/Units/parser-go.r/github-issue-2430.d/README
@@ -1,0 +1,3 @@
+THis is a carsh test.
+Specifying --kinds-Go=f makes tags output empty.
+

--- a/Units/parser-go.r/github-issue-2430.d/args.ctags
+++ b/Units/parser-go.r/github-issue-2430.d/args.ctags
@@ -1,0 +1,1 @@
+--kinds-GO=f

--- a/Units/parser-go.r/github-issue-2430.d/input.go
+++ b/Units/parser-go.r/github-issue-2430.d/input.go
@@ -1,0 +1,6 @@
+// Taken from an issue #2430 opened by @aleb
+package main
+
+type Interval struct {
+        Start, Stop string
+}

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -692,9 +692,6 @@ static int makeTagFull (tokenInfo *const token, const goKind kind,
 
 	initRefTagEntry (&e, name, kind, role);
 
-	if (!GoKinds [kind].enabled)
-		return CORK_NIL;
-
 	e.lineNumber = token->lineNumber;
 	e.filePosition = token->filePosition;
 	if (argList)


### PR DESCRIPTION
Close #2430.

Nowadays, Go parser accesses corkIndex various way to fill fields.

On the other hand, makeTagFull checks whether the kinds of Go
is enabled or disabled; if a given kind is disabled, the
function doesn't make a tag for the kind. As the result it returns
CORK_NIL. So CORK_NIL is not suitable for filling the fields.

The main part of ctags has generic layer for doing the same as
the parser; the main part also checks whether a kind assigned to
a tagEntryInfo is enabled or not. For the optimization purpose,
early checking in a parser is good. However, it makes the code
for using cork indexes in parser sides complicated; a parser
must check the value returned from getEnryFromCorkIndex().

Signed-off-by: Masatake YAMATO <yamato@redhat.com>