### PR TITLE
Rust: allow arrays in function parameters

### DIFF
--- a/Units/parser-rust.r/rust-test_input.d/expected.tags
+++ b/Units/parser-rust.r/rust-test_input.d/expected.tags
@@ -24,6 +24,7 @@ a_anteater	input.rs	/^	a_anteater(isize),$/;"	e	enum:Animal
 a_bear	input.rs	/^	a_bear(isize),$/;"	e	enum:Animal
 a_cat	input.rs	/^	a_cat(isize),$/;"	e	enum:Animal
 a_dog	input.rs	/^	a_dog(isize),$/;"	e	enum:Animal
+array_param	input.rs	/^fn array_param(arr: [[u32; 3]; 4])$/;"	f	signature:(arr: [[u32; 3]; 4])
 bar	input.rs	/^	bar: isize$/;"	m	struct:A
 bar	input.rs	/^	bar: isize$/;"	m	struct:B
 do_z	input.rs	/^	fn do_z(&self) {$/;"	P	implementation:Foo	signature:(&self)

--- a/Units/parser-rust.r/rust-test_input.d/input.rs
+++ b/Units/parser-rust.r/rust-test_input.d/input.rs
@@ -47,6 +47,10 @@ pub fn where_foo<T>(a: T) where T: Send
 {
 }
 
+fn array_param(arr: [[u32; 3]; 4])
+{
+}
+
 /*
  * fn ignored_in_comment() {}
  */

--- a/parsers/rust.c
+++ b/parsers/rust.c
@@ -528,6 +528,7 @@ static void parseFn (lexerState *lexer, vString *scope, int parent_kind)
 	unsigned long line;
 	MIOPos pos;
 	int paren_level = 0;
+	int bracket_level = 0;
 	bool found_paren = false;
 	bool valid_signature = true;
 
@@ -545,9 +546,13 @@ static void parseFn (lexerState *lexer, vString *scope, int parent_kind)
 
 	/* HACK: This is a bit coarse as far as what tag entry means by
 	 * 'arglist'... */
-	while (lexer->cur_token != '{' && lexer->cur_token != ';')
+	while (lexer->cur_token != '{')
 	{
-		if (lexer->cur_token == '}')
+		if (lexer->cur_token == ';' && bracket_level == 0)
+		{
+			break;
+		}
+		else if (lexer->cur_token == '}')
 		{
 			valid_signature = false;
 			break;
@@ -566,6 +571,14 @@ static void parseFn (lexerState *lexer, vString *scope, int parent_kind)
 				break;
 			}
 		}
+		else if (lexer->cur_token == '[')
+		{
+			bracket_level++;
+		}
+		else if (lexer->cur_token == ']')
+		{
+			bracket_level--;
+		}
 		else if (lexer->cur_token == TOKEN_EOF)
 		{
 			valid_signature = false;
@@ -574,7 +587,7 @@ static void parseFn (lexerState *lexer, vString *scope, int parent_kind)
 		writeCurTokenToStr(lexer, arg_list);
 		advanceToken(lexer, false);
 	}
-	if (!found_paren || paren_level != 0)
+	if (!found_paren || paren_level != 0 || bracket_level != 0)
 		valid_signature = false;
 
 	if (valid_signature)


### PR DESCRIPTION
I noticed that ctags wouldn't generate a function entry for a signature like:

```rust
fn foo(arr: [u32; 3]) {}
```

The problem was that the parser stopped as soon as a ';' was encountered, probably assuming that it would be a statement delimiter and not an array type.

The fix is to keep track of brackets and ignore ';' if we have at least one opened bracket.

While I was at it I also reject the signature if the brackets aren't balanced, which means that the parser is now a little more strict than it was before and a (broken) function like this one will now be rejected:

```rust
fn bad(p: &[u32) {}
```