### PR TITLE
Fix and tidy up the Inko parser

### DIFF
--- a/Units/parser-inko.r/everything.d/expected.tags
+++ b/Units/parser-inko.r/everything.d/expected.tags
@@ -1,18 +1,17 @@
 A	input.inko	/^object A$/;"	o
+@number	input.inko	/^  @number: X$/;"	a	object:A
 in_a	input.inko	/^  def in_a {$/;"	m	object:A
-another	input.inko	/^  def another {}$/;"	m	object:A
+another	input.inko	/^  def another {}$/;"	m
 foo	input.inko	/^def foo {}$/;"	m
 B	input.inko	/^object B {$/;"	o
 in_b	input.inko	/^  def in_b {$/;"	m	object:B
-C	input.inko	/^  object C {$/;"	o	object:B
-nested_method	input.inko	/^    def nested_method {}$/;"	m	object:B.C
 global	input.inko	/^def global {}$/;"	m
 SomeTrait	input.inko	/^trait SomeTrait {$/;"	t
-Socket	input.inko	/^object Socket impl Foo {$/;"	o
+required_method	input.inko	/^  def required_method$/;"	m	trait:SomeTrait
+Socket	input.inko	/^object Socket {$/;"	o
 quack	input.inko	/^  def quack {}$/;"	m	object:Socket
 Socket	input.inko	/^impl Bar for Socket {$/;"	r	implements:Bar
 moo	input.inko	/^  def moo !! Integer {}$/;"	m	reopen:Socket
 Chickens	input.inko	/^impl Chickens {$/;"	r
 bok_bok	input.inko	/^  def bok_bok {}$/;"	m	reopen:Chickens
 NUMBER	input.inko	/^let NUMBER = 10$/;"	c
-@number	input.inko	/^let @number = 20$/;"	a

--- a/Units/parser-inko.r/everything.d/input.inko
+++ b/Units/parser-inko.r/everything.d/input.inko
@@ -2,6 +2,8 @@
 
 object A
 {
+  @number: X
+
   def in_a {
     { 20 }
   }
@@ -15,19 +17,16 @@ object B {
   def in_b {
     { 10  }
   }
-
-  object C {
-    def nested_method {}
-  }
 }
 
 def global {}
 
 trait SomeTrait {
   # def this_should_be_ignored {}
+  def required_method
 }
 
-object Socket impl Foo {
+object Socket {
   def quack {}
 }
 
@@ -40,4 +39,3 @@ impl Chickens {
 }
 
 let NUMBER = 10
-let @number = 20

--- a/Units/parser-inko.r/let.d/expected.tags
+++ b/Units/parser-inko.r/let.d/expected.tags
@@ -1,4 +1,2 @@
-CONSTANT	input.inko	/^let CONSTANT = 10$/;"	c
-Person	input.inko	/^object Person {$/;"	o
-init	input.inko	/^  def init(name: String) {$/;"	m	object:Person
-@name	input.inko	/^    let @name = name$/;"	a	method:Person.init
+FOO	input.inko	/^let FOO = 10$/;"	c
+BAR	input.inko	/^let BAR = 20$/;"	c

--- a/Units/parser-inko.r/let.d/input.inko
+++ b/Units/parser-inko.r/let.d/input.inko
@@ -1,7 +1,2 @@
-let CONSTANT = 10
-
-object Person {
-  def init(name: String) {
-    let @name = name
-  }
-}
+let FOO = 10
+let BAR = 20

--- a/Units/parser-inko.r/methods.d/expected.tags
+++ b/Units/parser-inko.r/methods.d/expected.tags
@@ -2,10 +2,6 @@ A	input.inko	/^object A {$/;"	o
 method_a	input.inko	/^  def method_a {}$/;"	m	object:A
 B	input.inko	/^object B {$/;"	o
 method_b	input.inko	/^  def method_b {}$/;"	m	object:B
-C	input.inko	/^object C {$/;"	o
-D	input.inko	/^  object D {$/;"	o	object:C
-E	input.inko	/^    object E {$/;"	o	object:C.D
-method_e	input.inko	/^      def method_e {}$/;"	m	object:C.D.E
 +	input.inko	/^def + {}$/;"	m
 -	input.inko	/^def - {}$/;"	m
 *	input.inko	/^def * {}$/;"	m

--- a/Units/parser-inko.r/methods.d/input.inko
+++ b/Units/parser-inko.r/methods.d/input.inko
@@ -6,14 +6,6 @@ object B {
   def method_b {}
 }
 
-object C {
-  object D {
-    object E {
-      def method_e {}
-    }
-  }
-}
-
 def + {}
 def - {}
 def * {}

--- a/Units/parser-inko.r/objects.d/expected.tags
+++ b/Units/parser-inko.r/objects.d/expected.tags
@@ -1,5 +1,4 @@
 A	input.inko	/^object A {}$/;"	o
 B	input.inko	/^object B {}$/;"	o
 C	input.inko	/^object C {$/;"	o
-D	input.inko	/^  object D {$/;"	o	object:C
-E	input.inko	/^    object E {}$/;"	o	object:C.D
+@foo	input.inko	/^  @foo: X$/;"	a	object:C

--- a/Units/parser-inko.r/objects.d/input.inko
+++ b/Units/parser-inko.r/objects.d/input.inko
@@ -2,7 +2,5 @@ object A {}
 object B {}
 
 object C {
-  object D {
-    object E {}
-  }
+  @foo: X
 }

--- a/Units/parser-inko.r/traits.d/expected.tags
+++ b/Units/parser-inko.r/traits.d/expected.tags
@@ -1,2 +1,11 @@
 A	input.inko	/^trait A {}$/;"	t
 B	input.inko	/^trait B: SomeRequiredTrait {}$/;"	t
+C	input.inko	/^trait C {$/;"	t
+foo	input.inko	/^  def foo() {}$/;"	m	trait:C
+bar	input.inko	/^  def bar() {}$/;"	m	trait:C
+required_method_foo	input.inko	/^  def required_method_foo$/;"	m	trait:C
+required_method_bar	input.inko	/^  def required_method_bar$/;"	m	trait:C
+wrapped_required_method	input.inko	/^  def wrapped_required_method($/;"	m	trait:C
+wrapped_default_method	input.inko	/^  def wrapped_default_method($/;"	m	trait:C
+blabla	input.inko	/^  def blabla {}$/;"	m	trait:C
+D	input.inko	/^trait D {}$/;"	t

--- a/Units/parser-inko.r/traits.d/input.inko
+++ b/Units/parser-inko.r/traits.d/input.inko
@@ -1,2 +1,20 @@
 trait A {}
 trait B: SomeRequiredTrait {}
+trait C {
+  def foo() {}
+  def bar() {}
+
+  def required_method_foo
+  def required_method_bar
+
+  def wrapped_required_method(
+    a: A
+  )
+
+  def wrapped_default_method(
+    a: A
+  ) {}
+
+  def blabla {}
+}
+trait D {}

--- a/optlib/inko.c
+++ b/optlib/inko.c
@@ -44,6 +44,9 @@ static void initializeInkoParser (const langType language)
 	                               "^\\}",
 	                               "", "", "{scope=pop}", NULL);
 	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^(@[a-zA-Z0-9_]+):",
+	                               "\\1", "a", "{scope=ref}", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
 	                               "^.",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "object",
@@ -65,11 +68,11 @@ static void initializeInkoParser (const langType language)
 	                               "^.",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "method",
-	                               "^([a-zA-Z0-9_?]+|\\[\\]=?|\\^|&|\\||\\*|\\+|\\-|/|>>|<<|%)[^{]*",
+	                               "^([a-zA-Z0-9_?]+|\\[\\]=?|\\^|&|\\||\\*|\\+|\\-|/|>>|<<|%)",
 	                               "\\1", "m", "{scope=push}", NULL);
 	addLanguageTagMultiTableRegex (language, "method",
-	                               "^\\{",
-	                               "", "", "{tleave}", NULL);
+	                               "^\\{|\n",
+	                               "", "", "{scope=pop}{tleave}", NULL);
 	addLanguageTagMultiTableRegex (language, "method",
 	                               "^.",
 	                               "", "", "", NULL);
@@ -91,9 +94,6 @@ static void initializeInkoParser (const langType language)
 	addLanguageTagMultiTableRegex (language, "impl",
 	                               "^.",
 	                               "", "", "", NULL);
-	addLanguageTagMultiTableRegex (language, "let",
-	                               "^(@[a-zA-Z0-9_]+)",
-	                               "\\1", "a", "{scope=ref}", NULL);
 	addLanguageTagMultiTableRegex (language, "let",
 	                               "^([A-Z][a-zA-Z0-9_]+)",
 	                               "\\1", "c", "{scope=ref}", NULL);

--- a/optlib/inko.ctags
+++ b/optlib/inko.ctags
@@ -3,7 +3,7 @@
 #
 #  Copyright (c) 2019, Yorick Peterse
 #
-#  Author: Yorick Peterse <yorickpeterse@gmail.com>
+#  Author: Yorick Peterse <yorick@yorickpeterse.com>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -49,6 +49,7 @@
 --_mtable-regex-Inko=toplevel/[[:blank:]]*let[[:blank:]]+//{tenter=let}
 --_mtable-regex-Inko=toplevel/\{//{placeholder}{scope=push}
 --_mtable-regex-Inko=toplevel/\}//{scope=pop}
+--_mtable-regex-Inko=toplevel/(@[a-zA-Z0-9_]+):/\1/a/{scope=ref}
 --_mtable-regex-Inko=toplevel/.//
 
 --_mtable-regex-Inko=object/([A-Z][a-zA-Z0-9_?]*)[^{]*/\1/o/{scope=push}
@@ -59,8 +60,8 @@
 --_mtable-regex-Inko=trait/\{//{tleave}
 --_mtable-regex-Inko=trait/.//
 
---_mtable-regex-Inko=method/([a-zA-Z0-9_?]+|\[\]=?|\^|&|\||\*|\+|\-|\/|>>|<<|%)[^{]*/\1/m/{scope=push}
---_mtable-regex-Inko=method/\{//{tleave}
+--_mtable-regex-Inko=method/([a-zA-Z0-9_?]+|\[\]=?|\^|&|\||\*|\+|\-|\/|>>|<<|%)/\1/m/{scope=push}
+--_mtable-regex-Inko=method/\{|\n//{scope=pop}{tleave}
 --_mtable-regex-Inko=method/.//
 
 --_mtable-regex-Inko=impl/([A-Z][a-zA-Z0-9_?]*)[[:blank:]]+for[[:blank:]]+([A-Z][a-zA-Z0-9_?]*)[^{]*/\2/r/{scope=push}{_field=implements:\1}
@@ -68,7 +69,6 @@
 --_mtable-regex-Inko=impl/\{//{tleave}
 --_mtable-regex-Inko=impl/.//
 
---_mtable-regex-Inko=let/(@[a-zA-Z0-9_]+)/\1/a/{scope=ref}
 --_mtable-regex-Inko=let/([A-Z][a-zA-Z0-9_]+)/\1/c/{scope=ref}
 --_mtable-regex-Inko=let/=//{tleave}
 --_mtable-regex-Inko=let/.//


### PR DESCRIPTION
This applies various fixes to the Inko regex parser, and updates my
Email address as I no longer use Gmail.

Required methods
================

Inko has a notion of required methods. These are defined without a body
like so:

    trait SomeTrait {
      def required_method(some_argument: Type)
    }

These were not parsed properly. In this commit we fix the parser so both
regular and required methods are parsed.

Nested objects and traits
=========================

The parser had support for nested objects and traits, like so:

    object A {
      object B {}
    }

Inko dropped support for this syntax quite some time ago, so we also
remove ctags support for this.

Attribute definitions
=====================

Inko's syntax for defining attributes changed a while ago. Instead of
using `let @foo = bar` you now define attribute types separately like
so:

    object A {
      @foo: SomeType
    }

This adds support for parsing this syntax, and drops support for the
`let` syntax.

Objects implementing traits
===========================

A test case used the syntax `object A impl B`, which Inko hasn't
supported in quite some time. This commit removes this example, as this
isn't valid Inko code any more.