### PR TITLE
Cxx: destroy the token returned from cxxTagCheckAndSetTypeField() for fixing memory leak

### DIFF
--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -834,11 +834,13 @@ void cxxParserEmitTemplateParameterTags(void)
 		if(!tag)
 			continue;
 
-		cxxTagCheckAndSetTypeField(
+		CXXToken * pTypeToken = cxxTagCheckAndSetTypeField(
 				g_cxx.oTemplateParameters.aTypeStarts[i],
 				g_cxx.oTemplateParameters.aTypeEnds[i]
 			);
 
 		cxxTagCommit();
+		if (pTypeToken)
+			cxxTokenDestroy(pTypeToken);
 	}
 }


### PR DESCRIPTION
The token returned from cxxTagCheckAndSetTypeField() must be freed after
calling cxxTagCommit().

The memory leak was introduced in dc4e754e0a00e90a4f57bc959a8345e629c110d1.
Close #2525.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>