### PR TITLE
CXX: Fix cpp branching in the namespace statement. 

### DIFF
--- a/Units/parser-cxx.r/namespace-and-preprocessor.cpp.d/args.ctags
+++ b/Units/parser-cxx.r/namespace-and-preprocessor.cpp.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-C++=*

--- a/Units/parser-cxx.r/namespace-and-preprocessor.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/namespace-and-preprocessor.cpp.d/expected.tags
@@ -1,0 +1,1 @@
+Name	input.cpp	/^	Name {$/;"	n	file:

--- a/Units/parser-cxx.r/namespace-and-preprocessor.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/namespace-and-preprocessor.cpp.d/input.cpp
@@ -1,0 +1,8 @@
+#ifdef SOMETHING
+	namespace
+#else
+	class
+#endif
+	Name {
+	};
+

--- a/parsers/cxx/cxx_parser_namespace.c
+++ b/parsers/cxx/cxx_parser_namespace.c
@@ -59,6 +59,7 @@ bool cxxParserParseNamespace(void)
 	}
 
 	cxxParserNewStatement(); // always a new statement
+	cppBeginStatement(); // but we're in the middle of it
 
 	int iScopeCount = 0;
 


### PR DESCRIPTION
Fixes parsing of Qt's qnamespace.h and similar.