### PR TITLE
main: extend hashtable api

### DIFF
--- a/main/htable.c
+++ b/main/htable.c
@@ -96,7 +96,7 @@ static void *entry_find (hentry* entry, const void* const key, hashTableEqualFun
 	return NULL;
 }
 
-static bool		entry_delete (hentry **entry, void *key, hashTableEqualFunc equalfn,
+static bool		entry_delete (hentry **entry, const void *key, hashTableEqualFunc equalfn,
 			      hashTableFreeFunc keyfreefn, hashTableFreeFunc valfreefn)
 {
 	while (*entry)
@@ -193,7 +193,7 @@ extern void*      hashTableGetItem   (hashTable *htable, const void * key)
 	return entry_find(htable->table[i], key, htable->equalfn);
 }
 
-extern bool     hashTableDeleteItem (hashTable *htable, void *key)
+extern bool     hashTableDeleteItem (hashTable *htable, const void *key)
 {
 	unsigned int i;
 
@@ -217,7 +217,7 @@ extern bool       hashTableForeachItem (hashTable *htable, hashTableForeachFunc 
 	return true;
 }
 
-static bool count (void *key CTAGS_ATTR_UNUSED, void *value CTAGS_ATTR_UNUSED, void *data)
+static bool count (const void *const key CTAGS_ATTR_UNUSED, void *value CTAGS_ATTR_UNUSED, void *data)
 {
 	int *c = data;
 	++*c;

--- a/main/htable.c
+++ b/main/htable.c
@@ -111,13 +111,15 @@ static bool		entry_delete (hentry **entry, void *key, hashTableEqualFunc equalfn
 	return false;
 }
 
-static void  entry_foreach (hentry *entry, hashTableForeachFunc proc, void *user_data)
+static bool  entry_foreach (hentry *entry, hashTableForeachFunc proc, void *user_data)
 {
 	while (entry)
 	{
-		proc (entry->key, entry->value, user_data);
+		if (!proc (entry->key, entry->value, user_data))
+			return false;
 		entry = entry->next;
 	}
+	return true;
 }
 
 extern hashTable *hashTableNew    (unsigned int size,
@@ -205,18 +207,21 @@ extern bool    hashTableHasItem    (hashTable *htable, const void *key)
 	return hashTableGetItem (htable, key)? true: false;
 }
 
-extern void       hashTableForeachItem (hashTable *htable, hashTableForeachFunc proc, void *user_data)
+extern bool       hashTableForeachItem (hashTable *htable, hashTableForeachFunc proc, void *user_data)
 {
 	unsigned int i;
 
 	for (i = 0; i < htable->size; i++)
-		entry_foreach(htable->table[i], proc, user_data);
+		if (!entry_foreach(htable->table[i], proc, user_data))
+			return false;
+	return true;
 }
 
-static void count (void *key CTAGS_ATTR_UNUSED, void *value CTAGS_ATTR_UNUSED, void *data)
+static bool count (void *key CTAGS_ATTR_UNUSED, void *value CTAGS_ATTR_UNUSED, void *data)
 {
 	int *c = data;
 	++*c;
+	return true;
 }
 
 extern int        hashTableCountItem   (hashTable *htable)

--- a/main/htable.h
+++ b/main/htable.h
@@ -18,7 +18,10 @@ typedef struct sHashTable hashTable;
 typedef unsigned int (* hashTableHashFunc)  (const void * const key);
 typedef bool      (* hashTableEqualFunc) (const void* a, const void* b);
 typedef void         (* hashTableFreeFunc)  (void * ptr);
-typedef void         (* hashTableForeachFunc) (void *key, void *value, void* user_data);
+
+/* To continue interation, return true.
+ * To break interation, return false. */
+typedef bool         (* hashTableForeachFunc) (void *key, void *value, void *user_data);
 
 unsigned int hashPtrhash (const void * x);
 bool hashPtreq (const void * a, const void * constb);
@@ -44,7 +47,14 @@ extern void       hashTablePutItem     (hashTable *htable, void *key, void *valu
 extern void*      hashTableGetItem     (hashTable *htable, const void * key);
 extern bool    hashTableHasItem     (hashTable * htable, const void * key);
 extern bool    hashTableDeleteItem  (hashTable *htable, void *key);
-extern void       hashTableForeachItem (hashTable *htable, hashTableForeachFunc proc, void *user_data);
+
+/* Return true if proc never returns false; proc returns true for all
+ * the items, or htable holds no item.
+ *
+ * Return false if htable holds at least one item and proc returns false
+ * for one of the items. */
+extern bool       hashTableForeachItem (hashTable *htable, hashTableForeachFunc proc, void *user_data);
+
 extern int        hashTableCountItem   (hashTable *htable);
 
 extern hashTable* hashTableIntNew (unsigned int size,

--- a/main/htable.h
+++ b/main/htable.h
@@ -14,6 +14,19 @@
 #include "general.h"
 #include <stdint.h>
 
+/* This hashtable allows adding multiple items for a same key.
+ *
+ * hashTablePutItem() adds a key/item pair to the htable even if the
+ * htable has an item for the key already.
+ *
+ * hashTableGetItem() returns the first occurrence item for a given
+ * key.
+ *
+ * hashTableDeleteItem() deletes the first occurrence item for a given
+ * key.
+ *
+ * Use hashTableForeachItemOnChain () to process all items for a same key.
+ */
 typedef struct sHashTable hashTable;
 typedef unsigned int (* hashTableHashFunc)  (const void * const key);
 typedef bool      (* hashTableEqualFunc) (const void* a, const void* b);
@@ -54,6 +67,12 @@ extern bool    hashTableDeleteItem  (hashTable *htable, const void *key);
  * Return false if htable holds at least one item and proc returns false
  * for one of the items. */
 extern bool       hashTableForeachItem (hashTable *htable, hashTableForeachFunc proc, void *user_data);
+
+/* This function is useful for htable having multiple items for a key.
+ * By giving a key, you can traverse all the items associated with the
+ * key via proc.  * "Chain" means group of items associated with a
+ * key. */
+extern bool       hashTableForeachItemOnChain (hashTable *htable, const void *key, hashTableForeachFunc proc, void *user_data);
 
 extern int        hashTableCountItem   (hashTable *htable);
 

--- a/main/htable.h
+++ b/main/htable.h
@@ -82,5 +82,7 @@ extern hashTable* hashTableIntNew (unsigned int size,
 								   hashTableFreeFunc keyfreefn);
 #define HT_PTR_TO_INT(P) ((int)(intptr_t)(P))
 #define HT_INT_TO_PTR(P) ((void*)(intptr_t)(P))
+#define HT_PTR_TO_UINT(P) ((unsigned int)(uintptr_t)(P))
+#define HT_UINT_TO_PTR(P) ((void*)(uintptr_t)(P))
 
 #endif	/* CTAGS_MAIN_HTABLE_H */

--- a/main/htable.h
+++ b/main/htable.h
@@ -21,7 +21,7 @@ typedef void         (* hashTableFreeFunc)  (void * ptr);
 
 /* To continue interation, return true.
  * To break interation, return false. */
-typedef bool         (* hashTableForeachFunc) (void *key, void *value, void *user_data);
+typedef bool         (* hashTableForeachFunc) (const void *key, void *value, void *user_data);
 
 unsigned int hashPtrhash (const void * x);
 bool hashPtreq (const void * a, const void * constb);
@@ -46,7 +46,7 @@ extern void       hashTableClear       (hashTable *htable);
 extern void       hashTablePutItem     (hashTable *htable, void *key, void *value);
 extern void*      hashTableGetItem     (hashTable *htable, const void * key);
 extern bool    hashTableHasItem     (hashTable * htable, const void * key);
-extern bool    hashTableDeleteItem  (hashTable *htable, void *key);
+extern bool    hashTableDeleteItem  (hashTable *htable, const void *key);
 
 /* Return true if proc never returns false; proc returns true for all
  * the items, or htable holds no item.

--- a/main/htable.h
+++ b/main/htable.h
@@ -14,18 +14,18 @@
 #include "general.h"
 #include <stdint.h>
 
-/* This hashtable allows adding multiple items for a same key.
+/* This hashtable allows adding multiple items for the same key.
  *
  * hashTablePutItem() adds a key/item pair to the htable even if the
  * htable has an item for the key already.
  *
- * hashTableGetItem() returns the first occurrence item for a given
+ * hashTableGetItem() returns the first occurrence item for the given
  * key.
  *
- * hashTableDeleteItem() deletes the first occurrence item for a given
+ * hashTableDeleteItem() deletes the first occurrence item for the given
  * key.
  *
- * Use hashTableForeachItemOnChain () to process all items for a same key.
+ * Use hashTableForeachItemOnChain () to process all items for the same key.
  */
 typedef struct sHashTable hashTable;
 typedef unsigned int (* hashTableHashFunc)  (const void * const key);


### PR DESCRIPTION
These are spin-off code developed during studying symbol tables before introducing rbtree.

These are not used anywhere, however, they may be useful in the future for u-ctags development.

* a callback function passed to hashTableForeachItem can break the interation.
* a new function hashTableForeachItemOnChain is for handling entries having the same key.

