### PR TITLE
SystemVerilog: support struct and union  member

### DIFF
--- a/Units/parser-verilog.r/systemverilog-assignment.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-assignment.d/expected.tags
@@ -7,19 +7,41 @@ y	input.sv	/^  int y;$/;"	r	module:assignment
 unpackedints2	input.sv	/^  int unpackedints2 [1:0] = '{2 {y}};$/;"	r	module:assignment
 n	input.sv	/^  int n[1:2][1:3] = '{2{'{3{y}}}};$/;"	r	module:assignment
 abkey	input.sv	/^  struct {int a; time b;} abkey[1:0];$/;"	S	module:assignment
+a	input.sv	/^  struct {int a; time b;} abkey[1:0];$/;"	w	struct:assignment.abkey
+b	input.sv	/^  struct {int a; time b;} abkey[1:0];$/;"	w	struct:assignment.abkey
 abkey_fun	input.sv	/^  struct {int a; time b;} abkey_fun[1:0] = '{'{a:bar(), b:2ns}, '{int:5, time:$time}};$/;"	S	module:assignment
+a	input.sv	/^  struct {int a; time b;} abkey_fun[1:0] = '{'{a:bar(), b:2ns}, '{int:5, time:$time}};$/;"	w	struct:assignment.abkey_fun
+b	input.sv	/^  struct {int a; time b;} abkey_fun[1:0] = '{'{a:bar(), b:2ns}, '{int:5, time:$time}};$/;"	w	struct:assignment.abkey_fun
 st	input.sv	/^  } st;$/;"	T	module:assignment
+x	input.sv	/^    int x;$/;"	w	typedef:assignment.st
+y	input.sv	/^    int y;$/;"	w	typedef:assignment.st
 k	input.sv	/^  int k = 1;$/;"	r	module:assignment
 s1	input.sv	/^  st s1 = '{1, 2+k}; \/\/ by position;$/;"	r	module:assignment
 s2	input.sv	/^  st s2 = '{x:2, y:3+k}; \/\/ by name$/;"	r	module:assignment
 s3	input.sv	/^  struct { int x; int y; } s3 = '{1, 2+k};$/;"	S	module:assignment
+x	input.sv	/^  struct { int x; int y; } s3 = '{1, 2+k};$/;"	w	struct:assignment.s3
+y	input.sv	/^  struct { int x; int y; } s3 = '{1, 2+k};$/;"	w	struct:assignment.s3
 s4	input.sv	/^  struct { int x; int y; } s4 = '{x:2, y:3+k};$/;"	S	module:assignment
+x	input.sv	/^  struct { int x; int y; } s4 = '{x:2, y:3+k};$/;"	w	struct:assignment.s4
+y	input.sv	/^  struct { int x; int y; } s4 = '{x:2, y:3+k};$/;"	w	struct:assignment.s4
 s5	input.sv	/^  st s5 = '{default:2};$/;"	r	module:assignment
 ab	input.sv	/^  typedef struct { int a; shortreal b; } ab;  \/\/ LRM 5.10$/;"	T	module:assignment
+a	input.sv	/^  typedef struct { int a; shortreal b; } ab;  \/\/ LRM 5.10$/;"	w	typedef:assignment.ab
+b	input.sv	/^  typedef struct { int a; shortreal b; } ab;  \/\/ LRM 5.10$/;"	w	typedef:assignment.ab
 abkey	input.sv	/^  ab abkey[1:0] = '{'{a:1, b:1.0}, '{int:2, shortreal:2.0}};$/;"	r	module:assignment
 ABC	input.sv	/^  } ABC, DEF;$/;"	S	module:assignment
+A	input.sv	/^    int A;$/;"	w	struct:assignment.ABC
+BC1	input.sv	/^    } BC1, BC2;$/;"	w	struct:assignment.ABC
+BC2	input.sv	/^    } BC1, BC2;$/;"	w	struct:assignment.ABC
 DEF	input.sv	/^  } ABC, DEF;$/;"	S	module:assignment
+A	input.sv	/^    int A;$/;"	w	struct:assignment.DEF
+BC1	input.sv	/^    } BC1, BC2;$/;"	w	struct:assignment.DEF
+BC2	input.sv	/^    } BC1, BC2;$/;"	w	struct:assignment.DEF
 sa	input.sv	/^  } sa;$/;"	T	module:assignment
+a	input.sv	/^    logic [7:0] a;$/;"	w	typedef:assignment.sa
+b	input.sv	/^    bit b;$/;"	w	typedef:assignment.sa
+c	input.sv	/^    bit signed [31:0] c;$/;"	w	typedef:assignment.sa
+s	input.sv	/^    string s;$/;"	w	typedef:assignment.sa
 s2	input.sv	/^  sa s2 = '{int:1, default:0, string:""};$/;"	r	module:assignment
 A3	input.sv	/^  int A3[1:3];$/;"	r	module:assignment
 AI3	input.sv	/^  typedef int AI3[1:3];$/;"	T	module:assignment

--- a/Units/parser-verilog.r/systemverilog-class.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-class.d/expected.tags
@@ -8,34 +8,34 @@ b	input.sv	/^    logic b;$/;"	r	class:test
 test.b	input.sv	/^    logic b;$/;"	r	class:test
 enum_simple	input.sv	/^    enum {enum_simple1, enum_simple2} enum_simple;$/;"	E	class:test
 test.enum_simple	input.sv	/^    enum {enum_simple1, enum_simple2} enum_simple;$/;"	E	class:test
-enum_simple2	input.sv	/^    enum {enum_simple1, enum_simple2} enum_simple;$/;"	c	enum:test.enum_simple
-test.enum_simple.enum_simple2	input.sv	/^    enum {enum_simple1, enum_simple2} enum_simple;$/;"	c	enum:test.enum_simple
 enum_simple1	input.sv	/^    enum {enum_simple1, enum_simple2} enum_simple;$/;"	c	enum:test.enum_simple
 test.enum_simple.enum_simple1	input.sv	/^    enum {enum_simple1, enum_simple2} enum_simple;$/;"	c	enum:test.enum_simple
+enum_simple2	input.sv	/^    enum {enum_simple1, enum_simple2} enum_simple;$/;"	c	enum:test.enum_simple
+test.enum_simple.enum_simple2	input.sv	/^    enum {enum_simple1, enum_simple2} enum_simple;$/;"	c	enum:test.enum_simple
 enum_var1	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	E	class:test
 test.enum_var1	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	E	class:test
-enum_const2	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var1
-test.enum_var1.enum_const2	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var1
 enum_const1	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var1
 test.enum_var1.enum_const1	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var1
+enum_const2	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var1
+test.enum_var1.enum_const2	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var1
 enum_var2	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	E	class:test
 test.enum_var2	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	E	class:test
-enum_const2	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var2
-test.enum_var2.enum_const2	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var2
 enum_const1	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var2
 test.enum_var2.enum_const1	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var2
+enum_const2	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var2
+test.enum_var2.enum_const2	input.sv	/^    enum {enum_const1, enum_const2} enum_var1, enum_var2;$/;"	c	enum:test.enum_var2
 enum_complex	input.sv	/^    } enum_complex;$/;"	E	class:test
 test.enum_complex	input.sv	/^    } enum_complex;$/;"	E	class:test
-enum_bit5	input.sv	/^      enum_bit5 [9:0] = 2'b10 ,$/;"	c	enum:test.enum_complex
-test.enum_complex.enum_bit5	input.sv	/^      enum_bit5 [9:0] = 2'b10 ,$/;"	c	enum:test.enum_complex
-enum_bit4	input.sv	/^      enum_bit4[0:10]=2'b10,$/;"	c	enum:test.enum_complex
-test.enum_complex.enum_bit4	input.sv	/^      enum_bit4[0:10]=2'b10,$/;"	c	enum:test.enum_complex
-enum_bit3	input.sv	/^      enum_bit3=2'b01,$/;"	c	enum:test.enum_complex
-test.enum_complex.enum_bit3	input.sv	/^      enum_bit3=2'b01,$/;"	c	enum:test.enum_complex
-enum_bit2	input.sv	/^      enum_bit2='x,$/;"	c	enum:test.enum_complex
-test.enum_complex.enum_bit2	input.sv	/^      enum_bit2='x,$/;"	c	enum:test.enum_complex
 enum_bit1	input.sv	/^      enum_bit1,$/;"	c	enum:test.enum_complex
 test.enum_complex.enum_bit1	input.sv	/^      enum_bit1,$/;"	c	enum:test.enum_complex
+enum_bit2	input.sv	/^      enum_bit2='x,$/;"	c	enum:test.enum_complex
+test.enum_complex.enum_bit2	input.sv	/^      enum_bit2='x,$/;"	c	enum:test.enum_complex
+enum_bit3	input.sv	/^      enum_bit3=2'b01,$/;"	c	enum:test.enum_complex
+test.enum_complex.enum_bit3	input.sv	/^      enum_bit3=2'b01,$/;"	c	enum:test.enum_complex
+enum_bit4	input.sv	/^      enum_bit4[0:10]=2'b10,$/;"	c	enum:test.enum_complex
+test.enum_complex.enum_bit4	input.sv	/^      enum_bit4[0:10]=2'b10,$/;"	c	enum:test.enum_complex
+enum_bit5	input.sv	/^      enum_bit5 [9:0] = 2'b10 ,$/;"	c	enum:test.enum_complex
+test.enum_complex.enum_bit5	input.sv	/^      enum_bit5 [9:0] = 2'b10 ,$/;"	c	enum:test.enum_complex
 mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:test
 test.mult	input.sv	/^    function mult (a, input b = 0);$/;"	f	class:test
 a	input.sv	/^    function mult (a, input b = 0);$/;"	p	function:test.mult

--- a/Units/parser-verilog.r/systemverilog-constraint.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-constraint.d/expected.tags
@@ -2,9 +2,9 @@ Bus	input.sv	/^class Bus;$/;"	C
 addr	input.sv	/^  rand bit[15:0] addr;$/;"	r	class:Bus
 data	input.sv	/^  rand bit[31:0] data;$/;"	r	class:Bus
 AddrType	input.sv	/^typedef enum {low, mid, high} AddrType;$/;"	T
-high	input.sv	/^typedef enum {low, mid, high} AddrType;$/;"	c	typedef:AddrType
-mid	input.sv	/^typedef enum {low, mid, high} AddrType;$/;"	c	typedef:AddrType
 low	input.sv	/^typedef enum {low, mid, high} AddrType;$/;"	c	typedef:AddrType
+mid	input.sv	/^typedef enum {low, mid, high} AddrType;$/;"	c	typedef:AddrType
+high	input.sv	/^typedef enum {low, mid, high} AddrType;$/;"	c	typedef:AddrType
 MyBus	input.sv	/^class MyBus extends Bus;$/;"	C
 atype	input.sv	/^  rand AddrType atype;$/;"	r	class:MyBus
 exercise_bus	input.sv	/^task exercise_bus (MyBus bus);$/;"	t

--- a/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
@@ -87,52 +87,52 @@ data	input.sv	/^  my_data_t data;$/;"	r	module:sub
 user_define_types_1	input.sv	/^module user_define_types_1;$/;"	m
 enum_test	input.sv	/^module enum_test;$/;"	m
 light1	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	E	module:enum_test
-green	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	c	enum:enum_test.light1
-yellow	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	c	enum:enum_test.light1
 red	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	c	enum:enum_test.light1
+yellow	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	c	enum:enum_test.light1
+green	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	c	enum:enum_test.light1
 light2	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	E	module:enum_test
-green	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	c	enum:enum_test.light2
-yellow	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	c	enum:enum_test.light2
 red	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	c	enum:enum_test.light2
+yellow	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	c	enum:enum_test.light2
+green	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	c	enum:enum_test.light2
 state	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	E	module:enum_test
-S2	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.state
-S1	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.state
-XX	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.state
 IDLE	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.state
+XX	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.state
+S1	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.state
+S2	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.state
 next	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	E	module:enum_test
-S2	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.next
-S1	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.next
-XX	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.next
 IDLE	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.next
+XX	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.next
+S1	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.next
+S2	input.sv	/^  enum integer {IDLE, XX='x, S1='b01, S2='b10} state, next;$/;"	c	enum:enum_test.next
 medal	input.sv	/^  enum {bronze=3, silver, gold} medal; \/\/ silver=4, gold=5$/;"	E	module:enum_test
-gold	input.sv	/^  enum {bronze=3, silver, gold} medal; \/\/ silver=4, gold=5$/;"	c	enum:enum_test.medal
-silver	input.sv	/^  enum {bronze=3, silver, gold} medal; \/\/ silver=4, gold=5$/;"	c	enum:enum_test.medal
 bronze	input.sv	/^  enum {bronze=3, silver, gold} medal; \/\/ silver=4, gold=5$/;"	c	enum:enum_test.medal
+silver	input.sv	/^  enum {bronze=3, silver, gold} medal; \/\/ silver=4, gold=5$/;"	c	enum:enum_test.medal
+gold	input.sv	/^  enum {bronze=3, silver, gold} medal; \/\/ silver=4, gold=5$/;"	c	enum:enum_test.medal
 medal2	input.sv	/^  enum bit [3:0] {bronze='h3, silver, gold='h5} medal2;$/;"	E	module:enum_test
-gold	input.sv	/^  enum bit [3:0] {bronze='h3, silver, gold='h5} medal2;$/;"	c	enum:enum_test.medal2
-silver	input.sv	/^  enum bit [3:0] {bronze='h3, silver, gold='h5} medal2;$/;"	c	enum:enum_test.medal2
 bronze	input.sv	/^  enum bit [3:0] {bronze='h3, silver, gold='h5} medal2;$/;"	c	enum:enum_test.medal2
+silver	input.sv	/^  enum bit [3:0] {bronze='h3, silver, gold='h5} medal2;$/;"	c	enum:enum_test.medal2
+gold	input.sv	/^  enum bit [3:0] {bronze='h3, silver, gold='h5} medal2;$/;"	c	enum:enum_test.medal2
 medal3	input.sv	/^  enum bit [3:0] {bronze=4'h3, silver, gold=4'h5} medal3;$/;"	E	module:enum_test
-gold	input.sv	/^  enum bit [3:0] {bronze=4'h3, silver, gold=4'h5} medal3;$/;"	c	enum:enum_test.medal3
-silver	input.sv	/^  enum bit [3:0] {bronze=4'h3, silver, gold=4'h5} medal3;$/;"	c	enum:enum_test.medal3
 bronze	input.sv	/^  enum bit [3:0] {bronze=4'h3, silver, gold=4'h5} medal3;$/;"	c	enum:enum_test.medal3
+silver	input.sv	/^  enum bit [3:0] {bronze=4'h3, silver, gold=4'h5} medal3;$/;"	c	enum:enum_test.medal3
+gold	input.sv	/^  enum bit [3:0] {bronze=4'h3, silver, gold=4'h5} medal3;$/;"	c	enum:enum_test.medal3
 boolean	input.sv	/^  typedef enum {NO, YES} boolean;$/;"	T	module:enum_test
-YES	input.sv	/^  typedef enum {NO, YES} boolean;$/;"	c	typedef:enum_test.boolean
 NO	input.sv	/^  typedef enum {NO, YES} boolean;$/;"	c	typedef:enum_test.boolean
+YES	input.sv	/^  typedef enum {NO, YES} boolean;$/;"	c	typedef:enum_test.boolean
 myvar	input.sv	/^  boolean myvar; \/\/ named type$/;"	r	module:enum_test
 E1	input.sv	/^  typedef enum { add=10, sub[5], jmp[6:8] } E1; \/\/ FIXME$/;"	T	module:enum_test
-jmp	input.sv	/^  typedef enum { add=10, sub[5], jmp[6:8] } E1; \/\/ FIXME$/;"	c	typedef:enum_test.E1
-sub	input.sv	/^  typedef enum { add=10, sub[5], jmp[6:8] } E1; \/\/ FIXME$/;"	c	typedef:enum_test.E1
 add	input.sv	/^  typedef enum { add=10, sub[5], jmp[6:8] } E1; \/\/ FIXME$/;"	c	typedef:enum_test.E1
+sub	input.sv	/^  typedef enum { add=10, sub[5], jmp[6:8] } E1; \/\/ FIXME$/;"	c	typedef:enum_test.E1
+jmp	input.sv	/^  typedef enum { add=10, sub[5], jmp[6:8] } E1; \/\/ FIXME$/;"	c	typedef:enum_test.E1
 vr	input.sv	/^  enum { register[2] = 1, register[2:4] = 10 } vr; \/\/ FIXME$/;"	E	module:enum_test
 register	input.sv	/^  enum { register[2] = 1, register[2:4] = 10 } vr; \/\/ FIXME$/;"	c	enum:enum_test.vr
 register	input.sv	/^  enum { register[2] = 1, register[2:4] = 10 } vr; \/\/ FIXME$/;"	c	enum:enum_test.vr
 cmplx_enum1	input.sv	/^  enum logic signed [3:0] { foo, bar } [1:0] cmplx_enum1; $/;"	E	module:enum_test
-bar	input.sv	/^  enum logic signed [3:0] { foo, bar } [1:0] cmplx_enum1; $/;"	c	enum:enum_test.cmplx_enum1
 foo	input.sv	/^  enum logic signed [3:0] { foo, bar } [1:0] cmplx_enum1; $/;"	c	enum:enum_test.cmplx_enum1
+bar	input.sv	/^  enum logic signed [3:0] { foo, bar } [1:0] cmplx_enum1; $/;"	c	enum:enum_test.cmplx_enum1
 cmplx_enum2	input.sv	/^  enum logic unsigned [3:0] { foo, bar } [] cmplx_enum2; $/;"	E	module:enum_test
-bar	input.sv	/^  enum logic unsigned [3:0] { foo, bar } [] cmplx_enum2; $/;"	c	enum:enum_test.cmplx_enum2
 foo	input.sv	/^  enum logic unsigned [3:0] { foo, bar } [] cmplx_enum2; $/;"	c	enum:enum_test.cmplx_enum2
+bar	input.sv	/^  enum logic unsigned [3:0] { foo, bar } [] cmplx_enum2; $/;"	c	enum:enum_test.cmplx_enum2
 delay_control	input.sv	/^module delay_control #(d, e);$/;"	m
 d	input.sv	/^module delay_control #(d, e);$/;"	c	module:delay_control
 e	input.sv	/^module delay_control #(d, e);$/;"	c	module:delay_control

--- a/Units/parser-verilog.r/systemverilog-package.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-package.d/expected.tags
@@ -1,6 +1,10 @@
 MyPackage	input.sv	/^package MyPackage;$/;"	K
 MyData	input.sv	/^    } MyData;$/;"	T	package:MyPackage
 MyPackage.MyData	input.sv	/^    } MyData;$/;"	T	package:MyPackage
+a	input.sv	/^        shortreal a;$/;"	w	typedef:MyPackage.MyData
+MyPackage.MyData.a	input.sv	/^        shortreal a;$/;"	w	typedef:MyPackage.MyData
+b	input.sv	/^        real b;$/;"	w	typedef:MyPackage.MyData
+MyPackage.MyData.b	input.sv	/^        real b;$/;"	w	typedef:MyPackage.MyData
 add	input.sv	/^    function MyData add(MyData x, y);$/;"	f	package:MyPackage
 MyPackage.add	input.sv	/^    function MyData add(MyData x, y);$/;"	f	package:MyPackage
 x	input.sv	/^    function MyData add(MyData x, y);$/;"	p	function:MyPackage.add

--- a/Units/parser-verilog.r/systemverilog-package.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-package.d/input.sv
@@ -9,6 +9,6 @@ package MyPackage;
     function MyData mul(MyData x, y);
         mul.b = x.b * y.b;
     endfunction
-endpackage : ComplexPkg
+endpackage : MyPackage
 
 reg var_to_check_context;

--- a/Units/parser-verilog.r/systemverilog-procedural.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-procedural.d/expected.tags
@@ -19,5 +19,5 @@ N	input.sv	/^  parameter N = 8;$/;"	c	module:procedural
 outer	input.sv	/^    for (int i = 0; i < N; i++) begin:outer$/;"	b	module:procedural
 inner	input.sv	/^      for (int j = 0; j < N; j++) begin : inner$/;"	b	block:procedural.outer
 state	input.sv	/^    enum { FSM_IDLE, FSM_ITER } state;$/;"	E	module:procedural
-FSM_ITER	input.sv	/^    enum { FSM_IDLE, FSM_ITER } state;$/;"	c	enum:procedural.state
 FSM_IDLE	input.sv	/^    enum { FSM_IDLE, FSM_ITER } state;$/;"	c	enum:procedural.state
+FSM_ITER	input.sv	/^    enum { FSM_IDLE, FSM_ITER } state;$/;"	c	enum:procedural.state

--- a/Units/parser-verilog.r/systemverilog-struct.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-struct.d/expected.tags
@@ -1,6 +1,124 @@
-IR	input.sv	/^  struct { bit [7:0] opcode; }IR; \/\/ not defined => IR:struct$/;"	S
-pack1	input.sv	/^  struct packed signed { int a; } pack1; \/\/ packed:struct => pack1:struct$/;"	S
-pack2	input.sv	/^  struct packed unsigned { int a;} pack2; \/\/ packed:struct => pack2:struct$/;"	S
-union1	input.sv	/^  union packed unsigned { logic [7:0] a; } union1; \/\/packed:struct => union1:struct$/;"	S
-pack3	input.sv	/^  struct packed signed { int a; } [3:0] pack3, pack4;$/;"	S
-pack4	input.sv	/^  struct packed signed { int a; } [3:0] pack3, pack4;$/;"	S
+S	input.sv	/^class S;$/;"	C
+IR	input.sv	/^  struct { bit [7:0] opcode; bit [23:0] addr; }IR;  \/\/ anonymous structure$/;"	S	class:S
+opcode	input.sv	/^  struct { bit [7:0] opcode; bit [23:0] addr; }IR;  \/\/ anonymous structure$/;"	w	struct:S.IR
+addr	input.sv	/^  struct { bit [7:0] opcode; bit [23:0] addr; }IR;  \/\/ anonymous structure$/;"	w	struct:S.IR
+foo	input.sv	/^  function foo;$/;"	f	class:S
+instruction	input.sv	/^  } instruction;      \/\/ named structure type$/;"	T	class:S
+opcode	input.sv	/^    bit [7:0] opcode;$/;"	w	typedef:S.instruction
+addr	input.sv	/^    bit [23:0] addr;$/;"	w	typedef:S.instruction
+IR1	input.sv	/^  instruction IR1;    \/\/ define variable$/;"	r	class:S
+pack1	input.sv	/^  } pack1; \/\/ signed, 2-state$/;"	S	class:S
+a	input.sv	/^    int a;$/;"	w	struct:S.pack1
+b	input.sv	/^    shortint b;$/;"	w	struct:S.pack1
+c	input.sv	/^    byte c;$/;"	w	struct:S.pack1
+d	input.sv	/^    bit [7:0] d;$/;"	w	struct:S.pack1
+pack2	input.sv	/^  } pack2; \/\/ unsigned, 4-state$/;"	S	class:S
+a	input.sv	/^    time a;$/;"	w	struct:S.pack2
+b	input.sv	/^    integer b;$/;"	w	struct:S.pack2
+c	input.sv	/^    logic [31:0] c;$/;"	w	struct:S.pack2
+s_atmcell	input.sv	/^  } s_atmcell;$/;"	T	class:S
+GFC	input.sv	/^    bit [3:0] GFC;$/;"	w	typedef:S.s_atmcell
+VPI	input.sv	/^    bit [7:0] VPI;$/;"	w	typedef:S.s_atmcell
+VCI	input.sv	/^    bit [11:0] VCI;$/;"	w	typedef:S.s_atmcell
+CLP	input.sv	/^    bit CLP;$/;"	w	typedef:S.s_atmcell
+PT	input.sv	/^    bit [3:0] PT ;$/;"	w	typedef:S.s_atmcell
+HEC	input.sv	/^    bit [7:0] HEC;$/;"	w	typedef:S.s_atmcell
+Payload	input.sv	/^    bit [47:0] [7:0] Payload;$/;"	w	typedef:S.s_atmcell
+filler	input.sv	/^    bit [2:0] filler;$/;"	w	typedef:S.s_atmcell
+packet1	input.sv	/^  } packet1;$/;"	T	class:S
+addr	input.sv	/^    int addr = 1 + constant;$/;"	w	typedef:S.packet1
+crc	input.sv	/^    int crc;$/;"	w	typedef:S.packet1
+data	input.sv	/^    byte data [4] = '{4{1}};$/;"	w	typedef:S.packet1
+pi	input.sv	/^  packet1 pi = '{1,2,'{2,3,4,5}}; \/\/suppresses the typedef initialization$/;"	r	class:S
+U	input.sv	/^class U;$/;"	C
+num	input.sv	/^  typedef union { int i; shortreal f; } num;  \/\/ named union type$/;"	T	class:U
+i	input.sv	/^  typedef union { int i; shortreal f; } num;  \/\/ named union type$/;"	w	typedef:U.num
+f	input.sv	/^  typedef union { int i; shortreal f; } num;  \/\/ named union type$/;"	w	typedef:U.num
+n	input.sv	/^  num n;$/;"	r	class:U
+tagged_st	input.sv	/^  } tagged_st;                        \/\/ named structure$/;"	T	class:U
+isfloat	input.sv	/^    bit isfloat;$/;"	w	typedef:U.tagged_st
+n	input.sv	/^    union { int i; shortreal f; } n;  \/\/ anonymous union type$/;"	w	typedef:U.tagged_st
+u_atmcell	input.sv	/^  } u_atmcell;$/;"	T	class:U
+acell	input.sv	/^    s_atmcell acell;$/;"	w	typedef:U.u_atmcell
+bit_slice	input.sv	/^    bit [423:0] bit_slice;$/;"	w	typedef:U.u_atmcell
+byte_slice	input.sv	/^    bit [52:0][7:0] byte_slice;$/;"	w	typedef:U.u_atmcell
+u1	input.sv	/^  u_atmcell u1;$/;"	r	class:U
+b	input.sv	/^  byte b; bit [3:0] nib;$/;"	r	class:U
+nib	input.sv	/^  byte b; bit [3:0] nib;$/;"	r	class:U
+O	input.sv	/^class O;$/;"	C
+IR	input.sv	/^  struct { bit [7:0] opcode; }IR;$/;"	S	class:O
+opcode	input.sv	/^  struct { bit [7:0] opcode; }IR;$/;"	w	struct:O.IR
+pack1	input.sv	/^  struct packed signed { int a; } pack1;$/;"	S	class:O
+a	input.sv	/^  struct packed signed { int a; } pack1;$/;"	w	struct:O.pack1
+pack2	input.sv	/^  struct packed unsigned { int a;} pack2;$/;"	S	class:O
+a	input.sv	/^  struct packed unsigned { int a;} pack2;$/;"	w	struct:O.pack2
+union1	input.sv	/^  union packed unsigned { logic [7:0] a; } union1;$/;"	S	class:O
+a	input.sv	/^  union packed unsigned { logic [7:0] a; } union1;$/;"	w	struct:O.union1
+pack3	input.sv	/^  struct packed signed { int a; } [3:0] pack3, pack4;$/;"	S	class:O
+a	input.sv	/^  struct packed signed { int a; } [3:0] pack3, pack4;$/;"	w	struct:O.pack3
+pack4	input.sv	/^  struct packed signed { int a; } [3:0] pack3, pack4;$/;"	S	class:O
+a	input.sv	/^  struct packed signed { int a; } [3:0] pack3, pack4;$/;"	w	struct:O.pack4
+user_t	input.sv	/^  typedef logic user_t;$/;"	T	class:O
+enum00_e	input.sv	/^  enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	E	class:O
+FOO	input.sv	/^  enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	c	enum:O.enum00_e
+BAR	input.sv	/^  enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	c	enum:O.enum00_e
+BAZ	input.sv	/^  enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	c	enum:O.enum00_e
+enum01_e	input.sv	/^  enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	E	class:O
+FOO	input.sv	/^  enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	c	enum:O.enum01_e
+BAR	input.sv	/^  enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	c	enum:O.enum01_e
+BAZ	input.sv	/^  enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	c	enum:O.enum01_e
+enum10_e	input.sv	/^  enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	E	class:O
+A	input.sv	/^  enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	c	enum:O.enum10_e
+B	input.sv	/^  enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	c	enum:O.enum10_e
+C	input.sv	/^  enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	c	enum:O.enum10_e
+enum11_e	input.sv	/^  enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	E	class:O
+A	input.sv	/^  enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	c	enum:O.enum11_e
+B	input.sv	/^  enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	c	enum:O.enum11_e
+C	input.sv	/^  enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	c	enum:O.enum11_e
+enum0_t	input.sv	/^  typedef enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum0_t ;$/;"	T	class:O
+FOO	input.sv	/^  typedef enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum0_t ;$/;"	c	typedef:O.enum0_t
+BAR	input.sv	/^  typedef enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum0_t ;$/;"	c	typedef:O.enum0_t
+BAZ	input.sv	/^  typedef enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum0_t ;$/;"	c	typedef:O.enum0_t
+enum1_t	input.sv	/^  typedef enum logic unsigned{A,B,C}[1:0]enum1_t;$/;"	T	class:O
+A	input.sv	/^  typedef enum logic unsigned{A,B,C}[1:0]enum1_t;$/;"	c	typedef:O.enum1_t
+B	input.sv	/^  typedef enum logic unsigned{A,B,C}[1:0]enum1_t;$/;"	c	typedef:O.enum1_t
+C	input.sv	/^  typedef enum logic unsigned{A,B,C}[1:0]enum1_t;$/;"	c	typedef:O.enum1_t
+complex0_s	input.sv	/^  } [1:0] complex0_s, complex1_s;$/;"	S	class:O
+a	input.sv	/^    logic a,b ;$/;"	w	struct:O.complex0_s
+b	input.sv	/^    logic a,b ;$/;"	w	struct:O.complex0_s
+s0	input.sv	/^    logic [15:0] [7:0] s0 , s1;$/;"	w	struct:O.complex0_s
+s1	input.sv	/^    logic [15:0] [7:0] s0 , s1;$/;"	w	struct:O.complex0_s
+struct0_s	input.sv	/^    } [15:0] [7:0] struct0_s, struct1_s;$/;"	w	struct:O.complex0_s
+struct1_s	input.sv	/^    } [15:0] [7:0] struct0_s, struct1_s;$/;"	w	struct:O.complex0_s
+enum00_e	input.sv	/^    enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	w	struct:O.complex0_s
+enum01_e	input.sv	/^    enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	w	struct:O.complex0_s
+enum10_e	input.sv	/^    enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	w	struct:O.complex0_s
+enum11_e	input.sv	/^    enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	w	struct:O.complex0_s
+d	input.sv	/^    bit[7:0][1:0]d,e;$/;"	w	struct:O.complex0_s
+e	input.sv	/^    bit[7:0][1:0]d,e;$/;"	w	struct:O.complex0_s
+complex1_s	input.sv	/^  } [1:0] complex0_s, complex1_s;$/;"	S	class:O
+a	input.sv	/^    logic a,b ;$/;"	w	struct:O.complex1_s
+b	input.sv	/^    logic a,b ;$/;"	w	struct:O.complex1_s
+s0	input.sv	/^    logic [15:0] [7:0] s0 , s1;$/;"	w	struct:O.complex1_s
+s1	input.sv	/^    logic [15:0] [7:0] s0 , s1;$/;"	w	struct:O.complex1_s
+struct0_s	input.sv	/^    } [15:0] [7:0] struct0_s, struct1_s;$/;"	w	struct:O.complex1_s
+struct1_s	input.sv	/^    } [15:0] [7:0] struct0_s, struct1_s;$/;"	w	struct:O.complex1_s
+enum00_e	input.sv	/^    enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	w	struct:O.complex1_s
+enum01_e	input.sv	/^    enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	w	struct:O.complex1_s
+enum10_e	input.sv	/^    enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	w	struct:O.complex1_s
+enum11_e	input.sv	/^    enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	w	struct:O.complex1_s
+d	input.sv	/^    bit[7:0][1:0]d,e;$/;"	w	struct:O.complex1_s
+e	input.sv	/^    bit[7:0][1:0]d,e;$/;"	w	struct:O.complex1_s
+complex_t	input.sv	/^  } [1:0] complex_t;$/;"	T	class:O
+a	input.sv	/^    logic a,b ;$/;"	w	typedef:O.complex_t
+b	input.sv	/^    logic a,b ;$/;"	w	typedef:O.complex_t
+s0	input.sv	/^    logic [15:0] [7:0] s0 , s1;$/;"	w	typedef:O.complex_t
+s1	input.sv	/^    logic [15:0] [7:0] s0 , s1;$/;"	w	typedef:O.complex_t
+struct0_s	input.sv	/^    } [15:0] [7:0] struct0_s, struct1_s;$/;"	w	typedef:O.complex_t
+struct1_s	input.sv	/^    } [15:0] [7:0] struct0_s, struct1_s;$/;"	w	typedef:O.complex_t
+enum00_e	input.sv	/^    enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	w	typedef:O.complex_t
+enum01_e	input.sv	/^    enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;$/;"	w	typedef:O.complex_t
+enum10_e	input.sv	/^    enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	w	typedef:O.complex_t
+enum11_e	input.sv	/^    enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	w	typedef:O.complex_t
+d	input.sv	/^    bit[7:0][1:0]d,e;$/;"	w	typedef:O.complex_t
+e	input.sv	/^    bit[7:0][1:0]d,e;$/;"	w	typedef:O.complex_t

--- a/Units/parser-verilog.r/systemverilog-struct.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-struct.d/input.sv
@@ -1,7 +1,118 @@
-  // 7.x
-  struct { bit [7:0] opcode; }IR; // not defined => IR:struct
-  struct packed signed { int a; } pack1; // packed:struct => pack1:struct
-  struct packed unsigned { int a;} pack2; // packed:struct => pack2:struct
-  union packed unsigned { logic [7:0] a; } union1; //packed:struct => union1:struct
+//
+// LRM 7. Aggregate data types
+//
+
+// 7.2 Structures
+class S;
+  struct { bit [7:0] opcode; bit [23:0] addr; }IR;  // anonymous structure
+                                                    // defines variable IR
+  function foo;
+    IR.opcode = 1;    // set field in IR.
+  endfunction
+  typedef struct {
+    bit [7:0] opcode;
+    bit [23:0] addr;
+  } instruction;      // named structure type
+  instruction IR1;    // define variable
+
+  // 7.2.1 Packed structures
+  struct packed signed {
+    int a;
+    shortint b;
+    byte c;
+    bit [7:0] d;
+  } pack1; // signed, 2-state
+
+  struct packed unsigned {
+    time a;
+    integer b;
+    logic [31:0] c;
+  } pack2; // unsigned, 4-state
+
+  typedef struct packed { // default unsigned
+    bit [3:0] GFC;
+    bit [7:0] VPI;
+    bit [11:0] VCI;
+    bit CLP;
+    bit [3:0] PT ;
+    bit [7:0] HEC;
+    bit [47:0] [7:0] Payload;
+    bit [2:0] filler;
+  } s_atmcell;
+
+  // 7.2.2 Assigning to structures
+  typedef struct {
+    int addr = 1 + constant;
+    int crc;
+    byte data [4] = '{4{1}};
+  } packet1;
+
+  packet1 pi = '{1,2,'{2,3,4,5}}; //suppresses the typedef initialization
+endclass
+
+// 7.3 Unions
+class U;
+  typedef union { int i; shortreal f; } num;  // named union type
+  num n;
+  n.f = 0.0;  // set n in floating point format
+
+  typedef struct {
+    bit isfloat;
+    union { int i; shortreal f; } n;  // anonymous union type
+  } tagged_st;                        // named structure
+
+  // 7.3.1 Packed unions
+  typedef union packed { // default unsigned
+    s_atmcell acell;
+    bit [423:0] bit_slice;
+    bit [52:0][7:0] byte_slice;
+  } u_atmcell;
+
+  u_atmcell u1;
+  byte b; bit [3:0] nib;
+  b = u1.bit_slice[415:408];    // same as b = u1.byte_slice[51];
+  nib = u1.bit_slice [423:420]; // same as nib = u1.acell.GFC;
+
+  // 7.3.2 Tagged unions
+  // FIXME: TBD
+endclass
+
+// orignal
+class O;
+  struct { bit [7:0] opcode; }IR;
+  struct packed signed { int a; } pack1;
+  struct packed unsigned { int a;} pack2;
+  union packed unsigned { logic [7:0] a; } union1;
   struct packed signed { int a; } [3:0] pack3, pack4;
 
+  // complex enum
+  typedef logic user_t;
+  enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;
+  enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;
+  typedef enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum0_t ;
+  typedef enum logic unsigned{A,B,C}[1:0]enum1_t;
+
+  // complex struct
+  struct packed signed {
+    logic a,b ;
+    logic [15:0] [7:0] s0 , s1;
+    struct {
+      logic x, y; // not emitted
+    } [15:0] [7:0] struct0_s, struct1_s;
+    enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;
+    enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;
+    bit[7:0][1:0]d,e;
+  } [1:0] complex0_s, complex1_s;
+
+  // complex typedef of struct
+  typedef struct packed signed {
+    logic a,b ;
+    logic [15:0] [7:0] s0 , s1;
+    struct {
+      logic x, y; // not emitted
+    } [15:0] [7:0] struct0_s, struct1_s;
+    enum user_t [1:0] { FOO, BAR, BAZ } [3:0] enum00_e, enum01_e ;
+    enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;
+    bit[7:0][1:0]d,e;
+  } [1:0] complex_t;
+endclass

--- a/Units/parser-verilog.r/systemverilog-typedef.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-typedef.d/expected.tags
@@ -20,11 +20,35 @@ type_enum_bit2.Y	input.sv	/^typedef enum bit [1:0] {Y, Z}    type_enum_bit2;$/;"
 Z	input.sv	/^typedef enum bit [1:0] {Y, Z}    type_enum_bit2;$/;"	c	typedef:type_enum_bit2
 type_enum_bit2.Z	input.sv	/^typedef enum bit [1:0] {Y, Z}    type_enum_bit2;$/;"	c	typedef:type_enum_bit2
 type_struct	input.sv	/^  } type_struct;$/;"	T
+struct_real	input.sv	/^  real       struct_real;$/;"	w	typedef:type_struct
+type_struct.struct_real	input.sv	/^  real       struct_real;$/;"	w	typedef:type_struct
+struct_bit	input.sv	/^  bit  [1:0] struct_bit;$/;"	w	typedef:type_struct
+type_struct.struct_bit	input.sv	/^  bit  [1:0] struct_bit;$/;"	w	typedef:type_struct
 type_union	input.sv	/^  } type_union;$/;"	T
+union_real	input.sv	/^  real       union_real;$/;"	w	typedef:type_union
+type_union.union_real	input.sv	/^  real       union_real;$/;"	w	typedef:type_union
+union_bit	input.sv	/^  bit  [1:0] union_bit;$/;"	w	typedef:type_union
+type_union.union_bit	input.sv	/^  bit  [1:0] union_bit;$/;"	w	typedef:type_union
 type_union_packed	input.sv	/^  } type_union_packed;$/;"	T
+union_bit1	input.sv	/^  bit  [1:0] union_bit1;$/;"	w	typedef:type_union_packed
+type_union_packed.union_bit1	input.sv	/^  bit  [1:0] union_bit1;$/;"	w	typedef:type_union_packed
+union_bit2	input.sv	/^  bit  [1:0] union_bit2;$/;"	w	typedef:type_union_packed
+type_union_packed.union_bit2	input.sv	/^  bit  [1:0] union_bit2;$/;"	w	typedef:type_union_packed
 type_union_tagged	input.sv	/^  } type_union_tagged;$/;"	T
+Invalid	input.sv	/^  void Invalid;$/;"	w	typedef:type_union_tagged
+type_union_tagged.Invalid	input.sv	/^  void Invalid;$/;"	w	typedef:type_union_tagged
+Valid	input.sv	/^  int Valid;$/;"	w	typedef:type_union_tagged
+type_union_tagged.Valid	input.sv	/^  int Valid;$/;"	w	typedef:type_union_tagged
 type_struct_union	input.sv	/^  } type_struct_union;$/;"	T
+struct_real	input.sv	/^  real       struct_real;$/;"	w	typedef:type_struct_union
+type_struct_union.struct_real	input.sv	/^  real       struct_real;$/;"	w	typedef:type_struct_union
+struct_union	input.sv	/^    } struct_union;$/;"	w	typedef:type_struct_union
+type_struct_union.struct_union	input.sv	/^    } struct_union;$/;"	w	typedef:type_struct_union
 type_strcut_packed_unsigned	input.sv	/^} type_strcut_packed_unsigned;$/;"	T
+upper	input.sv	/^  logic [7:0] upper;$/;"	w	typedef:type_strcut_packed_unsigned
+type_strcut_packed_unsigned.upper	input.sv	/^  logic [7:0] upper;$/;"	w	typedef:type_strcut_packed_unsigned
+lower	input.sv	/^  logic [7:0] lower;$/;"	w	typedef:type_strcut_packed_unsigned
+type_strcut_packed_unsigned.lower	input.sv	/^  logic [7:0] lower;$/;"	w	typedef:type_strcut_packed_unsigned
 type_bit	input.sv	/^typedef      bit                 type_bit;$/;"	T
 type_bit_bus	input.sv	/^typedef      bit [1:0]           type_bit_bus;$/;"	T
 type_bit_bus_array	input.sv	/^typedef      bit [1:0]           type_bit_bus_array [2:0];$/;"	T

--- a/Units/parser-verilog.r/systemverilog-typedef.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-typedef.d/expected.tags
@@ -5,20 +5,20 @@ fwd_type_class	input.sv	/^typedef class             fwd_type_class;$/;"	Q
 fwd_type_interface_class	input.sv	/^typedef interface class   fwd_type_interface_class;$/;"	Q
 fwd_type	input.sv	/^typedef                   fwd_type;$/;"	Q
 type_enum	input.sv	/^typedef enum           {no, yes} type_enum;$/;"	T
-yes	input.sv	/^typedef enum           {no, yes} type_enum;$/;"	c	typedef:type_enum
-type_enum.yes	input.sv	/^typedef enum           {no, yes} type_enum;$/;"	c	typedef:type_enum
 no	input.sv	/^typedef enum           {no, yes} type_enum;$/;"	c	typedef:type_enum
 type_enum.no	input.sv	/^typedef enum           {no, yes} type_enum;$/;"	c	typedef:type_enum
+yes	input.sv	/^typedef enum           {no, yes} type_enum;$/;"	c	typedef:type_enum
+type_enum.yes	input.sv	/^typedef enum           {no, yes} type_enum;$/;"	c	typedef:type_enum
 type_enum_bit	input.sv	/^typedef enum bit       {W, X}    type_enum_bit;$/;"	T
-X	input.sv	/^typedef enum bit       {W, X}    type_enum_bit;$/;"	c	typedef:type_enum_bit
-type_enum_bit.X	input.sv	/^typedef enum bit       {W, X}    type_enum_bit;$/;"	c	typedef:type_enum_bit
 W	input.sv	/^typedef enum bit       {W, X}    type_enum_bit;$/;"	c	typedef:type_enum_bit
 type_enum_bit.W	input.sv	/^typedef enum bit       {W, X}    type_enum_bit;$/;"	c	typedef:type_enum_bit
+X	input.sv	/^typedef enum bit       {W, X}    type_enum_bit;$/;"	c	typedef:type_enum_bit
+type_enum_bit.X	input.sv	/^typedef enum bit       {W, X}    type_enum_bit;$/;"	c	typedef:type_enum_bit
 type_enum_bit2	input.sv	/^typedef enum bit [1:0] {Y, Z}    type_enum_bit2;$/;"	T
-Z	input.sv	/^typedef enum bit [1:0] {Y, Z}    type_enum_bit2;$/;"	c	typedef:type_enum_bit2
-type_enum_bit2.Z	input.sv	/^typedef enum bit [1:0] {Y, Z}    type_enum_bit2;$/;"	c	typedef:type_enum_bit2
 Y	input.sv	/^typedef enum bit [1:0] {Y, Z}    type_enum_bit2;$/;"	c	typedef:type_enum_bit2
 type_enum_bit2.Y	input.sv	/^typedef enum bit [1:0] {Y, Z}    type_enum_bit2;$/;"	c	typedef:type_enum_bit2
+Z	input.sv	/^typedef enum bit [1:0] {Y, Z}    type_enum_bit2;$/;"	c	typedef:type_enum_bit2
+type_enum_bit2.Z	input.sv	/^typedef enum bit [1:0] {Y, Z}    type_enum_bit2;$/;"	c	typedef:type_enum_bit2
 type_struct	input.sv	/^  } type_struct;$/;"	T
 type_union	input.sv	/^  } type_union;$/;"	T
 type_union_packed	input.sv	/^  } type_union_packed;$/;"	T
@@ -31,27 +31,27 @@ type_bit_bus_array	input.sv	/^typedef      bit [1:0]           type_bit_bus_arra
 type_logic_signed_vec	input.sv	/^typedef      logic signed [7:0]  type_logic_signed_vec;$/;"	T
 type_bit_unsigned_vec	input.sv	/^typedef      bit unsigned [7:0]  type_bit_unsigned_vec;$/;"	T
 type_int_unsigned	input.sv	/^    } type_int_unsigned;$/;"	T
-cond2	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
-type_int_unsigned.cond2	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
-cond1	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
-type_int_unsigned.cond1	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
 cond0	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
 type_int_unsigned.cond0	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
+cond1	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
+type_int_unsigned.cond1	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
+cond2	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
+type_int_unsigned.cond2	input.sv	/^    cond0 = 0, cond1 = 1, cond2 = 2$/;"	c	typedef:type_int_unsigned
 type_enum_bit_bus_defined_values	input.sv	/^} type_enum_bit_bus_defined_values;$/;"	T
-D	input.sv	/^    D = {1'b1, 1'b1}$/;"	c	typedef:type_enum_bit_bus_defined_values
-type_enum_bit_bus_defined_values.D	input.sv	/^    D = {1'b1, 1'b1}$/;"	c	typedef:type_enum_bit_bus_defined_values
-C	input.sv	/^    C = 2'b10,$/;"	c	typedef:type_enum_bit_bus_defined_values
-type_enum_bit_bus_defined_values.C	input.sv	/^    C = 2'b10,$/;"	c	typedef:type_enum_bit_bus_defined_values
-B	input.sv	/^    B = 2'b01,$/;"	c	typedef:type_enum_bit_bus_defined_values
-type_enum_bit_bus_defined_values.B	input.sv	/^    B = 2'b01,$/;"	c	typedef:type_enum_bit_bus_defined_values
 A	input.sv	/^    A = 2'b00,$/;"	c	typedef:type_enum_bit_bus_defined_values
 type_enum_bit_bus_defined_values.A	input.sv	/^    A = 2'b00,$/;"	c	typedef:type_enum_bit_bus_defined_values
+B	input.sv	/^    B = 2'b01,$/;"	c	typedef:type_enum_bit_bus_defined_values
+type_enum_bit_bus_defined_values.B	input.sv	/^    B = 2'b01,$/;"	c	typedef:type_enum_bit_bus_defined_values
+C	input.sv	/^    C = 2'b10,$/;"	c	typedef:type_enum_bit_bus_defined_values
+type_enum_bit_bus_defined_values.C	input.sv	/^    C = 2'b10,$/;"	c	typedef:type_enum_bit_bus_defined_values
+D	input.sv	/^    D = {1'b1, 1'b1}$/;"	c	typedef:type_enum_bit_bus_defined_values
+type_enum_bit_bus_defined_values.D	input.sv	/^    D = {1'b1, 1'b1}$/;"	c	typedef:type_enum_bit_bus_defined_values
 foo_t	input.sv	/^typedef  bit [7:0]  foo_t ;$/;"	T
 bar_e	input.sv	/^} bar_e;$/;"	T
-Z	input.sv	/^    Z = -1$/;"	c	typedef:bar_e
-bar_e.Z	input.sv	/^    Z = -1$/;"	c	typedef:bar_e
-Y	input.sv	/^    Y = 'h0001,$/;"	c	typedef:bar_e
-bar_e.Y	input.sv	/^    Y = 'h0001,$/;"	c	typedef:bar_e
 X	input.sv	/^    X = 'h0000,$/;"	c	typedef:bar_e
 bar_e.X	input.sv	/^    X = 'h0000,$/;"	c	typedef:bar_e
+Y	input.sv	/^    Y = 'h0001,$/;"	c	typedef:bar_e
+bar_e.Y	input.sv	/^    Y = 'h0001,$/;"	c	typedef:bar_e
+Z	input.sv	/^    Z = -1$/;"	c	typedef:bar_e
+bar_e.Z	input.sv	/^    Z = -1$/;"	c	typedef:bar_e
 type_class	input.sv	/^typedef classname#(paramvalue) type_class;$/;"	T

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -82,7 +82,8 @@ typedef enum {
 	K_TYPEDEF,
 	K_CHECKER,
 	K_CLOCKING,
-	K_SEQUENCE
+	K_SEQUENCE,
+	K_MEMBER
 } verilogKind;
 
 typedef struct {
@@ -154,7 +155,8 @@ static kindDefinition SystemVerilogKinds [] = {
  { true, 'T', "typedef",   "type declarations" },
  { true, 'H', "checker",   "checkers" },
  { true, 'L', "clocking",  "clocking" },
- { true, 'q', "sequence",  "sequences" }
+ { true, 'q', "sequence",  "sequences" },
+ { true, 'w', "member",    "struct and union members" }
 };
 
 static const keywordAssoc KeywordTable [] = {
@@ -376,6 +378,7 @@ static bool findBlockName (tokenInfo *const token);
 static void processDefine (tokenInfo *const token);
 static int processType (tokenInfo* token, int c, verilogKind* kind);
 static int pushEnumNames (tokenInfo* token, int c);
+static int pushMembers (tokenInfo* token, int c);
 static bool readWordToken (tokenInfo *const token, int c);
 static int skipDelay(tokenInfo* token, int c);
 static int tagNameList (tokenInfo* token, int c);
@@ -404,6 +407,7 @@ static short isContainer (verilogKind kind)
 		case K_SEQUENCE:
 		case K_TYPEDEF:
 		case K_ENUM:
+		case K_STRUCT:
 			return true;
 		default:
 			return false;
@@ -416,6 +420,7 @@ static short isTempContext (tokenInfo const* token)
 	{
 		case K_TYPEDEF:
 		case K_ENUM:
+		case K_STRUCT:
 			return true;
 		default:
 			return false;
@@ -1158,8 +1163,8 @@ static void processStruct (tokenInfo *const token)
 	while (readWordToken (token, c))
 		c = skipWhite (vGetc ());
 
-	/* Skip struct contents */
-	c = skipWhite (skipPastMatch ("{}"));
+	/* create a list of members */
+	c = pushMembers (token, c);
 
 	/* Skip packed_dimension */
 	c = skipDimension (c);
@@ -1167,7 +1172,11 @@ static void processStruct (tokenInfo *const token)
 	/* Following identifiers are tag names */
 	verbose ("Find struct|union tags. Token %s kind %d\n", vStringValue (token->name), token->kind);
 	token->kind = kind;
-	tagNameList (token, c);
+	c = tagNameList (token, c);
+	ptrArrayClear (tagContents);
+
+	if (c == ';')
+		vUngetc (c);
 }
 
 // data_declaration ::=
@@ -1476,6 +1485,57 @@ static int pushEnumNames (tokenInfo* token, int c)
 	return c;
 }
 
+// create a list of struct/union members
+static int pushMembers (tokenInfo* token, int c)
+{
+	if (c == '{')
+	{
+		c = skipWhite (vGetc ());
+		do
+		{
+			verilogKind kind = K_UNDEFINED;	// set kind of context for processType()
+			if (readWordToken (token, c))
+				c = skipWhite (vGetc ());
+
+			c = processType (token, c, &kind);
+			do
+			{
+				token->kind = K_MEMBER;
+				ptrArrayAdd (tagContents, dupToken (token));
+				verbose ("Pushed struct/union member \"%s\"\n", vStringValue (token->name));
+
+				/* Skip unpacked dimensions */
+				c = skipDimension (skipWhite (c));
+
+				/* Skip value assignments */
+				if (c == '=')
+					c = skipExpression (vGetc ());
+
+				if (c != ',')
+					break;
+
+				c = skipWhite (vGetc ());
+				if (readWordToken (token, c))
+					c = skipWhite (vGetc ());
+				else
+				{
+					verbose ("Unexpected input.\n");
+					break;
+				}
+			} while (true);
+
+			/* Skip semicolon */
+			if (c == ';')
+				c = skipWhite (vGetc ());
+			/* End of enum elements list */
+			if (c == '}' || c == EOF)
+				break;
+		} while (true);
+		c = skipWhite (vGetc ());
+	}
+	return c;
+}
+
 // input
 //   kind: kind of context
 // output
@@ -1505,7 +1565,9 @@ static int processType (tokenInfo* token, int c, verilogKind* kind)
 		{
 			if (*kind == K_ENUM)
 				c = pushEnumNames (token, c);
-			else
+			else if (*kind == K_STRUCT)
+				c = pushMembers (token, c);
+			else	// for a nested structure
 				c = skipWhite (skipPastMatch ("{}"));
 		}
 		c = skipDimension (c);

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -997,9 +997,9 @@ static void createTag (tokenInfo *const token, verilogKind kind)
 		verbose ("Including tagContents: %d element(s)\n",
 				 ptrArrayCount(tagContents));
 
-		for (unsigned int i = ptrArrayCount (tagContents); i > 0; i--)
+		for (unsigned int i = 0; i < ptrArrayCount (tagContents); i++)
 		{
-			tokenInfo *content = ptrArrayItem (tagContents, i - 1);
+			tokenInfo *content = ptrArrayItem (tagContents, i);
 			createTag (content, content->kind);
 		}
 

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1508,6 +1508,7 @@ static int processType (tokenInfo* token, int c, verilogKind* kind)
 			else
 				c = skipWhite (skipPastMatch ("{}"));
 		}
+		c = skipDimension (c);
 
 		if (!readWordToken (token, c))
 			break;


### PR DESCRIPTION
Struct and union  members are emitted by this fix.
The kind "member" (w) is added.  (m and M were already used.)

Enum items are emitted in the defined order with `--sort=no` option.