### PR TITLE
vim: support new ":def" functions of vim9

### DIFF
--- a/Units/parser-vim.r/vim9-def-function.d/expected.tags
+++ b/Units/parser-vim.r/vim9-def-function.d/expected.tags
@@ -1,0 +1,1 @@
+Func	input.vim	/^def Func()$/;"	f

--- a/Units/parser-vim.r/vim9-def-function.d/input.vim
+++ b/Units/parser-vim.r/vim9-def-function.d/input.vim
@@ -1,0 +1,2 @@
+def Func()
+enddef

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -267,7 +267,7 @@ static void parseFunction (const unsigned char *line)
 	/* TODO - update struct to indicate inside function */
 	while ((line = readVimLine ()) != NULL)
 	{
-		if (wordMatchLen (line, "endfunction", 4))
+		if (wordMatchLen (line, "endfunction", 4) || wordMatchLen (line, "enddef", 6))
 		{
 			tagEntryInfo *e = getEntryInCorkQueue (index);
 			if (e)
@@ -584,7 +584,7 @@ static bool parseVimLine (const unsigned char *line, int infunction)
 		parseMap (skipWord (line));
 	}
 
-	else if (wordMatchLen (line, "function", 2))
+	else if (wordMatchLen (line, "function", 2) || wordMatchLen (line, "def", 3))
 	{
 		parseFunction (skipWord (line));
 	}


### PR DESCRIPTION
This PR tries to add support for the new [`:def` functions](https://vimhelp.org/vim9.txt.html#:def) introduced in Vim9.  See issue #2589 for more information.

I briefly tested the patch, and it seems to work.  That is now `ctags(1)` correctly generates tags for `:def` functions.

But I don't know if it's really correct; I don't know C.

If it is correct, I think I could also add support for constants defined with the [`:const`](https://vimhelp.org/eval.txt.html#:const) keyword.
