### PR TITLE
main: use actual line number in combined pattern fields

### DIFF
--- a/Tmain/excmd-combine-backward.d/stdout-expected.txt
+++ b/Tmain/excmd-combine-backward.d/stdout-expected.txt
@@ -1,2 +1,2 @@
-bar	input.cpp	3;?^bar(void)$?;"	f	typeref:typename:int	file:
-main	input.cpp	11;?^main(void)$?;"	f	typeref:typename:int
+bar	input.cpp	2;?^bar(void)$?;"	f	typeref:typename:int	file:
+main	input.cpp	10;?^main(void)$?;"	f	typeref:typename:int

--- a/Tmain/excmd-combine.d/stdout-expected.txt
+++ b/Tmain/excmd-combine.d/stdout-expected.txt
@@ -1,2 +1,2 @@
-bar	input.cpp	1;/^bar(void)$/;"	f	typeref:typename:int	file:
-main	input.cpp	9;/^main(void)$/;"	f	typeref:typename:int
+bar	input.cpp	2;/^bar(void)$/;"	f	typeref:typename:int	file:
+main	input.cpp	10;/^main(void)$/;"	f	typeref:typename:int

--- a/Tmain/extras-field-for-pseudo-tags.d/stdout-expected.txt
+++ b/Tmain/extras-field-for-pseudo-tags.d/stdout-expected.txt
@@ -1,7 +1,7 @@
 # option:  --format=1
 !_TAG_FILE_FORMAT	1	/original ctags format/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
@@ -12,7 +12,7 @@ main	input.c	/^int main (void) { return 0; }$/
 # option:  --format=2
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/;"	extras:pseudo
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/;"	extras:pseudo
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine/;"	extras:pseudo
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/;"	extras:pseudo
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/;"	extras:pseudo
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/;"	extras:pseudo
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/;"	extras:pseudo

--- a/Tmain/extras-field-for-pseudo-tags.d/stdout-expected.txt
+++ b/Tmain/extras-field-for-pseudo-tags.d/stdout-expected.txt
@@ -1,7 +1,7 @@
 # option:  --format=1
 !_TAG_FILE_FORMAT	1	/original ctags format/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
@@ -12,7 +12,7 @@ main	input.c	/^int main (void) { return 0; }$/
 # option:  --format=2
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/;"	extras:pseudo
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/;"	extras:pseudo
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/;"	extras:pseudo
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/;"	extras:pseudo
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/;"	extras:pseudo
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/;"	extras:pseudo
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/;"	extras:pseudo

--- a/Tmain/input-encoding-option.d/tags-expected.txt
+++ b/Tmain/input-encoding-option.d/tags-expected.txt
@@ -1,7 +1,7 @@
 !_TAG_FILE_ENCODING	UTF-8	//
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/

--- a/Tmain/input-encoding-option.d/tags-expected.txt
+++ b/Tmain/input-encoding-option.d/tags-expected.txt
@@ -1,7 +1,7 @@
 !_TAG_FILE_ENCODING	UTF-8	//
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/

--- a/Tmain/json-output-format.d/stdout-expected.txt
+++ b/Tmain/json-output-format.d/stdout-expected.txt
@@ -17,7 +17,7 @@
 # json --languages=+man --fields=* --extras=*
 {"_type": "ptag", "name": "JSON_OUTPUT_VERSION", "path": "0.0", "pattern": "in development"}
 {"_type": "ptag", "name": "TAG_FILE_SORTED", "path": "1", "pattern": "0=unsorted, 1=sorted, 2=foldcase"}
-{"_type": "ptag", "name": "TAG_OUTPUT_EXCMD", "path": "mixed", "pattern": "number, pattern, mixed, or combine(v2)"}
+{"_type": "ptag", "name": "TAG_OUTPUT_EXCMD", "path": "mixed", "pattern": "number, pattern, mixed, or combineV2"}
 {"_type": "ptag", "name": "TAG_PATTERN_LENGTH_LIMIT", "path": "96", "pattern": "0 for no limit"}
 {"_type": "ptag", "name": "TAG_PROGRAM_AUTHOR", "path": "Universal Ctags Team", "pattern": ""}
 {"_type": "ptag", "name": "TAG_PROGRAM_NAME", "path": "Universal Ctags", "pattern": "Derived from Exuberant Ctags"}

--- a/Tmain/json-output-format.d/stdout-expected.txt
+++ b/Tmain/json-output-format.d/stdout-expected.txt
@@ -17,7 +17,7 @@
 # json --languages=+man --fields=* --extras=*
 {"_type": "ptag", "name": "JSON_OUTPUT_VERSION", "path": "0.0", "pattern": "in development"}
 {"_type": "ptag", "name": "TAG_FILE_SORTED", "path": "1", "pattern": "0=unsorted, 1=sorted, 2=foldcase"}
-{"_type": "ptag", "name": "TAG_OUTPUT_EXCMD", "path": "mixed", "pattern": "number, pattern, mixed, or combine"}
+{"_type": "ptag", "name": "TAG_OUTPUT_EXCMD", "path": "mixed", "pattern": "number, pattern, mixed, or combine(v2)"}
 {"_type": "ptag", "name": "TAG_PATTERN_LENGTH_LIMIT", "path": "96", "pattern": "0 for no limit"}
 {"_type": "ptag", "name": "TAG_PROGRAM_AUTHOR", "path": "Universal Ctags Team", "pattern": ""}
 {"_type": "ptag", "name": "TAG_PROGRAM_NAME", "path": "Universal Ctags", "pattern": "Derived from Exuberant Ctags"}

--- a/Tmain/output-encoding-option.d/tags-expected.txt
+++ b/Tmain/output-encoding-option.d/tags-expected.txt
@@ -1,7 +1,7 @@
 !_TAG_FILE_ENCODING	cp932	//
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/

--- a/Tmain/output-encoding-option.d/tags-expected.txt
+++ b/Tmain/output-encoding-option.d/tags-expected.txt
@@ -1,7 +1,7 @@
 !_TAG_FILE_ENCODING	cp932	//
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/

--- a/Tmain/ptag-in-optlib-parser.d/stdout-expected.txt
+++ b/Tmain/ptag-in-optlib-parser.d/stdout-expected.txt
@@ -9,7 +9,7 @@
 !_TAG_KIND_DESCRIPTION!Sh	f,function	/functions/
 !_TAG_KIND_DESCRIPTION!Sh	h,heredoc	/label for here document/
 !_TAG_KIND_DESCRIPTION!Sh	s,script	/script files/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
@@ -26,7 +26,7 @@
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
 !_TAG_KIND_DESCRIPTION!foo	k,kind	/kinds/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/

--- a/Tmain/ptag-in-optlib-parser.d/stdout-expected.txt
+++ b/Tmain/ptag-in-optlib-parser.d/stdout-expected.txt
@@ -9,7 +9,7 @@
 !_TAG_KIND_DESCRIPTION!Sh	f,function	/functions/
 !_TAG_KIND_DESCRIPTION!Sh	h,heredoc	/label for here document/
 !_TAG_KIND_DESCRIPTION!Sh	s,script	/script files/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
@@ -26,7 +26,7 @@
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
 !_TAG_KIND_DESCRIPTION!foo	k,kind	/kinds/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/

--- a/Tmain/ptag-kind-sep.d/stdout-expected.txt
+++ b/Tmain/ptag-kind-sep.d/stdout-expected.txt
@@ -19,7 +19,7 @@
 !_TAG_KIND_SEPARATOR!PHP	\\	/nn/
 !_TAG_KIND_SEPARATOR!PHP	\\	/nt/
 !_TAG_KIND_SEPARATOR!PHP	\\	/nv/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/

--- a/Tmain/ptag-kind-sep.d/stdout-expected.txt
+++ b/Tmain/ptag-kind-sep.d/stdout-expected.txt
@@ -19,7 +19,7 @@
 !_TAG_KIND_SEPARATOR!PHP	\\	/nn/
 !_TAG_KIND_SEPARATOR!PHP	\\	/nt/
 !_TAG_KIND_SEPARATOR!PHP	\\	/nv/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/

--- a/Tmain/ptag-output-excmd.d/stdout-expected.txt
+++ b/Tmain/ptag-output-excmd.d/stdout-expected.txt
@@ -1,4 +1,4 @@
-!_TAG_OUTPUT_EXCMD	number	/number, pattern, mixed, or combine/
-!_TAG_OUTPUT_EXCMD	pattern	/number, pattern, mixed, or combine/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine/
-!_TAG_OUTPUT_EXCMD	combine	/number, pattern, mixed, or combine/
+!_TAG_OUTPUT_EXCMD	number	/number, pattern, mixed, or combine(v2)/
+!_TAG_OUTPUT_EXCMD	pattern	/number, pattern, mixed, or combine(v2)/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
+!_TAG_OUTPUT_EXCMD	combine(v2)	/number, pattern, mixed, or combine(v2)/

--- a/Tmain/ptag-output-excmd.d/stdout-expected.txt
+++ b/Tmain/ptag-output-excmd.d/stdout-expected.txt
@@ -1,4 +1,4 @@
-!_TAG_OUTPUT_EXCMD	number	/number, pattern, mixed, or combine(v2)/
-!_TAG_OUTPUT_EXCMD	pattern	/number, pattern, mixed, or combine(v2)/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combine(v2)/
-!_TAG_OUTPUT_EXCMD	combine(v2)	/number, pattern, mixed, or combine(v2)/
+!_TAG_OUTPUT_EXCMD	number	/number, pattern, mixed, or combineV2/
+!_TAG_OUTPUT_EXCMD	pattern	/number, pattern, mixed, or combineV2/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
+!_TAG_OUTPUT_EXCMD	combineV2	/number, pattern, mixed, or combineV2/

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -445,11 +445,7 @@ are not listed here. They are experimental or for debugging purpose.
 		for finding all matches.
 
 	combine
-		Combine adjusted line number and pattern with a semicolon.
-		ctags adjusts the line number by decrementing
-		or incrementing (if ``-B`` option is given) one.
-		This adjustment helps a client tool like vim to search the pattern
-		from the line before (or after) the pattern starts.
+		Concatenate the line number and pattern with a semicolon in between.
 
 ``--extra=[+|-]flags|*``
 	Equivalent to ``--extras=[+|-]flags|*``, which was introduced to

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -345,7 +345,7 @@ static int writeCtagsEntry (tagWriter *writer,
 	else
 	{
 		if (Option.locate == EX_COMBINE)
-			length += mio_printf(mio, "%lu;", tag->lineNumber + (Option.backward? 1: -1));
+			length += mio_printf(mio, "%lu;", tag->lineNumber);
 		length += mio_puts(mio, escapeFieldValue(writer, tag, FIELD_PATTERN));
 	}
 

--- a/main/writer.c
+++ b/main/writer.c
@@ -165,7 +165,7 @@ extern bool ptagMakeCtagsOutputExcmd (ptagDesc *desc,
 		excmd = "pattern";
 		break;
 	case EX_COMBINE:
-		excmd = "combine(v2)";
+		excmd = "combineV2";
 		break;
 	default:
 		AssertNotReached ();
@@ -173,7 +173,7 @@ extern bool ptagMakeCtagsOutputExcmd (ptagDesc *desc,
 		break;
 	}
 	return writePseudoTag (desc, excmd,
-						   "number, pattern, mixed, or combine(v2)",
+						   "number, pattern, mixed, or combineV2",
 						   NULL);
 }
 

--- a/main/writer.c
+++ b/main/writer.c
@@ -165,7 +165,7 @@ extern bool ptagMakeCtagsOutputExcmd (ptagDesc *desc,
 		excmd = "pattern";
 		break;
 	case EX_COMBINE:
-		excmd = "combine";
+		excmd = "combine(v2)";
 		break;
 	default:
 		AssertNotReached ();
@@ -173,7 +173,7 @@ extern bool ptagMakeCtagsOutputExcmd (ptagDesc *desc,
 		break;
 	}
 	return writePseudoTag (desc, excmd,
-						   "number, pattern, mixed, or combine",
+						   "number, pattern, mixed, or combine(v2)",
 						   NULL);
 }
 

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -445,11 +445,7 @@ are not listed here. They are experimental or for debugging purpose.
 		for finding all matches.
 
 	combine
-		Combine adjusted line number and pattern with a semicolon.
-		@CTAGS_NAME_EXECUTABLE@ adjusts the line number by decrementing
-		or incrementing (if ``-B`` option is given) one.
-		This adjustment helps a client tool like vim to search the pattern
-		from the line before (or after) the pattern starts.
+		Concatenate the line number and pattern with a semicolon in between.
 
 ``--extra=[+|-]flags|*``
 	Equivalent to ``--extras=[+|-]flags|*``, which was introduced to


### PR DESCRIPTION
See #2691. This makes it straightforward for client tools to "search the nearest occurence of pattern around the line", making good use of both the line number and search pattern.

I'll update #2698 once this is merged.