### PR TITLE
main,DTD,LdScript,Tcl: simplify the way to extend tokenInfo type

### DIFF
--- a/main/tokeninfo.h
+++ b/main/tokeninfo.h
@@ -36,7 +36,6 @@ struct tokenTypePair {
 };
 
 #define TOKEN(X)  ((tokenInfo *)X)
-#define TOKENX(X,T)  ((T *)(((char *)TOKEN(X)) + sizeof (tokenInfo)))
 
 struct tokenInfoClass {
 	unsigned int nPreAlloc;

--- a/parsers/dtd.c
+++ b/parsers/dtd.c
@@ -126,9 +126,12 @@ static void readToken (tokenInfo *const token, void *data CTAGS_ATTR_UNUSED);
 static void clearToken (tokenInfo *token);
 static void copyToken (tokenInfo *dest, tokenInfo *src, void *data CTAGS_ATTR_UNUSED);
 
-typedef struct sTokenExtra {
+typedef struct sDtdToken {
+	tokenInfo base;
 	int scopeIndex;
-} tokenExtra;
+} dtdToken;
+
+#define DTD(TOKEN) ((dtdToken *)TOKEN)
 
 static struct tokenInfoClass dtdTokenInfoClass = {
 	.nPreAlloc = 16,
@@ -136,7 +139,7 @@ static struct tokenInfoClass dtdTokenInfoClass = {
 	.keywordNone      = KEYWORD_NONE,
 	.typeForKeyword   = TOKEN_KEYWORD,
 	.typeForEOF       = TOKEN_EOF,
-	.extraSpace       = sizeof (tokenExtra),
+	.extraSpace       = sizeof (dtdToken) - sizeof (tokenInfo),
 	.read             = readToken,
 	.clear            = clearToken,
 	.copy             = copyToken,
@@ -154,13 +157,12 @@ static tokenInfo *newDtdToken (void)
 
 static void clearToken (tokenInfo *token)
 {
-	TOKENX (token, tokenExtra)->scopeIndex = CORK_NIL;
+	DTD (token)->scopeIndex = CORK_NIL;
 }
 
 static void copyToken (tokenInfo *dest, tokenInfo *src, void *data CTAGS_ATTR_UNUSED)
 {
-	TOKENX (dest, tokenExtra)->scopeIndex =
-		TOKENX (src, tokenExtra)->scopeIndex;
+	DTD (dest)->scopeIndex = DTD (src)->scopeIndex;
 }
 
 static void readToken (tokenInfo *const token, void *data CTAGS_ATTR_UNUSED)
@@ -290,7 +292,7 @@ static int makeDtdTagMaybe (tagEntryInfo *const e, tokenInfo *const token,
 					 role);
 	e->lineNumber = token->lineNumber;
 	e->filePosition = token->filePosition;
-	e->extensionFields.scopeIndex = TOKENX (token, tokenExtra)->scopeIndex;
+	e->extensionFields.scopeIndex = DTD (token)->scopeIndex;
 
 	return makeTagEntry (e);
 }
@@ -446,7 +448,7 @@ static void parseAttDefs (tokenInfo *const token)
 		}
 		else if (tokenIsType(token, CLOSE))
 		{
-			TOKENX (token, tokenExtra)->scopeIndex = CORK_NIL;
+			DTD (token)->scopeIndex = CORK_NIL;
 			tokenUnread (token);
 			break;
 		}
@@ -472,9 +474,9 @@ static void parseAttlist (tokenInfo *const token)
 										 DTD_PARAMETER_ENTITY_ELEMENT_NAME);
 				tokenDelete (identifier);
 
-				TOKENX (token, tokenExtra)->scopeIndex = index;
+				DTD (token)->scopeIndex = index;
 				parseAttDefs (token);
-				TOKENX (token, tokenExtra)->scopeIndex = CORK_NIL;
+				DTD (token)->scopeIndex = CORK_NIL;
 			}
 		}
 	}
@@ -486,9 +488,9 @@ static void parseAttlist (tokenInfo *const token)
 								 K_ELEMENT, DTD_ELEMENT_ATT_OWNER);
 		tokenDelete (element);
 
-		TOKENX (token, tokenExtra)->scopeIndex = index;
+		DTD (token)->scopeIndex = index;
 		parseAttDefs (token);
-		TOKENX (token, tokenExtra)->scopeIndex = CORK_NIL;
+		DTD (token)->scopeIndex = CORK_NIL;
 	}
 
 	tokenSkipToType (token, TOKEN_CLOSE);


### PR DESCRIPTION
The orignal code uses TOKENX macro for extending tokenType.
However, it makes parsers' code a bit complicated.
This change removes the macro. Instead, the code lines using the
macros are convrted to the classical downcast technique.

e.g.

    typedef struct sDtdToken {
	    tokenInfo base;
	    int scopeIndex;
    } dtdToken;

    #define DTD(TOKEN) ((dtdToken *)TOKEN)

    static struct tokenInfoClass dtdTokenInfoClass = {
	    ...
	    .extraSpace       = sizeof (dtdToken) - sizeof (tokenInfo),

    DTD (token)->scopeIndex;

Signed-off-by: Masatake YAMATO <yamato@redhat.com>