### PR TITLE
RpmSpec,Autoconf: parse %configure options 

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -6,6 +6,8 @@
 Asm            s/section         placement          on      placement where the assembled code goes
 AutoIt         S/script          local              on      local include
 AutoIt         S/script          system             on      system include
+Autoconf       e/optenable       cmdline            on      specified in a configure command line
+Autoconf       w/optwith         cmdline            on      specified in a configure command line
 Automake       c/condition       branched           on      used for branching
 Automake       d/directory       data               on      directory for DATA primary
 Automake       d/directory       library            on      directory for LIBRARIES primary
@@ -77,6 +79,8 @@ Vera           h/header          system             on      system header
 Asm            s/section         placement          on      placement where the assembled code goes
 AutoIt         S/script          local              on      local include
 AutoIt         S/script          system             on      system include
+Autoconf       e/optenable       cmdline            on      specified in a configure command line
+Autoconf       w/optwith         cmdline            on      specified in a configure command line
 Automake       c/condition       branched           on      used for branching
 Automake       d/directory       data               on      directory for DATA primary
 Automake       d/directory       library            on      directory for LIBRARIES primary

--- a/Units/parser-rpmspec.r/simple-rpmspec.d/expected.tags
+++ b/Units/parser-rpmspec.r/simple-rpmspec.d/expected.tags
@@ -17,3 +17,9 @@ docs	input.spec	/^%package docs$/;"	kind:package	line:37	package:ctags	roles:def
 ctags-docs	input.spec	/^%package docs$/;"	kind:package	line:37	package:ctags	roles:def
 universal-ctags-devel	input.spec	/^%package -n universal-ctags-devel$/;"	kind:package	line:41	package:ctags	roles:def
 ctags-universal-ctags-devel	input.spec	/^%package -n universal-ctags-devel$/;"	kind:package	line:41	package:ctags	roles:def
+libxml	input.spec	/^%configure --with-libxml=%{YES} --with-libyml=%{YES}\\$/;"	kind:optwith	line:49	roles:cmdline
+libyml	input.spec	/^%configure --with-libxml=%{YES} --with-libyml=%{YES}\\$/;"	kind:optwith	line:49	roles:cmdline
+foo	input.spec	/^	   --without-foo --enable-bar \\$/;"	kind:optwith	line:50	roles:cmdline
+bar	input.spec	/^	   --without-foo --enable-bar \\$/;"	kind:optenable	line:50	roles:cmdline
+baz	input.spec	/^	   --disable-baz\\$/;"	kind:optenable	line:51	roles:cmdline
+bazz	input.spec	/^	   --with-bazz=0$/;"	kind:optwith	line:52	roles:cmdline

--- a/Units/parser-rpmspec.r/simple-rpmspec.d/input.spec
+++ b/Units/parser-rpmspec.r/simple-rpmspec.d/input.spec
@@ -46,7 +46,10 @@ Something must be written here.
 %setup -q
 
 %build
-%configure --with-libxml=%{YES} --with-libyml=%{YES}
+%configure --with-libxml=%{YES} --with-libyml=%{YES}\
+	   --without-foo --enable-bar \
+	   --disable-baz\
+	   --with-bazz=0
 make
 
 %install

--- a/main/entry.c
+++ b/main/entry.c
@@ -1568,9 +1568,16 @@ extern void initTagEntry (tagEntryInfo *const e, const char *const name,
 extern void initRefTagEntry (tagEntryInfo *const e, const char *const name,
 			     int kindIndex, int roleIndex)
 {
+	initForeignRefTagEntry (e, name, getInputLanguage (), kindIndex, roleIndex);
+}
+
+extern void initForeignRefTagEntry (tagEntryInfo *const e, const char *const name,
+									langType langType,
+									int kindIndex, int roleIndex)
+{
 	initTagEntryFull(e, name,
 			 getInputLineNumber (),
-			 getInputLanguage (),
+			 langType,
 			 getInputFilePosition (),
 			 getInputFileTagPath (),
 			 kindIndex,

--- a/main/entry.h
+++ b/main/entry.h
@@ -130,7 +130,9 @@ extern void initTagEntry (tagEntryInfo *const e, const char *const name,
 			  int kindIndex);
 extern void initRefTagEntry (tagEntryInfo *const e, const char *const name,
 			     int kindIndex, int roleIndex);
-
+extern void initForeignRefTagEntry (tagEntryInfo *const e, const char *const name,
+									langType type,
+									int kindIndex, int roleIndex);
 extern void assignRole(tagEntryInfo *const e, int roleIndex);
 extern bool isRoleAssigned(const tagEntryInfo *const e, int roleIndex);
 

--- a/parsers/autoconf.c
+++ b/parsers/autoconf.c
@@ -11,6 +11,7 @@
 
 #include <string.h>
 
+#include "autoconf.h"
 #include "m4.h"
 
 #include "debug.h"
@@ -20,23 +21,23 @@
 #include "kind.h"
 #include "parse.h"
 
-enum {
-	PACKAGE_KIND,
-	TEMPLATE_KIND,
-	MACRO_KIND,
-	OPTWITH_KIND,
-	OPTENABLE_KIND,
-	SUBST_KIND,
-	CONDITION_KIND,
-	DEFINITION_KIND,
+
+static roleDefinition AutoconfOptwithRoles [] = {
+	{ true, "cmdline", "specified in a configure command line" },
+};
+
+static roleDefinition AutoconfOptenableRoles [] = {
+	{ true, "cmdline", "specified in a configure command line" },
 };
 
 static kindDefinition AutoconfKinds[] = {
 	{ true, 'p', "package", "packages" },
 	{ true, 't', "template", "templates" },
 	{ true, 'm', "macro", "autoconf macros" },
-	{ true, 'w', "optwith", "options specified with --with-..."},
-	{ true, 'e', "optenable", "options specified with --enable-..."},
+	{ true, 'w', "optwith", "options specified with --with-...",
+	  .referenceOnly = false, ATTACH_ROLES(AutoconfOptwithRoles)},
+	{ true, 'e', "optenable", "options specified with --enable-...",
+	  .referenceOnly = false, ATTACH_ROLES(AutoconfOptenableRoles)},
 	{ true, 's', "subst", "substitution keys"},
 	{ true, 'c', "condition", "automake conditions" },
 	{ true, 'd', "definition", "definitions" },
@@ -120,28 +121,28 @@ static int newMacroCallback (m4Subparser *m4 CTAGS_ATTR_UNUSED, const char* toke
 	case KEYWORD_NONE:
 		break;
 	case KEYWORD_init:
-		index = makeAutoconfTag (PACKAGE_KIND);
+		index = makeAutoconfTag (AUTOCONF_PACKAGE_KIND);
 		break;
 	case KEYWORD_template:
-		index = makeAutoconfTag (TEMPLATE_KIND);
+		index = makeAutoconfTag (AUTOCONF_TEMPLATE_KIND);
 		break;
 	case KEYWORD_defun:
-		index = makeAutoconfTag (MACRO_KIND);
+		index = makeAutoconfTag (AUTOCONF_MACRO_KIND);
 		break;
 	case KEYWORD_argwith:
-		index = makeAutoconfTag (OPTWITH_KIND);
+		index = makeAutoconfTag (AUTOCONF_OPTWITH_KIND);
 		break;
 	case KEYWORD_argenable:
-		index = makeAutoconfTag (OPTENABLE_KIND);
+		index = makeAutoconfTag (AUTOCONF_OPTENABLE_KIND);
 		break;
 	case KEYWORD_subst:
-		index = makeAutoconfTag (SUBST_KIND);
+		index = makeAutoconfTag (AUTOCONF_SUBST_KIND);
 		break;
 	case KEYWORD_conditional:
-		index = makeAutoconfTag (CONDITION_KIND);
+		index = makeAutoconfTag (AUTOCONF_CONDITION_KIND);
 		break;
 	case KEYWORD_define:
-		index = makeAutoconfTag (DEFINITION_KIND);
+		index = makeAutoconfTag (AUTOCONF_DEFINITION_KIND);
 		break;
 	default:
 		AssertNotReached ();

--- a/parsers/autoconf.h
+++ b/parsers/autoconf.h
@@ -1,0 +1,34 @@
+/*
+ *   Copyright (c) 2011, Colomban Wendling <colomban@geany.org>
+ *
+ *   This source code is released for free distribution under the terms of the
+ *   GNU General Public License version 2 or (at your option) any later version.
+ *
+ *   Autoconf parser interface exported to the other parsers
+ */
+
+#ifndef CTAGS_AUTOCONF_H
+#define CTAGS_AUTOCONF_H
+
+#include "general.h"
+
+enum {
+	AUTOCONF_PACKAGE_KIND,
+	AUTOCONF_TEMPLATE_KIND,
+	AUTOCONF_MACRO_KIND,
+	AUTOCONF_OPTWITH_KIND,
+	AUTOCONF_OPTENABLE_KIND,
+	AUTOCONF_SUBST_KIND,
+	AUTOCONF_CONDITION_KIND,
+	AUTOCONF_DEFINITION_KIND,
+} autoconfKind;
+
+typedef enum {
+	AUTOCONF_OPTWITH_CMDLINE_ROLE,
+} autoconfOptwithRole;
+
+typedef enum {
+	AUTOCONF_OPTENABLE_CMDLINE_ROLE,
+} autoconfOptenableRole;
+
+#endif	/* CTAGS_AUTOCONF_H */

--- a/source.mak
+++ b/source.mak
@@ -163,6 +163,9 @@ PEG_EXTRA_HEADS = $(PEG_INPUT:.peg=_pre.h) $(PEG_INPUT:.peg=_post.h)
 PEG_OBJS = $(PEG_SRCS:.c=.$(OBJEXT))
 
 PARSER_HEADS = \
+	parsers/autoconf.h \
+	parsers/cpreprocessor.h \
+	\
 	parsers/cxx/cxx_debug.h \
 	parsers/cxx/cxx_keyword.h \
 	parsers/cxx/cxx_parser_internal.h \
@@ -174,7 +177,6 @@ PARSER_HEADS = \
 	parsers/cxx/cxx_token.h \
 	parsers/cxx/cxx_token_chain.h \
 	\
-	parsers/cpreprocessor.h \
 	parsers/iniconf.h \
 	parsers/m4.h \
 	parsers/make.h \

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -329,6 +329,7 @@
     <ClInclude Include="..\main\writer_p.h" />
     <ClInclude Include="..\main\xtag.h" />
     <ClInclude Include="..\main\xtag_p.h" />
+    <ClInclude Include="..\parsers\autoconf.h" />
     <ClInclude Include="..\parsers\cpreprocessor.h" />
     <ClInclude Include="..\parsers\cxx\cxx_debug.h" />
     <ClInclude Include="..\parsers\cxx\cxx_keyword.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -719,6 +719,9 @@
     <ClInclude Include="..\main\xtag_p.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\parsers\autoconf.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\parsers\cpreprocessor.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
Autconf parser captures:

    ctags-libexecdir in "AC_ARG_WITH([ctags-libexecdir]," as optwith kind and
    tmpdir in "AC_ARG_ENABLE(tmpdir," as optenable kind.

These are captured as definitions tags.
This change is about reference tags for the kinds.

./configure script is invoked various places.
One of typical place is RPM spec file.
RPS spec files have a special notation (macro) for invoking
configure script: %configure ....

This change in RpmSpec parser scans the %configure lines.
If --enable-foo/--disable-bar/--with-baz/--without-bazz are
passed to %configure lines, the RpmSpec parser captures
foo/bar/baz/bazz as reference tags of optwith or optenable
kinds.
