### PR TITLE
Tcl: strict the way to recognize variable expansions

### DIFF
--- a/Units/parser-tcl.r/dollar-in-regex.d/expected.tags
+++ b/Units/parser-tcl.r/dollar-in-regex.d/expected.tags
@@ -1,0 +1,4 @@
+proc1	input.tcl	/^proc proc1 {} {$/;"	p
+proc2	input.tcl	/^proc proc2 {} {}$/;"	p
+proc3	input.tcl	/^proc proc3 {} {$/;"	p
+proc4	input.tcl	/^proc proc4 {} {}$/;"	p

--- a/Units/parser-tcl.r/dollar-in-regex.d/input.tcl
+++ b/Units/parser-tcl.r/dollar-in-regex.d/input.tcl
@@ -1,0 +1,17 @@
+# Taken from #2627 submitted by @surmish
+proc proc1 {} {
+  if {[regexp {[0-9]$} ""]} {
+    echo "matched"
+  }
+}
+
+proc proc2 {} {}
+
+proc proc3 {} {
+    set abc "hello"
+    puts ${abc}
+}
+
+proc proc4 {} {}
+
+proc3

--- a/Units/parser-tcl.r/escaping.d/expected.tags
+++ b/Units/parser-tcl.r/escaping.d/expected.tags
@@ -1,0 +1,2 @@
+proc1	input.tcl	/^proc proc1 {} {$/;"	p
+proc2	input.tcl	/^proc proc2  {} {}$/;"	p

--- a/Units/parser-tcl.r/escaping.d/input.tcl
+++ b/Units/parser-tcl.r/escaping.d/input.tcl
@@ -1,0 +1,6 @@
+# Taken from a comment in #2627 submitted by @surmish.
+proc proc1 {} {
+  expr {[string first "\\" $varName]==0}
+}
+
+proc proc2  {} {}

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -148,8 +148,13 @@ static void readString (vString *string)
 		case EOF:
 			return;
 		case '\\':
-			vStringPut (string, c);
-			escaped = true;
+			if (escaped)
+			{
+				vStringPut (string, c);
+				escaped = false;
+			}
+			else
+				escaped = true;
 			break;
 		case '"':
 			vStringPut (string, c);

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -283,10 +283,9 @@ static void readToken0 (tokenInfo *const token, struct sTclParserState *pstate)
 			if (c0 == EOF)
 				break;
 
-			tokenPutc (token, c0);
 			if (c0 == '{')
 			{
-
+				tokenPutc (token, c0);
 				while ((c0 = getcFromInputFile ()) != EOF)
 				{
 					tokenPutc (token, c0);
@@ -294,8 +293,13 @@ static void readToken0 (tokenInfo *const token, struct sTclParserState *pstate)
 						break;
 				}
 			}
-			else
+			else if (isalnum (c0))
+			{
+				tokenPutc (token, c0);
 				readIdentifier (token->string);
+			}
+			else
+				ungetcToInputFile (c0);
 			break;
 		}
 	default:


### PR DESCRIPTION
Close #2627.

For distinguishing $ in variable expansion and $ in a regex pattern,
This change makes the way to recognize variable expansions strict.

With this change, alnum char or `{' is expected after $ for variable
expansion.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>