### PR TITLE
CXX: Fix cpp branching in the namespace statement. 

### DIFF
--- a/parsers/cxx/cxx_parser_namespace.c
+++ b/parsers/cxx/cxx_parser_namespace.c
@@ -59,6 +59,7 @@ bool cxxParserParseNamespace(void)
 	}
 
 	cxxParserNewStatement(); // always a new statement
+	cppBeginStatement(); // but we're in the middle of it
 
 	int iScopeCount = 0;
 


### PR DESCRIPTION
Fixes parsing of Qt's qnamespace.h and similar.