### PR TITLE
 [SELF-INCOMPATIBLE]main: revise the form of --_roledef option 

### DIFF
--- a/Tmain/json-output-for-broken-input.d/run.sh
+++ b/Tmain/json-output-for-broken-input.d/run.sh
@@ -6,5 +6,5 @@ CTAGS=$1
 . ../utils.sh
 
 if is_feature_available "${CTAGS}" json; then
-	${CTAGS} --output-format=json -o - ./input.cs
+	${CTAGS} --quiet --options=NONE --output-format=json -o - ./input.cs
 fi

--- a/Tmain/kinddef.d/run.sh
+++ b/Tmain/kinddef.d/run.sh
@@ -112,8 +112,8 @@ ${CTAGS} --kinddef-MYTEST='x,kind,\{' --list-kinds-full=MYTEST
 
 title '# _refonly flag'
 ${CTAGS} --kinddef-MYTEST='x,kind,desc' --list-kinds-full=MYTEST
-${CTAGS} --kinddef-MYTEST='x,kind,desc' --_roledef-MYTEST=x.role,roleDesc --list-kinds-full=MYTEST
-${CTAGS} --kinddef-MYTEST='x,kind,desc{_refonly}' --_roledef-MYTEST=x.role,roleDesc --list-kinds-full=MYTEST
+${CTAGS} --kinddef-MYTEST='x,kind,desc' --_roledef-MYTEST.x=role,roleDesc --list-kinds-full=MYTEST
+${CTAGS} --kinddef-MYTEST='x,kind,desc{_refonly}' --_roledef-MYTEST.'{kind}'=role,roleDesc --list-kinds-full=MYTEST
 
 } > /tmp/ctags-tmain-$$.stdout 2>/tmp/ctags-tmain-$$.stderr
 

--- a/Tmain/load-conf-files-under-cwd-no-dot.d/run.sh
+++ b/Tmain/load-conf-files-under-cwd-no-dot.d/run.sh
@@ -5,4 +5,6 @@ CTAGS=$1
 
 . ../utils.sh
 
+skip_if_user_has_dot_ctags_d
+
 ${CTAGS}

--- a/Tmain/load-conf-files-under-cwd.d/run.sh
+++ b/Tmain/load-conf-files-under-cwd.d/run.sh
@@ -6,5 +6,6 @@ CTAGS=$1
 . ../utils.sh
 
 exit_if_win32 "$CTAGS"
+skip_if_user_has_dot_ctags_d
 
 ${CTAGS}

--- a/Tmain/roledef.d/run.sh
+++ b/Tmain/roledef.d/run.sh
@@ -19,80 +19,111 @@ title()
 {
 title '# echo unknown lang'
 ${CTAGS} --_roledef-NOSUCHLANG
-${CTAGS} --_roledef-NOSUCHLANG=v.role,roles
+${CTAGS} --_roledef-NOSUCHLANG.k=role,roles
+${CTAGS} --_roledef-NOSUCHLANG.'{kind}'=role,roles
 
-title '# no option value'
+title '# no kind spec'
 ${CTAGS} --_roledef-IMAGINARY
 ${CTAGS} --_roledef-IMAGINARY=
+${CTAGS} --_roledef-IMAGINARY=role
+${CTAGS} --_roledef-IMAGINARY=role,roles
 
-title '# echo unknown kind'
-${CTAGS} --_roledef-IMAGINARY=x            --_force-quit
-${CTAGS} --_roledef-IMAGINARY=x.           --_force-quit
-${CTAGS} --_roledef-IMAGINARY=x.role       --_force-quit
-${CTAGS} --_roledef-IMAGINARY=x.role,      --_force-quit
-${CTAGS} --_roledef-IMAGINARY=x.role,roles --_force-quit
+title '# echo unknown kind letter'
+${CTAGS} --_roledef-IMAGINARY.x=           --_force-quit
+${CTAGS} --_roledef-IMAGINARY.x=role       --_force-quit
+${CTAGS} --_roledef-IMAGINARY.x=role,      --_force-quit
+${CTAGS} --_roledef-IMAGINARY.x=role,roles --_force-quit
+
+title '# echo unknown kind name'
+${CTAGS} --_roledef-IMAGINARY.'{abc}'=           --_force-quit
+${CTAGS} --_roledef-IMAGINARY.'{abc}'=role       --_force-quit
+${CTAGS} --_roledef-IMAGINARY.'{abc}'=role,      --_force-quit
+${CTAGS} --_roledef-IMAGINARY.'{abc}'=role,roles --_force-quit
 
 title '# wrong char in a kind letter'
-${CTAGS} --_roledef-IMAGINARY=/
-${CTAGS} --_roledef-IMAGINARY=%.
-${CTAGS} --_roledef-IMAGINARY=^.role
-${CTAGS} --_roledef-IMAGINARY=#.role,roles
+${CTAGS} --_roledef-IMAGINARY.'/'=
+${CTAGS} --_roledef-IMAGINARY.'%'=
+${CTAGS} --_roledef-IMAGINARY.'^'=role
+${CTAGS} --_roledef-IMAGINARY.'#'=role,roles
+${CTAGS} --_roledef-IMAGINARY.'F'=role,roles
+${CTAGS} --_roledef-IMAGINARY.'{'=role,roles
+${CTAGS} --_roledef-IMAGINARY.'{v'=role,roles
+
+title '# wrong kind name'
+${CTAGS} --_roledef-IMAGINARY.'{file}'=role,roles
+${CTAGS} --_roledef-IMAGINARY.'{}'=role,roles
+${CTAGS} --_roledef-IMAGINARY.'{#}'=role,roles
 
 title '# empty role name'
-${CTAGS} --_roledef-IMAGINARY=v
-${CTAGS} --_roledef-IMAGINARY=v.
-${CTAGS} --_roledef-IMAGINARY=v.,
+${CTAGS} --_roledef-IMAGINARY.v=
+${CTAGS} --_roledef-IMAGINARY.v=,
+${CTAGS} --_roledef-IMAGINARY.v=,desc
+${CTAGS} --_roledef-IMAGINARY.'{variable}'=
+${CTAGS} --_roledef-IMAGINARY.'{variable}'=,
+${CTAGS} --_roledef-IMAGINARY.'{variable}'=,desc
 
 title '# wrong char in role name'
-${CTAGS} --_roledef-IMAGINARY=v.+role+,
+${CTAGS} --_roledef-IMAGINARY.v=+role+,
+${CTAGS} --_roledef-IMAGINARY.'{variable}'=+role+,
 
 title '# empty description'
-${CTAGS} --_roledef-IMAGINARY=v.role
-${CTAGS} --_roledef-IMAGINARY=v.role,
+${CTAGS} --_roledef-IMAGINARY.v=role
+${CTAGS} --_roledef-IMAGINARY.v=role,
+${CTAGS} --_roledef-IMAGINARY.'{variable}'=role
+${CTAGS} --_roledef-IMAGINARY.'{variable}'=role,
 
 title '# role is acceptable but no input file'
-${CTAGS} --_roledef-IMAGINARY=v.role,roles
+${CTAGS} --_roledef-IMAGINARY.v=role,roles
+${CTAGS} --_roledef-IMAGINARY.'{variable}'=role,roles
 
 title '# listing with --list-roles'
-${CTAGS} --_roledef-IMAGINARY=v.role,roles --list-roles=IMAGINARY
-${CTAGS} --_roledef-IMAGINARY=v.role,roles \
-		 --_roledef-IMAGINARY=v.foos,foods \
+${CTAGS} --_roledef-IMAGINARY.v=role,roles --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.'{variable}'=role,roles \
+		 --_roledef-IMAGINARY.v=foos,foods \
 		 --list-roles=IMAGINARY
 
 title '# listing with --list-kinds-full'
-${CTAGS} --_roledef-IMAGINARY=v.role,roles --list-kinds-full=IMAGINARY
-${CTAGS} --_roledef-IMAGINARY=v.role,roles \
-		 --_roledef-IMAGINARY=v.foos,foods \
+${CTAGS} --_roledef-IMAGINARY.v=role,roles --list-kinds-full=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.'{variable}'=role,roles \
+		 --_roledef-IMAGINARY.v=foos,foods \
 		 --list-kinds-full=IMAGINARY
 
 title '# inject a flag separator'
-${CTAGS} --_roledef-IMAGINARY='v.role,roles{foo}' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.v='role,roles{foo}' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.'{variable}'='role,roles{foo}' --list-roles=IMAGINARY
 
 title '# inject a broken flag separator(1)'
-${CTAGS} --_roledef-IMAGINARY='v.role,roles{foo' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.v='role,roles{foo' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.'{variable}'='role,roles{foo' --list-roles=IMAGINARY
 
 title '# inject a broken flag separator(2)'
-${CTAGS} --_roledef-IMAGINARY='v.role,roles{' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.v='role,roles{' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.'{variable}'='role,roles{' --list-roles=IMAGINARY
 
 title '# use a { in description (1)'
-${CTAGS} --_roledef-IMAGINARY='v.role,roles\{' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.v='role,roles\{' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.'{variable}'='role,roles\{' --list-roles=IMAGINARY
 
 title '# use a { in description (2)'
-${CTAGS} --_roledef-IMAGINARY='v.role,roles\{}' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.v='role,roles\{}' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.'{variable}'='role,roles\{}' --list-roles=IMAGINARY
 
 title '# use a \ in description'
-${CTAGS} --_roledef-IMAGINARY='v.role,roles\\backslash' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.v='role,roles\\backslash' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.'{variable}'='role,roles\\backslash' --list-roles=IMAGINARY
 
 title '# description started from {'
-${CTAGS} --_roledef-IMAGINARY='v.role,{' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.v='role,{' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.'{variable}'='role,{' --list-roles=IMAGINARY
 
 title '# description started from \{'
-${CTAGS} --_roledef-IMAGINARY='v.role,\{' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.v='role,\{' --list-roles=IMAGINARY
+${CTAGS} --_roledef-IMAGINARY.'{variable}'='role,\{' --list-roles=IMAGINARY
 
 title '# too many roles'
 opts=
 for i in $(seq 0 64); do
-	opts="$opts --_roledef-IMAGINARY=v.r$i,desc$i "
+	opts="$opts --_roledef-IMAGINARY.v=r$i,desc$i "
 done
 ${CTAGS} $opts
 

--- a/Tmain/roledef.d/stderr-expected.txt
+++ b/Tmain/roledef.d/stderr-expected.txt
@@ -1,38 +1,61 @@
 
 # echo unknown lang
 ctags: Unknown language "NOSUCHLANG" in "_roledef-NOSUCHLANG" option
-ctags: Unknown language "NOSUCHLANG" in "_roledef-NOSUCHLANG" option
+ctags: Unknown language "NOSUCHLANG" in "_roledef-NOSUCHLANG.k" option
+ctags: Unknown language "NOSUCHLANG" in "_roledef-NOSUCHLANG.{kind}" option
 
-# no option value
-ctags: no role definition specified in "--_roledef-IMAGINARY" option
-ctags: no role definition specified in "--_roledef-IMAGINARY" option
+# no kind spec
+ctags: no kind is specifined in "--_roledef-IMAGINARY="
+ctags: no kind is specifined in "--_roledef-IMAGINARY="
+ctags: no kind is specifined in "--_roledef-IMAGINARY=role"
+ctags: no kind is specifined in "--_roledef-IMAGINARY=role,roles"
 
-# echo unknown kind
-ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
-ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
-ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
-ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
-ctags: Warning: the kind for letter `x' specified in "--_roledef-IMAGINARY" option is not defined.
+# echo unknown kind letter
+ctags: the kind for letter `x' specified in "--_roledef-IMAGINARY.x" option is not defined.
+ctags: the kind for letter `x' specified in "--_roledef-IMAGINARY.x" option is not defined.
+ctags: the kind for letter `x' specified in "--_roledef-IMAGINARY.x" option is not defined.
+ctags: the kind for letter `x' specified in "--_roledef-IMAGINARY.x" option is not defined.
+
+# echo unknown kind name
+ctags: the kind for name `abc' specified in "--_roledef-IMAGINARY.{abc}" option is not defined.
+ctags: the kind for name `abc' specified in "--_roledef-IMAGINARY.{abc}" option is not defined.
+ctags: the kind for name `abc' specified in "--_roledef-IMAGINARY.{abc}" option is not defined.
+ctags: the kind for name `abc' specified in "--_roledef-IMAGINARY.{abc}" option is not defined.
 
 # wrong char in a kind letter
-ctags: the kind letter given in "--_roledef-IMAGINARY" option is not an alphabet or a number
-ctags: the kind letter given in "--_roledef-IMAGINARY" option is not an alphabet or a number
-ctags: the kind letter given in "--_roledef-IMAGINARY" option is not an alphabet or a number
-ctags: the kind letter given in "--_roledef-IMAGINARY" option is not an alphabet or a number
+ctags: the kind letter given in "--_roledef-IMAGINARY./" option is not an alphabet or a number
+ctags: the kind letter given in "--_roledef-IMAGINARY.%" option is not an alphabet or a number
+ctags: the kind letter given in "--_roledef-IMAGINARY.^" option is not an alphabet or a number
+ctags: the kind letter given in "--_roledef-IMAGINARY.#" option is not an alphabet or a number
+ctags: the kind letter `F' in "--_roledef-IMAGINARY.F" option is reserved for "file" kind, and no role can be attached to it
+ctags: no '}' representing the end of kind name in --_roledef-IMAGINARY.{ option: {
+ctags: no '}' representing the end of kind name in --_roledef-IMAGINARY.{v option: {v
+
+# wrong kind name
+ctags: don't define a role for F/file kind; it has no role: --_roledef-IMAGINARY.{file}
+ctags: the kind for name `' specified in "--_roledef-IMAGINARY.{}" option is not defined.
+ctags: the kind for name `#' specified in "--_roledef-IMAGINARY.{#}" option is not defined.
 
 # empty role name
-ctags: wrong role definition in "--_roledef-IMAGINARY" option: no period after kind letter `v'
-ctags: no role name specified in "--_roledef-IMAGINARY" option
-ctags: the role name in "--_roledef-IMAGINARY" option is empty
+ctags: no role description specified in "--_roledef-IMAGINARY.v" option
+ctags: the role name in "--_roledef-IMAGINARY.v" option is empty
+ctags: the role name in "--_roledef-IMAGINARY.v" option is empty
+ctags: no role description specified in "--_roledef-IMAGINARY.{variable}" option
+ctags: the role name in "--_roledef-IMAGINARY.{variable}" option is empty
+ctags: the role name in "--_roledef-IMAGINARY.{variable}" option is empty
 
 # wrong char in role name
-ctags: unacceptable char as part of role name in "--_roledef-IMAGINARY" option: +
+ctags: unacceptable char as part of role name in "--_roledef-IMAGINARY.v" option: +
+ctags: unacceptable char as part of role name in "--_roledef-IMAGINARY.{variable}" option: +
 
 # empty description
-ctags: no role description specified in "--_roledef-IMAGINARY" option
-ctags: found an empty role description in "--_roledef-IMAGINARY" option
+ctags: no role description specified in "--_roledef-IMAGINARY.v" option
+ctags: found an empty role description in "--_roledef-IMAGINARY.v" option
+ctags: no role description specified in "--_roledef-IMAGINARY.{variable}" option
+ctags: found an empty role description in "--_roledef-IMAGINARY.{variable}" option
 
 # role is acceptable but no input file
+ctags: No files specified. Try "ctags --help".
 ctags: No files specified. Try "ctags --help".
 
 # listing with --list-roles
@@ -43,8 +66,10 @@ ctags: No files specified. Try "ctags --help".
 
 # inject a broken flag separator(1)
 ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{foo"
 
 # inject a broken flag separator(2)
+ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 
 # use a { in description (1)
@@ -54,7 +79,8 @@ ctags: Warning: long flags specifier opened with `{' is not closed `}': "{"
 # use a \ in description
 
 # description started from {
-ctags: found an empty role description in "--_roledef-IMAGINARY" option
+ctags: found an empty role description in "--_roledef-IMAGINARY.v" option
+ctags: found an empty role description in "--_roledef-IMAGINARY.{variable}" option
 
 # description started from \{
 

--- a/Tmain/roledef.d/stdout-expected.txt
+++ b/Tmain/roledef.d/stdout-expected.txt
@@ -1,11 +1,15 @@
 
 # echo unknown lang
 
-# no option value
+# no kind spec
 
-# echo unknown kind
+# echo unknown kind letter
+
+# echo unknown kind name
 
 # wrong char in a kind letter
+
+# wrong kind name
 
 # empty role name
 
@@ -31,30 +35,44 @@ v       variable yes     no      2      NONE   variables
 # inject a flag separator
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      roles
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles
 
 # inject a broken flag separator(1)
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      roles
 
 # inject a broken flag separator(2)
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      roles
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles
 
 # use a { in description (1)
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles{
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      roles{
 
 # use a { in description (2)
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      roles{}
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles{}
 
 # use a \ in description
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      roles\backslash
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      roles\backslash
 
 # description started from {
 
 # description started from \{
+#KIND(L/N)  NAME ENABLED DESCRIPTION
+v/variable  role on      {
 #KIND(L/N)  NAME ENABLED DESCRIPTION
 v/variable  role on      {
 

--- a/Tmain/utils.sh
+++ b/Tmain/utils.sh
@@ -43,6 +43,13 @@ is_feature_available()
 	fi
 }
 
+skip_if_user_has_dot_ctags_d()
+{
+	if [ -d ~/.ctags.d ]; then
+		skip "this test case doesn't work well if you have ~/.ctags.d"
+	fi
+}
+
 exit_if_win32()
 {
 	is_feature_available $1 '!' win32

--- a/Units/option-regex-attaching-role.r/extending-existing-parser.d/args.ctags
+++ b/Units/option-regex-attaching-role.r/extending-existing-parser.d/args.ctags
@@ -11,9 +11,9 @@
 --langdef=myGauche{base=Scheme}
 
 --kinddef-myGauche=m,module,modules
---_roledef-myGauche=m.used,specified as argument for use
---_roledef-myGauche=m.exported,specified as argument for export
---_roledef-myGauche=m.selected,specified as argument for select
+--_roledef-myGauche.m=used,specified as argument for use
+--_roledef-myGauche.{module}=exported,specified as argument for export
+--_roledef-myGauche.{module}=selected,specified as argument for select
 
 --_tabledef-myGauche=main
 --_tabledef-myGauche=export

--- a/Units/option-regex-attaching-role.r/standing-alone-line-parser.d/args.ctags
+++ b/Units/option-regex-attaching-role.r/standing-alone-line-parser.d/args.ctags
@@ -7,9 +7,9 @@
 
 --_fielddef-FOO=assocMod,module associated with the namespace
 
---_roledef-FOO=m.used,refereed as an external module
---_roledef-FOO=m.loaded,loaded into the current name space
---_roledef-FOO=f.loaded,loaded into the current name space
+--_roledef-FOO.m=used,refereed as an external module
+--_roledef-FOO.{module}=loaded,loaded into the current name space
+--_roledef-FOO.f=loaded,loaded into the current name space
 
 --regex-FOO=/^defmod +([A-Z]+)/\1/m/
 --regex-FOO=/^use +([A-Z]+)/\1/m/{_role=used}

--- a/docs/man/ctags-optlib.7.rst
+++ b/docs/man/ctags-optlib.7.rst
@@ -151,7 +151,7 @@ OPTIONS
 
 	*name* must consist of alphanumeric characters, "#", or "+"
 	 ('[a-zA-Z0-9#+]+'). The graph characters other than "#" and
-	 "+" are disallowed (or reserved). Some of them ('[-=:{]') are
+	 "+" are disallowed (or reserved). Some of them ('[-=:{.]') are
 	 disallowed because they can make the command line parser of
 	 ctags confused. The rest of them are just
 	 reserved for future extending ctags.

--- a/main/options.c
+++ b/main/options.c
@@ -788,7 +788,10 @@ extern langType getLanguageComponentInOptionFull (const char *const option,
 		lang_len = colon - lang;
 	language = getNamedLanguageFull (lang, lang_len, noPretending);
 	if (language == LANG_IGNORE)
-		error (FATAL, "Unknown language \"%s\" in \"%s\" option", lang, option);
+	{
+		const char *langName = (lang_len == 0)? lang: eStrndup (lang, lang_len);
+		error (FATAL, "Unknown language \"%s\" in \"%s\" option", langName, option);
+	}
 
 	return language;
 }
@@ -2244,7 +2247,10 @@ static void processListRolesOptions (const char *const option CTAGS_ATTR_UNUSED,
 	{
 		lang = getNamedLanguage (parameter, sep - parameter);
 		if (lang == LANG_IGNORE)
-			error (FATAL, "Unknown language \"%s\" in \"%s\"", parameter, option);
+		{
+			const char *langName = eStrndup (parameter, sep - parameter);
+			error (FATAL, "Unknown language \"%s\" in \"%s\"", langName, option);
+		}
 	}
 	printLanguageRoles (lang, kindspecs,
 						localOption.withListHeader,

--- a/main/options.c
+++ b/main/options.c
@@ -482,8 +482,8 @@ static optionDescription ExperimentalLongOptionDescription [] = {
  {1,"       Define multitable regular expression for locating tags in specific language."},
  {1,"  --_pretend-<NEWLANG>=<OLDLANG>"},
  {1,"       Make NEWLANG parser pretend OLDLANG parser in lang: field."},
- {1,"  --_roledef-<LANG>=kind_letter.role_name,role_desc"},
- {1,"       Define new role for kind specified with <kind_letter> in <LANG>."},
+ {1,"  --_roledef-<LANG>.kind=role_name,role_desc"},
+ {1,"       Define new role for the kind in <LANG>."},
  {1,"  --_scopesep-<LANG>=[parent_kind_letter]/child_kind_letter:separator"},
  {1,"       Specify scope separator between <PARENT_KIND> and <KIND>."},
  {1,"       * as a kind letter matches any kind."},
@@ -766,7 +766,7 @@ extern langType getLanguageComponentInOptionFull (const char *const option,
 	size_t prefix_len;
 	langType language;
 	const char *lang;
-	char *colon = NULL;
+	char *sep = NULL;
 	size_t lang_len = 0;
 
 	Assert (prefix && prefix[0]);
@@ -782,10 +782,12 @@ extern langType getLanguageComponentInOptionFull (const char *const option,
 			return LANG_IGNORE;
 	}
 
-	/* --param-<LANG>:<PARAM>=... */
-	colon = strchr (lang, ':');
-	if (colon)
-		lang_len = colon - lang;
+	/* Extract <LANG> from
+	 * --param-<LANG>:<PARAM>=..., and
+	 * --_roledef-<LANG>.<KIND>=... */
+	sep = strpbrk (lang, ":.");
+	if (sep)
+		lang_len = sep - lang;
 	language = getNamedLanguageFull (lang, lang_len, noPretending);
 	if (language == LANG_IGNORE)
 	{

--- a/main/parse.c
+++ b/main/parse.c
@@ -2534,6 +2534,7 @@ static void freeRdef (roleDefinition *rdef)
 }
 
 static bool processLangDefineRole(const langType language,
+								  const char *const kindSpec,
 								  const char *const option,
 								  const char *const parameter)
 {
@@ -2541,51 +2542,61 @@ static bool processLangDefineRole(const langType language,
 
 	kindDefinition *kdef;
 	roleDefinition *rdef;
-	char kletter;
-	const char * p = parameter;
 	char *name;
 	char *description;
-	const char *tmp_start;
-	const char *tmp_end;
-	const char *flags;
 
 	Assert (0 <= language  &&  language < (int) LanguageCount);
+	Assert (parameter);
+
 	parser = LanguageTable + language;
 
-	Assert (p);
-
-	if (p[0] == '\0')
-		error (FATAL, "no role definition specified in \"--%s\" option", option);
-
-	kletter = p[0];
-	if (kletter == '.')
-		error (FATAL, "no kind letter specified in \"--%s\" option", option);
-	if (!isalnum ((unsigned char)kletter))
-		error (FATAL, "the kind letter given in \"--%s\" option is not an alphabet or a number", option);
-	else if (kletter == KIND_FILE_DEFAULT_LETTER)
-		error (FATAL, "the kind letter `F' in \"--%s\" option is reserved for \"file\" kind and no role can be attached to", option);
-
-	kdef = getKindForLetter (parser->kindControlBlock, kletter);
-
-	if (kdef == NULL)
+	if (*kindSpec == '{')
 	{
-		error (WARNING, "the kind for letter `%c' specified in \"--%s\" option is not defined.",
-			   kletter, option);
-		return true;
+		const char *end = strchr (kindSpec, '}');
+		if (end == NULL)
+			error (FATAL, "no '}' representing the end of kind name in --%s option: %s",
+				   option, kindSpec);
+		if (*(end + 1) != '\0')
+			error (FATAL, "garbage after the kind specification %s in --%s option",
+				   kindSpec, option);
+		char *kindName = eStrndup (kindSpec + 1, end - (kindSpec + 1));
+		if (strcmp (kindName, KIND_FILE_DEFAULT_NAME) == 0)
+			error (FATAL, "don't define a role for %c/%s kind; it has no role: --%s",
+				   KIND_FILE_DEFAULT_LETTER, KIND_FILE_DEFAULT_NAME,
+				   option);
+		kdef = getKindForName (parser->kindControlBlock, kindName);
+		if (kdef == NULL)
+			error (FATAL, "the kind for name `%s' specified in \"--%s\" option is not defined.",
+				   kindName, option);
+		eFree (kindName);
+	}
+	else
+	{
+		char kletter = *kindSpec;
+		if (!isalnum ((unsigned char)kletter))
+			error (FATAL, "the kind letter given in \"--%s\" option is not an alphabet or a number", option);
+		else if (kletter == KIND_FILE_DEFAULT_LETTER)
+			error (FATAL, "the kind letter `%c' in \"--%s\" option is reserved for \"%s\" kind, and no role can be attached to it",
+				   KIND_FILE_DEFAULT_LETTER, option, KIND_FILE_DEFAULT_NAME);
+		else if (*(kindSpec + 1) != '\0')
+			error (FATAL, "more than one letters are specified as a kind spec in \"--%s\" option: use `{' and `}' for specifying a kind name",
+				   option);
+
+		kdef = getKindForLetter (parser->kindControlBlock, kletter);
+		if (kdef == NULL)
+		{
+			error (FATAL, "the kind for letter `%c' specified in \"--%s\" option is not defined.",
+				   *kindSpec, option);
+			return true;
+		}
 	}
 
-	if (p[1] != '.')
-		error (FATAL, "wrong role definition in \"--%s\" option: no period after kind letter `%c'",
-			   option, kletter);
-
-	p += 2;
-	if (p[0] == '\0')
-		error (FATAL, "no role name specified in \"--%s\" option", option);
-	tmp_end = strchr (p, ',');
+	const char * p = parameter;
+	const char *tmp_end = strchr (p, ',');
 	if (!tmp_end)
 		error (FATAL, "no role description specified in \"--%s\" option", option);
 
-	tmp_start = p;
+	const char * tmp_start = p;
 	while (p != tmp_end)
 	{
 		if (!isalnum (*p))
@@ -2610,6 +2621,7 @@ static bool processLangDefineRole(const langType language,
 	if (p [0] == '\0' || p [0] == LONG_FLAGS_OPEN)
 		error (FATAL, "found an empty role description in \"--%s\" option", option);
 
+	const char *flags;
 	description = extractDescriptionAndFlags (p, &flags);
 
 	rdef = xCalloc (1, roleDefinition);
@@ -2638,13 +2650,25 @@ extern bool processKinddefOption (const char *const option, const char * const p
 
 extern bool processRoledefOption (const char *const option, const char * const parameter)
 {
-	langType language;
+#define PREFIX "_roledef-"
+#define PREFIX_LEN strlen(PREFIX)
 
-	language = getLanguageComponentInOption (option, "_roledef-");
+	langType language = getLanguageComponentInOption (option, PREFIX);
 	if (language == LANG_IGNORE)
 		return false;
 
-	return processLangDefineRole (language, option, parameter);
+	Assert (0 <= language  &&  language < (int) LanguageCount);
+	const char* kindSpec = option + PREFIX_LEN + strlen (getLanguageName (language));
+	if (*kindSpec == '\0')
+		error (FATAL, "no kind is specifined in \"--%s=%s\"", option, parameter);
+	if (*kindSpec != '.')
+		error (FATAL, "no delimiter (.) where a kindspec starts is found in \"--%s\": %c",
+			   option, *kindSpec);
+	kindSpec++;
+
+	return processLangDefineRole (language, kindSpec, option, parameter);
+#undef PREFIX
+#undef PREFIX_LEN
 }
 
 struct langKindDefinitionStruct {

--- a/main/parse.c
+++ b/main/parse.c
@@ -570,8 +570,8 @@ static bool processLangDefineScopesep(const langType language,
 		parentKindex = KIND_WILDCARD_INDEX;
 	else if (parentKletter == KIND_FILE_DEFAULT_LETTER)
 		error (FATAL,
-			   "the kind letter `F' in \"--%s\" option is reserved for \"file\" kind and no separator can be assigned to",
-			   option);
+			   "the kind letter `%c' in \"--%s\" option is reserved for \"%s\" kind and no separator can be assigned to",
+			   KIND_FILE_DEFAULT_LETTER, option, KIND_FILE_DEFAULT_NAME);
 	else if (isalpha (parentKletter))
 	{
 		kindDefinition *kdef = getKindForLetter (parser->kindControlBlock, parentKletter);
@@ -620,8 +620,8 @@ static bool processLangDefineScopesep(const langType language,
 	}
 	else if (kletter == KIND_FILE_DEFAULT_LETTER)
 		error (FATAL,
-			   "the kind letter `F' in \"--%s\" option is reserved for \"file\" kind and no separator can be assigned to",
-			   option);
+			   "the kind letter `%c' in \"--%s\" option is reserved for \"%s\" kind and no separator can be assigned to",
+			   KIND_FILE_DEFAULT_LETTER, option, KIND_FILE_DEFAULT_NAME);
 	else if (isalpha (kletter))
 	{
 		kindDefinition *kdef = getKindForLetter (parser->kindControlBlock, kletter);
@@ -2443,7 +2443,8 @@ static bool processLangDefineKind(const langType language,
 		)
 		error (FATAL, "the kind letter given in \"--%s\" option is not an alphabet", option);
 	else if (letter == KIND_FILE_DEFAULT_LETTER)
-		error (FATAL, "the kind letter `F' in \"--%s\" option is reserved for \"file\" kind", option);
+		error (FATAL, "the kind letter `%c' in \"--%s\" option is reserved for \"%s\" kind",
+			   KIND_FILE_DEFAULT_LETTER, option, KIND_FILE_DEFAULT_NAME);
 	else if (getKindForLetter (parser->kindControlBlock, letter))
 	{
 		error (WARNING, "the kind for letter `%c' specified in \"--%s\" option is already defined.",
@@ -3057,7 +3058,8 @@ extern bool processRolesOption (const char *const option, const char *const para
 		char *kindName = eStrndup (kind + 1, name_end - (kind + 1));
 		if (strcmp (kindName, KIND_FILE_DEFAULT_NAME) == 0)
 		{
-			error (WARNING, "don't enable/disable a role in F/file kind; it has no role: --%s",
+			error (WARNING, "don't enable/disable a role in %c/%s kind; it has no role: --%s",
+				   KIND_FILE_DEFAULT_LETTER, KIND_FILE_DEFAULT_NAME,
 				   option);
 			return true;
 		}
@@ -3077,7 +3079,8 @@ extern bool processRolesOption (const char *const option, const char *const para
 	{
 		if (*kind == KIND_FILE_DEFAULT_LETTER)
 		{
-			error (WARNING, "don't enable/disable a role in F/file kind; it has no role: --%s",
+			error (WARNING, "don't enable/disable a role in %c/%s kind; it has no role: --%s",
+				   KIND_FILE_DEFAULT_LETTER, KIND_FILE_DEFAULT_NAME,
 				   option);
 			return true;
 		}

--- a/main/parse.c
+++ b/main/parse.c
@@ -2809,7 +2809,7 @@ extern bool processKindsOption (
  * --roles-<LANG>.{kind1}=+{role0}-{role1}{role2}
  *
  *
- * How should --roledef be change to align --roles-<LANG> notation
+ * How --roledef should be change to align --roles-<LANG> notation
  * ---------------------------------------------------------------------
  *
  * --_roledef-<LANG>.k=role,description
@@ -2819,7 +2819,7 @@ extern bool processKindsOption (
  *  --_roledef-<LANG>=k.role,description
  *
  *
- * How should --param be change to align --roles-<LANG> notation
+ * How --param should be change to align --roles-<LANG> notation
  * ---------------------------------------------------------------------
  *
  * --_param-<LANG>.name=argument
@@ -2828,7 +2828,7 @@ extern bool processKindsOption (
  * --_param-<LANG>:name=argument
  *
  *
- * How should --paramdef be to align --roles-<LANG> notation
+ * How --paramdef should be to align --roles-<LANG> notation
  * ---------------------------------------------------------------------
  *
  * --_paramdef-<LANG>.name=[ default (desription) ]

--- a/man/ctags-optlib.7.rst.in
+++ b/man/ctags-optlib.7.rst.in
@@ -151,7 +151,7 @@ OPTIONS
 
 	*name* must consist of alphanumeric characters, "#", or "+"
 	 ('[a-zA-Z0-9#+]+'). The graph characters other than "#" and
-	 "+" are disallowed (or reserved). Some of them ('[-=:{]') are
+	 "+" are disallowed (or reserved). Some of them ('[-=:{.]') are
 	 disallowed because they can make the command line parser of
 	 @CTAGS_NAME_EXECUTABLE@ confused. The rest of them are just
 	 reserved for future extending @CTAGS_NAME_EXECUTABLE@.

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -114,16 +114,17 @@ my $options =
 
 	 push @{$_[0]->{'fielddefs'}}, { name => $name, desc => $desc };
        } ],
-     [ qr/^--_roledef-(.*)=([a-zA-Z])\.([a-zA-Z0-9]+),([^\{]+)/, sub {
-	   die "Don't use --_roledef-<LANG>=+ option before defining the language"
+     [ qr/^--_roledef-([^.]*)\.(?:([a-zA-Z])|\{([a-zA-Z][a-zA-Z0-9]*)\})=([a-zA-Z0-9]+),([^\{]+)/, sub {
+	   die "Don't use --_roledef-<LANG>.<KNID>=+ option before defining the language"
 	     if (! defined $_[0]->{'langdef'});
 	   die "Adding a field is allowed only to the language specified with --langdef: $1"
 	     unless ($_[0]->{'langdef'} eq $1);
 
 	   my $kind_found = 0;
 	   for (@{$_[0]->{'kinddefs'}}) {
-	       if ($_->{'letter'} eq $2) {
-		   my $role = { name => $3, desc => $4, owner => $_ };
+	       if ((defined $2 && $_->{'letter'} eq $2)
+		   || (defined $3 && $_->{'name'} eq $3)) {
+		   my $role = { name => $4, desc => $5, owner => $_ };
 		   push @{$_->{'roles'}}, $role;
 		   $kind_found = 1;
 		   last;

--- a/optlib/elm.ctags
+++ b/optlib/elm.ctags
@@ -27,7 +27,7 @@
 --kinddef-Elm=c,constructor,Type Constructor
 --kinddef-Elm=a,alias,Type Alias
 --kinddef-Elm=f,function,Functions
---_roledef-Elm=m.imported,imported module
+--_roledef-Elm.{module}=imported,imported module
 
 --regex-Elm=/^(port[[:blank:]]+)?module[[:blank:]]+([[:upper:]][[:alnum:]_.]*)/\2/m/{scope=push}{exclusive}
 --regex-Elm=/^import[[:blank:]]+[[:alnum:]_.]+[[:blank:]]+as[[:blank:]]+([[:alnum:]]+)/\1/n/{scope=clear}{exclusive}

--- a/optlib/kconfig.ctags
+++ b/optlib/kconfig.ctags
@@ -22,7 +22,7 @@
 --kinddef-Kconfig=k,kconfig,kconfig file
 --kinddef-Kconfig=C,choice,choices
 
---_roledef-Kconfig=k.source,kconfig file loaded with source directive
+--_roledef-Kconfig.{kconfig}=source,kconfig file loaded with source directive
 
 # Menus can be nested. Combine the parent menu and its child with "".
 --_scopesep-Kconfig=*/*:""


### PR DESCRIPTION
Clsoe #2596.

The original form of the option was

	--_roledef-<LANG>=<KIND-LETTER>.<ROLE>,<ROLE-DESCRIPTION>

This form doesn't align with the form of more popular (= use visible) option,
--roles-<LANG>.<KIND>=[+|-]<ROLE>.

For aligning the forms, this commit changes the form of --_roledef option
as following:

	   --_roledef-<LANG>.<KIND>=<ROLE>,<ROLE-DESCRIPTION>
