### PR TITLE
docs: fix simple typo, preceeded -> preceded

### DIFF
--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -42,13 +42,13 @@ typedef enum _CXXParserParseTemplateAngleBracketsResult
 
 static bool cxxTemplateTokenCheckIsNonTypeAndCompareWord(const CXXToken *t,void * szWord)
 {
-	// To be non type the token must NOT be preceeded by class/struct/union
+	// To be non type the token must NOT be preceded by class/struct/union
 	if(!t->pPrev)
 		return false;
 	if(cxxTokenTypeIs(t->pPrev,CXXTokenTypeKeyword))
 	{
 		if(cxxKeywordIsTypeRefMarker(t->pPrev->eKeyword))
-			return false; // preceeded by a type ref marker
+			return false; // preceded by a type ref marker
 
 		// otherwise it's probably something like "int"
 	}
@@ -79,7 +79,7 @@ static bool cxxTokenIsPresentInTemplateParametersAsNonType(CXXToken * t)
 
 static bool cxxTemplateTokenCheckIsTypeAndCompareWord(const CXXToken * t,void * szWord)
 {
-	// To be non type the token must be preceeded by class/struct/union
+	// To be non type the token must be preceded by class/struct/union
 	if(!t->pPrev)
 		return false;
 	if(!cxxTokenTypeIs(t->pPrev,CXXTokenTypeKeyword))


### PR DESCRIPTION
There is a small typo in parsers/cxx/cxx_parser_template.c.

Should read `preceded` rather than `preceeded`.

