### PR TITLE
Use SIZE_T_FMT_CHAR="z" in mk_mingw.mak

### DIFF
--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -4,9 +4,9 @@ include source.mak
 
 REGEX_DEFINES = -DHAVE_REGCOMP -D__USE_GNU -DHAVE_STDBOOL_H -DHAVE_STDINT_H -Dstrcasecmp=stricmp
 
-CFLAGS = -Wall -std=gnu99
+CFLAGS = -Wall -std=gnu99 -D__USE_MINGW_ANSI_STDIO
 # sizeof (size_t) == sizeof(unsigned long) == 4 on i686-w64-mingw32-gcc.
-SIZE_T_FMT_CHAR='""'
+SIZE_T_FMT_CHAR='"z"'
 COMMON_DEFINES=-DUSE_SYSTEM_STRNLEN
 DEFINES = -DWIN32 $(REGEX_DEFINES) -DHAVE_PACKCC $(COMMON_DEFINES)
 INCLUDES = -I. -Imain -Ignu_regex -Ifnmatch -Iparsers


### PR DESCRIPTION
```
gcc -c -O4 -Os -fexpensive-optimizations -Wall -std=gnu99 -DUSE_SYSTEM_STRNLEN -DSIZE_T_FMT_CHAR='""' -o misc/packcc/packcc.o misc/packcc/packcc.c

misc/packcc/packcc.c: In function 'generate_matching_string_code':
misc/packcc/packcc.c:2117:34: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
 2117 |             fprintf(gen->stream, "pcc_refill_buffer(ctx, %" SIZE_T_FMT_CHAR "u) < %" SIZE_T_FMT_CHAR "u ||\n", n, n);
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~                                                    ~
      |                                                                                                                |
      |                                                                                                                size_t {aka long long unsigned int}
misc/packcc/packcc.c:2117:34: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
misc/packcc/packcc.c:2117:34: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
misc/packcc/packcc.c:2117:34: warning: format '%u' expects argument of type 'unsigned int', but argument 4 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
misc/packcc/packcc.c:2120:38: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
 2120 |                 fprintf(gen->stream, "((const char *)(ctx->buffer.buf + ctx->pos))[%" SIZE_T_FMT_CHAR "u] != '%s' ||\n", i, escape_character(value[i], &s));
      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                    ~
      |                                                                                                                          |
      |                                                                                                                          size_t {aka long long unsigned int}
misc/packcc/packcc.c:2120:38: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
misc/packcc/packcc.c:2123:34: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
 2123 |             fprintf(gen->stream, "((const char *)(ctx->buffer.buf + ctx->pos))[%" SIZE_T_FMT_CHAR "u] != '%s'\n", i, escape_character(value[i], &s));
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                 ~
      |                                                                                                                   |
      |                                                                                                                   size_t {aka long long unsigned int}
misc/packcc/packcc.c:2123:34: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
misc/packcc/packcc.c:2127:34: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
 2127 |             fprintf(gen->stream, "ctx->pos += %" SIZE_T_FMT_CHAR "u;\n", n);
      |                                  ^~~~~~~~~~~~~~~                         ~
      |                                                                          |
      |                                                                          size_t {aka long long unsigned int}
misc/packcc/packcc.c:2127:34: warning: format '%u' expects argument of type 'unsigned int', but argument 3 has type 'size_t' {aka 'long long unsigned int'} [-Wformat=]
misc/packcc/packcc.c: In function 'generate_code':
misc/packcc/packcc.c:2354:21: warning: 'l1' may be used uninitialized in this function [-Wmaybe-uniniti
```
mk_mingw.mak does not specify properly format flag for format functions. This change specify `__USE_MINGW_ANSI_STDIO` in mk_mingw.mak. This fix is advised by @k-takata Thanks.