### PR TITLE
Fix typos in r.c

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -58,8 +58,8 @@ Python         i/module          indirectlyImported on      module imported in a
 Python         i/module          namespace          on      namespace from where classes/variables/functions are imported
 Python         x/unknown         imported           on      imported from the other module
 Python         x/unknown         indirectlyImported on      classes/variables/functions/modules imported in alternative name
-R              l/library         library            on      library attached by library fucntion
-R              l/library         require            on      library attached by require fucntion
+R              l/library         library            on      library attached by library function
+R              l/library         require            on      library attached by require function
 R              s/source          source             on      source loaded by source fucntion
 RpmSpec        m/macro           undef              on      undefined
 RpmSpec        p/patch           decl               on      declared for applying later
@@ -140,8 +140,8 @@ Python         i/module          indirectlyImported on      module imported in a
 Python         i/module          namespace          on      namespace from where classes/variables/functions are imported
 Python         x/unknown         imported           on      imported from the other module
 Python         x/unknown         indirectlyImported on      classes/variables/functions/modules imported in alternative name
-R              l/library         library            on      library attached by library fucntion
-R              l/library         require            on      library attached by require fucntion
+R              l/library         library            on      library attached by library function
+R              l/library         require            on      library attached by require function
 R              s/source          source             on      source loaded by source fucntion
 RpmSpec        m/macro           undef              on      undefined
 RpmSpec        p/patch           decl               on      declared for applying later

--- a/parsers/r.c
+++ b/parsers/r.c
@@ -14,7 +14,7 @@
 *   https://cran.r-project.org/manuals.html, and
 *   https://cran.r-project.org/doc/manuals/r-release/R-lang.html
 *
-*   The base library (including library and source fucntions) release is at
+*   The base library (including library and source functions) release is at
 *   https://stat.ethz.ch/R-manual/R-devel/library/base/html/00Index.html
 */
 
@@ -88,8 +88,8 @@ typedef enum {
 } rSourceRole;
 
 static roleDefinition RLibraryRoles [] = {
-	{ true, "library", "library attached by library fucntion" },
-	{ true, "require", "library attached by require fucntion" },
+	{ true, "library", "library attached by library function" },
+	{ true, "require", "library attached by require function" },
 };
 
 static roleDefinition RSourceRoles [] = {


### PR DESCRIPTION
This patch fix some spelling typos in r.c

Signed-off-by: Masanari Iida <standby24x7@gmail.com>
