### PR TITLE
C++: distinguish template declarations and specializations

### DIFF
--- a/Units/parser-cxx.r/bug1563476.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/bug1563476.cpp.d/expected.tags
@@ -1,3 +1,4 @@
 g	input.cpp	/^int g() {$/;"	f	typeref:typename:int
 IntroduceBitDef	input.cpp	/^struct IntroduceBitDef< Accessor, typename$/;"	s	file:
+Accessor	input.cpp	/^template< typename Accessor >$/;"	Z	struct:IntroduceBitDef
 f	input.cpp	/^ int f() { }$/;"	f	struct:IntroduceBitDef	typeref:typename:int	file:

--- a/Units/parser-cxx.r/template-nested-triangle-brackets.d/expected.tags
+++ b/Units/parser-cxx.r/template-nested-triangle-brackets.d/expected.tags
@@ -21,3 +21,4 @@ T	input-3.hpp	/^template <typename T> struct TemplateParameterStruct {};$/;"	Z	s
 ParameterStruct	input-3.hpp	/^struct ParameterStruct {};$/;"	s
 TestStruct	input-3.hpp	/^template <> struct TestStruct<ParameterStruct> {};$/;"	s	template:<ParameterStruct>
 TestStruct	input-3.hpp	/^template <typename P> struct TestStruct<TemplateParameterStruct<P>> {};$/;"	s	template:<TemplateParameterStruct<P>>
+P	input-3.hpp	/^template <typename P> struct TestStruct<TemplateParameterStruct<P>> {};$/;"	Z	struct:TestStruct

--- a/main/numarray.c
+++ b/main/numarray.c
@@ -100,16 +100,23 @@
 		}																\
 	}																	\
 																		\
-	extern bool prefix##ArrayHasTest (const prefix##Array *const current, \
+	extern bool prefix##ArrayHasTestWithOffset (const prefix##Array *const current, \
+									  const unsigned int offset,		\
 									  bool (*test)(const type num, void *userData),	\
 									  void *userData)					\
 	{																	\
 		bool result = false;											\
 		unsigned int i;													\
 		Assert (current != NULL);										\
-		for (i = 0  ;  ! result  &&  i < current->count  ;  ++i)		\
+		for (i = offset  ;  ! result  &&  i < current->count  ;  ++i)	\
 			result = (*test)(current->array [i], userData);				\
 		return result;													\
+	}																	\
+	extern bool prefix##ArrayHasTest (const prefix##Array *const current, \
+									  bool (*test)(const type num, void *userData),	\
+									  void *userData)					\
+	{																	\
+		return prefix##ArrayHasTestWithOffset (current, 0, test, userData);	\
 	}																	\
 																		\
 	static bool prefix##Eq (const type num, void *userData)				\

--- a/main/numarray.h
+++ b/main/numarray.h
@@ -29,6 +29,10 @@
 	extern type prefix##ArrayItem (const prefix##Array *const current, const unsigned int indx); \
 	extern type prefix##ArrayLast (const prefix##Array *const current); \
 	extern void prefix##ArrayDelete (prefix##Array *const current);		\
+	extern bool prefix##ArrayHasTestWithOffsest (const prefix##Array *const current, \
+									  const unsigned int offset, \
+									  bool (*test)(const type num, void *userData), \
+									  void *userData);					\
 	extern bool prefix##ArrayHasTest (const prefix##Array *const current, \
 									  bool (*test)(const type num, void *userData), \
 									  void *userData);					\

--- a/main/ptrarray.c
+++ b/main/ptrarray.c
@@ -121,10 +121,18 @@ extern bool ptrArrayHasTest (const ptrArray *const current,
 				  bool (*test)(const void *ptr, void *userData),
 				  void *userData)
 {
+	return ptrArrayHasTestWithOffset (current, 0, test, userData);
+}
+
+extern bool ptrArrayHasTestWithOffset (const ptrArray *const current,
+				  const unsigned int offset,
+				  bool (*test)(const void *ptr, void *userData),
+				  void *userData)
+{
 	bool result = false;
 	unsigned int i;
 	Assert (current != NULL);
-	for (i = 0  ;  ! result  &&  i < current->count  ;  ++i)
+	for (i = offset  ;  ! result  &&  i < current->count  ;  ++i)
 		result = (*test)(current->array [i], userData);
 	return result;
 }

--- a/main/ptrarray.h
+++ b/main/ptrarray.h
@@ -40,6 +40,10 @@ extern void ptrArrayDelete (ptrArray *const current);
 extern bool ptrArrayHasTest (const ptrArray *const current,
 				  bool (*test)(const void *ptr, void *userData),
 				  void *userData);
+extern bool ptrArrayHasTestWithOffset (const ptrArray *const current,
+				  const unsigned int offset,
+				  bool (*test)(const void *ptr, void *userData),
+				  void *userData);
 extern bool ptrArrayHas (const ptrArray *const current, void *ptr);
 extern void ptrArrayReverse (const ptrArray *const current);
 extern void ptrArrayDeleteItem (ptrArray* const current, unsigned int indx);

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1005,7 +1005,7 @@ static bool cxxParserParseClassStructOrUnionInternal(
 		// FIXME: Should we add the specialisation arguments somewhere?
 		//        Maybe as a separate field?
 
-		bRet = cxxParserParseTemplateAngleBracketsToSeparateChain();
+		bRet = cxxParserParseTemplateAngleBracketsToSeparateChain(true);
 
 		if(!bRet)
 		{
@@ -1309,11 +1309,8 @@ static bool cxxParserParseClassStructOrUnionInternal(
 				CXXScopeAccessPrivate : CXXScopeAccessPublic
 		);
 
-	if(
-			bGotTemplate &&
-			cxxTagKindEnabled(CXXTagCPPKindTEMPLATEPARAM)
-		)
-		cxxParserEmitTemplateParameterTags();
+	if(bGotTemplate)
+		cxxParserEmitTemplateParameterTagsAndReleaseResource();
 
 	vString * pScopeName = cxxScopeGetFullNameAsString();
 
@@ -1968,8 +1965,12 @@ void cxxParserCleanup(langType language CTAGS_ATTR_UNUSED,bool initialized CTAGS
 		cxxTokenChainDestroy(g_cxx.pTokenChain);
 	if(g_cxx.pTemplateTokenChain)
 		cxxTokenChainDestroy(g_cxx.pTemplateTokenChain);
-	if(g_cxx.pTemplateParameters)
+	while(g_cxx.pTemplateParameters)
+	{
+		ptrArray *pTemplateParameters = ptrArrayItem(g_cxx.pTemplateParameters, 0);
 		ptrArrayDelete(g_cxx.pTemplateParameters);
+		g_cxx.pTemplateParameters = pTemplateParameters;
+	}
 	// Restart coveralls: LCOV_EXCL_END
 
 	cxxScopeDone();

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -357,7 +357,7 @@ process_token:
 					}
 					break;
 					case CXXKeywordTEMPLATE:
-						if(!cxxParserParseTemplatePrefix())
+						if(!cxxParserParseTemplatePrefix(false))
 						{
 							CXX_DEBUG_LEAVE_TEXT("Failed to parse template");
 							return false;

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -1690,11 +1690,8 @@ int cxxParserEmitFunctionTags(
 		cxxTokenDestroy(pIdentifier);
 	}
 
-	if(
-			bGotTemplate &&
-			cxxTagKindEnabled(CXXTagCPPKindTEMPLATEPARAM)
-		)
-		cxxParserEmitTemplateParameterTags();
+	if(bGotTemplate)
+		cxxParserEmitTemplateParameterTagsAndReleaseResource();
 
 	CXX_DEBUG_LEAVE();
 	return iScopesPushed;

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -226,9 +226,15 @@ bool cxxParserParseAndCondenseCurrentSubchain(
 bool cxxParserParseUpToOneOf(unsigned int uTokenTypes,
 							 bool bCanReduceInnerElements);
 bool cxxParserParseIfForWhileSwitchCatchParenthesis(void);
-bool cxxParserParseTemplatePrefix(void);
-bool cxxParserParseTemplateAngleBracketsToSeparateChain(void);
-void cxxParserEmitTemplateParameterTags(void);
+
+// Resources for tracking template parameters allocated by cxxParserParseTemplate*()
+// internally must be freed by calling
+// cxxParserEmitTemplateParameterTagsAndReleaseResource() if cxxParserParseTemplate*()
+// returns true and bTemplateSpecialization is set true.
+bool cxxParserParseTemplatePrefix(bool bTemplateSpecialization);
+bool cxxParserParseTemplateAngleBracketsToSeparateChain(bool bTemplateSpecialization);
+void cxxParserEmitTemplateParameterTagsAndReleaseResource(void);
+
 bool cxxParserParseUsingClause(void);
 bool cxxParserParseAccessSpecifier(void);
 void cxxParserAnalyzeOtherStatement(void);

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -53,12 +53,26 @@ static bool cxxTokenIsPresentInTemplateParameters(CXXToken * t)
 			cxxTokenTypeIsOneOf(t,CXXTokenTypeIdentifier | CXXTokenTypeKeyword),
 			"Token must be identifier or keyword"
 		);
-
-	return ptrArrayHasTest(
+	CXX_DEBUG_ASSERT(
 			g_cxx.pTemplateParameters,
-			cxxTokenCompareWord,
-			vStringValue(t->pszWord)
+			"pTemplateParameters is not prepared"
 		);
+
+	ptrArray *pTemplateParameters = g_cxx.pTemplateParameters;
+
+	/* Search szWord in nested template parameters */
+	while(pTemplateParameters)
+	{
+		if(ptrArrayHasTestWithOffset(
+				pTemplateParameters,
+				1,
+				cxxTokenCompareWord,
+				vStringValue(t->pszWord)))
+			return true;
+		pTemplateParameters = ptrArrayItem(pTemplateParameters, 0);
+
+	}
+	return false;
 }
 
 //
@@ -512,8 +526,9 @@ cxxParserParseTemplateAngleBracketsInternal(bool bCaptureTypeParameters)
 					}
 
 					CXX_DEBUG_PRINT(
-							"Adding '%s' to template parameter list",
-							vStringValue(pParam->pszWord)
+							"Adding '%s' to template parameter list %p",
+							vStringValue(pParam->pszWord),
+							g_cxx.pTemplateParameters
 						);
 
 					ptrArrayAdd(g_cxx.pTemplateParameters,pParam);
@@ -597,8 +612,10 @@ static bool cxxParserParseTemplateAngleBrackets(void)
 //
 // Parses the template angle brackets and puts it in g_cxx.pTemplateTokenChain.
 //
-bool cxxParserParseTemplateAngleBracketsToSeparateChain(void)
+bool cxxParserParseTemplateAngleBracketsToSeparateChain(bool bTemplateSpecialization)
 {
+	bool bRet = true;
+
 	CXX_DEBUG_ENTER();
 
 	CXX_DEBUG_ASSERT(cxxParserCurrentLanguageIsCPP(),"This should be called only in C++");
@@ -616,16 +633,28 @@ bool cxxParserParseTemplateAngleBracketsToSeparateChain(void)
 	//       Not for template<template<>> as it is handled separately
 	//       But maybe for nasty things like template<...(template<>)...>?
 
-	if(g_cxx.pTemplateParameters)
-		ptrArrayClear(g_cxx.pTemplateParameters);
-	else
-		g_cxx.pTemplateParameters = ptrArrayNew(NULL);
+	// If bTemplateSpecialization is set, parameters stored to
+	// pTemplateParameters are never tagged. They are just used
+	// only in cxxTokenIsPresentInTemplateParameters.
+	ptrArray *pTemplateParameters = ptrArrayNew(NULL);
+
+	// The first slot of pTemplateParameters has a special purpose:
+	// keeping the upper level pTemplateParameters. The actual
+	// template parameters are stored to slots after the second.
+	ptrArrayAdd(pTemplateParameters, g_cxx.pTemplateParameters);
+	CXX_DEBUG_PRINT(
+		"Pushing a new template parameter array %p on %p",
+		pTemplateParameters,
+		g_cxx.pTemplateParameters
+		);
+	g_cxx.pTemplateParameters = pTemplateParameters;
 
 	if(!cxxParserParseTemplateAngleBrackets())
 	{
 		CXX_DEBUG_LEAVE_TEXT("Failed to parse angle brackets");
 		cxxTokenChainDestroy(pSave);
-		return false;
+		bRet = false;
+		goto out;
 	}
 
 	if(g_cxx.pTemplateTokenChain)
@@ -635,7 +664,14 @@ bool cxxParserParseTemplateAngleBracketsToSeparateChain(void)
 	g_cxx.pTokenChain = pSave;
 
 	CXX_DEBUG_LEAVE();
-	return true;
+ out:
+	if(!bRet || bTemplateSpecialization)
+	{
+		pTemplateParameters = ptrArrayItem(g_cxx.pTemplateParameters, 0);
+		ptrArrayDelete(g_cxx.pTemplateParameters);
+		g_cxx.pTemplateParameters = pTemplateParameters;
+	}
+	return bRet;
 }
 
 
@@ -643,7 +679,7 @@ bool cxxParserParseTemplateAngleBracketsToSeparateChain(void)
 // Parses a template<anything> prefix.
 // The parsed template parameter definition is stored in a separate token chain.
 //
-bool cxxParserParseTemplatePrefix(void)
+bool cxxParserParseTemplatePrefix(bool bTemplateSpecialization)
 {
 	CXX_DEBUG_ENTER();
 
@@ -672,39 +708,50 @@ bool cxxParserParseTemplatePrefix(void)
 		return true; // tolerate syntax error
 	}
 
-	bool bRet = cxxParserParseTemplateAngleBracketsToSeparateChain();
+	bool bRet = cxxParserParseTemplateAngleBracketsToSeparateChain(bTemplateSpecialization);
 
 	CXX_DEBUG_LEAVE();
 	return bRet;
 }
 
-void cxxParserEmitTemplateParameterTags(void)
+void cxxParserEmitTemplateParameterTagsAndReleaseResource(void)
 {
 	CXX_DEBUG_ASSERT(
 			g_cxx.pTemplateTokenChain &&
 			(g_cxx.pTemplateTokenChain->iCount > 0) &&
 			cxxParserCurrentLanguageIsCPP() &&
-			g_cxx.pTemplateParameters && // this should be ensured by chain existence
-			cxxTagKindEnabled(CXXTagCPPKindTEMPLATEPARAM),
+			g_cxx.pTemplateParameters, // this should be ensured by chain existence
 			"Template existence must be checked before calling this function"
 		);
 
-	int c = ptrArrayCount(g_cxx.pTemplateParameters);
-
-	for(int i=0;i<c;i++)
+	if(cxxTagKindEnabled(CXXTagCPPKindTEMPLATEPARAM))
 	{
-		CXXToken * t = (CXXToken *)ptrArrayItem(g_cxx.pTemplateParameters,i);
+		int c = ptrArrayCount(g_cxx.pTemplateParameters);
 
-		CXX_DEBUG_PRINT("Emitting template param tag for '%s'",vStringValue(t->pszWord));
+		for(int i=1;i<c;i++)
+		{
+			CXXToken * t = (CXXToken *)ptrArrayItem(g_cxx.pTemplateParameters,i);
 
-		tagEntryInfo * tag = cxxTagBegin(
-				CXXTagCPPKindTEMPLATEPARAM,
-				t
+			CXX_DEBUG_PRINT("Emitting template param tag for '%s'",vStringValue(t->pszWord));
+
+			tagEntryInfo * tag = cxxTagBegin(
+					CXXTagCPPKindTEMPLATEPARAM,
+					t
 			);
 
-		if(!tag)
-			continue;
+			if(!tag)
+				continue;
 
-		cxxTagCommit();
+			cxxTagCommit();
+		}
 	}
+
+	ptrArray *pTemplateParameters = ptrArrayItem(g_cxx.pTemplateParameters, 0);
+	CXX_DEBUG_PRINT(
+		"Poping a template parameter array %p, the new top is %p",
+		g_cxx.pTemplateParameters,
+		pTemplateParameters
+		);
+	ptrArrayDelete(g_cxx.pTemplateParameters);
+	g_cxx.pTemplateParameters = pTemplateParameters;
 }

--- a/parsers/cxx/cxx_parser_variable.c
+++ b/parsers/cxx/cxx_parser_variable.c
@@ -740,13 +740,10 @@ bool cxxParserExtractVariableDeclarations(CXXTokenChain * pChain,unsigned int uF
 				vStringDelete(pszProperties);
 		}
 
-		if(
-				bGotTemplate &&
-				cxxTagKindEnabled(CXXTagCPPKindTEMPLATEPARAM)
-			)
+		if(bGotTemplate)
 		{
 			cxxScopePush(pIdentifier,CXXScopeTypeVariable,CXXScopeAccessPublic);
-			cxxParserEmitTemplateParameterTags();
+			cxxParserEmitTemplateParameterTagsAndReleaseResource();
 			cxxScopePop();
 		} else {
 			cxxTokenDestroy(pIdentifier);


### PR DESCRIPTION
For the input:
```
template <typename T> struct TestStruct {};

template <typename T> struct TemplateParameterStruct {};

struct ParameterStruct {};

template <> struct TestStruct<ParameterStruct> {};

template <typename P> struct TestStruct<TemplateParameterStruct<P>> {};
```

with cmdline:
```
./ctags --kinds-C++=+Z --fields-C++=+'{template}' --sort=no  -o - input.cpp
```

Though the first T and the second T are taggged, P in the last line is not tagged.

---

C++: distinguish template declarations and specializations when capturing template parameters
    
    The original code doesn't distinguish them, so capturing template
    parameters is failed if a specialization is in a declaration like:
    
       template <typename P> struct TestStruct<TemplateParameterStruct<P>> {};
    
    When C++ parser finds '<typename', it allocates an array for capturing
    template parameters, and it stores 'P' in ' P>' to the array.  However,
    when the parser finds '<TemplateParameterStruct', the original code
    clears the array, and prepares to capture template parameters in
    '<TemplateParameterStruct<P>>'.  At this time 'P' is lost, and cannot
    be tagged.
    
    This change introduces multiple arrays for the purpose and manages
    them with a stack. Identifiers found during parsing <...> are stored
    in an array at the top of the stack. Looking up an identifier is done
    over all arrays in the stack from the top.
    
    So, for parsing '<typename P>', an array (X) is pushed to the stack.
    'P' is stored in the array X. For parsing '<TemplateParameterStruct<P>>',
    an array (Y) is pushed on array (X). The array (X) is not cleared.
    'P' is not lost and can be tagged.