### PR TITLE
main: rbtree based symbol table

### DIFF
--- a/Units/simple-texBeamer.d/expected.tags
+++ b/Units/simple-texBeamer.d/expected.tags
@@ -1,15 +1,9 @@
 Concept	input.tex	/^\\begin{frame}{Concept}$/;"	frametitle
-Concept	input.tex	/^\\begin{frame}{Concept}{kind}$/;"	frametitle
 kind	input.tex	/^\\begin{frame}{Concept}{kind}$/;"	framesubtitle	frametitle:Concept
-Concept	input.tex	/^\\begin{frame}\\frametitle{Concept}$/;"	frametitle
 field	input.tex	/^  \\framesubtitle{field}$/;"	framesubtitle	frametitle:Concept
-Concept	input.tex	/^\\begin{frame}{Concept}$/;"	frametitle
 extra	input.tex	/^  \\framesubtitle{extra}$/;"	framesubtitle	frametitle:Concept
-Concept	input.tex	/^\\begin{frame}[fragile]{Concept}{pseudo tag}$/;"	frametitle
 pseudo tag	input.tex	/^\\begin{frame}[fragile]{Concept}{pseudo tag}$/;"	framesubtitle	frametitle:Concept
 Options	input.tex	/^\\begin{frame}<1-2>\\frametitle{Options}$/;"	frametitle
 Optlib	input.tex	/^\\begin{frame}<1-2>[fragile]\\frametitle{Optlib}$/;"	frametitle
-Optlib	input.tex	/^\\begin{frame}<1-2>[fragile]\\frametitle{Optlib}\\framesubtitle{Line oriented parser}$/;"	frametitle
 Line oriented parser	input.tex	/^\\begin{frame}<1-2>[fragile]\\frametitle{Optlib}\\framesubtitle{Line oriented parser}$/;"	framesubtitle	frametitle:Optlib
-Optlib	input.tex	/^\\begin{frame}[<+->][plain]{Optlib}\\framesubtitle{Multiline parser}$/;"	frametitle
 Multiline parser	input.tex	/^\\begin{frame}[<+->][plain]{Optlib}\\framesubtitle{Multiline parser}$/;"	framesubtitle	frametitle:Optlib

--- a/configure.ac
+++ b/configure.ac
@@ -424,6 +424,7 @@ fi
 AC_C_CONST
 AC_OBJEXT
 AC_EXEEXT
+AC_C_TYPEOF
 
 if test "${enable_static}" = "yes"; then
 	LDFLAGS="$LDFLAGS -static"

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,9 @@ AH_TEMPLATE([L_tmpnam],
 AH_TEMPLATE([HAVE_STAT_ST_INO],
 	[Define this macro if the field "st_ino" exists in struct stat in
 	<sys/stat.h>.])
+AH_TEMPLATE([HAVE_STATEMENT_EXPRESSION_EXT],
+	[Define this macro if compiler supports statement expression non-standard
+	C feature.])
 AH_TEMPLATE([remove],
 	[Define remove to unlink if you have unlink(), but not remove().])
 AH_TEMPLATE([INT_MAX],
@@ -434,6 +437,16 @@ case "$host" in
 	;;
 esac
 AM_CONDITIONAL([HOST_MINGW], [test "x${host_mingw}" = "xyes"])
+
+AC_MSG_CHECKING(if compiler supprots statement expressions)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[
+int main(int argc, char **argv) {return ({ int x = 1; x + argc;});}
+])],[have_statment_expression_ext=yes],[have_statment_expression_ext=no])
+AC_MSG_RESULT($have_statment_expression_ext)
+if test yes = "$have_statment_expression_ext"; then
+	AC_DEFINE(HAVE_STATEMENT_EXPRESSION_EXT)
+fi
+
 
 # Check if struct stat contains st_ino.
 # MinGW has st_ino, but it doesn't work.

--- a/docs/internal.rst
+++ b/docs/internal.rst
@@ -346,11 +346,11 @@ enables it in your parser.
 
 		typedef struct {
 		...
-				boolean useCork;
+				unsigned int useCork;
 		...
 		} parserDefinition;
 
-Set `TRUE` to `useCork` like:
+Set `CORK_QUEUE` to `useCork` like:
 
 .. code-block:: c
 
@@ -359,11 +359,11 @@ Set `TRUE` to `useCork` like:
 	    ...
 	    parserDefinition *def = parserNew ("Clojure");
 	    ...
-	    def->useCork = TRUE;
+	    def->useCork = CORK_QUEUE;
 	    return def;
     }
 
-When ctags running a parser with `useCork` being `TRUE`, all output
+When ctags running a parser with `useCork` being `CORK_QUEUE`, all output
 requested via `makeTagEntry` function calling is stored to an internal
 queue, not to `tags` file.  When parsing an input file is done, the
 tag information stored automatically to the queue are flushed to
@@ -420,4 +420,4 @@ An example can be found in DTS parser:
     }
 
 Setting `requestAutomaticFQTag` to `TRUE` implies setting
-`useCork` to `TRUE`.
+`useCork` to `CORK_QUEUE`.

--- a/main/entry.h
+++ b/main/entry.h
@@ -116,6 +116,9 @@ struct sTagEntryInfo {
 	unsigned long sourceLineNumberDifference;
 };
 
+typedef bool (* entryForeachFunc) (unsigned int corkIndex,
+								   tagEntryInfo * entry,
+								   void * data);
 
 /*
 *   GLOBAL VARIABLES
@@ -143,6 +146,25 @@ extern int makeQualifiedTagEntry (const tagEntryInfo *const e);
 tagEntryInfo *getEntryInCorkQueue   (unsigned int n);
 tagEntryInfo *getEntryOfNestingLevel (const NestingLevel *nl);
 size_t        countEntryInCorkQueue (void);
+
+/* If a parser sets (CORK_QUEUE and )CORK_SYMTAB to useCork,
+ * the parsesr can use symbol lookup tables for the current input.
+ * Each scope has a symbol lookup table.
+ * To register an tag to the table, use registerEntry().
+ * registerEntry registers CORKINDEX to a symbol table of a parent tag
+ * specified in the scopeIndex field of the tag specified with CORKINDEX.
+ */
+void          registerEntry (unsigned int corkIndex);
+
+/* foreachEntriesInScope is for traversing the symbol table for a table
+ * specified with CORKINDEX. If CORK_NIL is given, this function traverses
+ * top-level entries. If name is NULL, this function traverses all entries
+ * under the scope.
+ */
+bool          foreachEntriesInScope (unsigned int corkIndex,
+									 const char *name, /* or NULL */
+									 entryForeachFunc func,
+									 void *data);
 
 extern void    markTagExtraBit     (tagEntryInfo *const tag, xtagType extra);
 extern bool isTagExtraBitMarked (const tagEntryInfo *const tag, xtagType extra);

--- a/main/entry_p.h
+++ b/main/entry_p.h
@@ -58,7 +58,7 @@ extern bool writePseudoTag (const ptagDesc *pdesc,
 			       const char *const pattern,
 			       const char *const parserName);
 
-void          corkTagFile(void);
+void          corkTagFile(unsigned int corkFlags);
 void          uncorkTagFile(void);
 
 extern void makeFileTag (const char *const fileName);

--- a/main/gcc-attr.h
+++ b/main/gcc-attr.h
@@ -16,10 +16,12 @@
 #if defined (__GNUC__) && !defined (__GNUG__)
 # define CTAGS_ATTR_UNUSED __attribute__((unused))
 # define CTAGS_ATTR_PRINTF(s,f)  __attribute__((format (printf, s, f)))
+# define CTAGA_ATTR_ALIGNED(X) __attribute__((aligned(X)))
 # define attr__noreturn __attribute__((__noreturn__))
 #else
 # define CTAGS_ATTR_UNUSED
 # define CTAGS_ATTR_PRINTF(s,f)
+# define CTAGA_ATTR_ALIGNED(X)
 # define attr__noreturn
 #endif
 

--- a/main/numarray.c
+++ b/main/numarray.c
@@ -36,7 +36,7 @@
 		return result;													\
 	}																	\
 																		\
-	extern void prefix##ArrayAdd (prefix##Array *const current, type num) \
+	extern unsigned int prefix##ArrayAdd (prefix##Array *const current, type num) \
 	{																	\
 		Assert (current != NULL);										\
 		if (current->count == current->max)								\
@@ -44,7 +44,8 @@
 			current->max *= 2;											\
 			current->array = xRealloc (current->array, current->max, type);	\
 		}																\
-		current->array [current->count++] = num;						\
+		current->array [current->count] = num;							\
+		return current->count++;										\
 	}																	\
 																		\
 	extern void prefix##ArrayRemoveLast (prefix##Array *const current)	\

--- a/main/numarray.h
+++ b/main/numarray.h
@@ -21,7 +21,7 @@
 	typedef struct s##Prefix##Array prefix##Array;						\
 																		\
 	extern prefix##Array *prefix##ArrayNew (void);						\
-	extern void prefix##ArrayAdd (prefix##Array *const current, type num); \
+	extern unsigned int prefix##ArrayAdd (prefix##Array *const current, type num); \
 	extern void prefix##ArrayRemoveLast (prefix##Array *const current);	\
 	extern void prefix##ArrayCombine (prefix##Array *const current, prefix##Array *const from);	\
 	extern void prefix##ArrayClear (prefix##Array *const current);		\

--- a/main/parse.h
+++ b/main/parse.h
@@ -66,7 +66,8 @@ typedef struct {
 
 typedef enum {
 	CORK_NO_USE,
-	CORK_QUEUE = (1 << 0),
+	CORK_QUEUE  = (1 << 0),
+	CORK_SYMTAB = (1 << 1),
 } corkUsage;
 
 struct sParserDefinition {

--- a/main/parse.h
+++ b/main/parse.h
@@ -64,6 +64,11 @@ typedef struct {
 	const int id;
 } keywordTable;
 
+typedef enum {
+	CORK_NO_USE,
+	CORK_QUEUE = (1 << 0),
+} corkUsage;
+
 struct sParserDefinition {
 	/* defined by parser */
 	char* name;                    /* name of language */
@@ -78,7 +83,7 @@ struct sParserDefinition {
 	rescanParser parser2;          /* rescanning parser (unusual case) */
 	selectLanguage* selectLanguage; /* may be used to resolve conflicts */
 	unsigned int method;           /* See METHOD_ definitions above */
-	bool useCork;
+	unsigned int useCork;		   /* bit or of corkUsage */
 	bool useMemoryStreamInput;
 	bool allowNullTag;
 	bool requestAutomaticFQTag;

--- a/main/ptrarray.c
+++ b/main/ptrarray.c
@@ -44,7 +44,7 @@ extern ptrArray *ptrArrayNew (ptrArrayDeleteFunc deleteFunc)
 	return result;
 }
 
-extern void ptrArrayAdd (ptrArray *const current, void *ptr)
+extern unsigned int ptrArrayAdd (ptrArray *const current, void *ptr)
 {
 	Assert (current != NULL);
 	if (current->count == current->max)
@@ -52,7 +52,8 @@ extern void ptrArrayAdd (ptrArray *const current, void *ptr)
 		current->max *= 2;
 		current->array = xRealloc (current->array, current->max, void*);
 	}
-	current->array [current->count++] = ptr;
+	current->array [current->count] = ptr;
+	return current->count++;
 }
 
 extern void *ptrArrayRemoveLast (ptrArray *const current)

--- a/main/ptrarray.h
+++ b/main/ptrarray.h
@@ -29,7 +29,7 @@ typedef void (*ptrArrayDeleteFunc) (void *data);
 */
 
 extern ptrArray *ptrArrayNew (ptrArrayDeleteFunc deleteFunc);
-extern void ptrArrayAdd (ptrArray *const current, void *ptr);
+extern unsigned int ptrArrayAdd (ptrArray *const current, void *ptr);
 extern void *ptrArrayRemoveLast (ptrArray *const current);
 extern void ptrArrayCombine (ptrArray *const current, ptrArray *const from);
 extern void ptrArrayClear (ptrArray *const current);

--- a/main/rbtree.c
+++ b/main/rbtree.c
@@ -1,0 +1,467 @@
+/*
+ * =============================================================================
+ *
+ *       Filename:  rbtree.c
+ *
+ *    Description:  rbtree(Red-Black tree) implementation adapted from linux
+ *                  kernel thus can be used in userspace c program.
+ *
+ *        Created:  09/02/2012 11:38:12 PM
+ *
+ *         Author:  Fu Haiping (forhappy), haipingf@gmail.com
+ *        Company:  ICT ( Institute Of Computing Technology, CAS )
+ *
+ * =============================================================================
+ */
+
+/*
+  Red Black Trees
+  (C) 1999  Andrea Arcangeli <andrea@suse.de>
+  (C) 2002  David Woodhouse <dwmw2@infradead.org>
+  
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  linux/lib/rbtree.c
+*/
+
+#include "rbtree.h"
+
+static void __rb_rotate_left(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *right = node->rb_right;
+	struct rb_node *parent = rb_parent(node);
+
+	if ((node->rb_right = right->rb_left))
+		rb_set_parent(right->rb_left, node);
+	right->rb_left = node;
+
+	rb_set_parent(right, parent);
+
+	if (parent)
+	{
+		if (node == parent->rb_left)
+			parent->rb_left = right;
+		else
+			parent->rb_right = right;
+	}
+	else
+		root->rb_node = right;
+	rb_set_parent(node, right);
+}
+
+static void __rb_rotate_right(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *left = node->rb_left;
+	struct rb_node *parent = rb_parent(node);
+
+	if ((node->rb_left = left->rb_right))
+		rb_set_parent(left->rb_right, node);
+	left->rb_right = node;
+
+	rb_set_parent(left, parent);
+
+	if (parent)
+	{
+		if (node == parent->rb_right)
+			parent->rb_right = left;
+		else
+			parent->rb_left = left;
+	}
+	else
+		root->rb_node = left;
+	rb_set_parent(node, left);
+}
+
+void rb_insert_color(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *parent, *gparent;
+
+	while ((parent = rb_parent(node)) && rb_is_red(parent))
+	{
+		gparent = rb_parent(parent);
+
+		if (parent == gparent->rb_left)
+		{
+			{
+				register struct rb_node *uncle = gparent->rb_right;
+				if (uncle && rb_is_red(uncle))
+				{
+					rb_set_black(uncle);
+					rb_set_black(parent);
+					rb_set_red(gparent);
+					node = gparent;
+					continue;
+				}
+			}
+
+			if (parent->rb_right == node)
+			{
+				register struct rb_node *tmp;
+				__rb_rotate_left(parent, root);
+				tmp = parent;
+				parent = node;
+				node = tmp;
+			}
+
+			rb_set_black(parent);
+			rb_set_red(gparent);
+			__rb_rotate_right(gparent, root);
+		} else {
+			{
+				register struct rb_node *uncle = gparent->rb_left;
+				if (uncle && rb_is_red(uncle))
+				{
+					rb_set_black(uncle);
+					rb_set_black(parent);
+					rb_set_red(gparent);
+					node = gparent;
+					continue;
+				}
+			}
+
+			if (parent->rb_left == node)
+			{
+				register struct rb_node *tmp;
+				__rb_rotate_right(parent, root);
+				tmp = parent;
+				parent = node;
+				node = tmp;
+			}
+
+			rb_set_black(parent);
+			rb_set_red(gparent);
+			__rb_rotate_left(gparent, root);
+		}
+	}
+
+	rb_set_black(root->rb_node);
+}
+
+static void __rb_erase_color(struct rb_node *node, struct rb_node *parent,
+			     struct rb_root *root)
+{
+	struct rb_node *other;
+
+	while ((!node || rb_is_black(node)) && node != root->rb_node)
+	{
+		if (parent->rb_left == node)
+		{
+			other = parent->rb_right;
+			if (rb_is_red(other))
+			{
+				rb_set_black(other);
+				rb_set_red(parent);
+				__rb_rotate_left(parent, root);
+				other = parent->rb_right;
+			}
+			if ((!other->rb_left || rb_is_black(other->rb_left)) &&
+			    (!other->rb_right || rb_is_black(other->rb_right)))
+			{
+				rb_set_red(other);
+				node = parent;
+				parent = rb_parent(node);
+			}
+			else
+			{
+				if (!other->rb_right || rb_is_black(other->rb_right))
+				{
+					rb_set_black(other->rb_left);
+					rb_set_red(other);
+					__rb_rotate_right(other, root);
+					other = parent->rb_right;
+				}
+				rb_set_color(other, rb_color(parent));
+				rb_set_black(parent);
+				rb_set_black(other->rb_right);
+				__rb_rotate_left(parent, root);
+				node = root->rb_node;
+				break;
+			}
+		}
+		else
+		{
+			other = parent->rb_left;
+			if (rb_is_red(other))
+			{
+				rb_set_black(other);
+				rb_set_red(parent);
+				__rb_rotate_right(parent, root);
+				other = parent->rb_left;
+			}
+			if ((!other->rb_left || rb_is_black(other->rb_left)) &&
+			    (!other->rb_right || rb_is_black(other->rb_right)))
+			{
+				rb_set_red(other);
+				node = parent;
+				parent = rb_parent(node);
+			}
+			else
+			{
+				if (!other->rb_left || rb_is_black(other->rb_left))
+				{
+					rb_set_black(other->rb_right);
+					rb_set_red(other);
+					__rb_rotate_left(other, root);
+					other = parent->rb_left;
+				}
+				rb_set_color(other, rb_color(parent));
+				rb_set_black(parent);
+				rb_set_black(other->rb_left);
+				__rb_rotate_right(parent, root);
+				node = root->rb_node;
+				break;
+			}
+		}
+	}
+	if (node)
+		rb_set_black(node);
+}
+
+void rb_erase(struct rb_node *node, struct rb_root *root)
+{
+	struct rb_node *child, *parent;
+	int color;
+
+	if (!node->rb_left)
+		child = node->rb_right;
+	else if (!node->rb_right)
+		child = node->rb_left;
+	else
+	{
+		struct rb_node *old = node, *left;
+
+		node = node->rb_right;
+		while ((left = node->rb_left) != NULL)
+			node = left;
+
+		if (rb_parent(old)) {
+			if (rb_parent(old)->rb_left == old)
+				rb_parent(old)->rb_left = node;
+			else
+				rb_parent(old)->rb_right = node;
+		} else
+			root->rb_node = node;
+
+		child = node->rb_right;
+		parent = rb_parent(node);
+		color = rb_color(node);
+
+		if (parent == old) {
+			parent = node;
+		} else {
+			if (child)
+				rb_set_parent(child, parent);
+			parent->rb_left = child;
+
+			node->rb_right = old->rb_right;
+			rb_set_parent(old->rb_right, node);
+		}
+
+		node->rb_parent_color = old->rb_parent_color;
+		node->rb_left = old->rb_left;
+		rb_set_parent(old->rb_left, node);
+
+		goto color;
+	}
+
+	parent = rb_parent(node);
+	color = rb_color(node);
+
+	if (child)
+		rb_set_parent(child, parent);
+	if (parent)
+	{
+		if (parent->rb_left == node)
+			parent->rb_left = child;
+		else
+			parent->rb_right = child;
+	}
+	else
+		root->rb_node = child;
+
+ color:
+	if (color == RB_BLACK)
+		__rb_erase_color(child, parent, root);
+}
+
+static void rb_augment_path(struct rb_node *node, rb_augment_f func, void *data)
+{
+	struct rb_node *parent;
+
+up:
+	func(node, data);
+	parent = rb_parent(node);
+	if (!parent)
+		return;
+
+	if (node == parent->rb_left && parent->rb_right)
+		func(parent->rb_right, data);
+	else if (parent->rb_left)
+		func(parent->rb_left, data);
+
+	node = parent;
+	goto up;
+}
+
+/*
+ * after inserting @node into the tree, update the tree to account for
+ * both the new entry and any damage done by rebalance
+ */
+void rb_augment_insert(struct rb_node *node, rb_augment_f func, void *data)
+{
+	if (node->rb_left)
+		node = node->rb_left;
+	else if (node->rb_right)
+		node = node->rb_right;
+
+	rb_augment_path(node, func, data);
+}
+
+/*
+ * before removing the node, find the deepest node on the rebalance path
+ * that will still be there after @node gets removed
+ */
+struct rb_node *rb_augment_erase_begin(struct rb_node *node)
+{
+	struct rb_node *deepest;
+
+	if (!node->rb_right && !node->rb_left)
+		deepest = rb_parent(node);
+	else if (!node->rb_right)
+		deepest = node->rb_left;
+	else if (!node->rb_left)
+		deepest = node->rb_right;
+	else {
+		deepest = rb_next(node);
+		if (deepest->rb_right)
+			deepest = deepest->rb_right;
+		else if (rb_parent(deepest) != node)
+			deepest = rb_parent(deepest);
+	}
+
+	return deepest;
+}
+
+/*
+ * after removal, update the tree to account for the removed entry
+ * and any rebalance damage.
+ */
+void rb_augment_erase_end(struct rb_node *node, rb_augment_f func, void *data)
+{
+	if (node)
+		rb_augment_path(node, func, data);
+}
+
+/*
+ * This function returns the first node (in sort order) of the tree.
+ */
+struct rb_node *rb_first(const struct rb_root *root)
+{
+	struct rb_node	*n;
+
+	n = root->rb_node;
+	if (!n)
+		return NULL;
+	while (n->rb_left)
+		n = n->rb_left;
+	return n;
+}
+
+struct rb_node *rb_last(const struct rb_root *root)
+{
+	struct rb_node	*n;
+
+	n = root->rb_node;
+	if (!n)
+		return NULL;
+	while (n->rb_right)
+		n = n->rb_right;
+	return n;
+}
+
+struct rb_node *rb_next(const struct rb_node *node)
+{
+	struct rb_node *parent;
+
+	if (rb_parent(node) == node)
+		return NULL;
+
+	/* If we have a right-hand child, go down and then left as far
+	   as we can. */
+	if (node->rb_right) {
+		node = node->rb_right; 
+		while (node->rb_left)
+			node=node->rb_left;
+		return (struct rb_node *)node;
+	}
+
+	/* No right-hand children.  Everything down and left is
+	   smaller than us, so any 'next' node must be in the general
+	   direction of our parent. Go up the tree; any time the
+	   ancestor is a right-hand child of its parent, keep going
+	   up. First time it's a left-hand child of its parent, said
+	   parent is our 'next' node. */
+	while ((parent = rb_parent(node)) && node == parent->rb_right)
+		node = parent;
+
+	return parent;
+}
+
+struct rb_node *rb_prev(const struct rb_node *node)
+{
+	struct rb_node *parent;
+
+	if (rb_parent(node) == node)
+		return NULL;
+
+	/* If we have a left-hand child, go down and then right as far
+	   as we can. */
+	if (node->rb_left) {
+		node = node->rb_left; 
+		while (node->rb_right)
+			node=node->rb_right;
+		return (struct rb_node *)node;
+	}
+
+	/* No left-hand children. Go up till we find an ancestor which
+	   is a right-hand child of its parent */
+	while ((parent = rb_parent(node)) && node == parent->rb_left)
+		node = parent;
+
+	return parent;
+}
+
+void rb_replace_node(struct rb_node *victim, struct rb_node *new,
+		     struct rb_root *root)
+{
+	struct rb_node *parent = rb_parent(victim);
+
+	/* Set the surrounding nodes to point to the replacement */
+	if (parent) {
+		if (victim == parent->rb_left)
+			parent->rb_left = new;
+		else
+			parent->rb_right = new;
+	} else {
+		root->rb_node = new;
+	}
+	if (victim->rb_left)
+		rb_set_parent(victim->rb_left, new);
+	if (victim->rb_right)
+		rb_set_parent(victim->rb_right, new);
+
+	/* Copy the pointers/colour from the victim to the replacement */
+	*new = *victim;
+}

--- a/main/rbtree.c
+++ b/main/rbtree.c
@@ -18,7 +18,7 @@
   Red Black Trees
   (C) 1999  Andrea Arcangeli <andrea@suse.de>
   (C) 2002  David Woodhouse <dwmw2@infradead.org>
-  
+
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; either version 2 of the License, or
@@ -401,7 +401,7 @@ struct rb_node *rb_next(const struct rb_node *node)
 	/* If we have a right-hand child, go down and then left as far
 	   as we can. */
 	if (node->rb_right) {
-		node = node->rb_right; 
+		node = node->rb_right;
 		while (node->rb_left)
 			node=node->rb_left;
 		return (struct rb_node *)node;
@@ -429,7 +429,7 @@ struct rb_node *rb_prev(const struct rb_node *node)
 	/* If we have a left-hand child, go down and then right as far
 	   as we can. */
 	if (node->rb_left) {
-		node = node->rb_left; 
+		node = node->rb_left;
 		while (node->rb_right)
 			node=node->rb_right;
 		return (struct rb_node *)node;

--- a/main/rbtree.c
+++ b/main/rbtree.c
@@ -36,6 +36,7 @@
   linux/lib/rbtree.c
 */
 
+#include "general.h"
 #include "rbtree.h"
 
 static void __rb_rotate_left(struct rb_node *node, struct rb_root *root)

--- a/main/rbtree.h
+++ b/main/rbtree.h
@@ -1,0 +1,216 @@
+/*
+ * =============================================================================
+ *
+ *       Filename:  rbtree.h
+ *
+ *    Description:  rbtree(Red-Black tree) implementation adapted from linux
+ *                  kernel thus can be used in userspace c program.
+ *
+ *        Created:  09/02/2012 11:36:11 PM
+ *
+ *         Author:  Fu Haiping (forhappy), haipingf@gmail.com
+ *        Company:  ICT ( Institute Of Computing Technology, CAS )
+ *
+ * =============================================================================
+ */
+
+/*
+  Red Black Trees
+  (C) 1999  Andrea Arcangeli <andrea@suse.de>
+  
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+  linux/include/linux/rbtree.h
+
+  To use rbtrees you'll have to implement your own insert and search cores.
+  This will avoid us to use callbacks and to drop drammatically performances.
+  I know it's not the cleaner way,  but in C (not in C++) to get
+  performances and genericity...
+
+  Some example of insert and search follows here. The search is a plain
+  normal search over an ordered tree. The insert instead must be implemented
+  in two steps: First, the code must insert the element in order as a red leaf
+  in the tree, and then the support library function rb_insert_color() must
+  be called. Such function will do the not trivial work to rebalance the
+  rbtree, if necessary.
+
+-----------------------------------------------------------------------
+static inline struct page * rb_search_page_cache(struct inode * inode,
+						 unsigned long offset)
+{
+	struct rb_node * n = inode->i_rb_page_cache.rb_node;
+	struct page * page;
+
+	while (n)
+	{
+		page = rb_entry(n, struct page, rb_page_cache);
+
+		if (offset < page->offset)
+			n = n->rb_left;
+		else if (offset > page->offset)
+			n = n->rb_right;
+		else
+			return page;
+	}
+	return NULL;
+}
+
+static inline struct page * __rb_insert_page_cache(struct inode * inode,
+						   unsigned long offset,
+						   struct rb_node * node)
+{
+	struct rb_node ** p = &inode->i_rb_page_cache.rb_node;
+	struct rb_node * parent = NULL;
+	struct page * page;
+
+	while (*p)
+	{
+		parent = *p;
+		page = rb_entry(parent, struct page, rb_page_cache);
+
+		if (offset < page->offset)
+			p = &(*p)->rb_left;
+		else if (offset > page->offset)
+			p = &(*p)->rb_right;
+		else
+			return page;
+	}
+
+	rb_link_node(node, parent, p);
+
+	return NULL;
+}
+
+static inline struct page * rb_insert_page_cache(struct inode * inode,
+						 unsigned long offset,
+						 struct rb_node * node)
+{
+	struct page * ret;
+	if ((ret = __rb_insert_page_cache(inode, offset, node)))
+		goto out;
+	rb_insert_color(node, &inode->i_rb_page_cache);
+ out:
+	return ret;
+}
+-----------------------------------------------------------------------
+*/
+
+#ifndef	_LINUX_RBTREE_H
+#define	_LINUX_RBTREE_H
+
+#if defined(container_of)
+  #undef container_of
+  #define container_of(ptr, type, member) ({			\
+        const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
+        (type *)( (char *)__mptr - offsetof(type,member) );})
+#else
+  #define container_of(ptr, type, member) ({			\
+        const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
+        (type *)( (char *)__mptr - offsetof(type,member) );})
+#endif
+
+#if defined(offsetof)
+  #undef offsetof
+  #define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#else 
+  #define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+#endif
+
+#undef NULL
+#if defined(__cplusplus)
+  #define NULL 0
+#else
+  #define NULL ((void *)0)
+#endif
+
+struct rb_node
+{
+	unsigned long  rb_parent_color;
+#define	RB_RED		0
+#define	RB_BLACK	1
+	struct rb_node *rb_right;
+	struct rb_node *rb_left;
+} __attribute__((aligned(sizeof(long))));
+    /* The alignment might seem pointless, but allegedly CRIS needs it */
+
+struct rb_root
+{
+	struct rb_node *rb_node;
+};
+
+
+#define rb_parent(r)   ((struct rb_node *)((r)->rb_parent_color & ~3))
+#define rb_color(r)   ((r)->rb_parent_color & 1)
+#define rb_is_red(r)   (!rb_color(r))
+#define rb_is_black(r) rb_color(r)
+#define rb_set_red(r)  do { (r)->rb_parent_color &= ~1; } while (0)
+#define rb_set_black(r)  do { (r)->rb_parent_color |= 1; } while (0)
+
+static inline void rb_set_parent(struct rb_node *rb, struct rb_node *p)
+{
+	rb->rb_parent_color = (rb->rb_parent_color & 3) | (unsigned long)p;
+}
+static inline void rb_set_color(struct rb_node *rb, int color)
+{
+	rb->rb_parent_color = (rb->rb_parent_color & ~1) | color;
+}
+
+#define RB_ROOT	(struct rb_root) { NULL, }
+#define	rb_entry(ptr, type, member) container_of(ptr, type, member)
+
+#define RB_EMPTY_ROOT(root)	((root)->rb_node == NULL)
+#define RB_EMPTY_NODE(node)	(rb_parent(node) == node)
+#define RB_CLEAR_NODE(node)	(rb_set_parent(node, node))
+
+static inline void rb_init_node(struct rb_node *rb)
+{
+	rb->rb_parent_color = 0;
+	rb->rb_right = NULL;
+	rb->rb_left = NULL;
+	RB_CLEAR_NODE(rb);
+}
+
+extern void rb_insert_color(struct rb_node *, struct rb_root *);
+extern void rb_erase(struct rb_node *, struct rb_root *);
+
+typedef void (*rb_augment_f)(struct rb_node *node, void *data);
+
+extern void rb_augment_insert(struct rb_node *node,
+			      rb_augment_f func, void *data);
+extern struct rb_node *rb_augment_erase_begin(struct rb_node *node);
+extern void rb_augment_erase_end(struct rb_node *node,
+				 rb_augment_f func, void *data);
+
+/* Find logical next and previous nodes in a tree */
+extern struct rb_node *rb_next(const struct rb_node *);
+extern struct rb_node *rb_prev(const struct rb_node *);
+extern struct rb_node *rb_first(const struct rb_root *);
+extern struct rb_node *rb_last(const struct rb_root *);
+
+/* Fast replacement of a single node without remove/rebalance/add/rebalance */
+extern void rb_replace_node(struct rb_node *victim, struct rb_node *new, 
+			    struct rb_root *root);
+
+static inline void rb_link_node(struct rb_node * node, struct rb_node * parent,
+				struct rb_node ** rb_link)
+{
+	node->rb_parent_color = (unsigned long )parent;
+	node->rb_left = node->rb_right = NULL;
+
+	*rb_link = node;
+}
+
+#endif	/* _LINUX_RBTREE_H */
+

--- a/main/rbtree.h
+++ b/main/rbtree.h
@@ -107,19 +107,33 @@ static inline struct page * rb_insert_page_cache(struct inode * inode,
 -----------------------------------------------------------------------
 */
 
-#ifndef	_LINUX_RBTREE_H
-#define	_LINUX_RBTREE_H
+#ifndef	CTAGS_MAIN_RBTREE_H
+#define	CTAGS_MAIN_RBTREE_H
+
+#include "general.h"
+#include "inline.h"
+#include "gcc-attr.h"
 
 #if defined(container_of)
   #undef container_of
+#if defined(HAVE_TYPEOF) && defined(HAVE_STATEMENT_EXPRESSION_EXT)
   #define container_of(ptr, type, member) ({			\
         const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
         (type *)( (char *)__mptr - offsetof(type,member) );})
 #else
+  #define container_of(ptr, type, member) \
+        ((type *)( (char *)ptr - offsetof(type,member)))
+#endif	/* defined(HAVE_TYPEOF) && defined(HAVE_STATEMENT_EXPRESSION_EXT) */
+#else
+#if defined(HAVE_TYPEOF) && defined(HAVE_STATEMENT_EXPRESSION_EXT)
   #define container_of(ptr, type, member) ({			\
         const typeof( ((type *)0)->member ) *__mptr = (ptr);	\
         (type *)( (char *)__mptr - offsetof(type,member) );})
-#endif
+#else
+  #define container_of(ptr, type, member) \
+        ((type *)( (char *)ptr - offsetof(type,member)))
+#endif /* defined(HAVE_TYPEOF) && defined(HAVE_STATEMENT_EXPRESSION_EXT) */
+#endif /* defined(container_of) */
 
 #if defined(offsetof)
   #undef offsetof
@@ -142,7 +156,7 @@ struct rb_node
 #define	RB_BLACK	1
 	struct rb_node *rb_right;
 	struct rb_node *rb_left;
-} __attribute__((aligned(sizeof(long))));
+} CTAGA_ATTR_ALIGNED(sizeof(long));
     /* The alignment might seem pointless, but allegedly CRIS needs it */
 
 struct rb_root
@@ -158,11 +172,11 @@ struct rb_root
 #define rb_set_red(r)  do { (r)->rb_parent_color &= ~1; } while (0)
 #define rb_set_black(r)  do { (r)->rb_parent_color |= 1; } while (0)
 
-static inline void rb_set_parent(struct rb_node *rb, struct rb_node *p)
+CTAGS_INLINE void rb_set_parent(struct rb_node *rb, struct rb_node *p)
 {
 	rb->rb_parent_color = (rb->rb_parent_color & 3) | (unsigned long)p;
 }
-static inline void rb_set_color(struct rb_node *rb, int color)
+CTAGS_INLINE void rb_set_color(struct rb_node *rb, int color)
 {
 	rb->rb_parent_color = (rb->rb_parent_color & ~1) | color;
 }
@@ -174,7 +188,7 @@ static inline void rb_set_color(struct rb_node *rb, int color)
 #define RB_EMPTY_NODE(node)	(rb_parent(node) == node)
 #define RB_CLEAR_NODE(node)	(rb_set_parent(node, node))
 
-static inline void rb_init_node(struct rb_node *rb)
+CTAGS_INLINE void rb_init_node(struct rb_node *rb)
 {
 	rb->rb_parent_color = 0;
 	rb->rb_right = NULL;
@@ -203,7 +217,7 @@ extern struct rb_node *rb_last(const struct rb_root *);
 extern void rb_replace_node(struct rb_node *victim, struct rb_node *new,
 			    struct rb_root *root);
 
-static inline void rb_link_node(struct rb_node * node, struct rb_node * parent,
+CTAGS_INLINE void rb_link_node(struct rb_node * node, struct rb_node * parent,
 				struct rb_node ** rb_link)
 {
 	node->rb_parent_color = (unsigned long )parent;
@@ -212,4 +226,4 @@ static inline void rb_link_node(struct rb_node * node, struct rb_node * parent,
 	*rb_link = node;
 }
 
-#endif	/* _LINUX_RBTREE_H */
+#endif	/* CTAGS_MAIN_RBTREE_H */

--- a/main/rbtree.h
+++ b/main/rbtree.h
@@ -113,6 +113,7 @@ static inline struct page * rb_insert_page_cache(struct inode * inode,
 #include "general.h"
 #include "inline.h"
 #include "gcc-attr.h"
+#include <stdint.h>
 
 #if defined(container_of)
   #undef container_of
@@ -151,7 +152,7 @@ static inline struct page * rb_insert_page_cache(struct inode * inode,
 
 struct rb_node
 {
-	unsigned long  rb_parent_color;
+	uintptr_t  rb_parent_color;
 #define	RB_RED		0
 #define	RB_BLACK	1
 	struct rb_node *rb_right;
@@ -174,7 +175,7 @@ struct rb_root
 
 CTAGS_INLINE void rb_set_parent(struct rb_node *rb, struct rb_node *p)
 {
-	rb->rb_parent_color = (rb->rb_parent_color & 3) | (unsigned long)p;
+	rb->rb_parent_color = (rb->rb_parent_color & 3) | (uintptr_t)p;
 }
 CTAGS_INLINE void rb_set_color(struct rb_node *rb, int color)
 {
@@ -220,7 +221,7 @@ extern void rb_replace_node(struct rb_node *victim, struct rb_node *new,
 CTAGS_INLINE void rb_link_node(struct rb_node * node, struct rb_node * parent,
 				struct rb_node ** rb_link)
 {
-	node->rb_parent_color = (unsigned long )parent;
+	node->rb_parent_color = (uintptr_t)parent;
 	node->rb_left = node->rb_right = NULL;
 
 	*rb_link = node;

--- a/main/rbtree.h
+++ b/main/rbtree.h
@@ -17,7 +17,7 @@
 /*
   Red Black Trees
   (C) 1999  Andrea Arcangeli <andrea@suse.de>
-  
+
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
   the Free Software Foundation; either version 2 of the License, or
@@ -124,7 +124,7 @@ static inline struct page * rb_insert_page_cache(struct inode * inode,
 #if defined(offsetof)
   #undef offsetof
   #define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
-#else 
+#else
   #define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
 #endif
 
@@ -200,7 +200,7 @@ extern struct rb_node *rb_first(const struct rb_root *);
 extern struct rb_node *rb_last(const struct rb_root *);
 
 /* Fast replacement of a single node without remove/rebalance/add/rebalance */
-extern void rb_replace_node(struct rb_node *victim, struct rb_node *new, 
+extern void rb_replace_node(struct rb_node *victim, struct rb_node *new,
 			    struct rb_root *root);
 
 static inline void rb_link_node(struct rb_node * node, struct rb_node * parent,
@@ -213,4 +213,3 @@ static inline void rb_link_node(struct rb_node * node, struct rb_node * parent,
 }
 
 #endif	/* _LINUX_RBTREE_H */
-

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -855,7 +855,7 @@ EOF
 
     if ($opts->{'useCork'}) {
 	print <<EOF;
-	def->useCork       = 1;
+	def->useCork       = CORK_QUEUE;
 EOF
     }
     if (@{$opts->{'kinddefs'}}) {

--- a/optlib/cmake.c
+++ b/optlib/cmake.c
@@ -245,7 +245,7 @@ extern parserDefinition* CMakeParser (void)
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
-	def->useCork       = 1;
+	def->useCork       = CORK_QUEUE;
 	def->kindTable     = CMakeKindTable;
 	def->kindCount     = ARRAY_SIZE(CMakeKindTable);
 	def->initialize    = initializeCMakeParser;

--- a/optlib/ctags-optlib.c
+++ b/optlib/ctags-optlib.c
@@ -52,7 +52,7 @@ extern parserDefinition* CtagsParser (void)
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
-	def->useCork       = 1;
+	def->useCork       = CORK_QUEUE;
 	def->kindTable     = CtagsKindTable;
 	def->kindCount     = ARRAY_SIZE(CtagsKindTable);
 	def->tagRegexTable = CtagsTagRegexTable;

--- a/optlib/elixir.c
+++ b/optlib/elixir.c
@@ -123,7 +123,7 @@ extern parserDefinition* ElixirParser (void)
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
-	def->useCork       = 1;
+	def->useCork       = CORK_QUEUE;
 	def->kindTable     = ElixirKindTable;
 	def->kindCount     = ARRAY_SIZE(ElixirKindTable);
 	def->fieldTable    = ElixirFieldTable;

--- a/optlib/elm.c
+++ b/optlib/elm.c
@@ -85,7 +85,7 @@ extern parserDefinition* ElmParser (void)
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
-	def->useCork       = 1;
+	def->useCork       = CORK_QUEUE;
 	def->kindTable     = ElmKindTable;
 	def->kindCount     = ARRAY_SIZE(ElmKindTable);
 	def->tagRegexTable = ElmTagRegexTable;

--- a/optlib/inko.c
+++ b/optlib/inko.c
@@ -155,7 +155,7 @@ extern parserDefinition* InkoParser (void)
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
-	def->useCork       = 1;
+	def->useCork       = CORK_QUEUE;
 	def->kindTable     = InkoKindTable;
 	def->kindCount     = ARRAY_SIZE(InkoKindTable);
 	def->fieldTable    = InkoFieldTable;

--- a/optlib/man.c
+++ b/optlib/man.c
@@ -65,7 +65,7 @@ extern parserDefinition* ManParser (void)
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
-	def->useCork       = 1;
+	def->useCork       = CORK_QUEUE;
 	def->kindTable     = ManKindTable;
 	def->kindCount     = ARRAY_SIZE(ManKindTable);
 	def->tagRegexTable = ManTagRegexTable;

--- a/optlib/markdown.c
+++ b/optlib/markdown.c
@@ -452,7 +452,7 @@ extern parserDefinition* MarkdownParser (void)
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
-	def->useCork       = 1;
+	def->useCork       = CORK_QUEUE;
 	def->kindTable     = MarkdownKindTable;
 	def->kindCount     = ARRAY_SIZE(MarkdownKindTable);
 	def->fieldTable    = MarkdownFieldTable;

--- a/optlib/puppetManifest.c
+++ b/optlib/puppetManifest.c
@@ -651,7 +651,7 @@ extern parserDefinition* PuppetManifestParser (void)
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
-	def->useCork       = 1;
+	def->useCork       = CORK_QUEUE;
 	def->kindTable     = PuppetManifestKindTable;
 	def->kindCount     = ARRAY_SIZE(PuppetManifestKindTable);
 	def->requestAutomaticFQTag = true;

--- a/optlib/systemtap.c
+++ b/optlib/systemtap.c
@@ -425,7 +425,7 @@ extern parserDefinition* SystemTapParser (void)
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
-	def->useCork       = 1;
+	def->useCork       = CORK_QUEUE;
 	def->kindTable     = SystemTapKindTable;
 	def->kindCount     = ARRAY_SIZE(SystemTapKindTable);
 	def->initialize    = initializeSystemTapParser;

--- a/parsers/ansibleplaybook.c
+++ b/parsers/ansibleplaybook.c
@@ -224,7 +224,7 @@ extern parserDefinition* AnsiblePlaybookParser (void)
 	def->kindTable         = AnsiblePlaybookKinds;
 	def->kindCount     = ARRAY_SIZE (AnsiblePlaybookKinds);
 	def->parser        = findAnsiblePlaybookTags;
-	def->useCork       = true;
+	def->useCork       = CORK_QUEUE;
 	return def;
 }
 

--- a/parsers/ant.c
+++ b/parsers/ant.c
@@ -270,7 +270,7 @@ extern parserDefinition* AntParser (void)
 	def->parser = findAntTags;
 	def->tagXpathTableTable = antXpathTableTable;
 	def->tagXpathTableCount = ARRAY_SIZE (antXpathTableTable);
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	def->selectLanguage = selectors;
 	def->xpathFileSpecs = xpathFileSpecs;
 	def->xpathFileSpecCount = ARRAY_SIZE (xpathFileSpecs);

--- a/parsers/asciidoc.c
+++ b/parsers/asciidoc.c
@@ -406,7 +406,7 @@ extern parserDefinition* AsciidocParser (void)
 	def->extensions = extensions;
 	def->parser = findAsciidocTags;
 	/* do we even need to use Cork? */
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 
 	return def;
 }

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -412,6 +412,6 @@ extern parserDefinition* AsmParser (void)
 	def->keywordTable = AsmKeywords;
 	def->keywordCount = ARRAY_SIZE (AsmKeywords);
 	def->selectLanguage = selectors;
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	return def;
 }

--- a/parsers/autoconf.c
+++ b/parsers/autoconf.c
@@ -188,7 +188,7 @@ extern parserDefinition* AutoconfParser (void)
 	def->patterns = patterns;
 	def->extensions = extensions;
 	def->parser = findAutoconfTags;
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 
 	def->keywordTable = autoconfKeywordTable;
 	def->keywordCount = ARRAY_SIZE (autoconfKeywordTable);

--- a/parsers/autoit.c
+++ b/parsers/autoit.c
@@ -314,6 +314,6 @@ parserDefinition *AutoItParser (void)
 	def->fieldCount = ARRAY_SIZE (AutoItFields);
 	def->extensions = extensions;
 	def->parser     = findAutoItTags;
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }

--- a/parsers/automake.c
+++ b/parsers/automake.c
@@ -350,6 +350,6 @@ extern parserDefinition* AutomakeParser (void)
 	def->extensions = extensions;
 	def->patterns   = patterns;
 	def->parser     = findAutomakeTags;
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3585,7 +3585,7 @@ extern parserDefinition* OldCParser (void)
 	def->enabled = 0;
 
 	/* cpreprocessor wants corkQueue. */
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }
 
@@ -3601,7 +3601,7 @@ extern parserDefinition* DParser (void)
 	// end: field is not tested.
 
 	/* cpreprocessor wants corkQueue. */
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }
 
@@ -3628,7 +3628,7 @@ extern parserDefinition* OldCppParser (void)
 	def->enabled = 0;
 
 	/* cpreprocessor wants corkQueue. */
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }
 
@@ -3646,7 +3646,7 @@ extern parserDefinition* CsharpParser (void)
 	// end: field is not tested.
 
 	/* cpreprocessor wants corkQueue. */
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }
 
@@ -3659,7 +3659,7 @@ extern parserDefinition* JavaParser (void)
 	def->extensions = extensions;
 	def->parser2    = findCTags;
 	def->initialize = initializeJavaParser;
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }
 
@@ -3675,7 +3675,7 @@ extern parserDefinition* VeraParser (void)
 	// end: field is not tested.
 
 	/* cpreprocessor wants corkQueue. */
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 
 	return def;
 }

--- a/parsers/clojure.c
+++ b/parsers/clojure.c
@@ -189,6 +189,6 @@ extern parserDefinition *ClojureParser (void)
 	def->extensions = extensions;
 	def->aliases = aliases;
 	def->parser = findClojureTags;
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	return def;
 }

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -2141,6 +2141,6 @@ extern parserDefinition* CPreProParser (void)
 	def->parameterHandlerTable = CpreProParameterHandlerTable;
 	def->parameterHandlerCount = ARRAY_SIZE(CpreProParameterHandlerTable);
 
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	return def;
 }

--- a/parsers/cxx/cxx.c
+++ b/parsers/cxx/cxx.c
@@ -93,7 +93,7 @@ parserDefinition * CParser (void)
 	def->initialize = cxxCParserInitialize;
 	def->finalize = cxxParserCleanup;
 	def->selectLanguage = selectors;
-	def->useCork = true; // We use corking to block output until the end of file
+	def->useCork = CORK_QUEUE; // We use corking to block output until the end of file
 
 	return def;
 }
@@ -128,7 +128,7 @@ parserDefinition * CppParser (void)
 	def->initialize = cxxCppParserInitialize;
 	def->finalize = cxxParserCleanup;
 	def->selectLanguage = selectors;
-	def->useCork = true; // We use corking to block output until the end of file
+	def->useCork = CORK_QUEUE; // We use corking to block output until the end of file
 
 	return def;
 }
@@ -157,7 +157,7 @@ parserDefinition * CUDAParser (void)
 	def->initialize = cxxCUDAParserInitialize;
 	def->finalize = cxxParserCleanup;
 	def->selectLanguage = NULL;
-	def->useCork = true; // We use corking to block output until the end of file
+	def->useCork = CORK_QUEUE; // We use corking to block output until the end of file
 
 	return def;
 }

--- a/parsers/cxx/cxx_qtmoc.c
+++ b/parsers/cxx/cxx_qtmoc.c
@@ -336,7 +336,7 @@ extern parserDefinition* QtMocParser (void)
 
 	def->parser = findQtMocTags;
 	def->initialize = initialize;
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 
 	return def;
 }

--- a/parsers/dbusintrospect.c
+++ b/parsers/dbusintrospect.c
@@ -262,7 +262,7 @@ DbusIntrospectParser (void)
 	def->parser        = findDbusIntrospectTags;
 	def->tagXpathTableTable = dbusIntrospectXpathTableTable;
 	def->tagXpathTableCount = ARRAY_SIZE (dbusIntrospectXpathTableTable);
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	def->selectLanguage = selectors;
 	def->xpathFileSpecs = xpathFileSpecs;
 	def->xpathFileSpecCount = ARRAY_SIZE (xpathFileSpecs);

--- a/parsers/diff.c
+++ b/parsers/diff.c
@@ -208,6 +208,6 @@ extern parserDefinition* DiffParser (void)
 	def->kindCount  = ARRAY_SIZE (DiffKinds);
 	def->extensions = extensions;
 	def->parser     = findDiffTags;
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }

--- a/parsers/dtd.c
+++ b/parsers/dtd.c
@@ -620,7 +620,7 @@ extern parserDefinition* DtdParser (void)
 	def->keywordTable = DtdKeywordTable;
 	def->keywordCount = ARRAY_SIZE (DtdKeywordTable);
 
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	def->requestAutomaticFQTag = true;
 
 	return def;

--- a/parsers/fypp.c
+++ b/parsers/fypp.c
@@ -473,7 +473,7 @@ extern parserDefinition* FyppParser (void)
 	def->parameterHandlerTable = FyppParameterHandlerTable;
 	def->parameterHandlerCount = ARRAY_SIZE(FyppParameterHandlerTable);
 
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 
 	fyppGuestParser = vStringNewInit ("Fortran");
 

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -1393,7 +1393,7 @@ extern parserDefinition *GoParser (void)
 	def->keywordCount = ARRAY_SIZE (GoKeywordTable);
 	def->fieldTable = GoFields;
 	def->fieldCount = ARRAY_SIZE (GoFields);
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	def->requestAutomaticFQTag = true;
 	return def;
 }

--- a/parsers/iniconf.c
+++ b/parsers/iniconf.c
@@ -237,7 +237,7 @@ extern parserDefinition* IniconfParser (void)
 	def->kindCount  = ARRAY_SIZE (IniconfKinds);
 	def->extensions = extensions;
 	def->parser     = findIniconfTags;
-	def->useCork   = true;
+	def->useCork   = CORK_QUEUE;
 
 	return def;
 }

--- a/parsers/itcl.c
+++ b/parsers/itcl.c
@@ -329,7 +329,7 @@ extern parserDefinition* ITclParser (void)
 
 	def->extensions = extensions;
 	def->parser = findITclTags;
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	def->requestAutomaticFQTag = true;
 
 	def->keywordTable = ITclKeywordTable;

--- a/parsers/ldscript.c
+++ b/parsers/ldscript.c
@@ -759,7 +759,7 @@ extern parserDefinition* LdScriptParser (void)
 	def->fieldTable = LdScriptFields;
 	def->fieldCount = ARRAY_SIZE (LdScriptFields);
 
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 
 	return def;
 }

--- a/parsers/m4.c
+++ b/parsers/m4.c
@@ -522,7 +522,7 @@ extern parserDefinition* M4Parser (void)
 	def->kindCount = ARRAY_SIZE(M4Kinds);
 	def->extensions = extensions;
 	def->parser = findM4Tags;
-	def->useCork = 1;
+	def->useCork = CORK_QUEUE;
 	def->keywordTable = m4KeywordTable;
 	def->keywordCount = ARRAY_SIZE (m4KeywordTable);
 

--- a/parsers/maven2.c
+++ b/parsers/maven2.c
@@ -282,7 +282,7 @@ Maven2Parser (void)
 	def->parser        = findMaven2Tags;
 	def->tagXpathTableTable  = maven2XpathTableTable;
 	def->tagXpathTableCount  = ARRAY_SIZE (maven2XpathTableTable);
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	def->selectLanguage = selectors;
 	def->fieldTable = Maven2Fields;
 	def->fieldCount = ARRAY_SIZE (Maven2Fields);

--- a/parsers/moose.c
+++ b/parsers/moose.c
@@ -513,7 +513,7 @@ extern parserDefinition* MooseParser (void)
 
 	def->initialize = initializeMooseParser;
 	def->parser = findMooseTags;
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 
 	return def;
 }

--- a/parsers/nsis.c
+++ b/parsers/nsis.c
@@ -389,6 +389,6 @@ extern parserDefinition* NsisParser (void)
 	def->fieldTable = NsisFields;
 	def->fieldCount = ARRAY_SIZE (NsisFields);
 	def->parser     = findNsisTags;
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -1351,6 +1351,6 @@ extern parserDefinition *ObjcParser (void)
 	def->selectLanguage = selectors;
 	def->keywordTable = objcKeywordTable;
 	def->keywordCount = ARRAY_SIZE (objcKeywordTable);
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	return def;
 }

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -652,7 +652,7 @@ extern parserDefinition* PerlParser (void)
 	def->selectLanguage = selectors;
 
 	/* Subparsers need this */
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 
 	return def;
 }

--- a/parsers/protobuf.c
+++ b/parsers/protobuf.c
@@ -349,7 +349,7 @@ extern parserDefinition* ProtobufParser (void)
 	def->keywordCount = ARRAY_SIZE (ProtobufKeywordTable);
 
 	/* cpreprocessor wants corkQueue. */
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 
 	return def;
 }

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -1362,7 +1362,7 @@ extern parserDefinition* PythonParser (void)
 	def->keywordCount = ARRAY_SIZE (PythonKeywordTable);
 	def->fieldTable = PythonFields;
 	def->fieldCount = ARRAY_SIZE (PythonFields);
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	def->requestAutomaticFQTag = true;
 	return def;
 }

--- a/parsers/pythonloggingconfig.c
+++ b/parsers/pythonloggingconfig.c
@@ -119,7 +119,7 @@ extern parserDefinition* PythonLoggingConfigParser (void)
 	def->kindTable      = PythonLoggingConfigKinds;
 	def->kindCount  = ARRAY_SIZE (PythonLoggingConfigKinds);
 	def->parser     = findPythonLoggingConfigTags;
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 
 	return def;
 }

--- a/parsers/relaxng.c
+++ b/parsers/relaxng.c
@@ -256,7 +256,7 @@ RelaxNGParser (void)
 	def->parser        = findRelaxNGTags;
 	def->tagXpathTableTable = relaxngXpathTableTable;
 	def->tagXpathTableCount = ARRAY_SIZE (relaxngXpathTableTable);
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	/* def->selectLanguage = selectors; */
 	def->dependencies = dependencies;
 	def->dependencyCount = ARRAY_SIZE (dependencies);

--- a/parsers/rpmspec.c
+++ b/parsers/rpmspec.c
@@ -392,7 +392,7 @@ extern parserDefinition* RpmSpecParser (void)
 	def->initialize = initializeRpmSpecParser;
 	def->parser = findRpmSpecTags;
 	def->method     = METHOD_REGEX;
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	def->requestAutomaticFQTag = true;
 	return def;
 }

--- a/parsers/rst.c
+++ b/parsers/rst.c
@@ -388,7 +388,7 @@ extern parserDefinition* RstParser (void)
 	def->fieldTable = RstFields;
 	def->fieldCount = ARRAY_SIZE (RstFields);
 
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 
 	return def;
 }

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -805,6 +805,6 @@ extern parserDefinition* RubyParser (void)
 	def->parser     = findRubyTags;
 	def->fieldTable = RubyFields;
 	def->fieldCount = ARRAY_SIZE (RubyFields);
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }

--- a/parsers/sh.c
+++ b/parsers/sh.c
@@ -485,6 +485,6 @@ extern parserDefinition* ShParser (void)
 	def->extensions = extensions;
 	def->aliases = aliases;
 	def->parser     = findShTags;
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }

--- a/parsers/systemdunit.c
+++ b/parsers/systemdunit.c
@@ -135,6 +135,6 @@ extern parserDefinition* SystemdUnitParser (void)
 	def->kindCount  = ARRAY_SIZE (SystemdUnitKinds);
 	def->extensions = extensions;
 	def->parser     = findSystemdUnitTags;
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -719,7 +719,7 @@ extern parserDefinition* TclParser (void)
 	def->keywordCount = ARRAY_SIZE (TclKeywordTable);
 
 	def->parser     = findTclTags;
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	def->requestAutomaticFQTag = true;
 	def->defaultScopeSeparator = "::";
 	def->defaultRootScopeSeparator = "::";

--- a/parsers/tcloo.c
+++ b/parsers/tcloo.c
@@ -175,7 +175,7 @@ extern parserDefinition* TclOOParser (void)
 	def->kindCount = ARRAY_SIZE(TclOOKinds);
 
 	def->parser = findTclOOTags;
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	def->requestAutomaticFQTag = true;
 
 	return def;

--- a/parsers/tex-beamer.c
+++ b/parsers/tex-beamer.c
@@ -63,6 +63,7 @@ static struct TexParseStrategy frametitle_strategy[] = {
 		.kindIndex = K_FRAMETITLE,
 		.roleIndex = ROLE_DEFINITION_INDEX,
 		.name = NULL,
+		.unique = false,
 	},
 	{
 		.type = '{',
@@ -70,6 +71,8 @@ static struct TexParseStrategy frametitle_strategy[] = {
 		.kindIndex = K_FRAMETITLE,
 		.roleIndex = ROLE_DEFINITION_INDEX,
 		.name = NULL,
+		.unique = true,
+		.scopeIndex = CORK_NIL,	/* root scope */
 	},
 	{
 		.type = 0
@@ -90,6 +93,7 @@ static struct TexParseStrategy framesubtitle_strategy[] = {
 		.kindIndex = K_FRAMESUBTITLE,
 		.roleIndex = ROLE_DEFINITION_INDEX,
 		.name = NULL,
+		.unique = false,
 	},
 	{
 		.type = 0
@@ -121,7 +125,8 @@ static struct TexParseStrategy frame_env_strategy [] = {
 		.flags = TEX_NAME_FLAG_INCLUDING_WHITESPACE,
 		.kindIndex = K_FRAMETITLE,
 		.roleIndex = ROLE_DEFINITION_INDEX,
-		.name = NULL,
+		.unique = true,
+		.scopeIndex = CORK_NIL,	/* root scope */
 	},
 	{
 		/* This should not be optoinal. */
@@ -130,6 +135,7 @@ static struct TexParseStrategy frame_env_strategy [] = {
 		.kindIndex = K_FRAMESUBTITLE,
 		.roleIndex = ROLE_DEFINITION_INDEX,
 		.name = NULL,
+		.unique = false,
 	},
 	{
 		.type = 0

--- a/parsers/tex-beamer.c
+++ b/parsers/tex-beamer.c
@@ -258,7 +258,7 @@ extern parserDefinition* TexBeamerParser (void)
 	def->kindCount = ARRAY_SIZE(beamerKinds);
 
 	def->parser = findBeamerTags;
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 
 	return def;
 }

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -271,11 +271,44 @@ static int getScopeInfo(texKind kind, vString *const parentName)
 /*
  *	 Tag generation functions
  */
+
+struct symbolData {
+	langType lang;
+	int kind;
+	int *corkQueue;
+};
+
+static bool findTheName (unsigned int corkIndex, tagEntryInfo *entry, void *data)
+{
+	struct symbolData *symbolData = data;
+
+	if (entry->langType == symbolData->lang && entry->kindIndex == symbolData->kind)
+	{
+		/* TODO: The case operation should be removed */
+		*symbolData->corkQueue = (unsigned int)corkIndex;
+		return false;
+	}
+	return true;
+}
+
 static int makeTexTag (tokenInfo *const token, int kind,
-					   int roleIndex)
+					   int roleIndex, bool unique, int scopeIndex)
 {
 	int corkQueue = CORK_NIL;
 	const char *const name = vStringValue (token->string);
+
+	if (unique)
+	{
+		struct symbolData data = {
+			.lang = getInputLanguage(),
+			.kind = kind,
+			.corkQueue = &corkQueue,
+		};
+		/* TODO: The case operation should be removed */
+		if (foreachEntriesInScope ((unsigned int)scopeIndex, name, findTheName, (void *)&data) == false)
+			return *data.corkQueue;
+	}
+
 	tagEntryInfo e;
 	initTagEntry (&e, name, kind);
 
@@ -284,13 +317,17 @@ static int makeTexTag (tokenInfo *const token, int kind,
 
 	vString *parentName = NULL;
 
+
+	if (unique)
+		e.extensionFields.scopeIndex = scopeIndex;
+
 	/* Filling e.extensionFields.scopeKindIndex and
-	 * e.extensionFields.scopeName can be filled with the value calculated
-	 * from getScopeInfo() with the kind parameter only if the kind is defined
-	 * in the Tex parser.
-	 * Is a subparser indirectly calls this function, getScopeInfo() doesn't
-	 * work well. So in the a context of a subparser, the scope fields should
-	 * not be filled here.
+	 * e.extensionFields.scopeName can be filled from "kind" parameter
+	 * of this function only when Tex parser calls this function. The
+	 * fields cannot be filled with a kind defined in a subparser.
+	 * Subparsers may fill the scope after running strategy. So in the
+	 * context of a subparser, filling the scope fields here is not
+	 * needed.
 	 */
 	if (Lang_tex == getInputLanguage ())
 	{
@@ -307,6 +344,10 @@ static int makeTexTag (tokenInfo *const token, int kind,
 
 	corkQueue = makeTagEntry (&e);
 	vStringDelete (parentName);	/* NULL is o.k. */
+
+	if (unique)
+		registerEntry (corkQueue);
+
 	return corkQueue;
 }
 
@@ -549,7 +590,8 @@ static bool parseWithStrategy (tokenInfo *token,
 			if (!exclusive && capture_name && vStringLength (name->string) > 0)
 			{
 				if (s->kindIndex != KIND_GHOST_INDEX)
-					s->corkIndex = makeTexTag (name, s->kindIndex, s->roleIndex);
+					s->corkIndex = makeTexTag (name, s->kindIndex, s->roleIndex,
+											   s->unique, s->scopeIndex);
 
 				if (s->name)
 					vStringCopy(s->name, name->string);
@@ -605,7 +647,8 @@ static bool parseWithStrategy (tokenInfo *token,
 				vStringStripTrailing (name->string);
 
 				if (s->kindIndex != KIND_GHOST_INDEX)
-					s->corkIndex = makeTexTag (name, s->kindIndex, s->roleIndex);
+					s->corkIndex = makeTexTag (name, s->kindIndex, s->roleIndex,
+											   s->unique, s->scopeIndex);
 
 				if (s->name)
 					vStringCopy(s->name, name->string);
@@ -669,6 +712,7 @@ static bool parseTagFull (tokenInfo *const token, texKind kind, int roleIndex, b
 			.kindIndex = kind,
 			.roleIndex = roleIndex,
 			.name = taggedName,
+			.unique = false,
 		},
 		{
 			.type = 0
@@ -682,6 +726,7 @@ static bool parseTagFull (tokenInfo *const token, texKind kind, int roleIndex, b
 		strategy [0].roleIndex = roleIndex;
 		strategy [0].flags |= TEX_NAME_FLAG_EXCLUSIVE;
 		strategy [0].name = taggedName;
+		strategy [0].unique = false;
 	}
 	else
 	{
@@ -765,6 +810,7 @@ static bool parseNewcommand (tokenInfo *const token, bool *tokenUnprocessed)
 			.kindIndex = TEXTAG_COMMAND,
 			.roleIndex = ROLE_DEFINITION_INDEX,
 			.name = NULL,
+			.unique = false,
 		},
 		{
 			.type = '[',
@@ -806,6 +852,7 @@ static bool parseNewcounter (tokenInfo *const token, bool *tokenUnprocessed)
 			.kindIndex = TEXTAG_COUNTER,
 			.roleIndex = ROLE_DEFINITION_INDEX,
 			.name = NULL,
+			.unique = false,
 		},
 		{
 			.type = '[',
@@ -1046,6 +1093,6 @@ extern parserDefinition* TexParser (void)
 	def->finalize   = finalize;
 	def->keywordTable =  TexKeywordTable;
 	def->keywordCount = ARRAY_SIZE (TexKeywordTable);
-	def->useCork = CORK_QUEUE;
+	def->useCork = CORK_QUEUE  | CORK_SYMTAB;
 	return def;
 }

--- a/parsers/tex.h
+++ b/parsers/tex.h
@@ -65,6 +65,13 @@ struct TexParseStrategy {
 	/* Store the string surrounded by one of paris.
 	 * If you don't need to store the string, set NULL here. */
 	vString *name;
+
+	/* If true, make at most one tag for the name in the scope specified
+	 * with scopeIndex. When making a tag, scopeIndex is set to
+	 * extensionFields.scopeIndex only if unique is true.
+	 * scopeIndex is never referred if unique if false. */
+	bool unique;
+	int scopeIndex;
 };
 
 typedef struct sTexSubparser texSubparser;

--- a/parsers/tex.h
+++ b/parsers/tex.h
@@ -42,7 +42,7 @@ enum TexNameFlag {
 };
 
 struct TexParseStrategy {
-	/* expected token type '<', '[', '*', and '{' are supported.
+	/* Expected token type '<', '[', '*', and '{' are supported.
 	 * 0 means the end of strategies.
 	 *
 	 * A string between <>, [], or {} (pairs) can be tagged or store to

--- a/parsers/typescript.c
+++ b/parsers/typescript.c
@@ -2107,7 +2107,7 @@ extern parserDefinition *TypeScriptParser (void)
 	def->finalize   = finalize;
 	def->keywordTable = TsKeywordTable;
 	def->keywordCount = ARRAY_SIZE (TsKeywordTable);
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	def->requestAutomaticFQTag = true;
 
 	def->initStats = initStats;

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -723,6 +723,6 @@ extern parserDefinition *VimParser (void)
 	def->extensions = extensions;
 	def->patterns   = patterns;
 	def->parser     = findVimTags;
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	return def;
 }

--- a/parsers/xslt.c
+++ b/parsers/xslt.c
@@ -347,7 +347,7 @@ XsltParser (void)
 	def->parser        = findXsltTags;
 	def->tagXpathTableTable = xsltXpathTableTable;
 	def->tagXpathTableCount = ARRAY_SIZE (xsltXpathTableTable);
-	def->useCork = true;
+	def->useCork = CORK_QUEUE;
 	def->dependencies = dependencies;
 	def->dependencyCount = ARRAY_SIZE (dependencies);
 

--- a/parsers/yaml.c
+++ b/parsers/yaml.c
@@ -166,7 +166,7 @@ extern parserDefinition* YamlParser (void)
 	def->kindTable = YamlKinds;
 	def->extensions = extensions;
 	def->parser     = findYamlTags;
-	def->useCork    = true;
+	def->useCork    = CORK_QUEUE;
 	def->kindTable         = YamlKinds;
 	def->kindCount     = ARRAY_SIZE (YamlKinds);
 	def->useMemoryStreamInput = true;

--- a/source.mak
+++ b/source.mak
@@ -32,6 +32,7 @@ MAIN_PUBLIC_HEADS =		\
 	main/parse.h		\
 	main/promise.h		\
 	main/ptrarray.h		\
+	main/rbtree.h		\
 	main/read.h		\
 	main/routines.h		\
 	main/selectors.h	\
@@ -117,6 +118,7 @@ LIB_SRCS =			\
 	main/promise.c			\
 	main/ptag.c			\
 	main/ptrarray.c			\
+	main/rbtree.c			\
 	main/read.c			\
 	main/routines.c			\
 	main/seccomp.c			\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -131,6 +131,7 @@
     <ClCompile Include="..\main\promise.c" />
     <ClCompile Include="..\main\ptag.c" />
     <ClCompile Include="..\main\ptrarray.c" />
+    <ClCompile Include="..\main\rbtree.c" />
     <ClCompile Include="..\main\read.c" />
     <ClCompile Include="..\main\repoinfo.c" />
     <ClCompile Include="..\main\routines.c" />
@@ -310,6 +311,7 @@
     <ClInclude Include="..\main\promise_p.h" />
     <ClInclude Include="..\main\ptag_p.h" />
     <ClInclude Include="..\main\ptrarray.h" />
+    <ClInclude Include="..\main\rbtree.h" />
     <ClInclude Include="..\main\read.h" />
     <ClInclude Include="..\main\read_p.h" />
     <ClInclude Include="..\main\routines.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClCompile Include="..\main\ptrarray.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
+    <ClCompile Include="..\main\rbtree.c">
+      <Filter>Source Files\Main</Filter>
+    </ClCompile>
     <ClCompile Include="..\main\read.c">
       <Filter>Source Files\Main</Filter>
     </ClCompile>
@@ -660,6 +663,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\ptrarray.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\main\rbtree.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\read.h">


### PR DESCRIPTION
This is the result of a study in #2427.
I removed code related to CPreProcessor and SystemVerilog.

The changes for entry.h in 81647c1 excite you, a parser developer.

06a1588 may also be interesting.

TODO:
- [ ] write abot the new API to docs/*.rst.
- [ ] unify the type representing cork indexes to "int", not "unsigned int".

Test cases are not included in this change.