### PR TITLE
gitignore: add ctags-lang-python generated manpage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ man/ctags-client-tools.7.html
 man/ctags-incompatibilities.7
 man/ctags-incompatibilities.7.html
 man/ctags-incompatibilities.7.rst
+man/ctags-lang-python.7
+man/ctags-lang-python.7.html
+man/ctags-lang-python.7.rst
 man/ctags-optlib.7
 man/ctags-optlib.7.html
 man/ctags-optlib.7.rst


### PR DESCRIPTION
forgotten when adding the new ctags-lang-python man page recently