### PR TITLE
SystemVerilog: typed parameter support

### DIFF
--- a/Units/parser-verilog.r/systemverilog-2d-array.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-2d-array.d/expected.tags
@@ -1,5 +1,5 @@
 my_pack	input.sv	/^package my_pack;$/;"	K
-MY_WIDTH	input.sv	/^    localparam int MY_WIDTH                  = 1;$/;"	r	package:my_pack
-MY_DEPTH	input.sv	/^    localparam int MY_DEPTH                  = 2;$/;"	r	package:my_pack
+MY_WIDTH	input.sv	/^    localparam int MY_WIDTH                  = 1;$/;"	c	package:my_pack
+MY_DEPTH	input.sv	/^    localparam int MY_DEPTH                  = 2;$/;"	c	package:my_pack
 my_t	input.sv	/^    typedef logic [MY_DEPTH-1:0][MY_WIDTH-1:0]  my_t;$/;"	T	package:my_pack
 my_t2	input.sv	/^    typedef logic   [MY_DEPTH-1:0] 	 [MY_WIDTH-1:0] 	 my_t2;$/;"	T	package:my_pack

--- a/Units/parser-verilog.r/systemverilog-typed-parameter.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-typed-parameter.d/expected.tags
@@ -1,0 +1,3 @@
+default_name	input.sv	/^  parameter string default_name = "John Smith"; \/\/ default_name:register => default_name:const/;"	c
+flag	input.sv	/^  parameter logic flag = 1 ; \/\/ flags:register => flags:constant$/;"	c
+r1	input.sv	/^  parameter real r1 = 3.5e17; \/\/ r1:register => r1:constant$/;"	c

--- a/Units/parser-verilog.r/systemverilog-typed-parameter.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-typed-parameter.d/input.sv
@@ -1,0 +1,6 @@
+  // 6.16 String data type
+  parameter string default_name = "John Smith"; // default_name:register => default_name:constant
+
+  // 6.20 Constants
+  parameter logic flag = 1 ; // flags:register => flags:constant
+  parameter real r1 = 3.5e17; // r1:register => r1:constant

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1236,8 +1236,8 @@ static void tagNameList (tokenInfo* token, int c)
 
 			if (localKind != K_UNDEFINED || isAlreadyTaggedAs (token, K_TYPEDEF))
 			{
-				/* Update kind unless it's a port or an ignored keyword */
-				if (token->kind != K_PORT && localKind != K_IGNORE)
+				/* Update kind unless it's a port, a constant (parameter) or an ignored keyword */
+				if (token->kind != K_PORT && token->kind != K_CONSTANT && localKind != K_IGNORE)
 				{
 					token->kind = localKind;
 				}


### PR DESCRIPTION
A typed parameter was reported as register-kind instead of constant-kind.

For example,

```systemverilog
localparam int MY_WIDTH                  = 1;
```

MY_WIDTH was reported as register-kind.  On the line 1200, `token->kind` was overwritten K_REGISTER of `int`.
This fix the issue not to overwrite `token->kind` when it is K_CONSTANT.
