### PR TITLE
CPreProcessor,C: skip #ifdef __cplusplus ~ #endif branch

### DIFF
--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -311,9 +311,20 @@ static void findAsmTags (void)
 	vString *operator = vStringNew ();
 	const unsigned char *line;
 
-	cppInit (false, false, false, false,
-			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX, KIND_GHOST_INDEX, 0, 0,
-			 FIELD_UNKNOWN);
+	const struct cppInitData initData = {
+		.state = false,
+		.hasAtLiteralStrings = false,
+		.hasCxxRawLiteralStrings = false,
+		.hasSingleQuoteLiteralNumbers = false,
+		.defineMacroKindIndex = KIND_GHOST_INDEX,
+		.macroUndefRoleIndex = 0,
+		.macroParamKindIndex = KIND_GHOST_INDEX,
+		.macrodefFieldIndex = FIELD_UNKNOWN,
+		.headerKindIndex = KIND_GHOST_INDEX,
+		.headerSystemRoleIndex = 0,
+		.headerLocalRoleIndex = 0,
+	};
+	cppInit (&initData);
 
 	 int lastMacroCorkIndex = CORK_NIL;
 

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -323,6 +323,7 @@ static void findAsmTags (void)
 		.headerKindIndex = KIND_GHOST_INDEX,
 		.headerSystemRoleIndex = 0,
 		.headerLocalRoleIndex = 0,
+		.skip__cplusplus_branch = false,
 	};
 	cppInit (&initData);
 

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3508,6 +3508,7 @@ static rescanReason findCTags (const unsigned int passCount)
 		.headerKindIndex = kind_for_header,
 		.headerSystemRoleIndex = role_for_header_system,
 		.headerLocalRoleIndex = role_for_header_local,
+		.skip__cplusplus_branch = !isInputLanguage (Lang_cpp),
 	};
 	cppInit (&initData);
 

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -3496,11 +3496,20 @@ static rescanReason findCTags (const unsigned int passCount)
 		role_for_header_local = VR_HEADER_LOCAL;
 	}
 
-	cppInit ((bool) (passCount > 1), isInputLanguage (Lang_csharp), isInputLanguage(Lang_cpp),
-		 isInputLanguage(Lang_vera),
-		 kind_for_define, role_for_macro_undef, kind_for_param,
-		 kind_for_header, role_for_header_system, role_for_header_local,
-		 FIELD_UNKNOWN);
+	const struct cppInitData initData = {
+		.state = (bool) (passCount > 1),
+		.hasAtLiteralStrings = isInputLanguage (Lang_csharp),
+		.hasCxxRawLiteralStrings = isInputLanguage(Lang_cpp),
+		.hasSingleQuoteLiteralNumbers = isInputLanguage(Lang_vera),
+		.defineMacroKindIndex = kind_for_define,
+		.macroUndefRoleIndex = role_for_macro_undef,
+		.macroParamKindIndex = kind_for_param,
+		.macrodefFieldIndex = FIELD_UNKNOWN,
+		.headerKindIndex = kind_for_header,
+		.headerSystemRoleIndex = role_for_header_system,
+		.headerLocalRoleIndex = role_for_header_local,
+	};
+	cppInit (&initData);
 
 	Signature = vStringNew ();
 

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -244,18 +244,9 @@ extern unsigned int cppGetDirectiveNestLevel (void)
 	return Cpp.directive.nestLevel;
 }
 
-static void cppInitCommon(langType clientLang,
-		     const bool state, const bool hasAtLiteralStrings,
-		     const bool hasCxxRawLiteralStrings,
-		     const bool hasSingleQuoteLiteralNumbers,
-		     int defineMacroKindIndex,
-		     int macroUndefRoleIndex,
-		     int macroParamKindIndex,
-		     int headerKindIndex,
-		     int headerSystemRoleIndex, int headerLocalRoleIndex,
-		     int macrodefFieldIndex)
+static void cppInitCommon(langType clientLang, const struct cppInitData *initData)
 {
-	BraceFormat = state;
+	BraceFormat = initData->state;
 
 	CXX_DEBUG_PRINT("cppInit: brace format is %d",BraceFormat);
 
@@ -277,17 +268,17 @@ static void cppInitCommon(langType clientLang,
 	Cpp.charOrStringContents = vStringNew();
 
 	Cpp.resolveRequired = false;
-	Cpp.hasAtLiteralStrings = hasAtLiteralStrings;
-	Cpp.hasCxxRawLiteralStrings = hasCxxRawLiteralStrings;
-	Cpp.hasSingleQuoteLiteralNumbers = hasSingleQuoteLiteralNumbers;
+	Cpp.hasAtLiteralStrings = initData->hasAtLiteralStrings;
+	Cpp.hasCxxRawLiteralStrings = initData->hasCxxRawLiteralStrings;
+	Cpp.hasSingleQuoteLiteralNumbers = initData->hasSingleQuoteLiteralNumbers;
 
-	if (defineMacroKindIndex != KIND_GHOST_INDEX)
+	if (initData->defineMacroKindIndex != KIND_GHOST_INDEX)
 	{
-		Cpp.defineMacroKindIndex = defineMacroKindIndex;
+		Cpp.defineMacroKindIndex = initData->defineMacroKindIndex;
 		Cpp.useClientLangDefineMacroKindIndex = true;
 
-		Cpp.macroUndefRoleIndex = macroUndefRoleIndex;
-		Cpp.macrodefFieldIndex = macrodefFieldIndex;
+		Cpp.macroUndefRoleIndex = initData->macroUndefRoleIndex;
+		Cpp.macrodefFieldIndex = initData->macrodefFieldIndex;
 	}
 	else
 	{
@@ -298,9 +289,9 @@ static void cppInitCommon(langType clientLang,
 		Cpp.macrodefFieldIndex = CPreProFields [F_MACRODEF].ftype;
 	}
 
-	if (macroParamKindIndex != KIND_GHOST_INDEX)
+	if (initData->macroParamKindIndex != KIND_GHOST_INDEX)
 	{
-		Cpp.macroParamKindIndex = macroParamKindIndex;
+		Cpp.macroParamKindIndex = initData->macroParamKindIndex;
 		Cpp.useClientLangMacroParamKindIndex = true;
 	}
 	else
@@ -309,13 +300,13 @@ static void cppInitCommon(langType clientLang,
 		Cpp.useClientLangMacroParamKindIndex = false;
 	}
 
-	if (headerKindIndex != KIND_GHOST_INDEX)
+	if (initData->headerKindIndex != KIND_GHOST_INDEX)
 	{
-		Cpp.headerKindIndex = headerKindIndex;
+		Cpp.headerKindIndex = initData->headerKindIndex;
 		Cpp.useClientLangHeaderKindIndex = true;
 
-		Cpp.headerSystemRoleIndex = headerSystemRoleIndex;
-		Cpp.headerLocalRoleIndex =  headerLocalRoleIndex;
+		Cpp.headerSystemRoleIndex = initData->headerSystemRoleIndex;
+		Cpp.headerLocalRoleIndex =  initData->headerLocalRoleIndex;
 	}
 	else
 	{
@@ -343,23 +334,10 @@ static void cppInitCommon(langType clientLang,
 		: NULL;
 }
 
-extern void cppInit (const bool state, const bool hasAtLiteralStrings,
-		     const bool hasCxxRawLiteralStrings,
-		     const bool hasSingleQuoteLiteralNumbers,
-		     int defineMacroKindIndex,
-		     int macroUndefRoleIndex,
-		     int macroParamKindIndex,
-		     int headerKindIndex,
-		     int headerSystemRoleIndex, int headerLocalRoleIndex,
-		     int macrodefFieldIndex)
+extern void cppInit (const struct cppInitData *initData)
 {
 	langType client = getInputLanguage ();
-
-	cppInitCommon (client, state, hasAtLiteralStrings,
-				   hasCxxRawLiteralStrings, hasSingleQuoteLiteralNumbers,
-				   defineMacroKindIndex, macroUndefRoleIndex, macroParamKindIndex,
-				   headerKindIndex, headerSystemRoleIndex, headerLocalRoleIndex,
-				   macrodefFieldIndex);
+	cppInitCommon (client, initData);
 }
 
 extern void cppTerminate (void)
@@ -1634,10 +1612,21 @@ process:
 
 static void findCppTags (void)
 {
-	cppInitCommon (Cpp.lang, 0, false, false, false,
-				   KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX,
-				   KIND_GHOST_INDEX, 0, 0,
-				   FIELD_UNKNOWN);
+	struct cppInitData initData = {
+		.state = 0,
+		.hasAtLiteralStrings = false,
+		.hasCxxRawLiteralStrings = false,
+		.hasSingleQuoteLiteralNumbers = false,
+		.defineMacroKindIndex = KIND_GHOST_INDEX,
+		.macroUndefRoleIndex = 0,
+		.macroParamKindIndex = KIND_GHOST_INDEX,
+		.macrodefFieldIndex = FIELD_UNKNOWN,
+		.headerKindIndex = KIND_GHOST_INDEX,
+		.headerSystemRoleIndex = 0,
+		.headerLocalRoleIndex = 0,
+	};
+
+	cppInitCommon (Cpp.lang, &initData);
 
 	findRegexTagsMainloop (cppGetc);
 

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -91,6 +91,8 @@ struct cppInitData {
 	int headerKindIndex;
 	int headerSystemRoleIndex;
 	int headerLocalRoleIndex;
+
+	bool skip__cplusplus_branch; /* #ifdef __cplusplus ... #endif */
 };
 
 extern void cppInit (const struct cppInitData *initData);

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -74,7 +74,7 @@
 extern bool cppIsBraceFormat (void);
 extern unsigned int cppGetDirectiveNestLevel (void);
 
-/* Don't forget to set useCort true in your parser.
+/* Don't forget to add CORK_QUEUE to useCork in your parser.
  * The corkQueue is needed to capture macro parameters.
  */
 extern void cppInit (const bool state,

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -77,16 +77,23 @@ extern unsigned int cppGetDirectiveNestLevel (void);
 /* Don't forget to add CORK_QUEUE to useCork in your parser.
  * The corkQueue is needed to capture macro parameters.
  */
-extern void cppInit (const bool state,
-		     const bool hasAtLiteralStrings,
-		     const bool hasCxxRawLiteralStrings,
-		     const bool hasSingleQuoteLiteralNumbers,
-		     int defineMacroKindIndex,
-		     int macroUndefRoleIndex,
-		     int headerKindIndex,
-		     int headerSystemRoleIndex, int headerLocalRoleIndex,
-		     int macroParamKindIndex,
-		     int macrodefFieldIndex);
+struct cppInitData {
+	bool state;
+	bool hasAtLiteralStrings;
+	bool hasCxxRawLiteralStrings;
+	bool hasSingleQuoteLiteralNumbers;
+
+	int defineMacroKindIndex;
+	int macroUndefRoleIndex;
+	int macroParamKindIndex;
+	int macrodefFieldIndex;
+
+	int headerKindIndex;
+	int headerSystemRoleIndex;
+	int headerLocalRoleIndex;
+};
+
+extern void cppInit (const struct cppInitData *initData);
 
 extern void cppTerminate (void);
 extern void cppBeginStatement (void);

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1821,7 +1821,8 @@ bool cxxParserParseIfForWhileSwitchCatchParenthesis(void)
 	return true;
 }
 
-static rescanReason cxxParserMain(const unsigned int passCount)
+static rescanReason cxxParserMain(const unsigned int passCount,
+								  bool cppSkip__cpluscplus_branch)
 {
 	cxxScopeClear();
 	cxxTokenAPINewFile();
@@ -1848,6 +1849,7 @@ static rescanReason cxxParserMain(const unsigned int passCount)
 		.headerKindIndex = kind_for_header,
 		.headerSystemRoleIndex = role_for_header_system,
 		.headerLocalRoleIndex = role_for_header_local,
+		.skip__cplusplus_branch = cppSkip__cpluscplus_branch,
 	};
 
 	cppInit(&initData);
@@ -1885,7 +1887,7 @@ rescanReason cxxCParserMain(const unsigned int passCount)
 	g_cxx.bConfirmedCPPLanguage = false;
 	cxxKeywordEnablePublicProtectedPrivate(false);
 
-	rescanReason r = cxxParserMain(passCount);
+	rescanReason r = cxxParserMain(passCount, true);
 	CXX_DEBUG_LEAVE();
 	return r;
 }
@@ -1899,7 +1901,7 @@ rescanReason cxxCUDAParserMain(const unsigned int passCount)
 	g_cxx.bConfirmedCPPLanguage = false;
 	cxxKeywordEnablePublicProtectedPrivate(false);
 
-	rescanReason r = cxxParserMain(passCount);
+	rescanReason r = cxxParserMain(passCount, true);
 	CXX_DEBUG_LEAVE();
 	return r;
 }
@@ -1915,7 +1917,7 @@ rescanReason cxxCppParserMain(const unsigned int passCount)
 	g_cxx.bConfirmedCPPLanguage = !isInputHeaderFile();
 	cxxKeywordEnablePublicProtectedPrivate(g_cxx.bConfirmedCPPLanguage);
 
-	rescanReason r = cxxParserMain(passCount);
+	rescanReason r = cxxParserMain(passCount, false);
 	CXX_DEBUG_LEAVE();
 	return r;
 }

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1836,19 +1836,21 @@ static rescanReason cxxParserMain(const unsigned int passCount)
 
 	Assert(passCount < 3);
 
-	cppInit(
-			(bool) (passCount > 1),
-			false,
-			true, // raw literals
-			false,
-			kind_for_define,
-			role_for_macro_undef,
-			kind_for_macro_param,
-			kind_for_header,
-			role_for_header_system,
-			role_for_header_local,
-			g_cxx.pFieldOptions[CXXTagFieldMacrodef].ftype
-		);
+	const struct cppInitData initData = {
+		.state = (bool) (passCount > 1),
+		.hasAtLiteralStrings = false,
+		.hasCxxRawLiteralStrings = true, // raw literals
+		.hasSingleQuoteLiteralNumbers = false,
+		.defineMacroKindIndex = kind_for_define,
+		.macroUndefRoleIndex = role_for_macro_undef,
+		.macroParamKindIndex = kind_for_macro_param,
+		.macrodefFieldIndex = g_cxx.pFieldOptions[CXXTagFieldMacrodef].ftype,
+		.headerKindIndex = kind_for_header,
+		.headerSystemRoleIndex = role_for_header_system,
+		.headerLocalRoleIndex = role_for_header_local,
+	};
+
+	cppInit(&initData);
 
 	g_cxx.iChar = ' ';
 

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -38,10 +38,20 @@ static tagRegexTable dtsTagRegexTable [] = {
 */
 static void runCppGetc (void)
 {
-	cppInit (false, false, false, false,
-			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX,
-			 KIND_GHOST_INDEX, 0, 0,
-			 FIELD_UNKNOWN);
+	const struct cppInitData initData = {
+		.state = false,
+		.hasAtLiteralStrings = false,
+		.hasCxxRawLiteralStrings = false,
+		.hasSingleQuoteLiteralNumbers = false,
+		.defineMacroKindIndex = KIND_GHOST_INDEX,
+		.macroUndefRoleIndex = 0,
+		.macroParamKindIndex = KIND_GHOST_INDEX,
+		.macrodefFieldIndex = FIELD_UNKNOWN,
+		.headerKindIndex = KIND_GHOST_INDEX,
+		.headerSystemRoleIndex = 0,
+		.headerLocalRoleIndex = 0,
+	};
+	cppInit (&initData);
 
 	findRegexTagsMainloop (cppGetc);
 

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -50,6 +50,7 @@ static void runCppGetc (void)
 		.headerKindIndex = KIND_GHOST_INDEX,
 		.headerSystemRoleIndex = 0,
 		.headerLocalRoleIndex = 0,
+		.skip__cplusplus_branch = false,
 	};
 	cppInit (&initData);
 

--- a/parsers/ldscript.c
+++ b/parsers/ldscript.c
@@ -696,10 +696,20 @@ static void findLdScriptTags (void)
 	tokenInfo *const token = newLdScriptToken ();
 	tokenInfo *const tmp = newLdScriptToken ();
 
-	cppInit (false, false, false, false,
-			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX,
-			 KIND_GHOST_INDEX, 0, 0,
-			 FIELD_UNKNOWN);
+	const struct cppInitData initData = {
+		.state = false,
+		.hasAtLiteralStrings = false,
+		.hasCxxRawLiteralStrings = false,
+		.hasSingleQuoteLiteralNumbers = false,
+		.defineMacroKindIndex = KIND_GHOST_INDEX,
+		.macroUndefRoleIndex = 0,
+		.macroParamKindIndex = KIND_GHOST_INDEX,
+		.macrodefFieldIndex = FIELD_UNKNOWN,
+		.headerKindIndex = KIND_GHOST_INDEX,
+		.headerSystemRoleIndex = 0,
+		.headerLocalRoleIndex = 0,
+	};
+	cppInit (&initData);
 
 	do {
 		tokenRead (token);

--- a/parsers/ldscript.c
+++ b/parsers/ldscript.c
@@ -708,6 +708,7 @@ static void findLdScriptTags (void)
 		.headerKindIndex = KIND_GHOST_INDEX,
 		.headerSystemRoleIndex = 0,
 		.headerLocalRoleIndex = 0,
+		.skip__cplusplus_branch = false,
 	};
 	cppInit (&initData);
 

--- a/parsers/protobuf.c
+++ b/parsers/protobuf.c
@@ -654,10 +654,20 @@ static void findProtobufTags0 (bool oneshot, int originalScopeCorkIndex)
 
 static void findProtobufTags (void)
 {
-	cppInit (false, false, false, false,
-			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX,
-			 KIND_GHOST_INDEX, 0, 0,
-			 FIELD_UNKNOWN);
+	const struct cppInitData initData = {
+		.state = false,
+		.hasAtLiteralStrings = false,
+		.hasCxxRawLiteralStrings = false,
+		.hasSingleQuoteLiteralNumbers = false,
+		.defineMacroKindIndex = KIND_GHOST_INDEX,
+		.macroUndefRoleIndex = 0,
+		.macroParamKindIndex = KIND_GHOST_INDEX,
+		.macrodefFieldIndex = FIELD_UNKNOWN,
+		.headerKindIndex = KIND_GHOST_INDEX,
+		.headerSystemRoleIndex = 0,
+		.headerLocalRoleIndex = 0,
+	};
+	cppInit (&initData);
 	token.value = vStringNew ();
 
 	nextToken ();

--- a/parsers/protobuf.c
+++ b/parsers/protobuf.c
@@ -666,6 +666,7 @@ static void findProtobufTags (void)
 		.headerKindIndex = KIND_GHOST_INDEX,
 		.headerSystemRoleIndex = 0,
 		.headerLocalRoleIndex = 0,
+		.skip__cplusplus_branch = false,
 	};
 	cppInit (&initData);
 	token.value = vStringNew ();


### PR DESCRIPTION
Close #2647.

   C parser doesn't work when C++ code "extern "C" {" and "}" is given.
    
        $ cat /tmp/extern-c.c
        extern "C" {
        #ifdef X
          void f() {}
        #else
          void g() {}
        #endif
        }
        $ u-ctags --output-format=xref --kinds-c=+plz --fields=+nie -o - /tmp/extern-c.c
        f                function      3 /tmp/extern-c.c  void f() {}
    
        $ cat /tmp/none-extern-c.c
        #ifdef X
          void f() {}
        #else
          void g() {}
        #endif
        $ u-ctags --output-format=xref --kinds-c=+plz --fields=+nie -o - /tmp/none-extern-c.c
        f                function      2 /tmp/none-extern-c.c void f() {}
        g                function      4 /tmp/none-extern-c.c void g() {}
    
    The function g() is missed if the code is surrounded by extern "C" { and }.
    
    This change uses a heuristic rule to skip the code in the C parser.
    
    In most of cases, the code is in #ifdef __cplusplus ~ #endif branch.
    So when the CPreProcessor parser detects #ifdef __cplusplus ~ #endif,
    with this change, the CPreProcessor parser doesn't pass the code inside __cplusplus branch
    to its client parser that requests to the CPreProcessor parser to do so.
    
    C parser requests it. C++ parser doesn't.
    
    Signed-off-by: Masatake YAMATO <yamato@redhat.com>
