### PR TITLE
Format --list-fields output as console code block

### DIFF
--- a/docs/output-json.rst
+++ b/docs/output-json.rst
@@ -61,6 +61,8 @@ However, some of them are represented in integer type and/or boolean type.
 What kind of JSON data types used in a field can be known with the output
 of ``--list-fields`` option:
 
+.. code-block:: console
+
         $ ./ctags --list-fields
         #LETTER NAME            ENABLED LANGUAGE         XFMT   JSTYPE DESCRIPTION
         N       name            on      NONE             TRUE   s--    tag name (fixed field)


### PR DESCRIPTION
Currently the way output rendered on https://docs.ctags.io/en/latest/output-json.html is not particularly pretty; judging by GitHub preview this PR should change that.