### PR TITLE
SystemVerilog: fix for typedef with signed/unsigned

### DIFF
--- a/Units/parser-verilog.r/systemverilog-typedef.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-typedef.d/expected.tags
@@ -19,6 +19,7 @@ no	input.sv	/^typedef enum           {no, yes} type_enum;$/;"	c	typedef:type_enu
 type_bit	input.sv	/^typedef      bit                 type_bit;$/;"	T
 type_bit_bus	input.sv	/^typedef      bit [1:0]           type_bit_bus;$/;"	T
 type_bit_bus_array	input.sv	/^typedef      bit [1:0]           type_bit_bus_array [2:0];$/;"	T
+type_bit_unsigned_vec	input.sv	/^typedef      bit unsigned [7:0]  type_bit_unsigned_vec;$/;"	T
 type_class	input.sv	/^typedef classname#(paramvalue) type_class;$/;"	T
 type_enum	input.sv	/^typedef enum           {no, yes} type_enum;$/;"	T
 type_enum.no	input.sv	/^typedef enum           {no, yes} type_enum;$/;"	c	typedef:type_enum
@@ -38,6 +39,8 @@ type_int_unsigned	input.sv	/^    } type_int_unsigned;$/;"	T
 type_int_unsigned.cond0	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
 type_int_unsigned.cond1	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
 type_int_unsigned.cond2	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
+type_logic_signed_vec	input.sv	/^typedef      logic signed [7:0]  type_logic_signed_vec;$/;"	T
+type_strcut_packed_unsigned	input.sv	/^} type_strcut_packed_unsigned;$/;"	T
 type_struct	input.sv	/^  } type_struct;$/;"	T
 type_struct_union	input.sv	/^  } type_struct_union;$/;"	T
 type_union	input.sv	/^  } type_union;$/;"	T

--- a/Units/parser-verilog.r/systemverilog-typedef.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-typedef.d/input.sv
@@ -37,9 +37,16 @@ typedef struct {
     } struct_union;
   } type_struct_union;
 
+typedef struct packed unsigned {
+  logic [7:0] upper;
+  logic [7:0] lower;
+} type_strcut_packed_unsigned;
+
 typedef      bit                 type_bit;
 typedef      bit [1:0]           type_bit_bus;
 typedef      bit [1:0]           type_bit_bus_array [2:0];
+typedef      logic signed [7:0]  type_logic_signed_vec;
+typedef      bit unsigned [7:0]  type_bit_unsigned_vec;
 
 typedef enum int unsigned{
     cond0 = 0, cond1 = 1, cond2 = 2

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -996,7 +996,10 @@ static void processStruct (tokenInfo *const token)
 	}
 	else
 	{
-		verbose ("Syntax error on struct or union. Token %s kind %d\n", vStringValue (token->name), token->kind);
+		verbose ("Prototype struct found \"%s\"\n", vStringValue (token->name));
+		token->kind = K_PROTOTYPE;
+		createTag (token);
+		return;
 	}
 
 	/* Skip packed_dimension */
@@ -1037,6 +1040,11 @@ static void processTypedef (tokenInfo *const token)
 				token->kind = K_TYPEDEF;
 				processEnum (token);
 				return;
+			case K_STRUCT:
+				/* Call enum processing function */
+				token->kind = K_TYPEDEF;
+				processStruct (token);
+				return;
 			default :
 				break;
 		}
@@ -1061,15 +1069,6 @@ static void processTypedef (tokenInfo *const token)
 	if (c == '{')
 	{
 		c = skipWhite (skipPastMatch ("{}"));
-	}
-	else
-	{
-		/* Typedefs of struct/union that have no contents are forward
-		 * declarations and are considered prototypes */
-		if (token->kind == K_STRUCT)
-		{
-			currentContext->prototype = true;
-		}
 	}
 
 	/* Skip past class parameter override */

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1052,6 +1052,13 @@ static void processTypedef (tokenInfo *const token)
 		c = skipWhite (vGetc ());
 	}
 
+	/* Skip signed or unsiged */
+	if (isIdentifierCharacter (c))
+	{
+		readIdentifier (token, c);
+		c = skipWhite (vGetc ());
+	}
+
 	/* Skip bus width definition */
 	while (c == '[')
 	{


### PR DESCRIPTION
This fixes one of issues on #2618 

```systemverilog
  // src/reg/uvm_reg_model.svh
  `define UVM_REG_DATA_WIDTH 8
  typedef  bit unsigned [`UVM_REG_DATA_WIDTH-1:0]  uvm_reg_data_t ; // unsigned:typedef => uvm_reg_data_t:typedef

  // src/base/uvm_object_globals.svh
  typedef logic signed [63:0] uvm_integral_t; // signed:typedef => uvm_integral_t:typedef
```

44fc82f skips `unsigned` or `signed` in a typedef statement properly.
b4ff316 uses processStuct() for typedef for `struct`.  This is more consistent with the implementation for `enum`.


