### PR TITLE
Ruby: fix a typo in accessing elements in the mixin spec array

### DIFF
--- a/Units/parser-ruby.r/ruby-mixin-field.d/expected.tags
+++ b/Units/parser-ruby.r/ruby-mixin-field.d/expected.tags
@@ -2,6 +2,8 @@ X	input.rb	/^module X$/;"	m
 hi	input.rb	/^  def hi$/;"	f	module:X
 Y	input.rb	/^module Y$/;"	m
 hoi	input.rb	/^  def hoi$/;"	f	module:Y
+Z	input.rb	/^module Z$/;"	m
+zoo	input.rb	/^  def zoo$/;"	f	module:Z
 A	input.rb	/^class A$/;"	c	mixin:include:X,include:Y
 hi	input.rb	/^  def hi$/;"	f	class:A
 B	input.rb	/^class B$/;"	c	mixin:include:X
@@ -10,7 +12,7 @@ C	input.rb	/^class C$/;"	c	mixin:prepend:X,prepend:Y
 hi	input.rb	/^  def hi$/;"	f	class:C
 D	input.rb	/^class D$/;"	c	mixin:prepend:X
 prep	input.rb	/^  def self.prep$/;"	S	class:D
-E	input.rb	/^class E$/;"	c	mixin:extend:X,extend:Y
+E	input.rb	/^class E$/;"	c	mixin:extend:X,extend:Y,extend:Z
 hi	input.rb	/^  def hi$/;"	f	class:E
 F	input.rb	/^class F$/;"	c	mixin:extend:X
 prep	input.rb	/^  def self.prep$/;"	S	class:F

--- a/Units/parser-ruby.r/ruby-mixin-field.d/input.rb
+++ b/Units/parser-ruby.r/ruby-mixin-field.d/input.rb
@@ -12,6 +12,12 @@ module Y
   end
 end
 
+module Z
+  def zoo
+    p "Calling 'zoo' in Z."
+  end
+end
+
 class A
   include X
   def hi
@@ -46,6 +52,7 @@ class E
     p "Calling 'hi' in E."
   end
   extend Y
+  extend Z
 end
 
 class F

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -518,7 +518,7 @@ static void attachMixinField (int corkIndex, stringList *mixinSpec)
 	for (unsigned int i = 1; i < stringListCount (mixinSpec); i++)
 	{
 		vStringPut (mixinField, ',');
-		vStringCat (mixinField, stringListItem (mixinSpec, 1));
+		vStringCat (mixinField, stringListItem (mixinSpec, i));
 	}
 
 	attachParserFieldToCorkEntry (corkIndex, RubyFields [F_MIXIN].ftype,


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>