### PR TITLE
Ruby: improve mixin detection

### DIFF
--- a/Units/parser-ruby.r/ruby-mixin-field.d/expected.tags
+++ b/Units/parser-ruby.r/ruby-mixin-field.d/expected.tags
@@ -18,3 +18,5 @@ F	input.rb	/^class F$/;"	c	mixin:extend:X
 prep	input.rb	/^  def self.prep$/;"	S	class:F
 G	input.rb	/^class G$/;"	c	mixin:include:X,prepend:Y,extend:Z
 prep	input.rb	/^  def self.prep$/;"	S	class:G
+H	input.rb	/^class H$/;"	c	mixin:include:X,prepend:Y,extend:Z
+prep	input.rb	/^  def self.prep$/;"	S	class:H

--- a/Units/parser-ruby.r/ruby-mixin-field.d/expected.tags
+++ b/Units/parser-ruby.r/ruby-mixin-field.d/expected.tags
@@ -16,3 +16,5 @@ E	input.rb	/^class E$/;"	c	mixin:extend:X,extend:Y,extend:Z
 hi	input.rb	/^  def hi$/;"	f	class:E
 F	input.rb	/^class F$/;"	c	mixin:extend:X
 prep	input.rb	/^  def self.prep$/;"	S	class:F
+G	input.rb	/^class G$/;"	c	mixin:include:X,prepend:Y,extend:Z
+prep	input.rb	/^  def self.prep$/;"	S	class:G

--- a/Units/parser-ruby.r/ruby-mixin-field.d/input.rb
+++ b/Units/parser-ruby.r/ruby-mixin-field.d/input.rb
@@ -60,3 +60,11 @@ class F
     extend X
   end
 end
+
+class G
+  include(X)
+  def self.prep
+    prepend (Y)
+  end
+  extend ( Z)
+end

--- a/Units/parser-ruby.r/ruby-mixin-field.d/input.rb
+++ b/Units/parser-ruby.r/ruby-mixin-field.d/input.rb
@@ -68,3 +68,19 @@ class G
   end
   extend ( Z)
 end
+
+class H
+  if true
+    unless false
+      include(X)
+    end
+  end
+  def self.prep
+    if true
+      unless false
+        prepend (Y)
+      end
+    end
+  end
+  extend ( Z)
+end

--- a/main/nestlevel.c
+++ b/main/nestlevel.c
@@ -100,23 +100,19 @@ extern void nestingLevelsPop(NestingLevels *nls)
 	nls->n--;
 }
 
-extern NestingLevel *nestingLevelsGetCurrent(const NestingLevels *nls)
-{
-	Assert (nls != NULL);
-
-	if (nls->n < 1)
-		return NULL;
-
-	return NL_NTH(nls, (nls->n - 1));
-}
-
-extern NestingLevel *nestingLevelsGetNth(const NestingLevels *nls, int n)
+extern NestingLevel *nestingLevelsGetNthFromRoot (const NestingLevels *nls, int n)
 {
 	Assert (nls != NULL);
 	if (nls->n > n && n >= 0)
 		return  NL_NTH(nls, n);
 	else
 		return NULL;
+}
+
+extern NestingLevel *nestingLevelsGetNthParent (const NestingLevels *nls, int n)
+{
+	Assert (nls != NULL);
+	return nestingLevelsGetNthFromRoot (nls, nls->n - 1 - n);
 }
 
 extern void *nestingLevelGetUserData (const NestingLevel *nl)

--- a/main/nestlevel.h
+++ b/main/nestlevel.h
@@ -48,8 +48,9 @@ extern void nestingLevelsFree(NestingLevels *nls);
 extern NestingLevel *nestingLevelsPush(NestingLevels *nls, int corkIndex);
 extern NestingLevel * nestingLevelsTruncate(NestingLevels *nls, int depth, int corkIndex);
 extern void nestingLevelsPop(NestingLevels *nls);
-extern NestingLevel *nestingLevelsGetCurrent(const NestingLevels *nls);
-extern NestingLevel *nestingLevelsGetNth(const NestingLevels *nls, int n);
+#define nestingLevelsGetCurrent(NLS) nestingLevelsGetNthParent((NLS), 0)
+extern NestingLevel *nestingLevelsGetNthFromRoot(const NestingLevels *nls, int n);
+extern NestingLevel *nestingLevelsGetNthParent(const NestingLevels *nls, int n);
 
 extern void *nestingLevelGetUserData (const NestingLevel *nl);
 

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -87,7 +87,7 @@ static vString* nestingLevelsToScope (const NestingLevels* nls)
 	vString* result = vStringNew ();
 	for (i = 0; i < nls->n; ++i)
 	{
-	    NestingLevel *nl = nestingLevelsGetNth (nls, i);
+	    NestingLevel *nl = nestingLevelsGetNthFromRoot (nls, i);
 	    tagEntryInfo *e = getEntryOfNestingLevel (nl);
 	    if (e && strlen (e->name) > 0 && (!e->placeholder))
 	    {
@@ -467,7 +467,7 @@ static void readAndStoreMixinSpec (const unsigned char** cp, const char *how_mix
 
 	if (e->kindIndex == K_SINGLETON)
 	{
-		nl = nestingLevelsGetNth (nesting, nesting->n - 2);
+		nl = nestingLevelsGetNthParent (nesting, 1);
 		if (nl == NULL)
 			return;
 		e = getEntryOfNestingLevel (nl);

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -476,8 +476,13 @@ static void readAndStoreMixinSpec (const unsigned char** cp, const char *how_mix
 	if (! (e->kindIndex == K_CLASS || e->kindIndex == K_MODULE))
 		return;
 
-	if (isspace (**cp))
+	if (isspace (**cp) || (**cp == '('))
 	{
+		if (isspace (**cp))
+			skipWhitespace (cp);
+		if (**cp == '(')
+			++*cp;
+
 		vString *spec = vStringNewInit (how_mixin);
 		vStringPut(spec, ':');
 


### PR DESCRIPTION
* detect method style mixin as suggested in #2481, and
 * ignore unnamed blocks like "while", "if", ... when detecting mixing method invocations.