### PR TITLE
SystemVerilog: use the symbol table to recognize the types for ports

### DIFF
--- a/Units/parser-verilog.r/systemverilog-symtab.d/args.ctags
+++ b/Units/parser-verilog.r/systemverilog-symtab.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--extras=+q

--- a/Units/parser-verilog.r/systemverilog-symtab.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-symtab.d/expected.tags
@@ -1,0 +1,6 @@
+int32_t	input.sv	/^typedef bit[31:0] int32_t;$/;"	T
+mod	input.sv	/^module mod($/;"	m
+clk	input.sv	/^  input bit clk,$/;"	p	module:mod
+mod.clk	input.sv	/^  input bit clk,$/;"	p	module:mod
+a	input.sv	/^  input int32_t a$/;"	p	module:mod
+mod.a	input.sv	/^  input int32_t a$/;"	p	module:mod

--- a/Units/parser-verilog.r/systemverilog-symtab.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-symtab.d/input.sv
@@ -1,0 +1,7 @@
+// Takne from #2413 submitted by @antoinemadec
+typedef bit[31:0] int32_t;
+module mod(
+  input bit clk,
+  input int32_t a
+);
+endmodule

--- a/main/entry.h
+++ b/main/entry.h
@@ -160,6 +160,10 @@ void          registerEntry (unsigned int corkIndex);
  * specified with CORKINDEX. If CORK_NIL is given, this function traverses
  * top-level entries. If name is NULL, this function traverses all entries
  * under the scope.
+ *
+ * If FUNC returns false, this function returns false.
+ * If FUNC never returns false, this func returns true.
+ * If FUNC is not called because no node for NAME in the symbol table.
  */
 bool          foreachEntriesInScope (unsigned int corkIndex,
 									 const char *name, /* or NULL */


### PR DESCRIPTION
Close #2413.

The original code could not capture "a" in "mod" in the following input because
the parser didn't recognize "int32_t" before "a" is a name of type:

    typedef bit[31:0] int32_t;
    module mod(
      input bit clk,
      input int32_t a
    );
    endmodule

This change makes the parser look up the cork symbol table when the
parser reads a token with unknown kind. A typedef like int32_t is
stored to the symbol table when making a tag for it. As the result, the
parser can resolve the kind for the token as typedef when parsing
int32_t in "input int32_t a".

Signed-off-by: Masatake YAMATO <yamato@redhat.com>