### PR TITLE
build-sys: display an error message when pkg-config or autoreconf is not found

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,8 +2,14 @@
 
 set -xe
 
-type autoreconf > /dev/null || exit 1
-type pkg-config > /dev/null || exit 1
+type autoreconf > /dev/null 2>&1 || {
+	echo "No autotools (autoconf and automake) found" 1>&2
+	exit 1
+}
+type pkg-config > /dev/null 2>&1 || {
+	echo "No pkg-config found" 1>&2
+	exit 1
+}
 
 if [ -z "${MAKE}" ]; then
 	if type make > /dev/null; then


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>