### PR TITLE
Cxx: fix memory leak in field attaching

### DIFF
--- a/main/entry.h
+++ b/main/entry.h
@@ -184,17 +184,39 @@ extern bool isTagExtraBitMarked (const tagEntryInfo *const tag, xtagType extra);
 /* If any extra bit is on, return true. */
 extern bool isTagExtra (const tagEntryInfo *const tag);
 
-/* Attaching parser speicific fields
+/* Functions for attaching parser specific fields
  *
- * If your parser doesn't use Cork API, use attachParserField() with specifying
- * inCorkQueue to false.
- * If your parser use Cork API, use use attachParserField() with specifying
- * inCorkQueue to true, or use attachParserFieldToCorkEntry().
- * attachParserField takes tagEntryInfo object.
- * attachParserFieldToCorkEntry takes an index on the CorkQueue.
+ * Case A:
  *
- * Calling either one, the caller owns VALUE. If the parser allocates VALUE
- * dynamically, the parser must free it.
+ * If your parser uses the Cork API, and your parser called
+ * makeTagEntry () already, you can use both
+ * attachParserFieldToCorkEntry () and attachParserField ().  Your
+ * parser has the cork index returned from makeTagEntry ().  With the
+ * cork index, your parser can call attachParserFieldToCorkEntry ().
+ * If your parser already call getEntryInCorkQueue () to get the tag
+ * entry for the cork index, your parser can call attachParserField ()
+ * with passing true for `inCorkQueue' parameter. attachParserField ()
+ * is a bit faster than attachParserFieldToCorkEntry ().
+ *
+ * attachParserField () and attachParserFieldToCorkEntry () duplicates
+ * the memory object specified with `value' and stores the duplicated
+ * object to the entry on the cork queue. So the parser must/can free
+ * the original one passed to the functions after calling. The cork
+ * queue manages the life of the duplicated object. It is not the
+ * parser's concern.
+ *
+ *
+ * Case B:
+ *
+ * If your parser called one of initTagEntry () family but didn't call
+ * makeTagEntry () for a tagEntry yet, use attachParserField () with
+ * false for `inCorkQueue' whether your parser uses the Cork API or
+ * not.
+ *
+ * The parser (== caller) keeps the memory object specified with `value'
+ * till calling makeTagEntry (). The parser must free the memory object
+ * after calling makeTagEntry () if it is allocated dynamically in the
+ * parser side.
  */
 extern void attachParserField (tagEntryInfo *const tag, bool inCorkQueue, fieldType ftype, const char* value);
 extern void attachParserFieldToCorkEntry (int index, fieldType ftype, const char* value);

--- a/main/trashbox.h
+++ b/main/trashbox.h
@@ -50,6 +50,16 @@ extern TrashBoxDestroyItemProc trashBoxTakeBack  (TrashBox* trash_box, void* ite
 extern void      trashBoxFree      (TrashBox* trash_box, void* item);
 extern void      trashBoxMakeEmpty (TrashBox* trash_box);
 
+/* A parser trash box is prepared when `parser' method of a parser is called.
+ * The parser can register a pair of a memory object and destructor for the object to
+ * the trash box with parserTrashBoxPut ().
+ *
+ * The registered memory objects are destructed after `parser' method is finished in
+ * the main side. You can delay the destruction with parserTrashBoxPut ().
+ *
+ * You can unregister the pair in the `parser' method with parserTrashBoxTakeBack ().
+ * In that case, specify the memory object of the pair as the argument.
+ */
 extern void* parserTrashBoxPut  (void* item, TrashBoxDestroyItemProc destroy);
 extern TrashBoxDestroyItemProc parserTrashBoxTakeBack  (void* item);
 

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -16,6 +16,7 @@
 #include "entry.h"
 #include "../cpreprocessor.h"
 #include "routines.h"
+#include "trashbox.h"
 #include "xtag.h"
 
 #define CXX_COMMON_MACRO_ROLES(__langPrefix) \
@@ -527,7 +528,11 @@ void cxxTagSetField(unsigned int uField,const char * szValue,bool bCopyValue)
 	if(!g_cxx.pFieldOptions[uField].enabled)
 		return;
 
-	attachParserField(&g_oCXXTag,bCopyValue,g_cxx.pFieldOptions[uField].ftype,szValue);
+	/* If we make a copy for the value, the copy must be freed after
+	 * calling cxxTagCommit() for g_oCXXTag. The parser trash box
+	 * allows us to delay freeing the copy. */
+	attachParserField(&g_oCXXTag,false,g_cxx.pFieldOptions[uField].ftype,
+					  bCopyValue?parserTrashBoxPut(eStrdup(szValue),eFree):szValue);
 }
 
 void cxxTagSetCorkQueueField(


### PR DESCRIPTION
Close #2524.

When attaching a field to a tag, the original code calls
attachParserField() wrong way. The caller must own the field value
passed to attachParserField(); the caller must free the memory
object for the value after calling makeTagEntry().
However, the original code didn't do so. As the result, the memory
object for the value was leaked.

This change introduces the parser trash box. After calling
attachParserField(), the caller puts the memory object to the trash
box; the memory object is freed when parsing the current input file is
completed.