### PR TITLE
Ruby: capture required libraries as reference tags

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -58,6 +58,9 @@ Python         x/unknown         imported           on      imported from the ot
 Python         x/unknown         indirectlyImported on      classes/variables/functions/modules imported in alternative name
 RpmSpec        m/macro           undef              on      undefined
 RpmSpec        p/patch           decl               on      declared for applying later
+Ruby           L/library         loaded             on      loaded by "load" method
+Ruby           L/library         required           on      loaded by "require" method
+Ruby           L/library         requiredRel        on      loaded by "require_relative" method
 Sh             h/heredoc         endmarker          on      end marker
 Sh             s/script          loaded             on      loaded
 SystemdUnit    u/unit            After              on      referred in After key
@@ -132,6 +135,9 @@ Python         x/unknown         imported           on      imported from the ot
 Python         x/unknown         indirectlyImported on      classes/variables/functions/modules imported in alternative name
 RpmSpec        m/macro           undef              on      undefined
 RpmSpec        p/patch           decl               on      declared for applying later
+Ruby           L/library         loaded             on      loaded by "load" method
+Ruby           L/library         required           on      loaded by "require" method
+Ruby           L/library         requiredRel        on      loaded by "require_relative" method
 Sh             h/heredoc         endmarker          on      end marker
 Sh             s/script          loaded             on      loaded
 SystemdUnit    u/unit            After              on      referred in After key

--- a/Tmain/tmain-example.d/stdout-expected.txt
+++ b/Tmain/tmain-example.d/stdout-expected.txt
@@ -5,3 +5,4 @@ S  singleton methods
 C  constants
 A  accessors
 a  aliases
+L  libraries

--- a/Units/parser-ruby.r/ruby-library.d/args.ctags
+++ b/Units/parser-ruby.r/ruby-library.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+r
+--fields=+r

--- a/Units/parser-ruby.r/ruby-library.d/expected.tags
+++ b/Units/parser-ruby.r/ruby-library.d/expected.tags
@@ -1,0 +1,6 @@
+a	input.rb	/^require "a"$/;"	L	roles:required
+b	input.rb	/^require("b")$/;"	L	roles:required
+c	input.rb	/^require_relative "c"$/;"	L	roles:requiredRel
+d	input.rb	/^require_relative("d")$/;"	L	roles:requiredRel
+e.rb	input.rb	/^load "e.rb"$/;"	L	roles:loaded
+f.rb	input.rb	/^load("f.rb")$/;"	L	roles:loaded

--- a/Units/parser-ruby.r/ruby-library.d/input.rb
+++ b/Units/parser-ruby.r/ruby-library.d/input.rb
@@ -1,0 +1,11 @@
+require "a"
+require("b")
+require_relative "c"
+require_relative("d")
+load "e.rb"
+load("f.rb")
+autoload :C
+autoload :D, "g"
+autoload(:G)
+autoload(:H, "h")
+


### PR DESCRIPTION
With this change, Ruby parser can capture "foo", bar", and "baz.rb" in 
* require "foo",
* require_relative "bar", and
* load "baz.rb"
.
scope files for the tags are not filled because I wonder how they should be.

autoload is not covered in this pull request.
