### PR TITLE
Revise the type for cork index

### DIFF
--- a/main/entry.h
+++ b/main/entry.h
@@ -116,7 +116,7 @@ struct sTagEntryInfo {
 	unsigned long sourceLineNumberDifference;
 };
 
-typedef bool (* entryForeachFunc) (unsigned int corkIndex,
+typedef bool (* entryForeachFunc) (int corkIndex,
 								   tagEntryInfo * entry,
 								   void * data);
 
@@ -143,7 +143,7 @@ extern int makeQualifiedTagEntry (const tagEntryInfo *const e);
 
 
 #define CORK_NIL 0
-tagEntryInfo *getEntryInCorkQueue   (unsigned int n);
+tagEntryInfo *getEntryInCorkQueue   (int n);
 tagEntryInfo *getEntryOfNestingLevel (const NestingLevel *nl);
 size_t        countEntryInCorkQueue (void);
 
@@ -154,7 +154,7 @@ size_t        countEntryInCorkQueue (void);
  * registerEntry registers CORKINDEX to a symbol table of a parent tag
  * specified in the scopeIndex field of the tag specified with CORKINDEX.
  */
-void          registerEntry (unsigned int corkIndex);
+void          registerEntry (int corkIndex);
 
 /* foreachEntriesInScope is for traversing the symbol table for a table
  * specified with CORKINDEX. If CORK_NIL is given, this function traverses
@@ -165,7 +165,7 @@ void          registerEntry (unsigned int corkIndex);
  * If FUNC never returns false, this func returns true.
  * If FUNC is not called because no node for NAME in the symbol table.
  */
-bool          foreachEntriesInScope (unsigned int corkIndex,
+bool          foreachEntriesInScope (int corkIndex,
 									 const char *name, /* or NULL */
 									 entryForeachFunc func,
 									 void *data);
@@ -175,7 +175,7 @@ bool          foreachEntriesInScope (unsigned int corkIndex,
  * just returns one of them. Returning CORK_NIL means there is no entry
  * for NAME.
  */
-int           anyEntryInScope       (unsigned int corkIndex,
+int           anyEntryInScope       (int corkIndex,
 									 const char *name);
 
 extern void    markTagExtraBit     (tagEntryInfo *const tag, xtagType extra);

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -207,7 +207,7 @@ struct guestRequest {
 };
 
 struct lregexControlBlock {
-	unsigned long currentScope;
+	int currentScope;
 	ptrArray *entries [2];
 
 	ptrArray *tables;
@@ -1436,7 +1436,7 @@ static unsigned long getInputLineNumberInRegPType (enum regexParserType regptype
 static void fillEndLineFieldOfUpperScopes (struct lregexControlBlock *lcb, unsigned long endline)
 {
 	tagEntryInfo *entry;
-	unsigned int n = lcb->currentScope;
+	int n = lcb->currentScope;
 
 	while ((entry = getEntryInCorkQueue (n))
 		   && (entry->extensionFields.endLine == 0))
@@ -1460,7 +1460,7 @@ static void matchTagPattern (struct lregexControlBlock *lcb,
 														  patbuf->u.tag.kindIndex):
 		vStringNewInit ("");
 	bool placeholder = !!((patbuf->scopeActions & SCOPE_PLACEHOLDER) == SCOPE_PLACEHOLDER);
-	unsigned long scope = CORK_NIL;
+	int scope = CORK_NIL;
 	int n;
 
 	vStringStripLeading (name);
@@ -2299,7 +2299,7 @@ extern void addRegexTable (struct lregexControlBlock *lcb, const char *name)
 	ptrArrayAdd (lcb->tables, table);
 }
 
-static void dumpSstack(FILE* fp, unsigned long scope)
+static void dumpSstack(FILE* fp, int scope)
 {
 	fprintf (fp, "scope : ");
 	while (scope != CORK_NIL)

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -2301,10 +2301,10 @@ extern void addRegexTable (struct lregexControlBlock *lcb, const char *name)
 
 static void dumpSstack(FILE* fp, int scope)
 {
+	tagEntryInfo *entry;
 	fprintf (fp, "scope : ");
-	while (scope != CORK_NIL)
+	while ((entry = getEntryInCorkQueue (scope)))
 	{
-		tagEntryInfo *entry = getEntryInCorkQueue (scope);
 		fprintf(fp, "%s", entry->name);
 
 		scope = entry->extensionFields.scopeIndex;

--- a/main/parse.c
+++ b/main/parse.c
@@ -4844,7 +4844,8 @@ static void createCTSTTags (void)
 						assignRole(&e, R_ROLES_KIND_D_ROLE);
 						qindex = makeTagEntry (&e);
 						qe = getEntryInCorkQueue (qindex);
-						assignRole(qe, R_ROLES_KIND_B_ROLE);
+						if (qe)
+							assignRole(qe, R_ROLES_KIND_B_ROLE);
 						break;
 					}
 					case K_ROLES_DISABLED:

--- a/parsers/ansibleplaybook.c
+++ b/parsers/ansibleplaybook.c
@@ -69,13 +69,9 @@ static void popBlockType (struct sAnsiblePlaybookSubparser *ansible,
 	ansible->type_stack = s->next;
 
 	s->next = NULL;
-	if (s->associatedCorkIndex != CORK_NIL)
-	{
-		tagEntryInfo *tag;
-
-		tag = getEntryInCorkQueue (s->associatedCorkIndex);
+	tagEntryInfo *tag = getEntryInCorkQueue (s->associatedCorkIndex);
+	if (tag)
 		attachYamlPosition (tag, token, true);
-	}
 
 	eFree (s);
 }

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -190,7 +190,7 @@ static void makeAsmTag (
 		const bool labelCandidate,
 		const bool nameFollows,
 		const bool directive,
-		unsigned int *lastMacroCorkIndex)
+		int *lastMacroCorkIndex)
 {
 	if (vStringLength (name) > 0)
 	{
@@ -315,7 +315,7 @@ static void findAsmTags (void)
 			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX, KIND_GHOST_INDEX, 0, 0,
 			 FIELD_UNKNOWN);
 
-	unsigned int lastMacroCorkIndex = CORK_NIL;
+	 int lastMacroCorkIndex = CORK_NIL;
 
 	while ((line = asmReadLineFromInputFile ()) != NULL)
 	{

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -227,12 +227,10 @@ static void makeAsmTag (
 													 kind_for_directive);
 				break;
 			case K_PSUEDO_MACRO_END:
-				if (*lastMacroCorkIndex != CORK_NIL)
-				{
-					macro_tag = getEntryInCorkQueue (*lastMacroCorkIndex);
+				macro_tag = getEntryInCorkQueue (*lastMacroCorkIndex);
+				if (macro_tag)
 					macro_tag->extensionFields.endLine = getInputLineNumber ();
-					*lastMacroCorkIndex = CORK_NIL;
-				}
+				*lastMacroCorkIndex = CORK_NIL;
 				break;
 			case K_SECTION:
 				makeSimpleRefTag (operator,

--- a/parsers/automake.c
+++ b/parsers/automake.c
@@ -194,12 +194,8 @@ static void valueCallback (makeSubparser *make, char *name)
 	int k;
 	tagEntryInfo elt;
 
-
-	if (p == CORK_NIL)
-		return;
-
 	parent = getEntryInCorkQueue (p);
-	if ((parent->kindIndex == K_AM_DIR)
+	if (parent && (parent->kindIndex == K_AM_DIR)
 	    && (parent->extensionFields.roleBits))
 	{
 		int roleIndex;

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3193,11 +3193,9 @@ static void checkStatementEnd (statementInfo *const st, int corkIndex)
 {
 	const tokenInfo *const token = activeToken (st);
 
-	if (corkIndex != CORK_NIL)
-	{
-		tagEntryInfo *e = getEntryInCorkQueue (corkIndex);
+	tagEntryInfo *e = getEntryInCorkQueue (corkIndex);
+	if (e)
 		e->extensionFields.endLine = token->lineNumber;
-	}
 
 	if (isType (token, TOKEN_COMMA))
 		reinitStatement (st, true);

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -792,7 +792,8 @@ static void makeParamTag (vString *name, bool placeholder)
 	if (placeholder)
 	{
 		tagEntryInfo *e = getEntryInCorkQueue (r);
-		e->placeholder = 1;
+		if (e)
+			e->placeholder = 1;
 	}
 }
 
@@ -875,9 +876,9 @@ static int directiveDefine (const int c, bool undef)
 				else
 					r = makeDefineTag (vStringValue (Cpp.directive.name), NULL, undef);
 
-				if (r != CORK_NIL)
+				tagEntryInfo *e = getEntryInCorkQueue (r);
+				if (e)
 				{
-					tagEntryInfo *e = getEntryInCorkQueue (r);
 					e->lineNumber = lineNumber;
 					e->filePosition = filePosition;
 					patchScopeFieldOfParameters (param_start, param_end, r);
@@ -1239,7 +1240,8 @@ static int skipToEndOfChar ()
 static void attachFields (int macroCorkIndex, unsigned long endLine, const char *macrodef)
 {
 	tagEntryInfo *tag = getEntryInCorkQueue (macroCorkIndex);
-	Assert(tag);
+	if (!tag)
+		return;
 
 	tag->extensionFields.endLine = endLine;
 	if (macrodef)

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -843,7 +843,7 @@ static int directiveDefine (const int c, bool undef)
 			if (p == '(')
 			{
 				vString *param = vStringNew ();
-				int param_start = countEntryInCorkQueue();
+				int param_start = (int)countEntryInCorkQueue();
 				do {
 					p = cppGetcFromUngetBufferOrFile ();
 					if (isalnum(p) || p == '_' || p == '$'
@@ -864,7 +864,7 @@ static int directiveDefine (const int c, bool undef)
 				} while (p != ')' && p != EOF);
 				vStringDelete (param);
 
-				int param_end = countEntryInCorkQueue();
+				int param_end = (int)countEntryInCorkQueue();
 				if (p == ')')
 				{
 					vString *signature = vStringNew ();

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -834,11 +834,13 @@ void cxxParserEmitTemplateParameterTags(void)
 		if(!tag)
 			continue;
 
-		cxxTagCheckAndSetTypeField(
+		CXXToken * pTypeToken = cxxTagCheckAndSetTypeField(
 				g_cxx.oTemplateParameters.aTypeStarts[i],
 				g_cxx.oTemplateParameters.aTypeEnds[i]
 			);
 
 		cxxTagCommit();
+		if (pTypeToken)
+			cxxTokenDestroy(pTypeToken);
 	}
 }

--- a/parsers/diff.c
+++ b/parsers/diff.c
@@ -118,18 +118,18 @@ static int parseHunk (const unsigned char* cp, vString *hunk, int scope_index)
 			return i;
 	vStringNCopyS (hunk, start, end - start);
 	i = makeSimpleTag (hunk, K_HUNK);
-	if (i > CORK_NIL && scope_index > CORK_NIL)
-	{
-		tagEntryInfo *e =  getEntryInCorkQueue (i);
+	tagEntryInfo *e =  getEntryInCorkQueue (i);
+	if (e && scope_index > CORK_NIL)
 		e->extensionFields.scopeIndex = scope_index;
-	}
 	return i;
 }
 
 static void markTheLastTagAsDeletedFile (int scope_index)
 {
 	tagEntryInfo *e =  getEntryInCorkQueue (scope_index);
-	e->kindIndex = K_DELETED_FILE;
+
+	if (e)
+		e->kindIndex = K_DELETED_FILE;
 }
 
 static void findDiffTags (void)

--- a/parsers/dtd.c
+++ b/parsers/dtd.c
@@ -13,6 +13,7 @@
 #include "general.h"
 #include "tokeninfo.h"
 
+#include "debug.h"
 #include "entry.h"
 #include "keyword.h"
 #include "parse.h"
@@ -297,7 +298,7 @@ static int makeDtdTagMaybe (tagEntryInfo *const e, tokenInfo *const token,
 	return makeTagEntry (e);
 }
 
-static void backpatchEndField (unsigned int index, unsigned long lineNumber)
+static void backpatchEndField (int index, unsigned long lineNumber)
 {
 	tagEntryInfo *ep = getEntryInCorkQueue (index);
 
@@ -308,7 +309,7 @@ static void backpatchEndField (unsigned int index, unsigned long lineNumber)
 static void parseEntity (tokenInfo *const token)
 {
 	tagEntryInfo e;
-	unsigned int index = CORK_NIL;
+	int index = CORK_NIL;
 
 	tokenRead (token);
 	if (token->type == '%')
@@ -349,10 +350,10 @@ static tokenInfo *parserParameterEntityRef (tokenInfo *const token)
 static void parseElement (tokenInfo *const token, bool skipToClose)
 {
 	tagEntryInfo e;
-	size_t original_index;
+	int original_index;
 
 	if (skipToClose)
-		original_index = countEntryInCorkQueue ();
+		original_index = (int)countEntryInCorkQueue ();
 
 	tokenRead (token);
 	if (token->type == '%')
@@ -378,14 +379,11 @@ static void parseElement (tokenInfo *const token, bool skipToClose)
 
 	if (skipToClose)
 	{
-		size_t current_index;
-		current_index = countEntryInCorkQueue ();
+		int current_index = (int)countEntryInCorkQueue ();
 		if (tokenSkipToType (token, TOKEN_CLOSE)
 			&& (current_index > original_index))
 		{
-			unsigned int index;
-
-			for (index = original_index; index < current_index; index++)
+			for (int index = original_index; index < current_index; index++)
 				backpatchEndField (index, token->lineNumber);
 		}
 	}
@@ -458,7 +456,7 @@ static void parseAttDefs (tokenInfo *const token)
 static void parseAttlist (tokenInfo *const token)
 {
 	tagEntryInfo e;
-	unsigned int index = CORK_NIL;
+	int index = CORK_NIL;
 
 	tokenRead (token);
 	if (token->type == '%')
@@ -499,7 +497,7 @@ static void parseAttlist (tokenInfo *const token)
 
 static void parseNotation (tokenInfo *const token)
 {
-	unsigned int index = CORK_NIL;
+	int index = CORK_NIL;
 	tagEntryInfo e;
 
 	tokenRead (token);
@@ -561,10 +559,9 @@ static void parseSection (tokenInfo *const token)
 			if (condition)
 			{
 				tagEntryInfo e;
-				unsigned int index;
-				index = makeDtdTagMaybe (&e, condition,
-										 K_PARAMETER_ENTITY,
-										 DTD_PARAMETER_ENTITY_CONDITION);
+				int index = makeDtdTagMaybe (&e, condition,
+											 K_PARAMETER_ENTITY,
+											 DTD_PARAMETER_ENTITY_CONDITION);
 				tokenDelete (condition);
 				tokenRead (token);
 				if (token->type == '[')

--- a/parsers/fypp.c
+++ b/parsers/fypp.c
@@ -212,13 +212,9 @@ static bool macro_end_cb (const char *line,
 {
 	struct fyppParseCtx *ctx = userData;
 
-	if (ctx->macro_cork_index == CORK_NIL)
-		return true;
-
 	tagEntryInfo *e = getEntryInCorkQueue (ctx->macro_cork_index);
-	ctx->macro_cork_index = CORK_NIL;
-
-	e->extensionFields.endLine = getInputLineNumber ();
+	if (e)
+		e->extensionFields.endLine = getInputLineNumber ();
 	ctx->macro_cork_index = CORK_NIL;
 
 	fypp_end_cb (line, matches, count, userData);

--- a/parsers/iniconf.c
+++ b/parsers/iniconf.c
@@ -96,14 +96,9 @@ static void makeIniconfTagMaybe (const char *section, const char *key, const cha
 	}
 	else
 	{
-		if (*index != CORK_NIL)
-		{
-			tagEntryInfo *last;
-
-			last = getEntryInCorkQueue (*index);
-			if (last)
-				last->extensionFields.endLine = getInputLineNumber ();
-		}
+		tagEntryInfo *last = getEntryInCorkQueue (*index);
+		if (last)
+			last->extensionFields.endLine = getInputLineNumber ();
 
 		initTagEntry (&e, section, K_SECTION);
 		*index = makeTagEntry (&e);

--- a/parsers/itcl.c
+++ b/parsers/itcl.c
@@ -148,11 +148,9 @@ static void parseSubobject (tokenInfo *token, int parent, enum ITclKind kind, ke
 	}
 
 	skipToEndOfTclCmdline (token);
-	if (r != CORK_NIL)
-	{
-		tagEntryInfo *e = getEntryInCorkQueue (r);
+	tagEntryInfo *e = getEntryInCorkQueue (r);
+	if (e)
 		e->extensionFields.endLine = token->lineNumber;
-	}
 }
 
 

--- a/parsers/m4.c
+++ b/parsers/m4.c
@@ -500,10 +500,11 @@ static void findM4Tags(void)
 			ungetcToInputFile(c);
 			readQuotedWord(token);
 		}
-		else if (c == ')'&& (index != CORK_NIL))
+		else if (c == ')')
 		{
 			tagEntryInfo *e = getEntryInCorkQueue (index);
-			e->extensionFields.endLine = getInputLineNumber ();
+			if (e)
+				e->extensionFields.endLine = getInputLineNumber ();
 			index = CORK_NIL;
 		}
 	}

--- a/parsers/maven2.c
+++ b/parsers/maven2.c
@@ -216,12 +216,9 @@ findMaven2TagsForTable (enum maven2XpathTable tindex,
 
 	findXMLTags (ctx, node, tindex, &corkIndexes);
 
-	if ( corkIndexes [K_ARTIFACT_ID] != CORK_NIL
-	     && corkIndexes [K_GROUP_ID] != CORK_NIL)
-	{
-		tagEntryInfo *tag = getEntryInCorkQueue (corkIndexes [K_ARTIFACT_ID]);
+	tagEntryInfo *tag = getEntryInCorkQueue (corkIndexes [K_ARTIFACT_ID]);
+	if (tag && corkIndexes [K_GROUP_ID] != CORK_NIL)
 		tag->extensionFields.scopeIndex = corkIndexes [K_GROUP_ID];
-	}
 }
 
 static void makeTagRecursively (xmlNode *node,

--- a/parsers/moose.c
+++ b/parsers/moose.c
@@ -150,13 +150,9 @@ static void inputStart (subparser *s)
 static void inputEnd (subparser *s)
 {
 	struct mooseSubparser *moose = (struct mooseSubparser *)s;
-
-	if (moose->classCork != CORK_NIL)
-	{
-		tagEntryInfo *e = getEntryInCorkQueue (moose->classCork);
-		Assert (e);
+	tagEntryInfo *e = getEntryInCorkQueue (moose->classCork);
+	if (e)
 		e->extensionFields.endLine = getInputLineNumber ();
-	}
 
 	if (moose->superClass)
 		eFree ((char *)moose->superClass);
@@ -212,11 +208,10 @@ static void leaveMoose (struct mooseSubparser *moose)
 {
 	moose->notContinuousExtendsLines = true;
 
-	if (moose->classCork == CORK_NIL)
+	tagEntryInfo *e = getEntryInCorkQueue (moose->classCork);
+	if (!e)
 		return;
 
-	tagEntryInfo *e = getEntryInCorkQueue (moose->classCork);
-	Assert (e);
 	e->extensionFields.endLine = getInputLineNumber ();
 
 	moose->classCork = CORK_NIL;
@@ -228,12 +223,11 @@ static void enterMoose (struct mooseSubparser *moose)
 {
 	moose->notContinuousExtendsLines = true;
 
-	if (moose->packageCork == CORK_NIL)
+	tagEntryInfo *perl_e = getEntryInCorkQueue (moose->packageCork);
+	if (!perl_e)
 		return;
 
 	moose->notInMoose = false;
-	tagEntryInfo *perl_e = getEntryInCorkQueue (moose->packageCork);
-	Assert (perl_e);
 
 	tagEntryInfo moose_e;
 	initTagEntry (&moose_e, perl_e->name, K_CLASS);
@@ -289,7 +283,8 @@ static bool findExtendsClass (const char *line,
 
 	moose->notContinuousExtendsLines = true;
 
-	if (moose->classCork == CORK_NIL)
+	tagEntryInfo *e = getEntryInCorkQueue (moose->classCork);
+	if (!e)
 		return true;
 
 	const char *input = line + matches[1].start;
@@ -304,8 +299,6 @@ static bool findExtendsClass (const char *line,
 		return true;
 	}
 
-	tagEntryInfo *e = getEntryInCorkQueue (moose->classCork);
-	Assert (e);
 	if (e->extensionFields.inheritance == NULL)
 		e->extensionFields.inheritance = vStringDeleteUnwrap (str);
 
@@ -321,7 +314,8 @@ static bool findExtendsClassContinuation (const char *line,
 	moose->notContinuousExtendsLines = true;
 
 	tagEntryInfo *e = getEntryInCorkQueue (moose->classCork);
-	Assert (e);
+	if (!e)
+		return true;
 
 	const char *input = line + matches[1].start;
 	vString *str;

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -461,8 +461,8 @@ static void parseImplemMethods (vString * const ident, objcToken what);
 static vString *tempName = NULL;
 static vString *parentName = NULL;
 static objcKind parentType = K_INTERFACE;
-static unsigned int parentCorkIndex = CORK_NIL;
-static unsigned int categoryCorkIndex = CORK_NIL;
+static int parentCorkIndex = CORK_NIL;
+static int categoryCorkIndex = CORK_NIL;
 
 /* used to prepare tag for OCaml, just in case their is a need to
  * add additional information to the tag. */
@@ -483,7 +483,7 @@ static void pushEnclosingContext (const vString * parent, objcKind type)
 	parentType = type;
 }
 
-static void pushEnclosingContextFull (const vString * parent, objcKind type, unsigned int corkIndex)
+static void pushEnclosingContextFull (const vString * parent, objcKind type, int corkIndex)
 {
 	pushEnclosingContext (parent, type);
 	parentCorkIndex = corkIndex;
@@ -495,7 +495,7 @@ static void popEnclosingContext (void)
 	parentCorkIndex = CORK_NIL;
 }
 
-static void pushCategoryContext (unsigned int category_index)
+static void pushCategoryContext (int category_index)
 {
 	categoryCorkIndex = category_index;
 }
@@ -628,7 +628,7 @@ static void parseMethodsNameCommon (vString * const ident, objcToken what,
 									parseNext reEnter,
 									parseNext nextAction)
 {
-	unsigned int index;
+	int index;
 
 	switch (what)
 	{
@@ -746,7 +746,7 @@ static void parseCategory (vString * const ident, objcToken what)
 			else
 				toDoNext = &parseImplemMethods;
 
-			unsigned int index = addTag (ident, K_CATEGORY);
+			int index = addTag (ident, K_CATEGORY);
 			pushCategoryContext (index);
 		}
 	}
@@ -913,7 +913,7 @@ static void parseProtocol (vString * const ident, objcToken what)
 {
 	if (what == ObjcIDENTIFIER)
 	{
-		unsigned int index = addTag (ident, K_PROTOCOL);
+		int index = addTag (ident, K_PROTOCOL);
 		pushEnclosingContextFull (ident, K_PROTOCOL, index);
 	}
 	toDoNext = &parseMethods;
@@ -923,7 +923,7 @@ static void parseImplementation (vString * const ident, objcToken what)
 {
 	if (what == ObjcIDENTIFIER)
 	{
-		unsigned int index = addTag (ident, K_IMPLEMENTATION);
+		int index = addTag (ident, K_IMPLEMENTATION);
 		pushEnclosingContextFull (ident, K_IMPLEMENTATION, index);
 	}
 	toDoNext = &parseImplemMethods;
@@ -933,7 +933,7 @@ static void parseInterface (vString * const ident, objcToken what)
 {
 	if (what == ObjcIDENTIFIER)
 	{
-		unsigned int index = addTag (ident, K_INTERFACE);
+		int index = addTag (ident, K_INTERFACE);
 		pushEnclosingContextFull (ident, K_INTERFACE, index);
 	}
 

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -1227,7 +1227,7 @@ static void setIndent (tokenInfo *const token)
 	{
 		if (lv->corkIndex != CORK_NIL)
 		{
-			tagEntryInfo *e = getEntryInCorkQueue ((unsigned int) lv->corkIndex);
+			tagEntryInfo *e = getEntryInCorkQueue (lv->corkIndex);
 
 			e->extensionFields.endLine = token->lineNumber;
 		}

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -1225,12 +1225,9 @@ static void setIndent (tokenInfo *const token)
 
 	while (lv && PY_NL (lv)->indentation >= token->indent)
 	{
-		if (lv->corkIndex != CORK_NIL)
-		{
-			tagEntryInfo *e = getEntryInCorkQueue (lv->corkIndex);
-
+		tagEntryInfo *e = getEntryInCorkQueue (lv->corkIndex);
+		if (e)
 			e->extensionFields.endLine = token->lineNumber;
-		}
 
 		nestingLevelsPop (PythonNestingLevels);
 		lv = nestingLevelsGetCurrent (PythonNestingLevels);

--- a/parsers/rpmspec.c
+++ b/parsers/rpmspec.c
@@ -331,9 +331,9 @@ static bool check_line_continuation (const char *line,
 	TRACE_PRINT("Line %04d continuation: %d -> %d",
 				getInputLineNumber(), rejecting, ctx->rejecting);
 
-	if (rejecting && (!ctx->rejecting) && (ctx->macro_index != CORK_NIL))
+	tagEntryInfo *e = getEntryInCorkQueue (ctx->macro_index);
+	if (rejecting && (!ctx->rejecting) && e)
 	{
-		tagEntryInfo *e = getEntryInCorkQueue (ctx->macro_index);
 		e->extensionFields.endLine = getInputLineNumber();
 		ctx->macro_index = CORK_NIL;
 	}

--- a/parsers/sh.c
+++ b/parsers/sh.c
@@ -258,9 +258,9 @@ static int hdocStateReadDestfileName (struct hereDocParsingState *hstate,
 
 static void hdocStateUpdateTag (struct hereDocParsingState *hstate, unsigned long endLine)
 {
-	if (hstate->corkIndex != CORK_NIL)
+	tagEntryInfo *tag = getEntryInCorkQueue (hstate->corkIndex);
+	if (tag)
 	{
-		tagEntryInfo *tag = getEntryInCorkQueue (hstate->corkIndex);
 		tag->extensionFields.endLine = endLine;
 		hstate->corkIndex = CORK_NIL;
 	}

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -403,7 +403,7 @@ static void notifyNamespaceImport (tokenInfo *const token)
 	}
 }
 
-static int notifyCommand (tokenInfo *const token, unsigned int parent)
+static int notifyCommand (tokenInfo *const token, int parent)
 {
 	subparser *sub;
 	int r = CORK_NIL;
@@ -457,7 +457,7 @@ static void collectSignature (const tokenInfo *const token, collector * col)
 }
 
 static void parseProc (tokenInfo *const token,
-					   unsigned int parent)
+					   int parent)
 {
 	int index = CORK_NIL;
 	int index_fq = CORK_NIL;
@@ -583,7 +583,7 @@ static void parseProc (tokenInfo *const token,
 }
 
 static void parseNamespace (tokenInfo *const token,
-							unsigned int parent)
+							int parent)
 {
 	tokenRead (token);
 	if (tokenIsEOF(token))

--- a/parsers/tex-beamer.c
+++ b/parsers/tex-beamer.c
@@ -185,11 +185,9 @@ static void reportStrategicParsing (texSubparser *s,
 	}
 	else if (strategy == framesubtitle_strategy)
 	{
-		if (strategy [1].corkIndex != CORK_NIL)
-		{
-			tagEntryInfo *e = getEntryInCorkQueue (strategy [1].corkIndex);
+		tagEntryInfo *e = getEntryInCorkQueue (strategy [1].corkIndex);
+		if (e)
 			e->extensionFields.scopeIndex = b->lastTitleCorkIndex;
-		}
 	}
 	else if (strategy == frame_env_strategy)
 	{
@@ -197,12 +195,10 @@ static void reportStrategicParsing (texSubparser *s,
 
 		if (strategy [3].corkIndex != CORK_NIL)
 			b->lastTitleCorkIndex = strategy [3].corkIndex;
-		if (b->lastTitleCorkIndex != CORK_NIL
-			&& strategy [4].corkIndex != CORK_NIL)
-		{
-			tagEntryInfo *e = getEntryInCorkQueue (strategy [4].corkIndex);
+
+		tagEntryInfo *e = getEntryInCorkQueue (strategy [4].corkIndex);
+		if (e && b->lastTitleCorkIndex != CORK_NIL)
 			e->extensionFields.scopeIndex = b->lastTitleCorkIndex;
-		}
 	}
 }
 
@@ -220,12 +216,9 @@ static bool readEnviromentEndNotify (texSubparser *s,
 	if (strcmp (vStringValue (env), "frame") == 0)
 	{
 		struct beamerSubparser *b = (struct beamerSubparser *)s;
-		if (b->lastTitleCorkIndex != CORK_NIL)
-		{
-			tagEntryInfo *e = getEntryInCorkQueue (b->lastTitleCorkIndex);
-			if (e)
-				e->extensionFields.endLine = getInputLineNumber ();
-		}
+		tagEntryInfo *e = getEntryInCorkQueue (b->lastTitleCorkIndex);
+		if (e)
+			e->extensionFields.endLine = getInputLineNumber ();
 		return true;
 	}
 	return false;

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -278,14 +278,14 @@ struct symbolData {
 	int *corkQueue;
 };
 
-static bool findTheName (unsigned int corkIndex, tagEntryInfo *entry, void *data)
+static bool findTheName (int corkIndex, tagEntryInfo *entry, void *data)
 {
 	struct symbolData *symbolData = data;
 
 	if (entry->langType == symbolData->lang && entry->kindIndex == symbolData->kind)
 	{
 		/* TODO: The case operation should be removed */
-		*symbolData->corkQueue = (unsigned int)corkIndex;
+		*symbolData->corkQueue = corkIndex;
 		return false;
 	}
 	return true;
@@ -305,7 +305,7 @@ static int makeTexTag (tokenInfo *const token, int kind,
 			.corkQueue = &corkQueue,
 		};
 		/* TODO: The case operation should be removed */
-		if (foreachEntriesInScope ((unsigned int)scopeIndex, name, findTheName, (void *)&data) == false)
+		if (foreachEntriesInScope (scopeIndex, name, findTheName, (void *)&data) == false)
 			return *data.corkQueue;
 	}
 

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -345,7 +345,7 @@ static int makeTexTag (tokenInfo *const token, int kind,
 	corkQueue = makeTagEntry (&e);
 	vStringDelete (parentName);	/* NULL is o.k. */
 
-	if (unique)
+	if (unique && corkQueue != CORK_NIL)
 		registerEntry (corkQueue);
 
 	return corkQueue;

--- a/parsers/typescript.c
+++ b/parsers/typescript.c
@@ -1680,8 +1680,12 @@ static void parseClassBody (const int scope, tokenInfo *const token)
 	if (inheritance)
 	{
 		tagEntryInfo *klass = getEntryInCorkQueue (scope);
-		klass->extensionFields.inheritance = vStringDeleteUnwrap (inheritance);
-		inheritance = NULL;
+		if (klass)
+		{
+			klass->extensionFields.inheritance = vStringDeleteUnwrap (inheritance);
+			inheritance = NULL;
+		}
+		vStringDelete (inheritance);
 	}
 
 	tokenInfo *member = NULL;

--- a/parsers/typescript.c
+++ b/parsers/typescript.c
@@ -326,7 +326,7 @@ static void clearPoolToken (void *data)
 static void deletePoolToken (void *data)
 {
 	tokenInfo *token = data;
-	if (token->string) vStringDelete (token->string);
+	vStringDelete (token->string); /* NULL is acceptable */
 	eFree (token);
 }
 
@@ -1673,7 +1673,7 @@ static void parseClassBody (const int scope, tokenInfo *const token)
 
 	if (! parsed)
 	{
-		if (inheritance) vStringDelete (inheritance);
+		vStringDelete (inheritance); /* NULL is acceptable. */
 		return;
 	}
 

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1135,7 +1135,7 @@ static void processClass (tokenInfo *const token)
 	}
 }
 
-static bool doesNameForKindExist (unsigned int corkIndex, tagEntryInfo *entry, void *data)
+static bool doesNameForKindExist (int corkIndex, tagEntryInfo *entry, void *data)
 {
 	verilogKind *kind = data;
 

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -269,12 +269,9 @@ static void parseFunction (const unsigned char *line)
 	{
 		if (wordMatchLen (line, "endfunction", 4))
 		{
-			tagEntryInfo *e;
-			if (index != CORK_NIL)
-			{
-				e = getEntryInCorkQueue (index);
+			tagEntryInfo *e = getEntryInCorkQueue (index);
+			if (e)
 				e->extensionFields.endLine = getInputLineNumber ();
-			}
 			break;
 		}
 

--- a/peg/varlink_post.h
+++ b/peg/varlink_post.h
@@ -31,7 +31,8 @@ static void popKind (struct parserCtx *auxil, bool popScopeToo)
 	if (popScopeToo)
 	{
 		tagEntryInfo *e = getEntryInCorkQueue (auxil->scope_cork_index);
-		auxil->scope_cork_index = e->extensionFields.scopeIndex;
+		if (e)
+			auxil->scope_cork_index = e->extensionFields.scopeIndex;
 	}
 }
 


### PR DESCRIPTION
This pull request does two things.

1. In some places unsigned int is used for the index for an entry in the cork queue.
     This change them to int. In addition, this change introduces INT_MAX as the limits of entries 
     in the queue. If a parser enqueues more than INT_MAX items, makeTagEntry returns CORK_NIL,
     and rejects queuing.

2. This change adds more code to handle the case that makeTagEntry() returns CORK_NIL.


