### PR TITLE
docs(man): Fix typos in man

### DIFF
--- a/docs/man/ctags-client-tools.7.rst
+++ b/docs/man/ctags-client-tools.7.rst
@@ -273,7 +273,7 @@ So, client tools need to:
 inside the expressions. If the expression also contains strings, ``"`` in the
 strings needs to be replaced by ``\"``.
 
-Client tools written in Lisp could buid the expression using lists. ``prin1``
+Client tools written in Lisp could build the expression using lists. ``prin1``
 (in Common Lisp style Lisps) and ``write`` (in Scheme style Lisps) can
 translate the list into a string that can be directly used. For example, in
 EmacsLisp:
@@ -303,7 +303,7 @@ replaced by ``'"'"'`` to prevent broken expressions and shell injection.
 Parse Readtags Output
 ~~~~~~~~~~~~~~~~~~~~~
 In the output of readtags, tabs can appear in all field values (e.g., the tag
-name itself cound contain tabs), which makes it hard to split the line into
+name itself could contain tabs), which makes it hard to split the line into
 fields. Client tools should use the ``-E`` option, which keeps the escape
 sequences in the tags file, so the only field that could contain tabs is the
 pattern field.

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -1289,7 +1289,7 @@ are not listed here. They are experimental or for debugging purpose.
 		$ ctags --put-field-prefix --fields='{line}{end}' -o - /tmp/hello.c
 		main	/tmp/hello.c	/^main(int argc, char **argv)$/;"	f	line:3	UCTAGSend:6
 
-	In the above exapmle, the prefix is put to "end" field which is
+	In the above example, the prefix is put to "end" field which is
 	newly introduced in Universal-ctags.
 
 ``--quiet[=yes|no]``

--- a/docs/man/readtags.1.rst
+++ b/docs/man/readtags.1.rst
@@ -215,7 +215,7 @@ The expressions ``#/PATTERN/`` and ``#/PATTERN/i`` are for interactive use.
 Readtags also offers an alias ``string->regexp``, so ``#/PATTERN/`` is equal to
 ``(string->regexp "PATTERN")``, and ``#/PATTERN/i`` is equal to
 ``(string->regexp "PATTERN" :case-fold #t)``. ``string->regexp`` doesn't need to
-prefix "\" for inclulding "/" in a pattern. ``string->regexp`` may simplify a
+prefix "\" for including "/" in a pattern. ``string->regexp`` may simplify a
 client tool building an expression. See also :ref:`ctags-client-tools(7) <ctags-client-tools(7)>` for making an
 expression in your tool.
 
@@ -310,5 +310,5 @@ Darren Hiebert <dhiebert@users.sourceforge.net>
 http://DarrenHiebert.com/
 
 The readtags command and libreadtags maintained at Universal-ctags
-are derrived from readtags.c and readtags.h developd at
+are derived from readtags.c and readtags.h developd at
 http://ctags.sourceforge.net.


### PR DESCRIPTION
Fix spelling typos in ctags-client-tools.7,rst, ctags.1.rst and readtags.1.rst.
