### PR TITLE
SystemVerilog: handle an identifier include '$'

### DIFF
--- a/Units/parser-verilog.r/systemverilog-github646.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-github646.d/expected.tags
@@ -1,1 +1,1 @@
-0	input.sv	/^function 0:/;"	f
+function	input.sv	/^function 0:/;"	f

--- a/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
@@ -88,5 +88,8 @@ e	input.sv	/^module delay_control #(d, e);$/;"	c	module:delay_control
 rega	input.sv	/^  int rega, regb, regr;$/;"	r	module:delay_control
 regb	input.sv	/^  int rega, regb, regr;$/;"	r	module:delay_control
 regr	input.sv	/^  int rega, regb, regr;$/;"	r	module:delay_control
-rega	input.sv	/^    #d rega = regb; \/\/ d is defined as a parameter  FIXME$/;"	r	module:delay_control
-regr	input.sv	/^    #regr regr = regr + 1; \/\/ delay is the value in regr  FIXME$/;"	r	module:delay_control
+delay_control_wire	input.sv	/^module delay_control_wire #(d, e);$/;"	m
+d	input.sv	/^module delay_control_wire #(d, e);$/;"	c	module:delay_control_wire
+e	input.sv	/^module delay_control_wire #(d, e);$/;"	c	module:delay_control_wire
+w$ire	input.sv	/^  wire w$ire, wire$;  \/\/ '$' included$/;"	n	module:delay_control_wire
+wire$	input.sv	/^  wire w$ire, wire$;  \/\/ '$' included$/;"	n	module:delay_control_wire

--- a/Units/parser-verilog.r/systemverilog-net-var.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-net-var.d/input.sv
@@ -165,8 +165,17 @@ module delay_control #(d, e);
   int rega, regb, regr;
   initial begin
     #10 rega = regb;
-    #d rega = regb; // d is defined as a parameter  FIXME
+    #d rega = regb; // d is defined as a parameter
     #((d+e)/2) rega = regb; // delay is average of d and e
-    #regr regr = regr + 1; // delay is the value in regr  FIXME
+    #regr regr = regr + 1; // delay is the value in regr
   end
+endmodule
+
+// 10.3 Continuous assignments
+module delay_control_wire #(d, e);
+  wire wirea #10 = wireb;
+  wire wireb #d = wireb;
+  wire wirec #((d+e)/2) = wireb;
+  wire wired #wirer = wirer + 1;
+  wire w$ire, wire$;  // '$' included
 endmodule

--- a/Units/parser-verilog.r/verilog-github624.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-github624.d/expected.tags
@@ -1,1 +1,1 @@
-0	input.v	/^functionﬁ::0$/;"	f
+function	input.v	/^functionﬁ::0$/;"	f

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1006,12 +1006,10 @@ static void processEnd (tokenInfo *const token)
 	}
 }
 
-static void processPortList (int c)
+static void processPortList (tokenInfo *token, int c)
 {
 	if ((c = skipWhite (c)) == '(')
 	{
-		tokenInfo *token = newToken ();
-
 		/* Get next non-whitespace character after ( */
 		c = skipWhite (vGetc ());
 
@@ -1064,8 +1062,6 @@ static void processPortList (int c)
 		}
 
 		if (! isIdentifierCharacter (c)) vUngetc (c);
-
-		deleteToken (token);
 	}
 	else if (c != EOF)
 	{
@@ -1133,7 +1129,7 @@ static void processFunction (tokenInfo *const token)
 		createTag (token, kind);
 
 		/* Get port list from function */
-		processPortList (c);
+		processPortList (token, c);
 	}
 }
 
@@ -1483,7 +1479,7 @@ static void processDesignElement (tokenInfo *const token)
 			if (kind == K_MODPORT)
 				c = skipPastMatch ("()");	// ignore port list
 			else if (hasSimplePortList (kind))
-				processPortList (c);
+				processPortList (token, c);
 		}
 		else
 		{

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -791,8 +791,12 @@ static void updateKind (tokenInfo *const token)
 	token->kind = ((kind == K_UNDEFINED) && isIdentifier(token)) ? K_IDENTIFIER : kind;
 }
 
-static void createContext (tokenInfo *const scope)
+static void createContext (verilogKind kind, vString* const name)
 {
+	tokenInfo *const scope = newToken ();
+	vStringCopy (scope->name, name);
+	scope->kind = kind;
+
 	if (scope)
 	{
 		vString *contextName = vStringNew ();
@@ -939,11 +943,7 @@ static void createTag (tokenInfo *const token, verilogKind kind)
 	/* Push token as context if it is a container */
 	if (container)
 	{
-		tokenInfo *newScope = newToken ();
-
-		vStringCopy (newScope->name, token->name);
-		newScope->kind = kind;
-		createContext (newScope);
+		createContext (kind, token->name);
 
 		/* Include found contents in context */
 		if (tagContents != NULL)
@@ -1088,7 +1088,6 @@ static void processFunction (tokenInfo *const token)
 {
 	verilogKind kind = token->kind;	// K_FUNCTION or K_TASK
 	int c;
-	tokenInfo *classType;
 
 	/* Search for function name
 	 * Last identifier found before a '(' or a ';' is the function name */
@@ -1108,10 +1107,7 @@ static void processFunction (tokenInfo *const token)
 			if (c == ':')
 			{
 				verbose ("Found function declaration with class type %s\n", vStringValue (token->name));
-				classType = newToken ();
-				vStringCopy (classType->name, token->name);
-				classType->kind = K_CLASS;
-				createContext (classType);
+				createContext (K_CLASS, token->name);
 				currentContext->classScope = true;
 			}
 			else

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1382,38 +1382,40 @@ static tokenInfo * processParameterList (tokenInfo *token, int c)
 
 static void processClass (tokenInfo *const token)
 {
-	/*Note: At the moment, only identifies typedef name and not its contents */
 	int c;
-	tokenInfo *extra;
+	tokenInfo *classToken;
 	tokenInfo *parameters;
 
 	/* Get identifiers */
 	c = skipWhite (vGetc ());
-	if (readWordToken (token, c))
-		c = skipWhite (vGetc ());
+	if (!readWordToken (token, c))
+	{
+		verbose ("Unexpected input: class name is expected.\n");
+		return;
+	}
+
+	/* save token */
+	classToken = dupToken (token);
+	c = skipWhite (vGetc ());
 
 	/* Find class parameters list */
 	parameters = processParameterList (token, c);
 	c = skipWhite (vGetc ());
 
 	/* Search for inheritance information */
-	if (isIdentifierCharacter (c))
+	if (readWordToken (token, c))
 	{
-		extra = newToken ();
-
-		readWordToken (extra, c);
-		c = skipWhite (vGetc ());
-		if (strcmp (vStringValue (extra->name), "extends") == 0)
+		if (strcmp (vStringValue (token->name), "extends") == 0)
 		{
-			readWordToken (extra, c);
-			vStringCopy (token->inheritance, extra->name);
-			verbose ("Inheritance %s\n", vStringValue (token->inheritance));
+			c = skipWhite (vGetc ());
+			readWordToken (token, c);
+			vStringCopy (classToken->inheritance, token->name);
+			verbose ("Inheritance %s\n", vStringValue (classToken->inheritance));
 		}
-		deleteToken (extra);
 	}
 
-	/* Use last identifier to create tag */
-	createTag (token, K_CLASS);
+	createTag (classToken, K_CLASS);
+	deleteToken (classToken);
 
 	/* Add parameter list */
 	while (parameters)

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1328,7 +1328,7 @@ static void processTypedef (tokenInfo *const token)
 	createTag (token, K_TYPEDEF);
 }
 
-static tokenInfo * processParameterList (int c)
+static tokenInfo * processParameterList (tokenInfo *token, int c)
 {
 	tokenInfo *head = NULL;
 	tokenInfo *parameters = NULL;
@@ -1338,7 +1338,6 @@ static tokenInfo * processParameterList (int c)
 		c = skipWhite (vGetc ());
 		if (c == '(')
 		{
-			tokenInfo *token = newToken ();
 			do
 			{
 				c = skipWhite (vGetc ());
@@ -1351,15 +1350,15 @@ static tokenInfo * processParameterList (int c)
 						c = skipWhite (vGetc ());
 						if (c == ',' || c == ')' || c == '=')	// ignore user defined type
 						{
-							token->kind = K_CONSTANT;
-							token->parameter = parameter;
+							tokenInfo *param = dupToken (token);
+							param->kind = K_CONSTANT;
+							param->parameter = parameter;
 							if (head == NULL)
 							{
-								head = token;
-								parameters = token;
+								head = param;
+								parameters = param;
 							} else
-								parameters = appendToken (parameters, token);	// append token on parameters
-							token = newToken ();
+								parameters = appendToken (parameters, param);	// append token on parameters
 
 							c = skipExpression (c);
 						}
@@ -1375,7 +1374,6 @@ static tokenInfo * processParameterList (int c)
 				}
 			} while (c != ')' && c != EOF);
 			c = skipWhite (vGetc ());
-			deleteToken (token);
 		}
 	}
 	vUngetc (c);
@@ -1395,7 +1393,7 @@ static void processClass (tokenInfo *const token)
 		c = skipWhite (vGetc ());
 
 	/* Find class parameters list */
-	parameters = processParameterList (c);
+	parameters = processParameterList (token, c);
 	c = skipWhite (vGetc ());
 
 	/* Search for inheritance information */
@@ -1462,7 +1460,7 @@ static void processDesignElement (tokenInfo *const token)
 		c = skipWhite (vGetc ());
 		if (c == '#')
 		{
-			tokenInfo *parameters = processParameterList (c);
+			tokenInfo *parameters = processParameterList (token, c);
 			while (parameters)
 			{
 				createTag (parameters, K_CONSTANT);


### PR DESCRIPTION
`isIdentifierCharacter() ` did not handle '$` properly.
I needed to simplify token handling for the better fix of it.
Delay handling is also improved.
