### PR TITLE
CXX: Allow usage of template keyword as disambiguator for dependent names

### DIFF
--- a/Units/parser-cxx.r/templates5.d/args.ctags
+++ b/Units/parser-cxx.r/templates5.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--kinds-C++=*
+--fields-c++=+{template}

--- a/Units/parser-cxx.r/templates5.d/expected.tags
+++ b/Units/parser-cxx.r/templates5.d/expected.tags
@@ -1,0 +1,11 @@
+Checks	input.cpp	/^struct Checks$/;"	s	file:
+Check	input.cpp	/^	template <typename X> static constexpr bool Check()$/;"	f	struct:Checks	typeref:typename:bool	file:	template:<typename X>
+X	input.cpp	/^	template <typename X> static constexpr bool Check()$/;"	Z	function:Checks::Check	typeref:meta:typename
+S	input.cpp	/^template<typename A, typename std::enable_if<Checks::template Check<A>(),bool>::type = true> cla/;"	c	file:	template:<typename A,typename std::enable_if<Checks::template Check<A> (),bool>::type=true>
+A	input.cpp	/^template<typename A, typename std::enable_if<Checks::template Check<A>(),bool>::type = true> cla/;"	Z	class:S	typeref:meta:typename
+foo	input.cpp	/^	template<typename U> void foo(){}$/;"	f	class:S	typeref:typename:void	file:	template:<typename U>
+U	input.cpp	/^	template<typename U> void foo(){}$/;"	Z	function:S::foo	typeref:meta:typename
+bar	input.cpp	/^template<typename T> void bar()$/;"	f	typeref:typename:void	template:<typename T>
+T	input.cpp	/^template<typename T> void bar()$/;"	Z	function:bar	typeref:meta:typename
+s	input.cpp	/^	S<T> s;$/;"	l	function:bar	typeref:typename:S<T>	file:
+marker	input.cpp	/^int marker;$/;"	v	typeref:typename:int

--- a/Units/parser-cxx.r/templates5.d/input.cpp
+++ b/Units/parser-cxx.r/templates5.d/input.cpp
@@ -1,0 +1,25 @@
+// template keyword used as disambiguator for dependent names
+
+#include <type_traits>
+
+struct Checks
+{
+	template <typename X> static constexpr bool Check()
+	{
+		return true;
+	}
+};
+
+template<typename A, typename std::enable_if<Checks::template Check<A>(),bool>::type = true> class S
+{
+	template<typename U> void foo(){}
+};
+
+template<typename T> void bar()
+{
+	S<T> s;
+	s.template foo<T>();
+}
+
+// Marker to make sure the parser doesn't bail out before this line.
+int marker;

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -587,15 +587,25 @@ cxxParserParseTemplateAngleBracketsInternal(bool bCaptureTypeParameters,int iNes
 
 					if(!cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeSmallerThanSign))
 					{
-						// aaargh...
-						CXX_DEBUG_PRINT(
-								"Found unexpected token '%s' of type 0x%02x",
-								vStringValue(g_cxx.pToken->pszWord),
-								g_cxx.pToken->eType
-							);
+						if(!cxxTokenTypeIs(g_cxx.pToken->pPrev->pPrev,CXXTokenTypeMultipleColons))
+						{
+							// aaargh...
+							CXX_DEBUG_PRINT(
+									"Found unexpected token '%s' of type 0x%02x",
+									vStringValue(g_cxx.pToken->pszWord),
+									g_cxx.pToken->eType
+								);
 
-						CXX_DEBUG_LEAVE_TEXT("No smaller than sign after template keyword");
-						return CXXParserParseTemplateAngleBracketsFailed;
+							CXX_DEBUG_LEAVE_TEXT("No smaller than sign after template keyword");
+							return CXXParserParseTemplateAngleBracketsFailed;
+						}
+
+						//
+						// Possibly X::template Something<Y,Z> disambiguation syntax.
+						// See https://en.cppreference.com/w/cpp/language/dependent_name
+						//
+						CXX_DEBUG_PRINT("But it's not followed by a < and has leading ::");
+						continue;
 					}
 
 					switch(


### PR DESCRIPTION
Handle the usage of the template keyword as disambiguator for dependent names.
(hardcore C++ : see https://en.cppreference.com/w/cpp/language/dependent_name).
Fixes #2534 .