### PR TITLE
gitignore: add ctags-lang-verilog generated manpage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ man/ctags-incompatibilities.7.rst
 man/ctags-lang-python.7
 man/ctags-lang-python.7.html
 man/ctags-lang-python.7.rst
+man/ctags-lang-verilog.7
+man/ctags-lang-verilog.7.html
+man/ctags-lang-verilog.7.rst
 man/ctags-optlib.7
 man/ctags-optlib.7.html
 man/ctags-optlib.7.rst


### PR DESCRIPTION
see title