### PR TITLE
SQL: emit event kind tags only when token is an identifier, string, or non-reserved keyword

### DIFF
--- a/Tmain/sql-null-tag-warning.d/input.sql
+++ b/Tmain/sql-null-tag-warning.d/input.sql
@@ -1,0 +1,3 @@
+-- Taken from #2504 opened by @koenmeersman
+select substr(sess_evnt.event, 1, 18) event
+from  v$session_event sess_evnt;

--- a/Tmain/sql-null-tag-warning.d/run.sh
+++ b/Tmain/sql-null-tag-warning.d/run.sh
@@ -1,0 +1,12 @@
+# Copyright: 2020 Masatake YAMATO
+# License: GPL-2
+
+. ../utils.sh
+
+CTAGS=$1
+
+V=
+# V=valgrind
+
+echo '# no warning should be printed' 1>&2
+$CTAGS --quiet --options=NONE -o - input.sql

--- a/Tmain/sql-null-tag-warning.d/stderr-expected.txt
+++ b/Tmain/sql-null-tag-warning.d/stderr-expected.txt
@@ -1,0 +1,1 @@
+# no warning should be printed

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -2149,8 +2149,12 @@ static void parseEvent (tokenInfo *const token)
 		readToken (token);
 	}
 
-	if (isKeyword (token, KEYWORD_handler) ||
-		isType (token, TOKEN_SEMICOLON))
+	if ((isKeyword (token, KEYWORD_handler) ||
+		 isType (token, TOKEN_SEMICOLON))
+		&& (isType (name, TOKEN_IDENTIFIER) ||
+			isType (name, TOKEN_STRING)     ||
+			(isType (name, TOKEN_KEYWORD)
+			 && (!isReservedWord (name)))))
 	{
 		makeSqlTag (name, SQLTAG_EVENT);
 	}


### PR DESCRIPTION
Close #2504.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>