### PR TITLE
Ruby: skip "public", "protected", and "private" when tagging methods

### DIFF
--- a/Units/parser-ruby.r/ruby-methods-for-visiblity.d/expected.tags
+++ b/Units/parser-ruby.r/ruby-methods-for-visiblity.d/expected.tags
@@ -1,0 +1,4 @@
+Mod	input.rb	/^module Mod$/;"	m
+a	input.rb	/^  public def a()  end$/;"	f	module:Mod
+b	input.rb	/^  private def b()  end$/;"	f	module:Mod
+c	input.rb	/^  protected def c()  end$/;"	f	module:Mod

--- a/Units/parser-ruby.r/ruby-methods-for-visiblity.d/expected.tags
+++ b/Units/parser-ruby.r/ruby-methods-for-visiblity.d/expected.tags
@@ -2,3 +2,5 @@ Mod	input.rb	/^module Mod$/;"	m
 a	input.rb	/^  public def a()  end$/;"	f	module:Mod
 b	input.rb	/^  private def b()  end$/;"	f	module:Mod
 c	input.rb	/^  protected def c()  end$/;"	f	module:Mod
+d	input.rb	/^  public_class_method def self.d()  end$/;"	S	module:Mod
+e	input.rb	/^  private_class_method def self.e()  end$/;"	S	module:Mod

--- a/Units/parser-ruby.r/ruby-methods-for-visiblity.d/input.rb
+++ b/Units/parser-ruby.r/ruby-methods-for-visiblity.d/input.rb
@@ -3,4 +3,6 @@ module Mod
   public def a()  end
   private def b()  end
   protected def c()  end
+  public_class_method def self.d()  end
+  private_class_method def self.e()  end
 end

--- a/Units/parser-ruby.r/ruby-methods-for-visiblity.d/input.rb
+++ b/Units/parser-ruby.r/ruby-methods-for-visiblity.d/input.rb
@@ -1,0 +1,6 @@
+# Skip public, protected, and private methods invocation
+module Mod
+  public def a()  end
+  private def b()  end
+  protected def c()  end
+end

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -1001,10 +1001,11 @@ static void findRubyTags (void)
 		}
 		else if (canMatchKeywordWithAssign (&cp, "alias_method"))
 			readAliasMethodAndEmitTags (&cp);
-		else if (canMatchKeywordWithAssign (&cp, "private")
-				 || canMatchKeywordWithAssign (&cp, "protected")
-				 || canMatchKeywordWithAssign (&cp, "public"))
-
+		else if ((canMatchKeywordWithAssign (&cp, "private")
+				  || canMatchKeywordWithAssign (&cp, "protected")
+				  || canMatchKeywordWithAssign (&cp, "public")
+				  || canMatchKeywordWithAssign (&cp, "private_class_method")
+				  || canMatchKeywordWithAssign (&cp, "public_class_method")))
 		{
 			skipWhitespace (&cp);
 			if (canMatchKeywordWithAssign (&cp, "def"))


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>