### PR TITLE
readtags: extend api for pseudo tags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,7 +52,7 @@ endif
 if USE_READCMD
 bin_PROGRAMS+= readtags
 readtags_CPPFLAGS = -I. -I$(srcdir) -I$(srcdir)/main -I$(srcdir)/libreadtags
-readtags_CFLAGS = $(COVERAGE_CFLAGS)
+readtags_CFLAGS = $(COVERAGE_CFLAGS) $(WARNING_CFLAGS)
 dist_readtags_SOURCES = $(READTAGS_SRCS) $(READTAGS_HEADS)
 readtags_CPPFLAGS += -DREADTAGS_DSL -I$(srcdir)/dsl
 dist_readtags_SOURCES += $(READTAGS_DSL_SRCS) $(READTAGS_DSL_HEADS)

--- a/Tmain/readtags-list-pseudo-tags.d/ptag-sort-no.tags
+++ b/Tmain/readtags-list-pseudo-tags.d/ptag-sort-no.tags
@@ -1,0 +1,44 @@
+!_JSON_OUTPUT_VERSION	0.0	/in development/
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/9b73623f/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_KIND_DESCRIPTION!C	d,macro	/macro definitions/
+!_TAG_KIND_DESCRIPTION!C	e,enumerator	/enumerators (values inside an enumeration)/
+!_TAG_KIND_DESCRIPTION!C	f,function	/function definitions/
+!_TAG_KIND_DESCRIPTION!C	g,enum	/enumeration names/
+!_TAG_KIND_DESCRIPTION!C	h,header	/included header files/
+!_TAG_KIND_DESCRIPTION!C	l,local	/local variables/
+!_TAG_KIND_DESCRIPTION!C	m,member	/struct, and union members/
+!_TAG_KIND_DESCRIPTION!C	p,prototype	/function prototypes/
+!_TAG_KIND_DESCRIPTION!C	s,struct	/structure names/
+!_TAG_KIND_DESCRIPTION!C	t,typedef	/typedefs/
+!_TAG_KIND_DESCRIPTION!C	u,union	/union names/
+!_TAG_KIND_DESCRIPTION!C	v,variable	/variable definitions/
+!_TAG_KIND_DESCRIPTION!C	x,externvar	/external and forward variable declarations/
+!_TAG_KIND_DESCRIPTION!C	z,parameter	/function parameters inside function definitions/
+!_TAG_KIND_DESCRIPTION!C	L,label	/goto labels/
+!_TAG_KIND_DESCRIPTION!C	D,macroparam	/parameters inside macro definitions/
+main	input.c	/^int main (void) { return 0; }$/;"	f	typeref:typename:int
+!_TAG_KIND_DESCRIPTION!EmacsLisp	u,unknown	/unknown type of definitions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	f,function	/functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	v,variable	/variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	c,const	/constants/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	m,macro	/macros/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	a,alias	/aliases for functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	V,varalias	/aliases for variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	s,subst	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	i,inline	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	e,error	/errors/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	M,minorMode	/minor modes/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	D,derivedMode	/derived major mode/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	C,custom	/customizable variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	G,group	/customization groups/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	H,face	/customizable faces/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	T,theme	/custom themes/
+afunc	input.el	/^(defun afunc () nil)$/;"	f

--- a/Tmain/readtags-list-pseudo-tags.d/ptag-sort-yes.tags
+++ b/Tmain/readtags-list-pseudo-tags.d/ptag-sort-yes.tags
@@ -1,0 +1,44 @@
+!_JSON_OUTPUT_VERSION	0.0	/in development/
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_KIND_DESCRIPTION!C	D,macroparam	/parameters inside macro definitions/
+!_TAG_KIND_DESCRIPTION!C	L,label	/goto labels/
+!_TAG_KIND_DESCRIPTION!C	d,macro	/macro definitions/
+!_TAG_KIND_DESCRIPTION!C	e,enumerator	/enumerators (values inside an enumeration)/
+!_TAG_KIND_DESCRIPTION!C	f,function	/function definitions/
+!_TAG_KIND_DESCRIPTION!C	g,enum	/enumeration names/
+!_TAG_KIND_DESCRIPTION!C	h,header	/included header files/
+!_TAG_KIND_DESCRIPTION!C	l,local	/local variables/
+!_TAG_KIND_DESCRIPTION!C	m,member	/struct, and union members/
+!_TAG_KIND_DESCRIPTION!C	p,prototype	/function prototypes/
+!_TAG_KIND_DESCRIPTION!C	s,struct	/structure names/
+!_TAG_KIND_DESCRIPTION!C	t,typedef	/typedefs/
+!_TAG_KIND_DESCRIPTION!C	u,union	/union names/
+!_TAG_KIND_DESCRIPTION!C	v,variable	/variable definitions/
+!_TAG_KIND_DESCRIPTION!C	x,externvar	/external and forward variable declarations/
+!_TAG_KIND_DESCRIPTION!C	z,parameter	/function parameters inside function definitions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	C,custom	/customizable variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	D,derivedMode	/derived major mode/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	G,group	/customization groups/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	H,face	/customizable faces/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	M,minorMode	/minor modes/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	T,theme	/custom themes/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	V,varalias	/aliases for variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	a,alias	/aliases for functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	c,const	/constants/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	e,error	/errors/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	f,function	/functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	i,inline	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	m,macro	/macros/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	s,subst	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	u,unknown	/unknown type of definitions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	v,variable	/variables/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/9b73623f/
+afunc	input.el	/^(defun afunc () nil)$/;"	f
+main	input.c	/^int main (void) { return 0; }$/;"	f	typeref:typename:int

--- a/Tmain/readtags-list-pseudo-tags.d/run.sh
+++ b/Tmain/readtags-list-pseudo-tags.d/run.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Copyright: 2020 Masatake YAMATO
+# License: GPL-2
+
+READTAGS=$3
+#V="valgrind --leak-check=full --track-origins=yes -v"
+V=
+
+. ../utils.sh
+
+echo '# SORT=NO'
+${V} ${READTAGS} -t ./ptag-sort-no.tags -D
+
+echo '# SORT=YES'
+${V} ${READTAGS} -t ./ptag-sort-yes.tags -D

--- a/Tmain/readtags-list-pseudo-tags.d/stdout-expected.txt
+++ b/Tmain/readtags-list-pseudo-tags.d/stdout-expected.txt
@@ -1,0 +1,86 @@
+# SORT=NO
+!_JSON_OUTPUT_VERSION	0.0	/in development/
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/9b73623f/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_KIND_DESCRIPTION!C	d,macro	/macro definitions/
+!_TAG_KIND_DESCRIPTION!C	e,enumerator	/enumerators (values inside an enumeration)/
+!_TAG_KIND_DESCRIPTION!C	f,function	/function definitions/
+!_TAG_KIND_DESCRIPTION!C	g,enum	/enumeration names/
+!_TAG_KIND_DESCRIPTION!C	h,header	/included header files/
+!_TAG_KIND_DESCRIPTION!C	l,local	/local variables/
+!_TAG_KIND_DESCRIPTION!C	m,member	/struct, and union members/
+!_TAG_KIND_DESCRIPTION!C	p,prototype	/function prototypes/
+!_TAG_KIND_DESCRIPTION!C	s,struct	/structure names/
+!_TAG_KIND_DESCRIPTION!C	t,typedef	/typedefs/
+!_TAG_KIND_DESCRIPTION!C	u,union	/union names/
+!_TAG_KIND_DESCRIPTION!C	v,variable	/variable definitions/
+!_TAG_KIND_DESCRIPTION!C	x,externvar	/external and forward variable declarations/
+!_TAG_KIND_DESCRIPTION!C	z,parameter	/function parameters inside function definitions/
+!_TAG_KIND_DESCRIPTION!C	L,label	/goto labels/
+!_TAG_KIND_DESCRIPTION!C	D,macroparam	/parameters inside macro definitions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	u,unknown	/unknown type of definitions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	f,function	/functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	v,variable	/variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	c,const	/constants/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	m,macro	/macros/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	a,alias	/aliases for functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	V,varalias	/aliases for variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	s,subst	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	i,inline	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	e,error	/errors/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	M,minorMode	/minor modes/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	D,derivedMode	/derived major mode/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	C,custom	/customizable variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	G,group	/customization groups/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	H,face	/customizable faces/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	T,theme	/custom themes/
+# SORT=YES
+!_JSON_OUTPUT_VERSION	0.0	/in development/
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_KIND_DESCRIPTION!C	D,macroparam	/parameters inside macro definitions/
+!_TAG_KIND_DESCRIPTION!C	L,label	/goto labels/
+!_TAG_KIND_DESCRIPTION!C	d,macro	/macro definitions/
+!_TAG_KIND_DESCRIPTION!C	e,enumerator	/enumerators (values inside an enumeration)/
+!_TAG_KIND_DESCRIPTION!C	f,function	/function definitions/
+!_TAG_KIND_DESCRIPTION!C	g,enum	/enumeration names/
+!_TAG_KIND_DESCRIPTION!C	h,header	/included header files/
+!_TAG_KIND_DESCRIPTION!C	l,local	/local variables/
+!_TAG_KIND_DESCRIPTION!C	m,member	/struct, and union members/
+!_TAG_KIND_DESCRIPTION!C	p,prototype	/function prototypes/
+!_TAG_KIND_DESCRIPTION!C	s,struct	/structure names/
+!_TAG_KIND_DESCRIPTION!C	t,typedef	/typedefs/
+!_TAG_KIND_DESCRIPTION!C	u,union	/union names/
+!_TAG_KIND_DESCRIPTION!C	v,variable	/variable definitions/
+!_TAG_KIND_DESCRIPTION!C	x,externvar	/external and forward variable declarations/
+!_TAG_KIND_DESCRIPTION!C	z,parameter	/function parameters inside function definitions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	C,custom	/customizable variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	D,derivedMode	/derived major mode/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	G,group	/customization groups/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	H,face	/customizable faces/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	M,minorMode	/minor modes/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	T,theme	/custom themes/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	V,varalias	/aliases for variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	a,alias	/aliases for functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	c,const	/constants/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	e,error	/errors/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	f,function	/functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	i,inline	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	m,macro	/macros/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	s,subst	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	u,unknown	/unknown type of definitions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	v,variable	/variables/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/9b73623f/

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -1701,3 +1701,7 @@ Examples of filter expressions
 	$ ./readtags  -e -t foo.tags -Q '(and (member "Foo" $inherits) (eq? $kind "class"))' -l
 	Bar	foo.py	/^class Bar (Foo):$/;"	kind:class	language:Python	inherits:Foo	access:public
 	Baz	foo.py	/^class Baz (Foo): $/;"	kind:class	language:Python	inherits:Foo	access:public
+
+Listing pseudo tags with ``-D``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+You can list all pseudo tags in a tags file with ``-D`` option.

--- a/libreadtags/.circleci/config.yml
+++ b/libreadtags/.circleci/config.yml
@@ -1,0 +1,55 @@
+version: 2
+jobs:
+  fedora31:
+    working_directory: ~/libreadtags
+    docker:
+      - image: docker.io/fedora:31
+    steps:
+      - run:
+          name: Install Git
+          command: |
+            yum -y install git
+      - checkout
+      - run:
+          name: Install build tools
+          command: |
+            yum -y install gcc automake autoconf libtool make
+      - run:
+          name: Build
+          command: |
+            bash ./autogen.sh
+            ./configure
+            make
+      - run:
+          name: Test
+          command: |
+            make check
+  fedora31_distcheck:
+    working_directory: ~/libreadtags
+    docker:
+      - image: docker.io/fedora:31
+    steps:
+      - run:
+          name: Install Git
+          command: |
+            yum -y install git
+      - checkout
+      - run:
+          name: Install build tools
+          command: |
+            yum -y install gcc automake autoconf libtool make
+      - run:
+          name: Build
+          command: |
+            bash ./autogen.sh
+            ./configure
+      - run:
+          name: Test
+          command: |
+            make distcheck
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - fedora31
+      - fedora31_distcheck

--- a/libreadtags/.gitignore
+++ b/libreadtags/.gitignore
@@ -24,3 +24,10 @@ m4
 Makefile
 Makefile.in
 missing
+test-driver
+
+tests/*.log
+tests/*.trs
+tests/test-api-tagsFind
+tests/test-api-tagsFirstPseudoTag
+tests/test-api-tagsOpen

--- a/libreadtags/Makefile.am
+++ b/libreadtags/Makefile.am
@@ -1,9 +1,10 @@
 AUTOMAKE_OPTIONS = foreign
 ACLOCAL_AMFLAGS = -I m4
 
+AM_CFLAGS=-Wall
+
 lib_LTLIBRARIES    = libreadtags.la
 libreadtags_la_LDFLAGS = -no-undefined -version-info $(LT_VERSION)
-
 
 libreadtags_la_SOURCES = readtags.c readtags.h
 nobase_include_HEADERS = readtags.h
@@ -12,5 +13,4 @@ EXTRA_DIST = libreadtags.pc.in
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libreadtags.pc
 
-
-
+SUBDIRS = . tests

--- a/libreadtags/configure.ac
+++ b/libreadtags/configure.ac
@@ -12,5 +12,6 @@ AC_SUBST(LT_VERSION, [0:0:0])
 AC_PROG_CC_C99
 
 AC_CONFIG_FILES([Makefile
-		libreadtags.pc])
+		libreadtags.pc
+		tests/Makefile])
 AC_OUTPUT

--- a/libreadtags/libreadtags.pc.in
+++ b/libreadtags/libreadtags.pc.in
@@ -4,7 +4,7 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libreadtags
-Description: command line editor library provides generic line editing, history, and tokenization functions.
+Description: a library for looking up tag entries in tag files
 Version: @VERSION@
 Requires:
 Libs: -L${libdir} -lreadtags

--- a/libreadtags/readtags.h
+++ b/libreadtags/readtags.h
@@ -150,9 +150,11 @@ typedef struct {
 *  information about the tag file. If successful, the function will return a
 *  handle which must be supplied to other calls to read information from the
 *  tag file, and info.status.opened will be set to true. If unsuccessful,
+*  the function will return NULL, and
 *  info.status.opened will be set to false and info.status.error_number will
 *  be set to the errno value representing the system error preventing the tag
-*  file from being successfully opened.
+*  file from being successfully opened. The error_number will be zero if the
+*  memory allocation for the handle is failed.
 */
 extern tagFile *tagsOpen (const char *const filePath, tagFileInfo *const info);
 
@@ -234,6 +236,19 @@ extern tagResult tagsFind (tagFile *const file, tagEntry *const entry, const cha
 *  or TagFailure if not.
 */
 extern tagResult tagsFindNext (tagFile *const file, tagEntry *const entry);
+
+/*
+*  Does the same as tagsFirst(), but is specialized to pseudo tags.
+*  If tagFileInfo doesn't contain pseudo tags you are interested, read
+*  them sequentially with this function and tagsNextPseudoTag().
+*/
+extern tagResult tagsFirstPseudoTag (tagFile *const file, tagEntry *const entry);
+
+/*
+*  Does the same as tagsNext(), but is specialized to pseudo tags. Use with
+*  tagsFirstPseudoTag().
+*/
+extern tagResult tagsNextPseudoTag (tagFile *const file, tagEntry *const entry);
 
 /*
 *  Call tagsTerminate() at completion of reading the tag file, which will

--- a/libreadtags/tests/Makefile.am
+++ b/libreadtags/tests/Makefile.am
@@ -1,0 +1,37 @@
+TESTS = \
+	\
+	test-api-tagsOpen \
+	test-api-tagsFind \
+	test-api-tagsFirstPseudoTag \
+	\
+	$(NULL)
+
+check_PROGRAMS = \
+	\
+	test-api-tagsOpen \
+	test-api-tagsFind \
+	test-api-tagsFirstPseudoTag \
+	\
+	$(NULL)
+
+EXTRA_DIST =
+
+AM_CPPFLAGS = -I $(top_srcdir)
+DEPS = $(top_builddir)/libreadtags.la
+LDADD = $(top_builddir)/libreadtags.la
+
+test_api_tagsOpen = test-api-tagsOpen.c
+test_api_tagsOpen_DEPENDENCIES = $(DEPS)
+EXTRA_DIST += api-tagsOpen-ectags.tags
+
+test_api_tagsFind = test-api-tagsFind.c
+test_api_tagsFind_DEPENDENCIES = $(DEPS)
+EXTRA_DIST += duplicated-names.c
+EXTRA_DIST += duplicated-names--sorted-yes.tags
+EXTRA_DIST += duplicated-names--sorted-no.tags
+EXTRA_DIST += duplicated-names--sorted-foldcase.tags
+
+test_api_tagsFirstPseudoTag = test-api-tagsFirstPseudoTag.c
+test_api_tagsFirstPseudoTag_DEPENDENCIES = $(DEPS)
+EXTRA_DIST += ptag-sort-no.tags
+EXTRA_DIST += ptag-sort-yes.tags

--- a/libreadtags/tests/api-tagsOpen-ectags.tags
+++ b/libreadtags/tests/api-tagsOpen-ectags.tags
@@ -1,0 +1,7 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.8	//
+main	test-api-tagsOpen.c	/^main(void)$/;"	f

--- a/libreadtags/tests/duplicated-names--sorted-foldcase.tags
+++ b/libreadtags/tests/duplicated-names--sorted-foldcase.tags
@@ -1,0 +1,21 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	2	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/9b73623f/
+M	input.c	/^int M (void) { return 0; }$/;"	f	typeref:typename:int
+m	input.c	/^int m;$/;"	v	typeref:typename:int
+main	input.c	/^int main(int n)$/;"	f	typeref:typename:int
+n	input.c	/^		int n;$/;"	l	function:main	typeref:typename:int	file:
+n	input.c	/^	for (int n = 0; n < 1; n++)$/;"	l	function:main	typeref:typename:int	file:
+n	input.c	/^	int n;$/;"	m	struct:n	typeref:typename:int	file:
+n	input.c	/^int main(int n)$/;"	z	function:main	typeref:typename:int	file:
+N	input.c	/^int N;$/;"	v	typeref:typename:int
+n	input.c	/^struct n {$/;"	s	file:
+n	input.c	/^typedef int n;$/;"	t	typeref:typename:int	file:
+O	input.c	/^int O (void) { return 0; }$/;"	f	typeref:typename:int
+o	input.c	/^int o;$/;"	v	typeref:typename:int

--- a/libreadtags/tests/duplicated-names--sorted-no.tags
+++ b/libreadtags/tests/duplicated-names--sorted-no.tags
@@ -1,0 +1,21 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/9b73623f/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+o	input.c	/^int o;$/;"	v	typeref:typename:int
+O	input.c	/^int O (void) { return 0; }$/;"	f	typeref:typename:int
+N	input.c	/^int N;$/;"	v	typeref:typename:int
+n	input.c	/^struct n {$/;"	s	file:
+n	input.c	/^	int n;$/;"	m	struct:n	typeref:typename:int	file:
+n	input.c	/^typedef int n;$/;"	t	typeref:typename:int	file:
+main	input.c	/^int main(int n)$/;"	f	typeref:typename:int
+n	input.c	/^int main(int n)$/;"	z	function:main	typeref:typename:int	file:
+n	input.c	/^	for (int n = 0; n < 1; n++)$/;"	l	function:main	typeref:typename:int	file:
+n	input.c	/^		int n;$/;"	l	function:main	typeref:typename:int	file:
+m	input.c	/^int m;$/;"	v	typeref:typename:int
+M	input.c	/^int M (void) { return 0; }$/;"	f	typeref:typename:int

--- a/libreadtags/tests/duplicated-names--sorted-yes.tags
+++ b/libreadtags/tests/duplicated-names--sorted-yes.tags
@@ -1,0 +1,21 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/9b73623f/
+M	input.c	/^int M (void) { return 0; }$/;"	f	typeref:typename:int
+N	input.c	/^int N;$/;"	v	typeref:typename:int
+O	input.c	/^int O (void) { return 0; }$/;"	f	typeref:typename:int
+m	input.c	/^int m;$/;"	v	typeref:typename:int
+main	input.c	/^int main(int n)$/;"	f	typeref:typename:int
+n	input.c	/^		int n;$/;"	l	function:main	typeref:typename:int	file:
+n	input.c	/^	for (int n = 0; n < 1; n++)$/;"	l	function:main	typeref:typename:int	file:
+n	input.c	/^	int n;$/;"	m	struct:n	typeref:typename:int	file:
+n	input.c	/^int main(int n)$/;"	z	function:main	typeref:typename:int	file:
+n	input.c	/^struct n {$/;"	s	file:
+n	input.c	/^typedef int n;$/;"	t	typeref:typename:int	file:
+o	input.c	/^int o;$/;"	v	typeref:typename:int

--- a/libreadtags/tests/duplicated-names.c
+++ b/libreadtags/tests/duplicated-names.c
@@ -1,0 +1,24 @@
+/*
+ * for s in yes foldcase no; do 
+ *   u-ctags --quiet --options=NONE -o duplicated-names--sorted-$s.tags --kinds-C='*' --sort=$s duplicated-names.c
+ * done
+ */
+int o;
+int O (void) { return 0; }
+
+int N;
+struct n {
+	int n;
+};
+typedef int n;
+int main(int n)
+{
+	for (int n = 0; n < 1; n++)
+	{
+		int n;
+		return 0;
+	}
+}
+
+int m;
+int M (void) { return 0; }

--- a/libreadtags/tests/ptag-sort-no.tags
+++ b/libreadtags/tests/ptag-sort-no.tags
@@ -1,0 +1,44 @@
+!_JSON_OUTPUT_VERSION	0.0	/in development/
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	0	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/9b73623f/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_KIND_DESCRIPTION!C	d,macro	/macro definitions/
+!_TAG_KIND_DESCRIPTION!C	e,enumerator	/enumerators (values inside an enumeration)/
+!_TAG_KIND_DESCRIPTION!C	f,function	/function definitions/
+!_TAG_KIND_DESCRIPTION!C	g,enum	/enumeration names/
+!_TAG_KIND_DESCRIPTION!C	h,header	/included header files/
+!_TAG_KIND_DESCRIPTION!C	l,local	/local variables/
+!_TAG_KIND_DESCRIPTION!C	m,member	/struct, and union members/
+!_TAG_KIND_DESCRIPTION!C	p,prototype	/function prototypes/
+!_TAG_KIND_DESCRIPTION!C	s,struct	/structure names/
+!_TAG_KIND_DESCRIPTION!C	t,typedef	/typedefs/
+!_TAG_KIND_DESCRIPTION!C	u,union	/union names/
+!_TAG_KIND_DESCRIPTION!C	v,variable	/variable definitions/
+!_TAG_KIND_DESCRIPTION!C	x,externvar	/external and forward variable declarations/
+!_TAG_KIND_DESCRIPTION!C	z,parameter	/function parameters inside function definitions/
+!_TAG_KIND_DESCRIPTION!C	L,label	/goto labels/
+!_TAG_KIND_DESCRIPTION!C	D,macroparam	/parameters inside macro definitions/
+main	input.c	/^int main (void) { return 0; }$/;"	f	typeref:typename:int
+!_TAG_KIND_DESCRIPTION!EmacsLisp	u,unknown	/unknown type of definitions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	f,function	/functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	v,variable	/variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	c,const	/constants/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	m,macro	/macros/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	a,alias	/aliases for functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	V,varalias	/aliases for variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	s,subst	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	i,inline	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	e,error	/errors/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	M,minorMode	/minor modes/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	D,derivedMode	/derived major mode/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	C,custom	/customizable variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	G,group	/customization groups/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	H,face	/customizable faces/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	T,theme	/custom themes/
+afunc	input.el	/^(defun afunc () nil)$/;"	f

--- a/libreadtags/tests/ptag-sort-yes.tags
+++ b/libreadtags/tests/ptag-sort-yes.tags
@@ -1,0 +1,44 @@
+!_JSON_OUTPUT_VERSION	0.0	/in development/
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_KIND_DESCRIPTION!C	D,macroparam	/parameters inside macro definitions/
+!_TAG_KIND_DESCRIPTION!C	L,label	/goto labels/
+!_TAG_KIND_DESCRIPTION!C	d,macro	/macro definitions/
+!_TAG_KIND_DESCRIPTION!C	e,enumerator	/enumerators (values inside an enumeration)/
+!_TAG_KIND_DESCRIPTION!C	f,function	/function definitions/
+!_TAG_KIND_DESCRIPTION!C	g,enum	/enumeration names/
+!_TAG_KIND_DESCRIPTION!C	h,header	/included header files/
+!_TAG_KIND_DESCRIPTION!C	l,local	/local variables/
+!_TAG_KIND_DESCRIPTION!C	m,member	/struct, and union members/
+!_TAG_KIND_DESCRIPTION!C	p,prototype	/function prototypes/
+!_TAG_KIND_DESCRIPTION!C	s,struct	/structure names/
+!_TAG_KIND_DESCRIPTION!C	t,typedef	/typedefs/
+!_TAG_KIND_DESCRIPTION!C	u,union	/union names/
+!_TAG_KIND_DESCRIPTION!C	v,variable	/variable definitions/
+!_TAG_KIND_DESCRIPTION!C	x,externvar	/external and forward variable declarations/
+!_TAG_KIND_DESCRIPTION!C	z,parameter	/function parameters inside function definitions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	C,custom	/customizable variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	D,derivedMode	/derived major mode/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	G,group	/customization groups/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	H,face	/customizable faces/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	M,minorMode	/minor modes/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	T,theme	/custom themes/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	V,varalias	/aliases for variables/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	a,alias	/aliases for functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	c,const	/constants/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	e,error	/errors/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	f,function	/functions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	i,inline	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	m,macro	/macros/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	s,subst	/inline function/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	u,unknown	/unknown type of definitions/
+!_TAG_KIND_DESCRIPTION!EmacsLisp	v,variable	/variables/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/9b73623f/
+afunc	input.el	/^(defun afunc () nil)$/;"	f
+main	input.c	/^int main (void) { return 0; }$/;"	f	typeref:typename:int

--- a/libreadtags/tests/test-api-tagsFind.c
+++ b/libreadtags/tests/test-api-tagsFind.c
@@ -1,0 +1,501 @@
+/*
+*   Copyright (c) 2020, Masatake YAMATO
+*
+*   This source code is released into the public domain.
+*
+*   Testing tagsFind() and tagsFindNext() API functions
+*/
+
+#include "readtags.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+
+struct expectation {
+	char *name;
+	char *file;
+	char *pattern;
+	char *kind;
+	char *scope_kind;
+	char *scope_name;
+	char *typeref;
+	int fileScope;
+};
+
+#define COUNT(x) (sizeof(x)/sizeof(x[0]))
+
+static int
+check_finding0 (tagFile *t, const char *name, const int options,
+			   struct expectation *expectations, int count)
+{
+	tagEntry e;
+	struct expectation *x;
+
+	for (int i = 0; i < count; i++)
+	{
+		fprintf (stderr, "[%d/%d] finding \"%s\" (%d)...", i + 1, count, name, options);
+		if (i == 0)
+		{
+			if (tagsFind (t, &e, name, options) != TagSuccess)
+			{
+				fprintf (stderr, "not found\n");
+				return 1;
+			}
+		}
+		else
+		{
+			if (tagsFindNext (t, &e) != TagSuccess)
+			{
+				fprintf (stderr, "not found\n");
+				return 1;
+			}
+		}
+		fprintf (stderr, "found\n");
+
+		x = expectations + i;
+
+		fprintf (stderr, "checking name field...");
+		if (!(e.name && strcmp (x->name, e.name) == 0))
+		{
+			fprintf (stderr, "unexpected: %s\n", e.name? e.name: "<NULL>");
+			return 1;
+		}
+		fprintf (stderr, "ok\n");
+
+		fprintf (stderr, "checking file field...");
+		if (!(e.file && strcmp (x->file, e.file) == 0))
+		{
+			fprintf (stderr, "unexpected\n");
+			return 1;
+		}
+		fprintf (stderr, "ok\n");
+
+		fprintf (stderr, "checking pattern field...");
+		if (!(e.address.pattern && strcmp (x->pattern, e.address.pattern) == 0))
+		{
+			fprintf (stderr, "unexpected: %s\n",
+					 e.address.pattern? e.address.pattern: "<NULL>");
+			return 1;
+		}
+		fprintf (stderr, "ok\n");
+
+		fprintf (stderr, "checking kind field...");
+		if (!(e.kind && strcmp (x->kind, e.kind) == 0))
+		{
+			fprintf (stderr, "unexpected\n");
+			return 1;
+		}
+		fprintf (stderr, "ok\n");
+
+		if (x->scope_kind)
+		{
+			fprintf (stderr, "checking scope field...");
+			const char *scope = tagsField (&e, x->scope_kind);
+			if (scope == NULL || strcmp (scope, x->scope_name) != 0)
+			{
+				fprintf (stderr, "unexpected: %s\n", scope? scope: "<NULL>");
+				return 1;
+			}
+			fprintf (stderr, "ok\n");
+		}
+
+		if (x->typeref)
+		{
+			fprintf (stderr, "checking typeref field...");
+			const char *typeref = tagsField (&e, "typeref");
+			if (typeref == NULL || strcmp (typeref, x->typeref) != 0)
+			{
+				fprintf (stderr, "unexpected: %s\n", typeref? typeref: "<NULL>");
+				return 1;
+			}
+			fprintf (stderr, "ok\n");
+		}
+
+		fprintf (stderr, "checking file field...");
+		if (x->fileScope != e.fileScope)
+		{
+			fprintf (stderr, "unexpected\n");
+			return 1;
+		}
+		fprintf (stderr, "ok\n");
+	}
+
+	if (tagsFindNext (t, &e) == TagSuccess)
+		return 1;
+
+	return 0;
+}
+
+static int
+check_finding (const char *tags, const char *name, const int options,
+			   struct expectation *expectations, int count)
+{
+	tagFile *t;
+	tagFileInfo info;
+
+	fprintf (stderr, "opening %s...", tags);
+	t = tagsOpen (tags, &info);
+	if (!t)
+	{
+		fprintf (stderr, "unexpected result (t: %p, opened: %d, error_number: %d)\n",
+				 t, info.status.opened, info.status.error_number);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	if (check_finding0 (t, name, options, expectations, count) != 0)
+		return 1;
+
+	fprintf (stderr, "closing the tag file...");
+	if (tagsClose (t) != TagSuccess)
+	{
+		fprintf (stderr, "unexpected result\n");
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+	return 0;
+}
+
+int
+main (void)
+{
+	char *srcdir = getenv ("srcdir");
+	if (srcdir)
+	{
+		if (chdir (srcdir) == -1)
+		{
+			perror ("chdir");
+			return 99;
+		}
+	}
+
+	/*
+	 * sorted=yes
+	 */
+	const char *tags_sorted_yes = "./duplicated-names--sorted-yes.tags";
+	struct expectation sorted_yes_FULLMATCH_OBSERVECASE [] = {
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^		int n;$/",
+			.kind = "l",
+			.scope_kind = "function",
+			.scope_name = "main",
+			.typeref = "typename:int",
+			.fileScope = 1,
+		},
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^	for (int n = 0; n < 1; n++)$/",
+			.kind = "l",
+			.scope_kind = "function",
+			.scope_name = "main",
+			.typeref = "typename:int",
+			.fileScope = 1,
+		},
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^	int n;$/",
+			.kind = "m",
+			.scope_kind = "struct",
+			.scope_name = "n",
+			.typeref = "typename:int",
+			.fileScope = 1,
+		},
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^int main(int n)$/",
+			.kind = "z",
+			.scope_kind = "function",
+			.scope_name = "main",
+			.typeref = "typename:int",
+			.fileScope = 1,
+		},
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^struct n {$/",
+			.kind = "s",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = NULL,
+			.fileScope = 1,
+		},
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^typedef int n;$/",
+			.kind = "t",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = "typename:int",
+			.fileScope = 1,
+		},
+	};
+
+	struct expectation sorted_yes_FULLMATCH_IGNORECASE [COUNT(sorted_yes_FULLMATCH_OBSERVECASE) + 1] = {
+		[0] = {
+			.name = "N",
+			.file = "input.c",
+			.pattern = "/^int N;$/",
+			.kind = "v",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = "typename:int",
+			.fileScope = 0,
+		},
+	};
+	for (int i = 0; i < COUNT(sorted_yes_FULLMATCH_OBSERVECASE); i++)
+		sorted_yes_FULLMATCH_IGNORECASE [i + 1] = sorted_yes_FULLMATCH_OBSERVECASE [i];
+
+	struct expectation sorted_yes_PARTIALMATCH_OBSERVECASE [] = {
+		{
+			.name = "m",
+			.file = "input.c",
+			.pattern = "/^int m;$/",
+			.kind = "v",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = "typename:int",
+			.fileScope = 0,
+		},
+		{
+			.name = "main",
+			.file = "input.c",
+			.pattern = "/^int main(int n)$/",
+			.kind = "f",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = "typename:int",
+			.fileScope = 0,
+		},
+	};
+
+	struct expectation sorted_yes_PARTIALMATCH_IGNORECASE [COUNT(sorted_yes_PARTIALMATCH_OBSERVECASE) + 1] = {
+		[0] = {
+			.name = "M",
+			.file = "input.c",
+			.pattern = "/^int M (void) { return 0; }$/",
+			.kind = "f",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = "typename:int",
+			.fileScope = 0,
+		},
+	};
+	for (int i = 0; i < COUNT(sorted_yes_PARTIALMATCH_OBSERVECASE); i++)
+		sorted_yes_PARTIALMATCH_IGNORECASE [i + 1] = sorted_yes_PARTIALMATCH_OBSERVECASE [i];
+
+	if (check_finding (tags_sorted_yes, "n", TAG_FULLMATCH|TAG_OBSERVECASE,
+					   sorted_yes_FULLMATCH_OBSERVECASE, COUNT(sorted_yes_FULLMATCH_OBSERVECASE)) != 0)
+		return 1;
+
+	if (check_finding (tags_sorted_yes, "n", TAG_FULLMATCH|TAG_IGNORECASE,
+					   sorted_yes_FULLMATCH_IGNORECASE, COUNT(sorted_yes_FULLMATCH_IGNORECASE)) != 0)
+		return 1;
+
+	if (check_finding (tags_sorted_yes, "m", TAG_PARTIALMATCH|TAG_OBSERVECASE,
+					   sorted_yes_PARTIALMATCH_OBSERVECASE, COUNT(sorted_yes_PARTIALMATCH_OBSERVECASE)) != 0)
+		return 1;
+
+	if (check_finding (tags_sorted_yes, "m", TAG_PARTIALMATCH|TAG_IGNORECASE,
+					   sorted_yes_PARTIALMATCH_IGNORECASE, COUNT(sorted_yes_PARTIALMATCH_IGNORECASE)) != 0)
+		return 1;
+
+
+	/*
+	 * sorted=no
+	 */
+	const char *tags_sorted_no = "./duplicated-names--sorted-no.tags";
+	struct expectation sorted_no_FULLMATCH_OBSERVECASE [] = {
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^struct n {$/",
+			.kind = "s",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = NULL,
+			.fileScope = 1,
+		},
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^	int n;$/",
+			.kind = "m",
+			.scope_kind = "struct",
+			.scope_name = "n",
+			.typeref = "typename:int",
+			.fileScope = 1,
+		},
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^typedef int n;$/",
+			.kind = "t",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = "typename:int",
+			.fileScope = 1,
+		},
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^int main(int n)$/",
+			.kind = "z",
+			.scope_kind = "function",
+			.scope_name = "main",
+			.typeref = "typename:int",
+			.fileScope = 1,
+		},
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^	for (int n = 0; n < 1; n++)$/",
+			.kind = "l",
+			.scope_kind = "function",
+			.scope_name = "main",
+			.typeref = "typename:int",
+			.fileScope = 1,
+		},
+		{
+			.name = "n",
+			.file = "input.c",
+			.pattern = "/^		int n;$/",
+			.kind = "l",
+			.scope_kind = "function",
+			.scope_name = "main",
+			.typeref = "typename:int",
+			.fileScope = 1,
+		},
+	};
+
+	struct expectation sorted_no_FULLMATCH_IGNORECASE [COUNT(sorted_no_FULLMATCH_OBSERVECASE) + 1] = {
+		[0] = {
+			.name = "N",
+			.file = "input.c",
+			.pattern = "/^int N;$/",
+			.kind = "v",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = "typename:int",
+			.fileScope = 0,
+		},
+	};
+	for (int i = 0; i < COUNT(sorted_no_FULLMATCH_OBSERVECASE); i++)
+		sorted_no_FULLMATCH_IGNORECASE [i + 1] = sorted_no_FULLMATCH_OBSERVECASE [i];
+
+	struct expectation sorted_no_PARTIALMATCH_OBSERVECASE [] = {
+		{
+			.name = "main",
+			.file = "input.c",
+			.pattern = "/^int main(int n)$/",
+			.kind = "f",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = "typename:int",
+			.fileScope = 0,
+		},
+		{
+			.name = "m",
+			.file = "input.c",
+			.pattern = "/^int m;$/",
+			.kind = "v",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = "typename:int",
+			.fileScope = 0,
+		},
+	};
+
+	struct expectation sorted_no_PARTIALMATCH_IGNORECASE [COUNT(sorted_no_PARTIALMATCH_OBSERVECASE) + 1] = {
+		[COUNT(sorted_no_PARTIALMATCH_OBSERVECASE)] = {
+			.name = "M",
+			.file = "input.c",
+			.pattern = "/^int M (void) { return 0; }$/",
+			.kind = "f",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = "typename:int",
+			.fileScope = 0,
+		},
+	};
+	for (int i = 0; i < COUNT(sorted_no_PARTIALMATCH_OBSERVECASE); i++)
+		sorted_no_PARTIALMATCH_IGNORECASE [i] = sorted_no_PARTIALMATCH_OBSERVECASE [i];
+
+	if (check_finding (tags_sorted_no, "n", TAG_FULLMATCH|TAG_OBSERVECASE,
+					   sorted_no_FULLMATCH_OBSERVECASE, COUNT(sorted_no_FULLMATCH_OBSERVECASE)) != 0)
+		return 1;
+
+	if (check_finding (tags_sorted_no, "n", TAG_FULLMATCH|TAG_IGNORECASE,
+					   sorted_no_FULLMATCH_IGNORECASE, COUNT(sorted_no_FULLMATCH_IGNORECASE)) != 0)
+		return 1;
+
+	if (check_finding (tags_sorted_no, "m", TAG_PARTIALMATCH|TAG_OBSERVECASE,
+					   sorted_no_PARTIALMATCH_OBSERVECASE, COUNT(sorted_no_PARTIALMATCH_OBSERVECASE)) != 0)
+		return 1;
+
+	if (check_finding (tags_sorted_no, "m", TAG_PARTIALMATCH|TAG_IGNORECASE,
+					   sorted_no_PARTIALMATCH_IGNORECASE, COUNT(sorted_no_PARTIALMATCH_IGNORECASE)) != 0)
+		return 1;
+
+
+	/*
+	 * sorted=foldcase
+	 */
+	const char *tags_sorted_foldcase = "./duplicated-names--sorted-foldcase.tags";
+	struct expectation sorted_foldcase_FULLMATCH_OBSERVECASE [COUNT(sorted_yes_FULLMATCH_OBSERVECASE)];
+	for (int i = 0; i < COUNT(sorted_foldcase_FULLMATCH_OBSERVECASE); i++)
+		sorted_foldcase_FULLMATCH_OBSERVECASE [i] =  sorted_yes_FULLMATCH_OBSERVECASE [i];
+
+	struct expectation sorted_foldcase_FULLMATCH_IGNORECASE [COUNT(sorted_foldcase_FULLMATCH_OBSERVECASE) + 1] = {
+		[4] = {
+			.name = "N",
+			.file = "input.c",
+			.pattern = "/^int N;$/",
+			.kind = "v",
+			.scope_kind = NULL,
+			.scope_name = NULL,
+			.typeref = "typename:int",
+			.fileScope = 0,
+		},
+		[5] = sorted_foldcase_FULLMATCH_OBSERVECASE[4],
+		[6] = sorted_foldcase_FULLMATCH_OBSERVECASE[5],
+	};
+	for (int i = 0; i < 4; i++)
+		sorted_foldcase_FULLMATCH_IGNORECASE [i] = sorted_foldcase_FULLMATCH_OBSERVECASE [i];
+
+	struct expectation sorted_foldcase_PARTIALMATCH_OBSERVECASE [COUNT(sorted_yes_PARTIALMATCH_OBSERVECASE)];
+	for (int i = 0; i < COUNT(sorted_foldcase_PARTIALMATCH_OBSERVECASE); i++)
+		sorted_foldcase_PARTIALMATCH_OBSERVECASE [i] =  sorted_yes_PARTIALMATCH_OBSERVECASE [i];
+
+	struct expectation sorted_foldcase_PARTIALMATCH_IGNORECASE [COUNT(sorted_yes_PARTIALMATCH_IGNORECASE)];
+	for (int i = 0; i < COUNT(sorted_foldcase_PARTIALMATCH_IGNORECASE); i++)
+		sorted_foldcase_PARTIALMATCH_IGNORECASE [i] =  sorted_yes_PARTIALMATCH_IGNORECASE [i];
+
+
+	if (check_finding (tags_sorted_foldcase, "n", TAG_FULLMATCH|TAG_OBSERVECASE,
+					   sorted_foldcase_FULLMATCH_OBSERVECASE, COUNT(sorted_foldcase_FULLMATCH_OBSERVECASE)) != 0)
+		return 1;
+
+	if (check_finding (tags_sorted_foldcase, "n", TAG_FULLMATCH|TAG_IGNORECASE,
+					   sorted_foldcase_FULLMATCH_IGNORECASE, COUNT(sorted_foldcase_FULLMATCH_IGNORECASE)) != 0)
+		return 1;
+
+	if (check_finding (tags_sorted_foldcase, "m", TAG_PARTIALMATCH|TAG_OBSERVECASE,
+					   sorted_foldcase_PARTIALMATCH_OBSERVECASE, COUNT(sorted_foldcase_PARTIALMATCH_OBSERVECASE)) != 0)
+		return 1;
+
+	if (check_finding (tags_sorted_foldcase, "m", TAG_PARTIALMATCH|TAG_IGNORECASE,
+					   sorted_foldcase_PARTIALMATCH_IGNORECASE, COUNT(sorted_foldcase_PARTIALMATCH_IGNORECASE)) != 0)
+		return 1;
+
+
+	return 0;
+}

--- a/libreadtags/tests/test-api-tagsFirstPseudoTag.c
+++ b/libreadtags/tests/test-api-tagsFirstPseudoTag.c
@@ -1,0 +1,240 @@
+/*
+*   Copyright (c) 2020, Masatake YAMATO
+*
+*   This source code is released into the public domain.
+*
+*   Testing tagsFirstPseudoTag() and tagsNextPseudoTag() API functions
+*/
+
+#include "readtags.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+
+struct expectation {
+	char *name;
+	char *file;
+	char *pattern;
+};
+
+#define COUNT(x) (sizeof(x)/sizeof(x[0]))
+
+static int
+check_iterating0 (tagFile *t, struct expectation *expectations, int count)
+{
+	tagEntry e;
+	struct expectation *x;
+
+	for (int i = 0; i < count; i++)
+	{
+		fprintf (stderr, "[%d/%d] interating ptags...", i + 1, count);
+		if (i == 0)
+		{
+			if (tagsFirstPseudoTag (t, &e) != TagSuccess)
+			{
+				fprintf (stderr, "no more ptag\n");
+				return 1;
+			}
+		}
+		else
+		{
+			if (tagsNextPseudoTag (t, &e) != TagSuccess)
+			{
+				fprintf (stderr, "no more ptag\n");
+				return 1;
+			}
+		}
+		fprintf (stderr, "found\n");
+
+		x = expectations + i;
+
+		fprintf (stderr, "checking name field...");
+		if (!(e.name && strcmp (x->name, e.name) == 0))
+		{
+			fprintf (stderr, "unexpected: %s\n", e.name? e.name: "<NULL>");
+			return 1;
+		}
+		fprintf (stderr, "ok\n");
+
+		fprintf (stderr, "checking file field...");
+		if (!(e.file && strcmp (x->file, e.file) == 0))
+		{
+			fprintf (stderr, "unexpected: %s\n", e.file? e.file: "<NULL>");
+			return 1;
+		}
+		fprintf (stderr, "ok\n");
+
+		fprintf (stderr, "checking pattern field...");
+		if (!(e.address.pattern && strcmp (x->pattern, e.address.pattern) == 0))
+		{
+			fprintf (stderr, "unexpected: %s\n",
+					 e.address.pattern? e.address.pattern: "<NULL>");
+			return 1;
+		}
+		fprintf (stderr, "ok\n");
+	}
+
+	fprintf (stderr, "verifying no remain....");
+	if (tagsNextPseudoTag (t, &e) == TagSuccess)
+	{
+		fprintf (stderr, "still existing\n");
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	return 0;
+}
+
+static int
+check_iterating (const char *tags, struct expectation *expectations, int count)
+{
+	tagFile *t;
+	tagFileInfo info;
+
+	fprintf (stderr, "opening %s...", tags);
+	t = tagsOpen (tags, &info);
+	if (!t)
+	{
+		fprintf (stderr, "unexpected result (t: %p, opened: %d, error_number: %d)\n",
+				 t, info.status.opened, info.status.error_number);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	if (check_iterating0 (t, expectations, count) != 0)
+		return 1;
+
+	fprintf (stderr, "closing the tag file...");
+	if (tagsClose (t) != TagSuccess)
+	{
+		fprintf (stderr, "unexpected result\n");
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+	return 0;
+}
+
+int
+main (void)
+{
+	char *srcdir = getenv ("srcdir");
+	if (srcdir)
+	{
+		if (chdir (srcdir) == -1)
+		{
+			perror ("chdir");
+			return 99;
+		}
+	}
+
+	/*
+	 * sorted=yes
+	 */
+	const char *tags_sorted_yes = "./ptag-sort-yes.tags";
+	struct expectation exp_sorted_yes [] = {
+		{ "!_JSON_OUTPUT_VERSION", "0.0", "/in development/", },
+		{ "!_TAG_FILE_FORMAT", "2", "/extended format; --format=1 will not append ;\" to lines/", },
+		{ "!_TAG_FILE_SORTED", "1", "/0=unsorted, 1=sorted, 2=foldcase/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "D,macroparam", "/parameters inside macro definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "L,label", "/goto labels/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "d,macro", "/macro definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "e,enumerator", "/enumerators (values inside an enumeration)/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "f,function", "/function definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "g,enum", "/enumeration names/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "h,header", "/included header files/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "l,local", "/local variables/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "m,member", "/struct, and union members/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "p,prototype", "/function prototypes/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "s,struct", "/structure names/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "t,typedef", "/typedefs/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "u,union", "/union names/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "v,variable", "/variable definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "x,externvar", "/external and forward variable declarations/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "z,parameter", "/function parameters inside function definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "C,custom", "/customizable variables/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "D,derivedMode", "/derived major mode/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "G,group", "/customization groups/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "H,face", "/customizable faces/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "M,minorMode", "/minor modes/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "T,theme", "/custom themes/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "V,varalias", "/aliases for variables/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "a,alias", "/aliases for functions/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "c,const", "/constants/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "e,error", "/errors/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "f,function", "/functions/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "i,inline", "/inline function/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "m,macro", "/macros/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "s,subst", "/inline function/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "u,unknown", "/unknown type of definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "v,variable", "/variables/", },
+		{ "!_TAG_OUTPUT_FILESEP", "slash", "/slash or backslash/", },
+		{ "!_TAG_OUTPUT_MODE", "u-ctags", "/u-ctags or e-ctags/", },
+		{ "!_TAG_PATTERN_LENGTH_LIMIT", "96", "/0 for no limit/", },
+		{ "!_TAG_PROGRAM_AUTHOR", "Universal Ctags Team", "//", },
+		{ "!_TAG_PROGRAM_NAME", "Universal Ctags", "/Derived from Exuberant Ctags/", },
+		{ "!_TAG_PROGRAM_URL", "https://ctags.io/", "/official site/", },
+		{ "!_TAG_PROGRAM_VERSION", "0.0.0", "/9b73623f/", },
+	};
+
+	if (check_iterating (tags_sorted_yes, exp_sorted_yes, COUNT(exp_sorted_yes)) != 0)
+		return 1;
+
+
+	/*
+	 * sorted=no
+	 */
+	const char *tags_sorted_no = "./ptag-sort-no.tags";
+	struct expectation exp_sorted_no [] = {
+		{ "!_JSON_OUTPUT_VERSION", "0.0", "/in development/", },
+		{ "!_TAG_FILE_FORMAT", "2", "/extended format; --format=1 will not append ;\" to lines/", },
+		{ "!_TAG_FILE_SORTED", "0", "/0=unsorted, 1=sorted, 2=foldcase/", },
+		{ "!_TAG_PROGRAM_AUTHOR", "Universal Ctags Team", "//", },
+		{ "!_TAG_PROGRAM_NAME", "Universal Ctags", "/Derived from Exuberant Ctags/", },
+		{ "!_TAG_PROGRAM_URL", "https://ctags.io/", "/official site/", },
+		{ "!_TAG_PROGRAM_VERSION", "0.0.0", "/9b73623f/", },
+		{ "!_TAG_OUTPUT_MODE", "u-ctags", "/u-ctags or e-ctags/", },
+		{ "!_TAG_OUTPUT_FILESEP", "slash", "/slash or backslash/", },
+		{ "!_TAG_PATTERN_LENGTH_LIMIT", "96", "/0 for no limit/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "d,macro", "/macro definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "e,enumerator", "/enumerators (values inside an enumeration)/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "f,function", "/function definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "g,enum", "/enumeration names/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "h,header", "/included header files/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "l,local", "/local variables/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "m,member", "/struct, and union members/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "p,prototype", "/function prototypes/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "s,struct", "/structure names/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "t,typedef", "/typedefs/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "u,union", "/union names/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "v,variable", "/variable definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "x,externvar", "/external and forward variable declarations/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "z,parameter", "/function parameters inside function definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "L,label", "/goto labels/", },
+		{ "!_TAG_KIND_DESCRIPTION!C", "D,macroparam", "/parameters inside macro definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "u,unknown", "/unknown type of definitions/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "f,function", "/functions/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "v,variable", "/variables/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "c,const", "/constants/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "m,macro", "/macros/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "a,alias", "/aliases for functions/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "V,varalias", "/aliases for variables/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "s,subst", "/inline function/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "i,inline", "/inline function/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "e,error", "/errors/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "M,minorMode", "/minor modes/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "D,derivedMode", "/derived major mode/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "C,custom", "/customizable variables/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "G,group", "/customization groups/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "H,face", "/customizable faces/", },
+		{ "!_TAG_KIND_DESCRIPTION!EmacsLisp", "T,theme", "/custom themes/", },
+	};
+
+	if (check_iterating (tags_sorted_no, exp_sorted_no, COUNT(exp_sorted_no)) != 0)
+		return 1;
+
+
+	return 0;
+}

--- a/libreadtags/tests/test-api-tagsOpen.c
+++ b/libreadtags/tests/test-api-tagsOpen.c
@@ -1,0 +1,161 @@
+/*
+*   Copyright (c) 2020, Masatake YAMATO
+*
+*   This source code is released into the public domain.
+*
+*   Testing tagsOpen() API function
+*/
+
+#include "readtags.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+
+static int
+check_info (tagFileInfo *info, tagFileInfo *expected)
+{
+
+	fprintf (stderr, "inspecting info->file.format...");
+	if (info->file.format != expected->file.format)
+	{
+		fprintf (stderr, "unexpected result: %d\n", info->file.format);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	fprintf (stderr, "inspecting info->file.sort...");
+	if (info->file.sort != expected->file.sort)
+	{
+		fprintf (stderr, "unexpected result: %d\n", info->file.sort);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	fprintf (stderr, "inspecting info->program.author...");
+	if (strcmp (info->program.author, expected->program.author))
+	{
+		fprintf (stderr, "unexpected result: %s\n", info->program.author);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	fprintf (stderr, "inspecting info->program.name...");
+	if (strcmp (info->program.name, expected->program.name))
+	{
+		fprintf (stderr, "unexpected result: %s\n", info->program.name);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	fprintf (stderr, "inspecting info->program.url...");
+	if (strcmp (info->program.url, expected->program.url))
+	{
+		fprintf (stderr, "unexpected result: %s\n", info->program.url);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	fprintf (stderr, "inspecting info->program.version...");
+	if (strcmp (info->program.version, expected->program.version))
+	{
+		fprintf (stderr, "unexpected result: %s\n", expected->program.version);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	return 0;
+}
+
+int
+main (void)
+{
+	char *srcdir = getenv ("srcdir");
+	if (srcdir)
+	{
+		if (chdir (srcdir) == -1)
+		{
+			perror ("chdir");
+			return 99;
+		}
+	}
+
+	tagFile *t;
+	tagFileInfo info;
+
+	const char *tags0 = "./no-such-file.tags";
+	fprintf (stderr, "opening no-existing tags file...");
+	t = tagsOpen (tags0, &info);
+	if (! (t == NULL
+		   && info.status.opened == 0
+		   && info.status.error_number != 0))
+	{
+		fprintf (stderr, "unexpected result (t: %p, opened: %d, error_number: %d)\n",
+				 t, info.status.opened, info.status.error_number);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	fprintf (stderr, "opening no-existing tags file with NULL tagFileInfo...");
+	t = tagsOpen (tags0, NULL);
+	if (t != NULL)
+	{
+		fprintf (stderr, "unexpected result (t: %p)\n", t);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	tagFileInfo expected1 = {
+		.file.format = 2,
+		.file.sort = TAG_SORTED,
+		.program.author = "Darren Hiebert",
+		.program.name = "Exuberant Ctags",
+		.program.url = "http://ctags.sourceforge.net",
+		.program.version = "5.8",
+	};
+	const char *tags1 = "./api-tagsOpen-ectags.tags";
+	fprintf (stderr, "opening an existing tags file...");
+	t = tagsOpen (tags1, &info);
+	if (t == NULL
+		|| info.status.opened == 0)
+	{
+		fprintf (stderr, "unexpected result (t: %p, opened: %d)\n",
+				 t, info.status.opened);
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+
+	if (check_info (&info, &expected1) != 0)
+		return 1;
+
+	fprintf (stderr, "closing the tag file...");
+	if (tagsClose (t) != TagSuccess)
+	{
+		fprintf (stderr, "unexpected result\n");
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	fprintf (stderr, "opening an existing tags file with NULL tagFileInfo...");
+	t = tagsOpen (tags1, NULL);
+	if (t == NULL)
+	{
+		fprintf (stderr, "unexpected result\n");
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+	fprintf (stderr, "closing the tag file...");
+	if (tagsClose (t) != TagSuccess)
+	{
+		fprintf (stderr, "unexpected result\n");
+		return 1;
+	}
+	fprintf (stderr, "ok\n");
+
+
+	return 0;
+}

--- a/misc/pull-libreadtags.sh
+++ b/misc/pull-libreadtags.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Update to the latest packcc
+#
+# Copyright (C) 2020 Universal Ctags Team
+# License: GPL 2 or later
+
+cd $(git rev-parse --show-toplevel)
+git subtree pull --prefix libreadtags https://github.com/universal-ctags/libreadtags.git master --squash

--- a/readtags-cmd/readtags-cmd.c
+++ b/readtags-cmd/readtags-cmd.c
@@ -108,7 +108,7 @@ static void findTag (const char *const name, const int options)
 	}
 }
 
-static void listTags (void)
+static void listTags (int pseudoTags)
 {
 	tagFileInfo info;
 	tagEntry entry;
@@ -118,6 +118,12 @@ static void listTags (void)
 		fprintf (stderr, "%s: cannot open tag file: %s: %s\n",
 				ProgramName, strerror (info.status.error_number), TagFileName);
 		exit (1);
+	}
+	else if (pseudoTags)
+	{
+		if (tagsFirstPseudoTag (file, &entry) == TagSuccess)
+			walkTags (file, &entry, tagsNextPseudoTag, printTag);
+		tagsClose (file);
 	}
 	else
 	{
@@ -138,6 +144,7 @@ static const char *const Usage =
 	"[-s[0|1]] [-t file] [-] [name(s)]\n\n"
 	"Options:\n"
 	"    -d           Turn on debugging output.\n"
+	"    -D           List all pseudo tags.\n"
 	"    -e           Include extension fields in output.\n"
 	"    -h           Print this help message.\n"
 	"    -i           Perform case-insensitive matching.\n"
@@ -216,11 +223,12 @@ extern int main (int argc, char **argv)
 				switch (arg [j])
 				{
 					case 'd': debugMode++; break;
+					case 'D': listTags (1); actionSupplied = 1; break;
 					case 'h': printUsage (stdout, 0); break;
 					case 'e': extensionFields = 1;         break;
 					case 'i': options |= TAG_IGNORECASE;   break;
 					case 'p': options |= TAG_PARTIALMATCH; break;
-					case 'l': listTags (); actionSupplied = 1; break;
+					case 'l': listTags (0); actionSupplied = 1; break;
 					case 'n': allowPrintLineNumber = 1; break;
 					case 't':
 						if (arg [j+1] != '\0')


### PR DESCRIPTION
This pull request adds -D option to readtags.

With -D option, readtags can dump all the pseudo tags including newly introduced ones in u-ctags.
Behind the -D option, the API of libreadtags is extended. The extended API is must for implementing multi-pass parsers.