### PR TITLE
main: introduce keyword group API

### DIFF
--- a/main/keyword.c
+++ b/main/keyword.c
@@ -256,3 +256,21 @@ extern void dumpKeywordTable (FILE *fp)
 		}
 	}
 }
+
+extern void addKeywordGroup (const struct keywordGroup *const groupdef,
+							 langType language)
+{
+	for (int i = 0; groupdef->keywords[i]; i++)
+	{
+		if (groupdef->addingUnlessExisting)
+		{
+			if (lookupKeyword (groupdef->keywords[i],
+							   language) != KEYWORD_NONE)
+				continue;		/* already added */
+		}
+		else
+			Assert (lookupKeyword (groupdef->keywords[i],
+								   language) == KEYWORD_NONE);
+		addKeyword (groupdef->keywords[i], language, groupdef->value);
+	}
+}

--- a/main/keyword.h
+++ b/main/keyword.h
@@ -27,4 +27,15 @@ extern void addKeyword (const char *const string, langType language, int value);
 extern int lookupKeyword (const char *const string, langType language);
 extern int lookupCaseKeyword (const char *const string, langType language);
 
+/*
+* KEYWORD GROUP API: Adding keywords for value in batch
+*/
+struct keywordGroup {
+	int value;
+	bool addingUnlessExisting;
+	const char *keywords []; 	/* NULL terminated */
+};
+
+extern void addKeywordGroup (const struct keywordGroup *const groupdef,
+							 langType language);
 #endif  /* CTAGS_MAIN_KEYWORD_H */

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -242,70 +242,80 @@ static tokenInfo *tagContents = NULL;
 static fieldDefinition *fieldTable = NULL;
 
 // IEEE Std 1364-2005 LRM, Appendix B "List of Keywords"
-static const char *verilogKeywords[] = {
-	"always", "and", "assign", "automatic", "begin", "buf", "bufif0",
-	"bufif1", "case", "casex", "casez", "cell", "cmos", "config",
-	"deassign", "default", "defparam", "design", "disable", "edge",
-	"else", "end", "endcase", "endconfig", "endfunction", "endgenerate",
-	"endmodule", "endprimitive", "endspecify", "endtable", "endtask",
-	"event", "for", "force", "forever", "fork", "function", "generate",
-	"genvar", "highz0", "highz1", "if", "ifnone", "incdir", "include",
-	"initial", "inout", "input", "instance", "integer", "join", "large",
-	"liblist", "library", "localparam", "macromodule", "medium", "module",
-	"nand", "negedge", "nmos", "nor", "noshowcancelled", "not", "notif0",
-	"notif1", "or", "output", "parameter", "pmos", "posedge", "primitive",
-	"pull0", "pull1", "pulldown", "pullup", "pulsestyle_onevent",
-	"pulsestyle_ondetect", "rcmos", "real", "realtime", "reg", "release",
-	"repeat", "rnmos", "rpmos", "rtran", "rtranif0", "rtranif1",
-	"scalared", "showcancelled", "signed", "small", "specify",
-	"specparam", "strong0", "strong1", "supply0", "supply1", "table",
-	"task", "time", "tran", "tranif0", "tranif1", "tri", "tri0", "tri1",
-	"triand", "trior", "trireg", "unsigned1", "use", "uwire", "vectored",
-	"wait", "wand", "weak0", "weak1", "while", "wire", "wor", "xnor", "xor"
+const static struct keywordGroup verilogKeywords = {
+	.value = K_IGNORE,
+	.addingUnlessExisting = true,
+	.keywords = {
+		"always", "and", "assign", "automatic", "begin", "buf", "bufif0",
+		"bufif1", "case", "casex", "casez", "cell", "cmos", "config",
+		"deassign", "default", "defparam", "design", "disable", "edge",
+		"else", "end", "endcase", "endconfig", "endfunction", "endgenerate",
+		"endmodule", "endprimitive", "endspecify", "endtable", "endtask",
+		"event", "for", "force", "forever", "fork", "function", "generate",
+		"genvar", "highz0", "highz1", "if", "ifnone", "incdir", "include",
+		"initial", "inout", "input", "instance", "integer", "join", "large",
+		"liblist", "library", "localparam", "macromodule", "medium", "module",
+		"nand", "negedge", "nmos", "nor", "noshowcancelled", "not", "notif0",
+		"notif1", "or", "output", "parameter", "pmos", "posedge", "primitive",
+		"pull0", "pull1", "pulldown", "pullup", "pulsestyle_onevent",
+		"pulsestyle_ondetect", "rcmos", "real", "realtime", "reg", "release",
+		"repeat", "rnmos", "rpmos", "rtran", "rtranif0", "rtranif1",
+		"scalared", "showcancelled", "signed", "small", "specify",
+		"specparam", "strong0", "strong1", "supply0", "supply1", "table",
+		"task", "time", "tran", "tranif0", "tranif1", "tri", "tri0", "tri1",
+		"triand", "trior", "trireg", "unsigned1", "use", "uwire", "vectored",
+		"wait", "wand", "weak0", "weak1", "while", "wire", "wor", "xnor", "xor",
+		NULL
+	},
 };
 // IEEE Std 1800-2017 LRM, Annex B "Keywords"
-static const char *systemVerilogKeywords[] = {
-	"accept_on", "alias", "always", "always_comb", "always_ff",
-	"always_latch", "and", "assert", "assign", "assume", "automatic",
-	"before", "begin", "bind", "bins", "binsof", "bit", "break", "buf",
-	"bufif0", "bufif1", "byte", "case", "casex", "casez", "cell",
-	"chandle", "checker", "class", "clocking", "cmos", "config", "const",
-	"constraint", "context", "continue", "cover", "covergroup",
-	"coverpoint", "cross", "deassign", "default", "defparam", "design",
-	"disable", "dist", "do", "edge", "else", "end", "endcase",
-	"endchecker", "endclass", "endclocking", "endconfig", "endfunction",
-	"endgenerate", "endgroup", "endinterface", "endmodule", "endpackage",
-	"endprimitive", "endprogram", "endproperty", "endspecify",
-	"endsequence", "endtable", "endtask", "enum", "event", "eventually",
-	"expect", "export", "extends", "extern", "final", "first_match",
-	"for", "force", "foreach", "forever", "fork", "forkjoin", "function",
-	"generate", "genvar", "global", "highz0", "highz1", "if", "iff",
-	"ifnone", "ignore_bins", "illegal_bins", "implements", "implies",
-	"import", "incdir", "include", "initial", "inout", "input", "inside",
-	"instance", "int", "integer", "interconnect", "interface",
-	"intersect", "join", "join_any", "join_none", "large", "let",
-	"liblist", "library", "local", "localparam", "logic", "longint",
-	"macromodule", "matches", "medium", "modport", "module", "nand",
-	"negedge", "nettype", "new", "nexttime", "nmos", "nor",
-	"noshowcancelled", "not", "notif0", "notif1", "null", "or", "output",
-	"package", "packed", "parameter", "pmos", "posedge", "primitive",
-	"priority", "program", "property", "protected", "pull0", "pull1",
-	"pulldown", "pullup", "pulsestyle_ondetect", "pulsestyle_onevent",
-	"pure", "rand", "randc", "randcase", "randsequence", "rcmos", "real",
-	"realtime", "ref", "reg", "reject_on", "release", "repeat",
-	"restrict", "return", "rnmos", "rpmos", "rtran", "rtranif0",
-	"rtranif1", "s_always", "s_eventually", "s_nexttime", "s_until",
-	"s_until_with", "scalared", "sequence", "shortint", "shortreal",
-	"showcancelled", "signed", "small", "soft", "solve", "specify",
-	"specparam", "static", "string", "strong", "strong0", "strong1",
-	"struct", "super", "supply0", "supply1", "sync_accept_on",
-	"sync_reject_on", "table", "tagged", "task", "this", "throughout",
-	"time", "timeprecision", "timeunit", "tran", "tranif0", "tranif1",
-	"tri", "tri0", "tri1", "triand", "trior", "trireg", "type", "typedef",
-	"union", "unique", "unique0", "unsigned", "until", "until_with",
-	"untyped", "use", "uwire", "var", "vectored", "virtual", "void",
-	"wait", "wait_order", "wand", "weak", "weak0", "weak1", "while",
-	"wildcard", "wire", "with", "within", "wor", "xnor", "xor"
+const static struct keywordGroup systemVerilogKeywords = {
+	.value = K_IGNORE,
+	.addingUnlessExisting = true,
+	.keywords = {
+		"accept_on", "alias", "always", "always_comb", "always_ff",
+		"always_latch", "and", "assert", "assign", "assume", "automatic",
+		"before", "begin", "bind", "bins", "binsof", "bit", "break", "buf",
+		"bufif0", "bufif1", "byte", "case", "casex", "casez", "cell",
+		"chandle", "checker", "class", "clocking", "cmos", "config", "const",
+		"constraint", "context", "continue", "cover", "covergroup",
+		"coverpoint", "cross", "deassign", "default", "defparam", "design",
+		"disable", "dist", "do", "edge", "else", "end", "endcase",
+		"endchecker", "endclass", "endclocking", "endconfig", "endfunction",
+		"endgenerate", "endgroup", "endinterface", "endmodule", "endpackage",
+		"endprimitive", "endprogram", "endproperty", "endspecify",
+		"endsequence", "endtable", "endtask", "enum", "event", "eventually",
+		"expect", "export", "extends", "extern", "final", "first_match",
+		"for", "force", "foreach", "forever", "fork", "forkjoin", "function",
+		"generate", "genvar", "global", "highz0", "highz1", "if", "iff",
+		"ifnone", "ignore_bins", "illegal_bins", "implements", "implies",
+		"import", "incdir", "include", "initial", "inout", "input", "inside",
+		"instance", "int", "integer", "interconnect", "interface",
+		"intersect", "join", "join_any", "join_none", "large", "let",
+		"liblist", "library", "local", "localparam", "logic", "longint",
+		"macromodule", "matches", "medium", "modport", "module", "nand",
+		"negedge", "nettype", "new", "nexttime", "nmos", "nor",
+		"noshowcancelled", "not", "notif0", "notif1", "null", "or", "output",
+		"package", "packed", "parameter", "pmos", "posedge", "primitive",
+		"priority", "program", "property", "protected", "pull0", "pull1",
+		"pulldown", "pullup", "pulsestyle_ondetect", "pulsestyle_onevent",
+		"pure", "rand", "randc", "randcase", "randsequence", "rcmos", "real",
+		"realtime", "ref", "reg", "reject_on", "release", "repeat",
+		"restrict", "return", "rnmos", "rpmos", "rtran", "rtranif0",
+		"rtranif1", "s_always", "s_eventually", "s_nexttime", "s_until",
+		"s_until_with", "scalared", "sequence", "shortint", "shortreal",
+		"showcancelled", "signed", "small", "soft", "solve", "specify",
+		"specparam", "static", "string", "strong", "strong0", "strong1",
+		"struct", "super", "supply0", "supply1", "sync_accept_on",
+		"sync_reject_on", "table", "tagged", "task", "this", "throughout",
+		"time", "timeprecision", "timeunit", "tran", "tranif0", "tranif1",
+		"tri", "tri0", "tri1", "triand", "trior", "trireg", "type", "typedef",
+		"union", "unique", "unique0", "unsigned", "until", "until_with",
+		"untyped", "use", "uwire", "var", "vectored", "virtual", "void",
+		"wait", "wait_order", "wand", "weak", "weak0", "weak1", "while",
+		"wildcard", "wire", "with", "within", "wor", "xnor", "xor",
+		NULL
+	},
 };
 
 // .enabled field cannot be shared by two languages
@@ -461,7 +471,7 @@ static char kindEnabled (const verilogKind kind)
 		return VerilogKinds[kind].enabled;
 }
 
-static void buildKeywordHash (const langType language, unsigned int idx, const char *keywords[], const unsigned int size)
+static void buildKeywordHash (const langType language, unsigned int idx)
 {
 	size_t i;
 	const size_t count = ARRAY_SIZE (KeywordTable);
@@ -471,23 +481,27 @@ static void buildKeywordHash (const langType language, unsigned int idx, const c
 		if (p->isValid [idx])
 			addKeyword (p->keyword, language, (int) p->kind);
 	}
-	/* mark unspecified Verilog/SystemVerilog keywords as K_IGNORE */
-	for (i = 0  ;  i < size  ;  ++i) {
-		if (lookupKeyword(keywords[i], language) == KEYWORD_NONE)
-			addKeyword (keywords[i], language, K_IGNORE);
-	}
+}
+
+static void addIgnoredKeywords (const langType language,
+								const struct keywordGroup *const ignoredKeyword)
+{
+	/* mark unspecified Verilog/SystemVexrilog keywords as K_IGNORE */
+	addKeywordGroup (ignoredKeyword, language);
 }
 
 static void initializeVerilog (const langType language)
 {
 	Lang_verilog = language;
-	buildKeywordHash (language, IDX_VERILOG, verilogKeywords, sizeof(verilogKeywords) / sizeof(char *));
+	buildKeywordHash (language, IDX_VERILOG);
+	addIgnoredKeywords (language, &verilogKeywords);
 }
 
 static void initializeSystemVerilog (const langType language)
 {
 	Lang_systemverilog = language;
-	buildKeywordHash (language, IDX_SYSTEMVERILOG, systemVerilogKeywords, sizeof(systemVerilogKeywords) / sizeof(char *));
+	buildKeywordHash (language, IDX_SYSTEMVERILOG);
+	addIgnoredKeywords (language, &systemVerilogKeywords);
 }
 
 static void vUngetc (int c)


### PR DESCRIPTION
Introduce a new function for adding keywords having the same value in batch.

Inspired from the code in (System)Verilog parser.


I would like to use the technique used in (System)Verilog parser in Vala parser I'm working on.

@hirooih, could you review my change for (System)Verilog parser?