### PR TITLE
main,refactor: don't hard-code per-parser ptags when emitting

### DIFF
--- a/main/parse.c
+++ b/main/parse.c
@@ -4031,11 +4031,11 @@ static void addParserPseudoTags (langType language)
 	parserObject *parser = LanguageTable + language;
 	if (!parser->pseudoTagPrinted)
 	{
-		makePtagIfEnabled (PTAG_KIND_DESCRIPTION, language, parser);
-		makePtagIfEnabled (PTAG_KIND_SEPARATOR, language, parser);
-		makePtagIfEnabled (PTAG_FIELD_DESCRIPTION, language, parser);
-		makePtagIfEnabled (PTAG_EXTRA_DESCRIPTION, language, parser);
-
+		for (int i = 0; i < PTAG_COUNT; i++)
+		{
+			if (isPtagParserSpecific (i))
+				makePtagIfEnabled (i, language, parser);
+		}
 		parser->pseudoTagPrinted = 1;
 	}
 }

--- a/main/ptag.c
+++ b/main/ptag.c
@@ -129,69 +129,69 @@ static ptagDesc ptagDescs [] = {
 	  false, "JSON_OUTPUT_VERSION",
 	  "the version of json output stream format",
 	  ptagMakeJsonOutputVersion,
-	  true },
+	  PTAGF_COMMON },
 	{ true, "TAG_FILE_FORMAT",
 	  "the version of tags file format",
 	  ptagMakeFormat,
-	  true },
+	  PTAGF_COMMON },
 	{ true, "TAG_FILE_SORTED",
 	  "how tags are sorted",
 	  ptagMakeHowSorted,
-	  true },
+	  PTAGF_COMMON },
 	{ true, "TAG_PROGRAM_AUTHOR",
 	  "the author of this ctags implementation",
 	  ptagMakeAuthor,
-	  true },
+	  PTAGF_COMMON },
 	{ true, "TAG_PROGRAM_NAME",
 	  "the name of this ctags implementation",
 	  ptagMakeProgName,
-	  true },
+	  PTAGF_COMMON },
 	{ true, "TAG_PROGRAM_URL",
 	  "the official site URL of this ctags implementation",
 	  ptagMakeProgURL,
-	  true },
+	  PTAGF_COMMON },
 	{ true, "TAG_PROGRAM_VERSION",
 	  "the version of this ctags implementation",
 	  ptagMakeProgVersion,
-	  true },
+	  PTAGF_COMMON },
 #ifdef HAVE_ICONV
 	{ true, "TAG_FILE_ENCODING",
 	  "the encoding used in output tags file",
 	  ptagMakeFileEncoding,
-	  true },
+	  PTAGF_COMMON },
 #endif
 	{ false, "TAG_KIND_SEPARATOR",
 	  "the separators used in kinds",
 	  ptagMakeKindSeparators,
-	  false },
+	  PTAGF_PARSER },
 	{ false, "TAG_KIND_DESCRIPTION",
 	  "the letters, names and descriptions of enabled kinds in the language",
 	  ptagMakeKindDescriptions,
-	  false },
+	  PTAGF_PARSER },
 	{ false, "TAG_FIELD_DESCRIPTION",
 	  "the names and descriptions of enabled fields",
 	  ptagMakeFieldDescriptions,
-	  true },
+	  PTAGF_COMMON|PTAGF_PARSER },
 	{ false, "TAG_EXTRA_DESCRIPTION",
 	  "the names and descriptions of enabled extras",
 	  ptagMakeExtraDescriptions,
-	  true },
+	  PTAGF_COMMON|PTAGF_PARSER },
 	{ true, "TAG_OUTPUT_MODE",
 	  "the output mode: u-ctags or e-ctags",
 	  ptagMakeCtagsOutputMode,
-	  true },
+	  PTAGF_COMMON },
 	{ true, "TAG_OUTPUT_FILESEP",
 	  "the separator used in file name (slash or backslash)",
 	  ptagMakeCtagsOutputFilesep,
-	  true },
+	  PTAGF_COMMON },
 	{ true, "TAG_PATTERN_LENGTH_LIMIT",
 	  "the limit of pattern length",
 	  ptagMakePatternLengthLimit,
-	  true },
+	  PTAGF_COMMON },
 	{ false, "TAG_PROC_CWD",
 	  "the current working directory of the tags generator",
 	  ptagMakeProcCwd,
-	  true },
+	  PTAGF_COMMON },
 };
 
 extern bool makePtagIfEnabled (ptagType type, langType language, const void *data)
@@ -254,7 +254,13 @@ extern ptagType getPtagTypeForName (const char *name)
 extern bool isPtagCommonInParsers  (ptagType type)
 {
 	ptagDesc* pdesc = getPtagDesc (type);
-	return pdesc->commonInParsers;
+	return pdesc->flags & PTAGF_COMMON;
+}
+
+extern bool isPtagParserSpecific (ptagType type)
+{
+	ptagDesc* pdesc = getPtagDesc (type);
+	return pdesc->flags & PTAGF_PARSER;
 }
 
 static int ptagCompare (struct colprintLine *a, struct colprintLine *b)

--- a/main/ptag_p.h
+++ b/main/ptag_p.h
@@ -44,6 +44,14 @@ typedef enum ePtagType { /* pseudo tag content control */
 	PTAG_COUNT
 } ptagType;
 
+typedef enum ePtagFlag {
+	/* use isPtagCommonInParsers() for testing. */
+	PTAGF_COMMON = 1 << 0,
+	/* use isPtagParserSpecific for testing.
+	 * PSEUDO_TAG_SEPARATOR is used for printing. */
+	PTAGF_PARSER = 1 << 1,
+} ptagFlag;
+
 struct sPtagDesc {
 	bool enabled;
 	const char* name;
@@ -57,7 +65,8 @@ struct sPtagDesc {
 	 * of the parser is passed as the thrid argument.
 	 */
 	bool (* makeTag) (ptagDesc *, langType, const void *);
-	bool commonInParsers;
+
+	ptagFlag flags;
 };
 
 extern bool makePtagIfEnabled (ptagType type, langType language, const void *data);
@@ -66,6 +75,7 @@ extern ptagType  getPtagTypeForName (const char *name);
 extern void printPtags (bool withListHeader, bool machinable, FILE *fp);
 extern bool isPtagEnabled (ptagType type);
 extern bool isPtagCommonInParsers (ptagType type);
+extern bool isPtagParserSpecific (ptagType type);
 extern bool enablePtag (ptagType type, bool state);
 
 #endif	/* CTAGS_MAIN_FIELD_H */

--- a/main/ptag_p.h
+++ b/main/ptag_p.h
@@ -65,7 +65,7 @@ extern ptagDesc* getPtagDesc (ptagType type);
 extern ptagType  getPtagTypeForName (const char *name);
 extern void printPtags (bool withListHeader, bool machinable, FILE *fp);
 extern bool isPtagEnabled (ptagType type);
-extern bool isPtagCommonInParsers  (ptagType type);
+extern bool isPtagCommonInParsers (ptagType type);
 extern bool enablePtag (ptagType type, bool state);
 
 #endif	/* CTAGS_MAIN_FIELD_H */


### PR DESCRIPTION
Per-parser ptags are lexically enumerated in parser.c
However, a ptag itself knows whether it is "Per-parser"
ptag or not. So the enumeration is not needed.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>