### PR TITLE
main: disable all objpools in debug build

### DIFF
--- a/main/debug.h
+++ b/main/debug.h
@@ -51,6 +51,10 @@
 # endif
 #endif
 
+#ifdef DEBUG
+/* This makes valgrind report an error earlier. */
+#define DISABLE_OBJPOOL
+#endif
 /*
 *   Data declarations
 */

--- a/main/objpool.c
+++ b/main/objpool.c
@@ -13,6 +13,7 @@
 */
 #include "general.h"  /* must always come first */
 
+#include "debug.h"
 #include "routines.h"
 #include "objpool.h"
 
@@ -75,7 +76,12 @@ extern void objPoolPut (objPool *pool, void *obj)
 	if (obj == NULL)
 		return;
 
-	if (ptrArrayCount (pool->array) < pool->size)
+	if (
+#ifdef DISABLE_OBJPOOL
+		0 &&
+#endif
+		ptrArrayCount (pool->array) < pool->size
+		)
 		ptrArrayAdd (pool->array, obj);
 	else
 		pool->deleteFunc (obj);


### PR DESCRIPTION
objpool makes the output of valgrind difficult to be understood.
When ./ctags is built with --enable-debugging, this change disables
all objpools.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>