### PR TITLE
Move EXTERNAL_PARSER_LIST ifdef to the beginnning of BuiltInParsers

### DIFF
--- a/main/parse.c
+++ b/main/parse.c
@@ -126,12 +126,12 @@ static parserDefinition *FallbackParser (void);
 static parserDefinition *CTagsParser (void);
 static parserDefinition *CTagsSelfTestParser (void);
 static parserDefinitionFunc* BuiltInParsers[] = {
-	CTagsParser,				/* This must be first entry. */
-	FallbackParser,				/* LANG_FALLBACK */
-	CTagsSelfTestParser,
 #ifdef EXTERNAL_PARSER_LIST
 	EXTERNAL_PARSER_LIST
 #else  /* ! EXTERNAL_PARSER_LIST */
+	CTagsParser,				/* This must be first entry. */
+	FallbackParser,				/* LANG_FALLBACK */
+	CTagsSelfTestParser,
 
 	PARSER_LIST,
 	XML_PARSER_LIST


### PR DESCRIPTION
Commit

82791c20ff8d01e7055bcbbb30db4999d2c3d463

moved CTagsParser, FallbackParser and CTagsSelfTestParser above the
ifdef which made these parsers included also when using
EXTERNAL_PARSER_LIST - this is not good for Geany because these three
parsers are "invisible" for it and shift the EXTERNAL_PARSER_LIST by 3.

This patch moves the ifdef back where it was before.