### PR TITLE
main: allow memory allocators to return NULL when the size is 0

### DIFF
--- a/main/kind.c
+++ b/main/kind.c
@@ -154,7 +154,7 @@ static void freeRoleControlBlock (struct roleControlBlock *rcb)
 		if (rcb->role[i].free)
 			rcb->role [i].free (rcb->role [i].def);
 	}
-	eFree (rcb->role);
+	eFreeNoNullCheck (rcb->role);
 	eFree (rcb);
 }
 
@@ -176,7 +176,8 @@ extern void freeKindControlBlock (struct kindControlBlock* kcb)
 	if (kcb->defaultScopeSeparator.separator)
 		eFree((char *)kcb->defaultScopeSeparator.separator);
 
-	eFree (kcb->kind);
+	if (kcb->kind)
+		eFree (kcb->kind);
 	eFree (kcb);
 }
 

--- a/main/main.c
+++ b/main/main.c
@@ -466,7 +466,7 @@ void interactiveLoop (cookedArgs *args CTAGS_ATTR_UNUSED, void *user)
 			{					/* read nbytes from stream */
 				unsigned char *data = eMalloc (size);
 				size = fread (data, 1, size, stdin);
-				MIO *mio = mio_new_memory (data, size, eRealloc, eFree);
+				MIO *mio = mio_new_memory (data, size, eRealloc, eFreeNoNullCheck);
 				parseFileWithMio (filename, mio, NULL);
 				mio_unref (mio);
 			}

--- a/main/mio.c
+++ b/main/mio.c
@@ -81,6 +81,7 @@ static void eFree (void *const ptr)
 {
 	free (ptr);
 }
+#define eFreeNoNullCheck eFree
 
 #  define Assert(c) do {} while(0)
 #  define AssertNotReached() do {} while(0)
@@ -390,7 +391,7 @@ MIO *mio_new_mio (MIO *base, long start, long size)
 	if (r != size)
 		goto cleanup;
 
-	submio = mio_new_memory (data, size, eRealloc, eFree);
+	submio = mio_new_memory (data, size, eRealloc, eFreeNoNullCheck);
 	if (! submio)
 		goto cleanup;
 

--- a/main/read.c
+++ b/main/read.c
@@ -627,7 +627,7 @@ extern MIO *getMio (const char *const fileName, const char *const openMode,
 			return mio_new_file (fileName, openMode);
 	}
 	fclose (src);
-	return mio_new_memory (data, size, eRealloc, eFree);
+	return mio_new_memory (data, size, eRealloc, eFreeNoNullCheck);
 }
 
 /* Return true if utf8 BOM is found */

--- a/main/routines.c
+++ b/main/routines.c
@@ -219,7 +219,7 @@ extern void *eMalloc (const size_t size)
 {
 	void *buffer = malloc (size);
 
-	if (buffer == NULL)
+	if (buffer == NULL && size != 0)
 		error (FATAL, "out of memory");
 
 	return buffer;
@@ -229,7 +229,7 @@ extern void *eCalloc (const size_t count, const size_t size)
 {
 	void *buffer = calloc (count, size);
 
-	if (buffer == NULL)
+	if (buffer == NULL && count != 0 && size != 0)
 		error (FATAL, "out of memory");
 
 	return buffer;
@@ -243,7 +243,7 @@ extern void *eRealloc (void *const ptr, const size_t size)
 	else
 	{
 		buffer = realloc (ptr, size);
-		if (buffer == NULL)
+		if (buffer == NULL && size != 0)
 			error (FATAL, "out of memory");
 	}
 	return buffer;


### PR DESCRIPTION
Close #2617.

man malloc(3):
    If size is 0, then malloc() returns either NULL, or a unique
    pointer value that can later be successfully passed to free().

The original code of eMalloc treats NULL returned from malloc as
"out of memory". This has been o.k. at least on GNU/Linux. On the
platform, malloc(0) return non-NULL value. However, on AIX, malloc(0)
return NULL. As the result ctags on AIX always stops with "out of
memory" in the very early stage of command execution.

With this change, ctags treats NULL returned from malloc as
"out of memory" only if the size is not 0.

This means NULL can be passed to eFree that doesn't accept
NULL. In such place, eFree invocations are replaced with
eFreeNoNullCheck that accept NULL.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>