### PR TITLE
[SELF-INCOMPATIBLE]LdScript: use "ld.script" as an entry of map pattern instead of "ld.*"

### DIFF
--- a/Tmain/list-map-patterns.d/stdout-expected.txt
+++ b/Tmain/list-map-patterns.d/stdout-expected.txt
@@ -1,8 +1,8 @@
 ## all|grep LdScript
 #LANGUAGE PATTERN
 LdScript  *.lds.S
-LdScript  ld.*
+LdScript  ld.script
 ## LdScript
 #PATTERN
 *.lds.S
-ld.*
+ld.script

--- a/parsers/ldscript.c
+++ b/parsers/ldscript.c
@@ -742,8 +742,9 @@ extern parserDefinition* LdScriptParser (void)
 	/* File name patters are picked from Linux kernel and ecos. */
 	static const char *const extensions [] = { "lds", "scr", "ld", "ldi", NULL };
 
-	/* lds.S must be here because Asm parser registers .S as an extension. */
-	static const char *const patterns [] = { "*.lds.S", "ld.*", NULL };
+	/* lds.S must be here because Asm parser registers .S as an extension.
+	 * ld.script is used in linux/arch/mips/boot/compressed/ld.script. */
+	static const char *const patterns [] = { "*.lds.S", "ld.script", NULL };
 
 	/* Emacs's mode */
 	static const char *const aliases [] = { "ld-script", NULL };


### PR DESCRIPTION
Close #2603.

The original pattern "ld.\*" matches "ld.c". As a result ld.c is parsed by LdScript
parser unexpectedly.

Originally, "ld.\*" was introduced for arch/mips/boot/compressed/ld.script of linux.
Replace "ld.\*" with "ld.script" as a more strict pattern.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>