### PR TITLE
SystemVerilog: support property:parameter (update for #2537)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -221,6 +221,7 @@ man_MANS = \
 	man/ctags-optlib.7 \
 	\
 	man/ctags-lang-python.7 \
+	man/ctags-lang-verilog.7 \
 	\
 	$(NULL)
 rst2man_verbose = $(rst2man_verbose_@AM_V@)

--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -34,3 +34,5 @@ x       UCTAGSxpath          no      NONE             s--    no    xpath for the
 -       UCTAGSassignmentop   no      R                s--    no    operator for assignment
 -       UCTAGSsectionMarker  no      ReStructuredText s--    no    character used for declaring section
 -       UCTAGSmixin          yes     Ruby             s--    no    how the class or module is mixed in (mixin:HOW:MODULE)
+-       UCTAGSparameter      no      SystemVerilog    --b    no    parameter whose value can be overridden.
+-       UCTAGSparameter      no      Verilog          --b    no    parameter whose value can be overridden.

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -52,6 +52,8 @@ z	kind	no	NONE	s--	no	[tags output] prepend "kind:" to k/ (or K/) field output, 
 -	assignmentop	no	R	s--	no	operator for assignment
 -	sectionMarker	no	ReStructuredText	s--	no	character used for declaring section
 -	mixin	yes	Ruby	s--	no	how the class or module is mixed in (mixin:HOW:MODULE)
+-	parameter	no	SystemVerilog	--b	no	parameter whose value can be overridden.
+-	parameter	no	Verilog	--b	no	parameter whose value can be overridden.
 #
 Foo	input.java	/^abstract public class Foo extends Bar$/
 x	input.java	/^    public int x;$/

--- a/Units/parser-verilog.r/systemverilog-parameter.d/args.ctags
+++ b/Units/parser-verilog.r/systemverilog-parameter.d/args.ctags
@@ -1,1 +1,2 @@
 --sort=no
+--fields-SystemVerilog=+{parameter}

--- a/Units/parser-verilog.r/systemverilog-parameter.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-parameter.d/expected.tags
@@ -1,16 +1,16 @@
 C	input.sv	/^class C #($/;"	C
-p	input.sv	/^  int p = 1$/;"	c	class:C
+p	input.sv	/^  int p = 1$/;"	c	class:C	parameter:
 q	input.sv	/^  parameter int q = 5;  \/\/ local parameter$/;"	c	class:C
 t	input.sv	/^  static task t;$/;"	t	class:C
 p	input.sv	/^    int p;$/;"	r	task:C.t
 x	input.sv	/^    int x = C::p;  \/\/ C::p disambiguates p$/;"	r	task:C.t
 C	input.sv	/^class C #($/;"	C
-p	input.sv	/^    int p = 1,$/;"	c	class:C
-T	input.sv	/^    type T = int$/;"	c	class:C
+p	input.sv	/^    int p = 1,$/;"	c	class:C	parameter:
+T	input.sv	/^    type T = int$/;"	c	class:C	parameter:
 f	input.sv	/^function C::T C::f();$/;"	f	class:C.C
 C	input.sv	/^virtual class C#(parameter DECODE_W, parameter ENCODE_W = $clog2(DECODE_W));$/;"	C	class:C
-DECODE_W	input.sv	/^virtual class C#(parameter DECODE_W, parameter ENCODE_W = $clog2(DECODE_W));$/;"	c	class:C.C
-ENCODE_W	input.sv	/^virtual class C#(parameter DECODE_W, parameter ENCODE_W = $clog2(DECODE_W));$/;"	c	class:C.C
+DECODE_W	input.sv	/^virtual class C#(parameter DECODE_W, parameter ENCODE_W = $clog2(DECODE_W));$/;"	c	class:C.C	parameter:
+ENCODE_W	input.sv	/^virtual class C#(parameter DECODE_W, parameter ENCODE_W = $clog2(DECODE_W));$/;"	c	class:C.C	parameter:
 ENCODER_f	input.sv	/^  static function logic [ENCODE_W-1:0] ENCODER_f$/;"	f	class:C.C
 DecodeIn	input.sv	/^      (input logic [DECODE_W-1:0] DecodeIn);$/;"	p	function:C.C.ENCODER_f
 i	input.sv	/^    for (int i = 0; i < DECODE_W; i++) begin$/;"	r	function:C.C.ENCODER_f
@@ -19,23 +19,23 @@ EncodeIn	input.sv	/^      (input logic [ENCODE_W-1:0] EncodeIn);$/;"	p	function:
 class	input.sv	/^interface class PutImp #(type PUT_T = logic); \/\/ FIXME$/;"	I
 class	input.sv	/^interface class GetImp #(type GET_T = logic); \/\/ FIXME$/;"	I	interface:class
 Fifo	input.sv	/^class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	C	interface:class.class
-T	input.sv	/^class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Fifo
-DEPTH	input.sv	/^class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Fifo
+T	input.sv	/^class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Fifo	parameter:
+DEPTH	input.sv	/^class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Fifo	parameter:
 myFifo	input.sv	/^  T myFifo[$:DEPTH-1];$/;"	r	class:class.class.Fifo
-put	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored$/;"	f	class:class.class.Fifo
-a	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored$/;"	p	function:class.class.Fifo.put
-get	input.sv	/^  virtual function T get(); \/\/ FIXME : to be ignored$/;"	f	class:class.class.Fifo
+put	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored?$/;"	f	class:class.class.Fifo
+a	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored?$/;"	p	function:class.class.Fifo.put
+get	input.sv	/^  virtual function T get(); \/\/ FIXME : to be ignored?$/;"	f	class:class.class.Fifo
 Stack	input.sv	/^class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	C	interface:class.class
-T	input.sv	/^class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Stack
-DEPTH	input.sv	/^class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Stack
+T	input.sv	/^class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Stack	parameter:
+DEPTH	input.sv	/^class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Stack	parameter:
 myFifo	input.sv	/^  T myFifo[$:DEPTH-1];$/;"	r	class:class.class.Stack
 put	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored$/;"	f	class:class.class.Stack
 a	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored$/;"	p	function:class.class.Stack.put
 get	input.sv	/^  virtual function T get(); \/\/ FIXME : to be ignored$/;"	f	class:class.class.Stack
 generic_fifo	input.sv	/^module generic_fifo$/;"	m	interface:class.class
-MSB	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:class.class.generic_fifo
-LSB	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:class.class.generic_fifo
-DEPTH	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:class.class.generic_fifo
+MSB	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:class.class.generic_fifo	parameter:
+LSB	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:class.class.generic_fifo	parameter:
+DEPTH	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:class.class.generic_fifo	parameter:
 in	input.sv	/^   (input  wire [MSB:LSB] in,$/;"	p	module:class.class.generic_fifo
 clk	input.sv	/^    input  wire clk, read, write, reset,$/;"	p	module:class.class.generic_fifo
 read	input.sv	/^    input  wire clk, read, write, reset,$/;"	p	module:class.class.generic_fifo
@@ -45,13 +45,80 @@ out	input.sv	/^    output logic [MSB:LSB] out,$/;"	p	module:class.class.generic_
 full	input.sv	/^    output logic full, empty );$/;"	p	module:class.class.generic_fifo
 empty	input.sv	/^    output logic full, empty );$/;"	p	module:class.class.generic_fifo
 generic_decoder	input.sv	/^module generic_decoder$/;"	m	interface:class.class
-num_code_bits	input.sv	/^  #(num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.generic_decoder
+num_code_bits	input.sv	/^  #(num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.generic_decoder	parameter:
 num_out_bits	input.sv	/^  #(num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.generic_decoder
 A	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:class.class.generic_decoder
 Y	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:class.class.generic_decoder
 int_t	input.sv	/^typedef int int_t;$/;"	T	interface:class.class
 user_defined_type_param	input.sv	/^module user_defined_type_param$/;"	m	interface:class.class
-um_code_bits	input.sv	/^  #(int_t num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.user_defined_type_param
+um_code_bits	input.sv	/^  #(int_t num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.user_defined_type_param	parameter:
 num_out_bits	input.sv	/^  #(int_t num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.user_defined_type_param
 A	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:class.class.user_defined_type_param
 Y	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:class.class.user_defined_type_param
+L1	input.sv	/^parameter L1 = 0;  \/\/  synonym for the localparam$/;"	c	interface:class.class	parameter:
+module_with_parameter_port_list	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	m	interface:class.class
+P1	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list	parameter:
+P2	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list	parameter:
+L2	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list
+L3	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list
+P3	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list	parameter:
+P4	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list	parameter:
+L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	module:class.class.module_with_parameter_port_list
+L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	module:class.class.module_with_parameter_port_list
+module_with_empty_parameter_port_list	input.sv	/^module module_with_empty_parameter_port_list #()$/;"	m	interface:class.class
+L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	module:class.class.module_with_empty_parameter_port_list
+L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	module:class.class.module_with_empty_parameter_port_list
+module_no_parameter_port_list	input.sv	/^module module_no_parameter_port_list$/;"	m	interface:class.class
+P5	input.sv	/^  parameter  P5 = "parameter";$/;"	c	module:class.class.module_no_parameter_port_list	parameter:
+L8	input.sv	/^  localparam L8 = "local parameter";$/;"	c	module:class.class.module_no_parameter_port_list
+class_with_parameter_port_list	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	C	interface:class.class
+P1	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list	parameter:
+P2	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list	parameter:
+L2	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list
+L3	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list
+P3	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list	parameter:
+P4	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list	parameter:
+L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	class:class.class.class_with_parameter_port_list
+L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	class:class.class.class_with_parameter_port_list
+class_with_empty_parameter_port_list	input.sv	/^class class_with_empty_parameter_port_list #();$/;"	C	interface:class.class
+L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	class:class.class.class_with_empty_parameter_port_list
+L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	class:class.class.class_with_empty_parameter_port_list
+class_no_parameter_port_list	input.sv	/^class class_no_parameter_port_list;$/;"	C	interface:class.class
+L8	input.sv	/^  parameter  L8 = "local parameter";  \/\/ synonym for the localparam (class only)$/;"	c	class:class.class.class_no_parameter_port_list
+L9	input.sv	/^  localparam L9 = "local parameter";$/;"	c	class:class.class.class_no_parameter_port_list
+program_with_parameter_port_list	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	P	interface:class.class
+P1	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list	parameter:
+P2	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list	parameter:
+L2	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list
+L3	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list
+P3	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list	parameter:
+P4	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list	parameter:
+L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	program:class.class.program_with_parameter_port_list
+L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	program:class.class.program_with_parameter_port_list
+program_with_empty_parameter_port_list	input.sv	/^program program_with_empty_parameter_port_list #()$/;"	P	interface:class.class
+L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	program:class.class.program_with_empty_parameter_port_list
+L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	program:class.class.program_with_empty_parameter_port_list
+program_no_parameter_port_list	input.sv	/^program program_no_parameter_port_list$/;"	P	interface:class.class
+P5	input.sv	/^  parameter  P5 = "parameter";$/;"	c	program:class.class.program_no_parameter_port_list	parameter:
+L8	input.sv	/^  localparam L8 = "local parameter";$/;"	c	program:class.class.program_no_parameter_port_list
+interface_with_parameter_port_list	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	I	interface:class.class
+P1	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list	parameter:
+P2	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list	parameter:
+L2	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list
+L3	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list
+P3	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list	parameter:
+P4	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list	parameter:
+L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	interface:class.class.interface_with_parameter_port_list
+L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	interface:class.class.interface_with_parameter_port_list
+interface_with_empty_parameter_port_list	input.sv	/^interface interface_with_empty_parameter_port_list #()$/;"	I	interface:class.class
+L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	interface:class.class.interface_with_empty_parameter_port_list
+L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	interface:class.class.interface_with_empty_parameter_port_list
+interface_no_parameter_port_list	input.sv	/^interface interface_no_parameter_port_list$/;"	I	interface:class.class
+P5	input.sv	/^  parameter  P5 = "parameter";$/;"	c	interface:class.class.interface_no_parameter_port_list	parameter:
+L8	input.sv	/^  localparam L8 = "local parameter";$/;"	c	interface:class.class.interface_no_parameter_port_list
+package_has_no_parameter_port_list	input.sv	/^package package_has_no_parameter_port_list;$/;"	K	interface:class.class
+L1	input.sv	/^  parameter  L1 = "local parameter";$/;"	c	package:class.class.package_has_no_parameter_port_list
+L2	input.sv	/^  localparam L2 = "local parameter";$/;"	c	package:class.class.package_has_no_parameter_port_list
+generate_constructs	input.sv	/^module generate_constructs;$/;"	m	interface:class.class
+L1	input.sv	/^    parameter  L1 = "local parameter";  \/\/ FIXME$/;"	c	module:class.class.generate_constructs	parameter:
+L2	input.sv	/^    localparam L2 = "local parameter";$/;"	c	module:class.class.generate_constructs

--- a/Units/parser-verilog.r/systemverilog-parameter.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-parameter.d/input.sv
@@ -55,10 +55,10 @@ endclass
 
 class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);
   T myFifo[$:DEPTH-1];
-  virtual function void put(T a); // FIXME : to be ignored
+  virtual function void put(T a); // FIXME : to be ignored?
     myFifo.push_back(a);
   endfunction
-  virtual function T get(); // FIXME : to be ignored
+  virtual function T get(); // FIXME : to be ignored?
     get = myFifo.pop_front();
   endfunction
 endclass
@@ -93,4 +93,104 @@ typedef int int_t;
 module user_defined_type_param
   #(int_t num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)
    (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);
+endmodule
+
+//
+// LRM 6.20.1 Parameter declaration syntax (#2537)
+//
+
+// compilation unit scope
+parameter L1 = 0;  //  synonym for the localparam
+
+module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4)
+( /*port list...*/ );
+  parameter  L4 = "local parameter";  // synonym for the localparam
+  localparam L5 = "local parameter";
+  // ...
+endmodule
+
+module module_with_empty_parameter_port_list #()
+( /*port list...*/ );
+  parameter  L6 = "local parameter";  // synonym for the localparam
+  localparam L7 = "local parameter";
+  // ...
+endmodule
+
+module module_no_parameter_port_list
+( /*port list...*/ );
+  parameter  P5 = "parameter";
+  localparam L8 = "local parameter";
+  // ...
+endmodule
+
+class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);
+  parameter  L4 = "local parameter";  // synonym for the localparam
+  localparam L5 = "local parameter";
+  // ...
+endclass
+
+class class_with_empty_parameter_port_list #();
+  parameter  L6 = "local parameter";  // synonym for the localparam
+  localparam L7 = "local parameter";
+  // ...
+endclass
+
+class class_no_parameter_port_list;
+  parameter  L8 = "local parameter";  // synonym for the localparam (class only)
+  localparam L9 = "local parameter";
+  // ...
+endclass
+
+program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4)
+( /*port list...*/ );
+  parameter  L4 = "local parameter";  // synonym for the localparam
+  localparam L5 = "local parameter";
+  // ...
+endprogram
+
+program program_with_empty_parameter_port_list #()
+( /*port list...*/ );
+  parameter  L6 = "local parameter";  // synonym for the localparam
+  localparam L7 = "local parameter";
+  // ...
+endprogram
+
+program program_no_parameter_port_list
+( /*port list...*/ );
+  parameter  P5 = "parameter";
+  localparam L8 = "local parameter";
+  // ...
+endprogram
+
+interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4)
+( /*port list...*/ );
+  parameter  L4 = "local parameter";  // synonym for the localparam
+  localparam L5 = "local parameter";
+  // ...
+endinterface
+
+interface interface_with_empty_parameter_port_list #()
+( /*port list...*/ );
+  parameter  L6 = "local parameter";  // synonym for the localparam
+  localparam L7 = "local parameter";
+  // ...
+endinterface
+
+interface interface_no_parameter_port_list
+( /*port list...*/ );
+  parameter  P5 = "parameter";
+  localparam L8 = "local parameter";
+  // ...
+endinterface
+
+package package_has_no_parameter_port_list;
+  parameter  L1 = "local parameter";
+  localparam L2 = "local parameter";
+endpackage
+
+module generate_constructs;
+  generate
+    parameter  L1 = "local parameter";  // FIXME
+    localparam L2 = "local parameter";
+  endgenerate
 endmodule

--- a/configure.ac
+++ b/configure.ac
@@ -725,6 +725,7 @@ AC_CONFIG_FILES([Makefile
 		 man/ctags-incompatibilities.7.rst
 		 man/ctags-optlib.7.rst
 		 man/ctags-lang-python.7.rst
+		 man/ctags-lang-verilog.7.rst
 		 man/readtags.1.rst
 		 ])
 

--- a/docs/man-pages.rst
+++ b/docs/man-pages.rst
@@ -11,6 +11,7 @@ Man pages
 	ctags-client-tools(7) <man/ctags-client-tools.7.rst>
 	ctags-incompatibilities(7) <man/ctags-incompatibilities.7.rst>
 	ctags-lang-python(7) <man/ctags-lang-python.7.rst>
+	ctags-lang-verilog(7) <man/ctags-lang-verilog.7.rst>
 	ctags-optlib(7) <man/ctags-optlib.7.rst>
 	readtags(1) <man/readtags.1.rst>
 	tags(5) <man/tags.5.rst>

--- a/docs/man/ctags-lang-verilog.7.rst
+++ b/docs/man/ctags-lang-verilog.7.rst
@@ -1,0 +1,109 @@
+.. _ctags_lang-verilog(7):
+
+======================================================================
+ctags-lang-verilog
+======================================================================
+
+:Version: 5.9.0
+:Manual group: Universal-ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**ctags** ... [--fields-Verilog=+{parameter}] ...
+|	**ctags** ... [--kinds-systemverilog=+Q] [--fields-SystemVerilog=+{parameter}] ...
+|	**ctags** --list-kinds-full={Verilog|SystemVerilog}
+|	**ctags** --list-fields={Verilog|SystemVerilog}
+
+    +---------------+---------------+-------------------+
+    | Language      | Language ID   | File Mapping      |
+    +===============+===============+===================+
+    | Verilog       | Verilog       | .v                |
+    +---------------+---------------+-------------------+
+    | SystemVerilog | SystemVerilog | .sv, .svh, svi    |
+    +---------------+---------------+-------------------+
+
+DESCRIPTION
+-----------
+This man page describes about the Verilog/SystemVerilog parser for Universal-ctags.
+
+It assumes the input file is written in the correct grammer.  Otherwise output of
+ctags is undefined.
+
+``parameter`` field
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the field ``parameter`` is enabled, a tagfield ``parameter:`` is added on a parameter whose
+value can be overridden on an instantiated module, interface, or program.
+This is useful for a editor plugin or extension to enable auto-instatiation of modules with
+parameters which can be overridden.
+
+.. code-block:: console
+
+    $ ctags ... --fields-Verilog=+{parameter} ...
+    $ ctags ... --fields-SystemVerilog=+{parameter} ...
+
+On the following source code tagfields ``parameter:`` are added on
+parameter ``P*``, not on ``L*``.  Note that ``L4`` and ``L6`` is declared by
+``parameter`` statement, but tagfields ``parameter:`` are not added,
+because they cannot be overridden.
+
+"input.sv"
+
+.. code-block:: systemverilog
+
+	// compilation unit scope
+	parameter L1 = "synonym for the localparam";
+
+	module with_parameter_port_list #(
+		P1,
+		localparam L2 = P1+1,
+		parameter P2)
+		( /*port list...*/ );
+		parameter  L3 = "synonym for the localparam";
+		localparam L4 = "localparam";
+		// ...
+	endmodule
+
+	module with_empty_parameter_port_list #()
+		( /*port list...*/ );
+		parameter  L5 = "synonym for the localparam";
+		localparam L6 = "localparam";
+		// ...
+	endmodule
+
+	module no_parameter_port_list
+		( /*port list...*/ );
+		parameter  P3 = "parameter";
+		localparam L7 = "localparam";
+		// ...
+	endmodule
+
+"output.tags"
+with "--options=NONE --sort=no -o - --fields-SystemVerilog=+{parameter} input.sv"
+
+.. code-block:: tags
+
+	L1      foo.sv  /^parameter L1 = "synonym for the localparam";$/;"      c       parameter:
+	with_parameter_port_list foo.sv  /^module with_parameter_port_list #($/;" m
+	P1      foo.sv  /^    P1, $/;"  c       module:with_parameter_port_list  parameter:
+	L2      foo.sv  /^    localparam L2 = P1+1,$/;" c       module:with_parameter_port_list
+	P2      foo.sv  /^    parameter P2)$/;" c       module:with_parameter_port_list  parameter:
+	L3      foo.sv  /^    parameter  L3 = "synonym for the localparam";$/;" c       module:with_parameter_port_list
+	L4      foo.sv  /^    localparam L4 = "localparam";$/;" c       module:with_parameter_port_list
+	with_empty_parameter_port_list   foo.sv  /^module with_empty_parameter_port_list #()$/;"  m
+	L5      foo.sv  /^    parameter  L5 = "synonym for the localparam";$/;" c       module:with_empty_parameter_port_list
+	L6      foo.sv  /^    localparam L6 = "localparam";$/;" c       module:with_empty_parameter_port_list
+	no_parameter_port_list   foo.sv  /^module no_parameter_port_list$/;"      m
+	P3      foo.sv  /^    parameter  P3 = "parameter";$/;"  c       module:no_parameter_port_list    parameter:
+	L7      foo.sv  /^    localparam L7 = "localparam";$/;" c       module:no_parameter_port_list
+
+Known Issues
+---------------------------------------------------------------------
+
+See https://github.com/universal-ctags/ctags/issues/TBD.
+
+
+SEE ALSO
+--------
+:ref:`ctags(1) <ctags(1)>`, :ref:`ctags-client-tools(7) <ctags-client-tools(7)>`

--- a/man/Makefile
+++ b/man/Makefile
@@ -48,6 +48,7 @@ IN_SOURCE_FILES = \
 	ctags-client-tools.7.rst.in \
 	\
 	ctags-lang-python.7.rst.in \
+	ctags-lang-verilog.7.rst.in \
 	\
 	readtags.1.rst.in \
 	\

--- a/man/ctags-lang-verilog.7.rst.in
+++ b/man/ctags-lang-verilog.7.rst.in
@@ -1,0 +1,109 @@
+.. _ctags_lang-verilog(7):
+
+======================================================================
+ctags-lang-verilog
+======================================================================
+
+:Version: @VERSION@
+:Manual group: Universal-ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**@CTAGS_NAME_EXECUTABLE@** ... [--fields-Verilog=+{parameter}] ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... [--kinds-systemverilog=+Q] [--fields-SystemVerilog=+{parameter}] ...
+|	**@CTAGS_NAME_EXECUTABLE@** --list-kinds-full={Verilog|SystemVerilog}
+|	**@CTAGS_NAME_EXECUTABLE@** --list-fields={Verilog|SystemVerilog}
+
+    +---------------+---------------+-------------------+
+    | Language      | Language ID   | File Mapping      |
+    +===============+===============+===================+
+    | Verilog       | Verilog       | .v                |
+    +---------------+---------------+-------------------+
+    | SystemVerilog | SystemVerilog | .sv, .svh, svi    |
+    +---------------+---------------+-------------------+
+
+DESCRIPTION
+-----------
+This man page describes about the Verilog/SystemVerilog parser for Universal-ctags.
+
+It assumes the input file is written in the correct grammer.  Otherwise output of
+ctags is undefined.
+
+``parameter`` field
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the field ``parameter`` is enabled, a tagfield ``parameter:`` is added on a parameter whose
+value can be overridden on an instantiated module, interface, or program.
+This is useful for a editor plugin or extension to enable auto-instatiation of modules with
+parameters which can be overridden.
+
+.. code-block:: console
+
+    $ ctags ... --fields-Verilog=+{parameter} ...
+    $ ctags ... --fields-SystemVerilog=+{parameter} ...
+
+On the following source code tagfields ``parameter:`` are added on
+parameter ``P*``, not on ``L*``.  Note that ``L4`` and ``L6`` is declared by
+``parameter`` statement, but tagfields ``parameter:`` are not added,
+because they cannot be overridden.
+
+"input.sv"
+
+.. code-block:: systemverilog
+
+	// compilation unit scope
+	parameter L1 = "synonym for the localparam";
+
+	module with_parameter_port_list #(
+		P1,
+		localparam L2 = P1+1,
+		parameter P2)
+		( /*port list...*/ );
+		parameter  L3 = "synonym for the localparam";
+		localparam L4 = "localparam";
+		// ...
+	endmodule
+
+	module with_empty_parameter_port_list #()
+		( /*port list...*/ );
+		parameter  L5 = "synonym for the localparam";
+		localparam L6 = "localparam";
+		// ...
+	endmodule
+
+	module no_parameter_port_list
+		( /*port list...*/ );
+		parameter  P3 = "parameter";
+		localparam L7 = "localparam";
+		// ...
+	endmodule
+
+"output.tags"
+with "--options=NONE --sort=no -o - --fields-SystemVerilog=+{parameter} input.sv"
+
+.. code-block:: tags
+
+	L1      foo.sv  /^parameter L1 = "synonym for the localparam";$/;"      c       parameter:
+	with_parameter_port_list foo.sv  /^module with_parameter_port_list #($/;" m
+	P1      foo.sv  /^    P1, $/;"  c       module:with_parameter_port_list  parameter:
+	L2      foo.sv  /^    localparam L2 = P1+1,$/;" c       module:with_parameter_port_list
+	P2      foo.sv  /^    parameter P2)$/;" c       module:with_parameter_port_list  parameter:
+	L3      foo.sv  /^    parameter  L3 = "synonym for the localparam";$/;" c       module:with_parameter_port_list
+	L4      foo.sv  /^    localparam L4 = "localparam";$/;" c       module:with_parameter_port_list
+	with_empty_parameter_port_list   foo.sv  /^module with_empty_parameter_port_list #()$/;"  m
+	L5      foo.sv  /^    parameter  L5 = "synonym for the localparam";$/;" c       module:with_empty_parameter_port_list
+	L6      foo.sv  /^    localparam L6 = "localparam";$/;" c       module:with_empty_parameter_port_list
+	no_parameter_port_list   foo.sv  /^module no_parameter_port_list$/;"      m
+	P3      foo.sv  /^    parameter  P3 = "parameter";$/;"  c       module:no_parameter_port_list    parameter:
+	L7      foo.sv  /^    localparam L7 = "localparam";$/;" c       module:no_parameter_port_list
+
+Known Issues
+---------------------------------------------------------------------
+
+See https://github.com/universal-ctags/ctags/issues/TBD.
+
+
+SEE ALSO
+--------
+ctags(1), ctags-client-tools(7)


### PR DESCRIPTION
This is a fix for #2537.

By adding option `--fields-SystemVerilog=+{property}` ctags outputs a tag `property:parameter` on parameters which can be overridden on instantiation.

I choose a generic name `property` instead of `definedWith`.   This is because, as we discussed on #2537, what we need is not how a constant is defined with, `parameter `or `localparam`.