### PR TITLE
CXX: Improve extraction of variables

### DIFF
--- a/Units/parser-c.r/end-field-of-var.d/expected.tags
+++ b/Units/parser-c.r/end-field-of-var.d/expected.tags
@@ -1,3 +1,7 @@
 n	input.c	/^int n [2] = {$/;"	v	line:1	typeref:typename:int[2]	end:4
 m0	input.c	/^int m0 [2] = {$/;"	v	line:7	typeref:typename:int[2]	end:10
 m1	input.c	/^}, m1 [3] = {$/;"	v	line:10	typeref:typename:int[3]	end:14
+point	input.c	/^struct point {$/;"	s	line:16	file:	end:18
+x	input.c	/^	int x, y;$/;"	m	line:17	struct:point	typeref:typename:int	file:	end:17
+y	input.c	/^	int x, y;$/;"	m	line:17	struct:point	typeref:typename:int	file:	end:17
+P	input.c	/^struct point P = {$/;"	v	line:20	typeref:struct:point	end:23

--- a/Units/parser-c.r/end-field-of-var.d/input.c
+++ b/Units/parser-c.r/end-field-of-var.d/input.c
@@ -12,3 +12,12 @@ int m0 [2] = {
 	6,
 	8,
 };
+
+struct point {
+	int x, y;
+};
+
+struct point P = {
+	.x = 1,
+	.y = 2,
+};

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1092,18 +1092,18 @@ static bool cxxParserParseClassStructOrUnionInternal(
 
 	if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeAssignment))
 	{
-		if(g_cxx.pTokenChain->iCount > 3)
-		{
-			// struct X Y = ...;
-			cxxParserExtractVariableDeclarations(g_cxx.pTokenChain,0);
-		}
+		// struct X Y = ...;
+		bool bCanExtractVariables = g_cxx.pTokenChain->iCount > 3;
 
 		// Skip the initialization (which almost certainly contains a block)
-		if(!cxxParserParseUpToOneOf(CXXTokenTypeEOF | CXXTokenTypeSemicolon, true))
+		if(!cxxParserParseUpToOneOf(CXXTokenTypeEOF | CXXTokenTypeSemicolon, false))
 		{
 			CXX_DEBUG_LEAVE_TEXT("Failed to parse up to EOF/semicolon");
 			return false;
 		}
+
+		if(bCanExtractVariables)
+			cxxParserExtractVariableDeclarations(g_cxx.pTokenChain,0);
 
 		cxxParserNewStatement();
 		CXX_DEBUG_LEAVE();


### PR DESCRIPTION
Avoid corrupting the token chain before extracting variables when an assignment is found. This allows us to extract more variables and also to attach end-line tags properly.