### PR TITLE
dsl: introduce true and false as aliases for #t and #f

### DIFF
--- a/Tmain/readtags-alias-for-boolean.d/input.c
+++ b/Tmain/readtags-alias-for-boolean.d/input.c
@@ -1,0 +1,4 @@
+/* ctags -o output.tags input.c */
+struct point3d {
+	int x, y ,z;
+};

--- a/Tmain/readtags-alias-for-boolean.d/output.tags
+++ b/Tmain/readtags-alias-for-boolean.d/output.tags
@@ -1,0 +1,13 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	0.0.0	/6d353f7f/
+point3d	input.c	/^struct point3d {$/;"	s	file:
+x	input.c	/^	int x, y ,z;$/;"	m	struct:point3d	typeref:typename:int	file:
+y	input.c	/^	int x, y ,z;$/;"	m	struct:point3d	typeref:typename:int	file:
+z	input.c	/^	int x, y ,z;$/;"	m	struct:point3d	typeref:typename:int	file:

--- a/Tmain/readtags-alias-for-boolean.d/run.sh
+++ b/Tmain/readtags-alias-for-boolean.d/run.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Copyright: 2020 Masatake YAMATO
+# License: GPL-2
+
+READTAGS=$3
+#V="valgrind --leak-check=full --track-origins=yes -v"
+V=
+
+. ../utils.sh
+
+if ! [ -x "${READTAGS}" ]; then
+	skip "no readtags"
+fi
+
+if ! ( "${READTAGS}" -h | grep -q -e -Q ); then
+    skip "no qualifier function in readtags"
+fi
+
+echo '!_ -Q #t point3d'
+${V} ${READTAGS} -t output.tags -Q '#t' point3d
+
+echo '!_ -Q ture point3d'
+${V} ${READTAGS} -t output.tags -Q 'true' point3d
+
+echo '!_ -Q #f point3d'
+${V} ${READTAGS} -t output.tags -Q '#f' point3d
+
+echo '!_ -Q false point3d'
+${V} ${READTAGS} -t output.tags -Q 'false' point3d
+
+echo '!_ -Q #t -l'
+${V} ${READTAGS} -t output.tags -Q '#t' -l
+
+echo '!_ -Q ture -l'
+${V} ${READTAGS} -t output.tags -Q 'true' -l
+
+echo '!_ -Q #f -l'
+${V} ${READTAGS} -t output.tags -Q '#f' -l
+
+echo '!_ -Q false -l'
+${V} ${READTAGS} -t output.tags -Q 'false' -l

--- a/Tmain/readtags-alias-for-boolean.d/stdout-expected.txt
+++ b/Tmain/readtags-alias-for-boolean.d/stdout-expected.txt
@@ -1,0 +1,18 @@
+!_ -Q #t point3d
+point3d	input.c	/^struct point3d {$/
+!_ -Q ture point3d
+point3d	input.c	/^struct point3d {$/
+!_ -Q #f point3d
+!_ -Q false point3d
+!_ -Q #t -l
+point3d	input.c	/^struct point3d {$/
+x	input.c	/^	int x, y ,z;$/
+y	input.c	/^	int x, y ,z;$/
+z	input.c	/^	int x, y ,z;$/
+!_ -Q ture -l
+point3d	input.c	/^struct point3d {$/
+x	input.c	/^	int x, y ,z;$/
+y	input.c	/^	int x, y ,z;$/
+z	input.c	/^	int x, y ,z;$/
+!_ -Q #f -l
+!_ -Q false -l

--- a/dsl/dsl.c
+++ b/dsl/dsl.c
@@ -74,6 +74,9 @@ static EsObject* builtin_entry_ref (EsObject *args, DSLEnv *env);
 static EsObject* builtin_add  (EsObject *args, DSLEnv *env);
 static EsObject* builtin_sub  (EsObject *args, DSLEnv *env);
 
+static EsObject* value_true (EsObject *args, DSLEnv *env);
+static EsObject* value_false (EsObject *args, DSLEnv *env);
+
 DECLARE_VALUE_FN(name);
 DECLARE_VALUE_FN(input);
 DECLARE_VALUE_FN(access);
@@ -124,6 +127,10 @@ static DSLProcBind pbinds [] = {
 	  .helpstr = "(upcate elt<string>|<list>) -> <string>|<list>" },
 	{ "print",   bulitin_debug_print, NULL, DSL_PATTR_CHECK_ARITY, 1,
 	  .helpstr = "(print OBJ) -> OBJ" },
+	{ "true",    value_true, NULL, 0, 0UL,
+	  .helpstr = "true -> #t" },
+	{ "false",    value_false, NULL, 0, 0UL,
+	  .helpstr = "true -> #f" },
 	{ "$",       builtin_entry_ref, NULL, DSL_PATTR_CHECK_ARITY, 1,
 	  .helpstr = "($ NAME) -> #f|<string>" },
 	{ "$name",           value_name,           NULL, DSL_PATTR_MEMORABLE, 0UL,},
@@ -948,4 +955,14 @@ static EsObject* builtin_sub  (EsObject *args, DSLEnv *env)
 	int bi = es_integer_get (b);
 
 	return es_object_autounref (es_integer_new (ai - bi));
+}
+
+static EsObject* value_true (EsObject *args, DSLEnv *env)
+{
+	return es_true;
+}
+
+static EsObject* value_false (EsObject *args, DSLEnv *env)
+{
+	return es_false;
 }


### PR DESCRIPTION
Consider writing a client tool runs on emacs.
The tool may use -Q and -S options of readtags.

The developers of the client tool may want to pass
an S expression built-in emacs lisp to readtags
directly.

However, there was a gap in what we call S expression
in emacs and readtags.

readtags's S expression is scheme based; #t and #f is
used as representation of boolean values. These representation
is not used in emacs. Further more, `#' is special character
(prefix of a reader macro) in emacs. So, it is hard for emacs
to build an S expression passed to readtags if the expression
includes a boolean value.

To fill the gap, this change introduces `true' and `false'
values to the readtags side. So the client tool that runs on
emacs doesn't doesn't have to use #t and #f directly in S
expression building process.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>