### PR TITLE
Ruby: extend mixin field

### DIFF
--- a/Units/parser-ruby.r/ruby-mixin-field.d/expected.tags
+++ b/Units/parser-ruby.r/ruby-mixin-field.d/expected.tags
@@ -6,3 +6,11 @@ A	input.rb	/^class A$/;"	c	mixin:include:X,include:Y
 hi	input.rb	/^  def hi$/;"	f	class:A
 B	input.rb	/^class B$/;"	c	mixin:include:X
 prep	input.rb	/^  def self.prep$/;"	S	class:B
+C	input.rb	/^class C$/;"	c	mixin:prepend:X,prepend:Y
+hi	input.rb	/^  def hi$/;"	f	class:C
+D	input.rb	/^class D$/;"	c	mixin:prepend:X
+prep	input.rb	/^  def self.prep$/;"	S	class:D
+E	input.rb	/^class E$/;"	c	mixin:extend:X,extend:Y
+hi	input.rb	/^  def hi$/;"	f	class:E
+F	input.rb	/^class F$/;"	c	mixin:extend:X
+prep	input.rb	/^  def self.prep$/;"	S	class:F

--- a/Units/parser-ruby.r/ruby-mixin-field.d/input.rb
+++ b/Units/parser-ruby.r/ruby-mixin-field.d/input.rb
@@ -25,3 +25,31 @@ class B
     include X
   end
 end
+
+class C
+  prepend X
+  def hi
+    p "Calling 'hi' in C."
+  end
+  prepend Y
+end
+
+class D
+  def self.prep
+    prepend X
+  end
+end
+
+class E
+  extend X
+  def hi
+    p "Calling 'hi' in E."
+  end
+  extend Y
+end
+
+class F
+  def self.prep
+    extend X
+  end
+end

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -635,6 +635,14 @@ static void findRubyTags (void)
 		{
 			readAndStoreMixinSpec (&cp, "include");
 		}
+		else if (canMatchKeywordWithAssign (&cp, "prepend"))
+		{
+			readAndStoreMixinSpec (&cp, "prepend");
+		}
+		else if (canMatchKeywordWithAssign (&cp, "extend"))
+		{
+			readAndStoreMixinSpec (&cp, "extend");
+		}
 		else if (canMatchKeywordWithAssign (&cp, "def"))
 		{
 			rubyKind kind = K_METHOD;


### PR DESCRIPTION
The solution developed in https://github.com/universal-ctags/ctags/pull/2478 is extended to deal with "prepend" and "extend" methods.

One thing I've noticed is `include`, `prepend` and `extend` are all methods, so it's valid to write:

``` ruby
class A
  prepend(X)
end
``` 
But it's not handled by current scheme.
