### PR TITLE
Markdown: use two dquotes as scope separator

### DIFF
--- a/Units/parser-markdown.r/scope-field-markdown.d/expected.tags
+++ b/Units/parser-markdown.r/scope-field-markdown.d/expected.tags
@@ -1,18 +1,18 @@
 a0	input.md	/^# a0$/;"	c
 b0	input.md	/^## b0$/;"	s	chapter:a0
-c0	input.md	/^### c0$/;"	S	section:a0"b0
+c0	input.md	/^### c0$/;"	S	section:a0""b0
 a1	input.md	/^# a1$/;"	c
 a2	input.md	/^# a2$/;"	c
 b20	input.md	/^## b20$/;"	s	chapter:a2
 b21	input.md	/^## b21$/;"	s	chapter:a2
-c21	input.md	/^### c21$/;"	S	section:a2"b21
+c21	input.md	/^### c21$/;"	S	section:a2""b21
 b22	input.md	/^## b22$/;"	s	chapter:a2
-c220	input.md	/^### c220$/;"	S	section:a2"b22
-c221	input.md	/^### c221$/;"	S	section:a2"b22
+c220	input.md	/^### c220$/;"	S	section:a2""b22
+c221	input.md	/^### c221$/;"	S	section:a2""b22
 b23	input.md	/^b23$/;"	s	chapter:a2
 a3	input.md	/^a3$/;"	c
 b31	input.md	/^b31$/;"	s	chapter:a3
 b32	input.md	/^b32$/;"	s	chapter:a3
-c320	input.md	/^### c320$/;"	S	section:a3"b32
-c321	input.md	/^### c321$/;"	S	section:a3"b32
+c320	input.md	/^### c320$/;"	S	section:a3""b32
+c321	input.md	/^### c321$/;"	S	section:a3""b32
 a4	input.md	/^a4$/;"	c

--- a/Units/parser-markdown.r/simple-markdown.d/expected.tags
+++ b/Units/parser-markdown.r/simple-markdown.d/expected.tags
@@ -1,24 +1,24 @@
 a	input.md	/^# a$/;"	c	sectionMarker:#
 b	input.md	/^## b$/;"	s	chapter:a	sectionMarker:#
-c	input.md	/^### c$/;"	S	section:a"b	sectionMarker:#
-d	input.md	/^#### d$/;"	t	subsection:a"b"c	sectionMarker:#
-e	input.md	/^##### e$/;"	T	subsubsection:a"b"c"d	sectionMarker:#
-f	input.md	/^###### f$/;"	u	l4subsection:a"b"c"d"e	sectionMarker:#
+c	input.md	/^### c$/;"	S	section:a""b	sectionMarker:#
+d	input.md	/^#### d$/;"	t	subsection:a""b""c	sectionMarker:#
+e	input.md	/^##### e$/;"	T	subsubsection:a""b""c""d	sectionMarker:#
+f	input.md	/^###### f$/;"	u	l4subsection:a""b""c""d""e	sectionMarker:#
 g	input.md	/^# g #$/;"	c	sectionMarker:##
 h	input.md	/^# h ##$/;"	c	sectionMarker:##
 i	input.md	/^## i #$/;"	s	chapter:h	sectionMarker:##
 j	input.md	/^## j ##$/;"	s	chapter:h	sectionMarker:##
 k	input.md	/^## k ###$/;"	s	chapter:h	sectionMarker:##
-l	input.md	/^### l #$/;"	S	section:h"k	sectionMarker:##
-m	input.md	/^### m ##$/;"	S	section:h"k	sectionMarker:##
-n	input.md	/^### n ###$/;"	S	section:h"k	sectionMarker:##
-o	input.md	/^### o ###$/;"	S	section:h"k	sectionMarker:##
-p	input.md	/^#### p #$/;"	t	subsection:h"k"o	sectionMarker:##
-q	input.md	/^#### q #####$/;"	t	subsection:h"k"o	sectionMarker:##
-r	input.md	/^##### r #$/;"	T	subsubsection:h"k"o"q	sectionMarker:##
-s	input.md	/^##### s ######$/;"	T	subsubsection:h"k"o"q	sectionMarker:##
-t	input.md	/^###### t #$/;"	u	l4subsection:h"k"o"q"s	sectionMarker:##
-u	input.md	/^###### u #######$/;"	u	l4subsection:h"k"o"q"s	sectionMarker:##
+l	input.md	/^### l #$/;"	S	section:h""k	sectionMarker:##
+m	input.md	/^### m ##$/;"	S	section:h""k	sectionMarker:##
+n	input.md	/^### n ###$/;"	S	section:h""k	sectionMarker:##
+o	input.md	/^### o ###$/;"	S	section:h""k	sectionMarker:##
+p	input.md	/^#### p #$/;"	t	subsection:h""k""o	sectionMarker:##
+q	input.md	/^#### q #####$/;"	t	subsection:h""k""o	sectionMarker:##
+r	input.md	/^##### r #$/;"	T	subsubsection:h""k""o""q	sectionMarker:##
+s	input.md	/^##### s ######$/;"	T	subsubsection:h""k""o""q	sectionMarker:##
+t	input.md	/^###### t #$/;"	u	l4subsection:h""k""o""q""s	sectionMarker:##
+u	input.md	/^###### u #######$/;"	u	l4subsection:h""k""o""q""s	sectionMarker:##
 A	input.md	/^A$/;"	c	sectionMarker:=
 B	input.md	/^B$/;"	c	sectionMarker:=
 C	input.md	/^C$/;"	c	sectionMarker:=

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -603,7 +603,8 @@ sub emit_patterns {
     emit_list $_[0], "patterns";
 }
 
-sub escape_dquotes {
+# TODO: handling '\'
+sub escape_as_cstr {
     my $input = shift;
     my $output = "";
 
@@ -629,7 +630,7 @@ sub emit_roledefs {
 	static roleDefinition $opts->{'Clangdef'}${Kind}RoleTable [] = {
 EOF
 	for (@{$_->{'roles'}}) {
-	    my $desc = escape_dquotes $_->{'desc'};
+	    my $desc = escape_as_cstr $_->{'desc'};
 	    print <<EOF;
 		{ true, "$_->{'name'}", "$desc" },
 EOF
@@ -702,7 +703,7 @@ EOF
       print <<EOF;
 		{
 EOF
-      my $desc = escape_dquotes $_->{'desc'};
+      my $desc = escape_as_cstr $_->{'desc'};
       print <<EOF;
 		  $enabled, \'$_->{'letter'}\', "$_->{'name'}", "$desc",
 EOF
@@ -795,7 +796,7 @@ sub emit_xtags {
 EOF
     for (@{$opts->{'extradefs'}}) {
       my $enabled = $_->{"enabled"}? "true": "false";
-      my $desc = escape_dquotes $_->{'desc'};
+      my $desc = escape_as_cstr $_->{'desc'};
       print <<EOF;
 		{
 		  .enabled     = $enabled,
@@ -819,7 +820,7 @@ sub emit_fields {
 EOF
     for (@{$opts->{'fielddefs'}}) {
       my $enabled = $_->{"enabled"}? "true": "false";
-      my $desc = escape_dquotes $_->{'desc'};
+      my $desc = escape_as_cstr $_->{'desc'};
       print <<EOF;
 		{
 		  .enabled     = $enabled,
@@ -900,14 +901,14 @@ EOF
 
     if ($opts->{'defaultScopeSeparator'}) {
 	$sep = "$opts->{'defaultScopeSeparator'}";
-	$sep = escape_dquotes "$sep" if ($sep eq '"');
+	$sep = escape_as_cstr "$sep";
 	print <<EOF;
 	def->defaultScopeSeparator = "$sep";
 EOF
     }
     if ($opts->{'defaultRootScopeSeparator'}) {
 	$sep = $opts->{'defaultRootScopeSeparator'};
-	$sep = escape_dquotes "$sep" if ($sep eq '"');
+	$sep = escape_as_cstr "$sep";
 	print <<EOF;
 	def->defaultRootScopeSeparator = "$sep";
 EOF

--- a/optlib/markdown.c
+++ b/optlib/markdown.c
@@ -457,7 +457,7 @@ extern parserDefinition* MarkdownParser (void)
 	def->kindCount     = ARRAY_SIZE(MarkdownKindTable);
 	def->fieldTable    = MarkdownFieldTable;
 	def->fieldCount    = ARRAY_SIZE(MarkdownFieldTable);
-	def->defaultScopeSeparator = "\"";
+	def->defaultScopeSeparator = "\"\"";
 	def->initialize    = initializeMarkdownParser;
 
 	return def;

--- a/optlib/markdown.ctags
+++ b/optlib/markdown.ctags
@@ -26,7 +26,7 @@
 --map-Markdown=+.md
 --map-Markdown=+.markdown
 
---_scopesep-Markdown=*/*:"
+--_scopesep-Markdown=*/*:""
 
 --kinddef-Markdown=c,chapter,chapsters
 --kinddef-Markdown=s,section,sections


### PR DESCRIPTION
Close #2434.
    
I introduced " as the scoped separator mistakenly. This should be  "".
    
NOTE: Using full qualified tag names in scope fields is still debatable.
