### PR TITLE
vim: support ":const" command which sets constants

### DIFF
--- a/Units/parser-vim.r/vim-const.d/expected.tags
+++ b/Units/parser-vim.r/vim-const.d/expected.tags
@@ -1,0 +1,1 @@
+s:CONSTANT	input.vim	/^const s:CONSTANT = 42$/;"	C

--- a/Units/parser-vim.r/vim-const.d/input.vim
+++ b/Units/parser-vim.r/vim-const.d/input.vim
@@ -1,0 +1,1 @@
+const s:CONSTANT = 42

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -46,7 +46,8 @@ typedef enum {
 	K_FUNCTION,
 	K_MAP,
 	K_VARIABLE,
-	K_FILENAME
+	K_FILENAME,
+	K_CONST,
 } vimKind;
 
 static kindDefinition VimKinds [] = {
@@ -56,6 +57,7 @@ static kindDefinition VimKinds [] = {
 	{ true,  'm', "map",      "maps" },
 	{ true,  'v', "variable", "variable definitions" },
 	{ true,  'n', "filename", "vimball filename" },
+	{ true,  'C', "constant", "constant definitions" },
 };
 
 /*
@@ -432,7 +434,7 @@ cleanUp:
 	return cmdProcessed;
 }
 
-static void parseLet (const unsigned char *line, int infunction)
+static void parseVariableOrConstant (const unsigned char *line, int infunction, int kindIndex)
 {
 	vString *name = vStringNew ();
 
@@ -482,7 +484,7 @@ static void parseLet (const unsigned char *line, int infunction)
 			vStringPut (name, (int) *cp);
 			++cp;
 		} while (isalnum ((int) *cp) || *cp == '_' || *cp == '#' || *cp == ':' || *cp == '$');
-		makeSimpleTag (name, K_VARIABLE);
+		makeSimpleTag (name, kindIndex);
 		vStringClear (name);
 	}
 
@@ -596,7 +598,11 @@ static bool parseVimLine (const unsigned char *line, int infunction)
 
 	else if (wordMatchLen (line, "let", 3))
 	{
-		parseLet (skipWord (line), infunction);
+		parseVariableOrConstant (skipWord (line), infunction, K_VARIABLE);
+	}
+	else if (wordMatchLen (line, "const", 4))
+	{
+		parseVariableOrConstant (skipWord (line), infunction, K_CONST);
 	}
 
 	return readNextLine;


### PR DESCRIPTION
This PR tries to add support for the Vim command [`:const`](https://vimhelp.org/eval.txt.html#:const).  The latter is used in Vimscript to set a constant.

---

I did not try to create a new C function to parse the command because:

   1. that's above my level
   2. I don't think it's necessary.  In Vim, `:const` is equivalent to `:let` followed by `:lockvar`; it's just a variable whose value is locked so that it can't change.

---

`:const` can be shortened into `:cons`, which is why I wrote `4` and not `5` here:

    else if (wordMatchLen (line, "let", 3) || wordMatchLen (line, "const", 4))
                                                                           ^

---

I added a simple test consisting of an input file and an expected output tags file.
I made sure all the Vim tests passed:

    make units LANGUAGES=Vim
