### PR TITLE
Cxx: attach the end: field to a prototype kind tag

### DIFF
--- a/Units/parser-cxx.r/cxx11enum.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11enum.cpp.d/expected.tags
@@ -46,6 +46,6 @@ CEC1	input.cpp	/^	enum class CEC1 : unsigned long int { CEC1_member1 };$/;"	g	cl
 CEC1_member1	input.cpp	/^	enum class CEC1 : unsigned long int { CEC1_member1 };$/;"	e	enum:Class::CEC1	file:
 CES1	input.cpp	/^	enum struct CES1 : int { CES1_member1 };$/;"	g	class:Class	typeref:typename:int	file:	end:30	properties:scopedenum
 CES1_member1	input.cpp	/^	enum struct CES1 : int { CES1_member1 };$/;"	e	enum:Class::CES1	file:
-Function1	input.cpp	/^	virtual enum CEC1 Function1(enum CE1 parameter);$/;"	p	class:Class	typeref:enum:CEC1	file:	properties:virtual
+Function1	input.cpp	/^	virtual enum CEC1 Function1(enum CE1 parameter);$/;"	p	class:Class	typeref:enum:CEC1	file:	end:31	properties:virtual
 E1_var1	input.cpp	/^enum E1 E1_var1;$/;"	v	typeref:enum:E1	end:41
 EC1_var1	input.cpp	/^enum EC1 EC1_var1[10][10];$/;"	v	typeref:enum:EC1[10][10]	end:42

--- a/Units/parser-cxx.r/end-field-for-prototype-kind.d/args.ctags
+++ b/Units/parser-cxx.r/end-field-for-prototype-kind.d/args.ctags
@@ -1,0 +1,2 @@
+--fields=+ne
+--kinds-C++=p

--- a/Units/parser-cxx.r/end-field-for-prototype-kind.d/expected.tags
+++ b/Units/parser-cxx.r/end-field-for-prototype-kind.d/expected.tags
@@ -1,0 +1,1 @@
+main	input.h	/^main$/;"	p	line:2	typeref:typename:int	end:11

--- a/Units/parser-cxx.r/end-field-for-prototype-kind.d/input.h
+++ b/Units/parser-cxx.r/end-field-for-prototype-kind.d/input.h
@@ -1,0 +1,11 @@
+int
+main
+(
+	int
+	argc
+	,
+	char
+	*
+	*
+	argv
+	);

--- a/Units/parser-cxx.r/function-return-types.d/expected.tags
+++ b/Units/parser-cxx.r/function-return-types.d/expected.tags
@@ -1,22 +1,22 @@
-p00	input.cpp	/^void p00();$/;"	p	typeref:typename:void	file:
-p01	input.cpp	/^int p01();$/;"	p	typeref:typename:int	file:
-p02	input.cpp	/^unsigned int p02();$/;"	p	typeref:typename:unsigned int	file:
-p03	input.cpp	/^auto p03() -> int;$/;"	p	typeref:typename:int	file:
-p04	input.cpp	/^int * p04();$/;"	p	typeref:typename:int *	file:
-p05	input.cpp	/^const unsigned long long int & p05();$/;"	p	typeref:typename:const unsigned long long int &	file:
-p06	input.cpp	/^static inline int * p06();$/;"	p	typeref:typename:int *	file:
-p07	input.cpp	/^std::string & p07();$/;"	p	typeref:typename:std::string &	file:
-p08	input.cpp	/^std::vector<std::string> * p08();$/;"	p	typeref:typename:std::vector<std::string> *	file:
-p09	input.cpp	/^auto p09() -> std::vector<std::string> ***;$/;"	p	typeref:typename:std::vector<std::string> ***	file:
-p10	input.cpp	/^auto p10() -> std::string;$/;"	p	typeref:typename:std::string	file:
-p11	input.cpp	/^auto p11() -> int (*)(int);$/;"	p	typeref:typename:int (*)(int)	file:
-p12	input.cpp	/^struct Struct p12();$/;"	p	typeref:struct:Struct	file:
-p13	input.cpp	/^Struct p13();$/;"	p	typeref:typename:Struct	file:
-p14	input.cpp	/^union Union p14();$/;"	p	typeref:union:Union	file:
-p15	input.cpp	/^Union p15();$/;"	p	typeref:typename:Union	file:
-p16	input.cpp	/^Class & p16();$/;"	p	typeref:typename:Class &	file:
-p17	input.cpp	/^const enum Enum p17();$/;"	p	typeref:typename:const enum Enum	file:
-p18	input.cpp	/^Enum p18();$/;"	p	typeref:typename:Enum	file:
+p00	input.cpp	/^void p00();$/;"	p	typeref:typename:void	file:	end:20
+p01	input.cpp	/^int p01();$/;"	p	typeref:typename:int	file:	end:21
+p02	input.cpp	/^unsigned int p02();$/;"	p	typeref:typename:unsigned int	file:	end:22
+p03	input.cpp	/^auto p03() -> int;$/;"	p	typeref:typename:int	file:	end:23
+p04	input.cpp	/^int * p04();$/;"	p	typeref:typename:int *	file:	end:24
+p05	input.cpp	/^const unsigned long long int & p05();$/;"	p	typeref:typename:const unsigned long long int &	file:	end:25
+p06	input.cpp	/^static inline int * p06();$/;"	p	typeref:typename:int *	file:	end:26
+p07	input.cpp	/^std::string & p07();$/;"	p	typeref:typename:std::string &	file:	end:27
+p08	input.cpp	/^std::vector<std::string> * p08();$/;"	p	typeref:typename:std::vector<std::string> *	file:	end:28
+p09	input.cpp	/^auto p09() -> std::vector<std::string> ***;$/;"	p	typeref:typename:std::vector<std::string> ***	file:	end:29
+p10	input.cpp	/^auto p10() -> std::string;$/;"	p	typeref:typename:std::string	file:	end:30
+p11	input.cpp	/^auto p11() -> int (*)(int);$/;"	p	typeref:typename:int (*)(int)	file:	end:31
+p12	input.cpp	/^struct Struct p12();$/;"	p	typeref:struct:Struct	file:	end:32
+p13	input.cpp	/^Struct p13();$/;"	p	typeref:typename:Struct	file:	end:33
+p14	input.cpp	/^union Union p14();$/;"	p	typeref:union:Union	file:	end:34
+p15	input.cpp	/^Union p15();$/;"	p	typeref:typename:Union	file:	end:35
+p16	input.cpp	/^Class & p16();$/;"	p	typeref:typename:Class &	file:	end:37
+p17	input.cpp	/^const enum Enum p17();$/;"	p	typeref:typename:const enum Enum	file:	end:38
+p18	input.cpp	/^Enum p18();$/;"	p	typeref:typename:Enum	file:	end:39
 f00	input.cpp	/^void f00()$/;"	f	typeref:typename:void	end:43
 f01	input.cpp	/^int f01()$/;"	f	typeref:typename:int	end:48
 f02	input.cpp	/^unsigned int f02()$/;"	f	typeref:typename:unsigned int	end:53
@@ -31,15 +31,15 @@ f10	input.cpp	/^auto f10() -> std::string$/;"	f	typeref:typename:std::string	end
 f11	input.cpp	/^auto f11() -> int (*)(int)$/;"	f	typeref:typename:int (*)(int)	end:101
 f13	input.cpp	/^template<typename A> std::vector<A> * f13()$/;"	f	typeref:typename:std::vector<A> *	end:106	template:<typename A>
 f14	input.cpp	/^template<typename A> auto f14() -> std::vector<A> *$/;"	f	typeref:typename:std::vector<A> *	end:111	template:<typename A>
-m00	input.cpp	/^	void m00();$/;"	p	class:X	typeref:typename:void	file:
+m00	input.cpp	/^	void m00();$/;"	p	class:X	typeref:typename:void	file:	end:116
 m01	input.cpp	/^	constexpr int m01(){ return 0; };$/;"	f	class:X	typeref:typename:int	file:	end:117
-m02	input.cpp	/^	unsigned int m02();$/;"	p	class:X	typeref:typename:unsigned int	file:
-m03	input.cpp	/^	static auto m03() -> int;$/;"	p	class:X	typeref:typename:int	file:
-m04	input.cpp	/^	int * m04();$/;"	p	class:X	typeref:typename:int *	file:
-m05	input.cpp	/^	const unsigned long long int & m05();$/;"	p	class:X	typeref:typename:const unsigned long long int &	file:
-m06	input.cpp	/^	static inline int * m06();$/;"	p	class:X	typeref:typename:int *	file:
-m07	input.cpp	/^	virtual std::string & m07();$/;"	p	class:X	typeref:typename:std::string &	file:
-m08	input.cpp	/^	std::vector<std::string> * m08();$/;"	p	class:X	typeref:typename:std::vector<std::string> *	file:
-m09	input.cpp	/^	auto m09() -> std::vector<std::string> ***;$/;"	p	class:X	typeref:typename:std::vector<std::string> ***	file:
-m10	input.cpp	/^	virtual auto m10() const -> std::string;$/;"	p	class:X	typeref:typename:std::string	file:
-m11	input.cpp	/^	virtual auto m11() const -> int (*)(int);$/;"	p	class:X	typeref:typename:int (*)(int)	file:
+m02	input.cpp	/^	unsigned int m02();$/;"	p	class:X	typeref:typename:unsigned int	file:	end:118
+m03	input.cpp	/^	static auto m03() -> int;$/;"	p	class:X	typeref:typename:int	file:	end:119
+m04	input.cpp	/^	int * m04();$/;"	p	class:X	typeref:typename:int *	file:	end:120
+m05	input.cpp	/^	const unsigned long long int & m05();$/;"	p	class:X	typeref:typename:const unsigned long long int &	file:	end:121
+m06	input.cpp	/^	static inline int * m06();$/;"	p	class:X	typeref:typename:int *	file:	end:122
+m07	input.cpp	/^	virtual std::string & m07();$/;"	p	class:X	typeref:typename:std::string &	file:	end:123
+m08	input.cpp	/^	std::vector<std::string> * m08();$/;"	p	class:X	typeref:typename:std::vector<std::string> *	file:	end:124
+m09	input.cpp	/^	auto m09() -> std::vector<std::string> ***;$/;"	p	class:X	typeref:typename:std::vector<std::string> ***	file:	end:125
+m10	input.cpp	/^	virtual auto m10() const -> std::string;$/;"	p	class:X	typeref:typename:std::string	file:	end:126
+m11	input.cpp	/^	virtual auto m11() const -> int (*)(int);$/;"	p	class:X	typeref:typename:int (*)(int)	file:	end:127

--- a/Units/parser-cxx.r/functions.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/functions.cpp.d/expected.tags
@@ -9,7 +9,7 @@ f03a02	input.cpp	/^auto f03(const int & f03a01,void * f03a02) -> const int &$/;"
 f04	input.cpp	/^auto f04() -> int (*)(int)$/;"	f	typeref:typename:int (*)(int)	signature:()	end:49
 f05	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	f	typeref:typename:std::string	file:	signature:(const int *** f05a01)	end:54
 f05a01	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	z	function:f05	typeref:typename:const int ***	file:
-f06	input.cpp	/^		auto f06(n01::c01 && f06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && f06a01)
+f06	input.cpp	/^		auto f06(n01::c01 && f06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && f06a01)	end:15
 f06	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	f	class:n01::n02	typeref:typename:n01::n02::type01 *	signature:(n01::c01 && f06a01)	end:59
 f06a01	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	z	function:n01::n02::f06	typeref:typename:n01::c01 &&	file:
 f07	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	f	typeref:typename:unsigned int	signature:(int (* f07a01)(int * x1,int x2),...)	end:64
@@ -24,15 +24,15 @@ f10a02	input.cpp	/^int f10(int f10a01,int f10a02[],int f10a03[2][3],int (f10a04)
 f10a03	input.cpp	/^int f10(int f10a01,int f10a02[],int f10a03[2][3],int (f10a04)[],int (f10a05)[][5])$/;"	z	function:f10	typeref:typename:int[2][3]	file:
 f10a04	input.cpp	/^int f10(int f10a01,int f10a02[],int f10a03[2][3],int (f10a04)[],int (f10a05)[][5])$/;"	z	function:f10	typeref:typename:int ()[]	file:
 f10a05	input.cpp	/^int f10(int f10a01,int f10a02[],int f10a03[2][3],int (f10a04)[],int (f10a05)[][5])$/;"	z	function:f10	typeref:typename:int ()[][5]	file:
-p01	input.cpp	/^int p01(int p01a01,int p01a02);$/;"	p	typeref:typename:int	file:	signature:(int p01a01,int p01a02)
-p02	input.cpp	/^unsigned short int * p02(unsigned int & p02a01,...);$/;"	p	typeref:typename:unsigned short int *	file:	signature:(unsigned int & p02a01,...)
-p03	input.cpp	/^auto p03(const int & p03a01,void * p03a02) -> const int &;$/;"	p	typeref:typename:const int &	file:	signature:(const int & p03a01,void * p03a02)
-p04	input.cpp	/^auto p04() -> int (*)(int);$/;"	p	typeref:typename:int (*)(int)	file:	signature:()
-p05	input.cpp	/^static std::string p05(const int *** p05a01);$/;"	p	typeref:typename:std::string	file:	signature:(const int *** p05a01)
-p06	input.cpp	/^		auto p06(n01::c01 && p06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && p06a01)
-p06	input.cpp	/^auto n01::n02::p06(n01::c01 && p06a01) -> n01::n02::type01 *;$/;"	p	class:n01::n02	typeref:typename:n01::n02::type01 *	file:	signature:(n01::c01 && p06a01)
-p07	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	p	typeref:typename:unsigned int	file:	signature:(int (* p07a01)(int * x1,int x2),...)
-p08	input.cpp	/^void (*p08(void (*)(int *p08a01)))(int *);$/;"	p	typeref:typename:void (*)(int *)	file:	signature:(void (*)(int * p08a01))
+p01	input.cpp	/^int p01(int p01a01,int p01a02);$/;"	p	typeref:typename:int	file:	signature:(int p01a01,int p01a02)	end:21
+p02	input.cpp	/^unsigned short int * p02(unsigned int & p02a01,...);$/;"	p	typeref:typename:unsigned short int *	file:	signature:(unsigned int & p02a01,...)	end:22
+p03	input.cpp	/^auto p03(const int & p03a01,void * p03a02) -> const int &;$/;"	p	typeref:typename:const int &	file:	signature:(const int & p03a01,void * p03a02)	end:23
+p04	input.cpp	/^auto p04() -> int (*)(int);$/;"	p	typeref:typename:int (*)(int)	file:	signature:()	end:24
+p05	input.cpp	/^static std::string p05(const int *** p05a01);$/;"	p	typeref:typename:std::string	file:	signature:(const int *** p05a01)	end:25
+p06	input.cpp	/^		auto p06(n01::c01 && p06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && p06a01)	end:16
+p06	input.cpp	/^auto n01::n02::p06(n01::c01 && p06a01) -> n01::n02::type01 *;$/;"	p	class:n01::n02	typeref:typename:n01::n02::type01 *	file:	signature:(n01::c01 && p06a01)	end:26
+p07	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	p	typeref:typename:unsigned int	file:	signature:(int (* p07a01)(int * x1,int x2),...)	end:27
+p08	input.cpp	/^void (*p08(void (*)(int *p08a01)))(int *);$/;"	p	typeref:typename:void (*)(int *)	file:	signature:(void (*)(int * p08a01))	end:28
 t01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t01a01)	end:85
 t01a01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	z	function:t01	typeref:typename:T &&	file:
 t02	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t02a01)	end:94

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1485,7 +1485,13 @@ check_function_signature:
 			// out its proper scope. Better avoid emitting this one.
 			CXX_DEBUG_PRINT("But it has been preceded by the 'friend' keyword: this is not a real prototype");
 		} else {
-			int iScopesPushed = cxxParserEmitFunctionTags(&oInfo,CXXTagKindPROTOTYPE,CXXEmitFunctionTagsPushScopes,NULL);
+			int piCorkQueueIndex;
+			int iScopesPushed = cxxParserEmitFunctionTags(&oInfo,CXXTagKindPROTOTYPE,CXXEmitFunctionTagsPushScopes, &piCorkQueueIndex);
+			if (piCorkQueueIndex != CORK_NIL)
+			{
+				CXXToken * t = cxxTokenChainLast(g_cxx.pTokenChain);
+				cxxParserSetEndLineForTagInCorkQueue (piCorkQueueIndex, t->iLineNumber);
+			}
 			while(iScopesPushed > 0)
 			{
 				cxxScopePop();


### PR DESCRIPTION
Close #2474.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>
```
[jet@living]~/var/ctags% ./ctags --fields=+e --kinds-C++=p -o - ./input.h
main	./input.h	/^main$/;"	p	typeref:typename:int	end:8
[jet@living]~/var/ctags% cat -n input.h                                  
     1	int
     2	main
     3	(
     4		int
     5		argc,
     6		char **
     7		argv
     8		);
[jet@living]~/var/ctags% ./ctags --fields=+e --kinds-C++=p -o - ./input.h
main	./input.h	/^main$/;"	p	typeref:typename:int	end:8
```