### PR TITLE
SystemVerilog,refactor: consistent input character handling

### DIFF
--- a/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
@@ -28,7 +28,6 @@ w1	input.sv	/^  interconnect w1;              \/\/ legal$/;"	n	module:Net_declar
 w2	input.sv	/^  interconnect [3:0] w2;        \/\/ legal$/;"	n	module:Net_declarations
 w3	input.sv	/^  interconnect [3:0] w3 [1:0];  \/\/ legal$/;"	n	module:Net_declarations
 wT	input.sv	/^  nettype T wT;$/;"	r	module:Net_declarations
-Tsum	input.sv	/^  nettype T wTsum with Tsum;  \/\/ FIXME: $/;"	r	module:Net_declarations
 w1	input.sv	/^  wT w1;$/;"	r	module:Net_declarations
 w2	input.sv	/^  wT w2[8];$/;"	r	module:Net_declarations
 w3	input.sv	/^  wTsum w3;$/;"	r	module:Net_declarations

--- a/Units/parser-verilog.r/systemverilog-net-var.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-net-var.d/input.sv
@@ -50,7 +50,7 @@ module Net_declarations;
 
   // 6.7.2 Net declarations with user-defined nettypes
   nettype T wT;
-  nettype T wTsum with Tsum;  // FIXME: 
+  //nettype T wTsum with Tsum;  // FIXME: "nettype" and "with" are unsupported
   wT w1;
   wT w2[8];
   wTsum w3;

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1231,7 +1231,7 @@ static void processTypedef (tokenInfo *const token)
 		vUngetc (c);
 }
 
-static void processParameterList (tokenInfo *token, int c)
+static int processParameterList (tokenInfo *token, int c)
 {
 	bool parameter = true;	// default "parameter"
 	if (c == '#')
@@ -1273,7 +1273,7 @@ static void processParameterList (tokenInfo *token, int c)
 			c = skipWhite (vGetc ());
 		}
 	}
-	vUngetc (c);
+	return c;
 }
 
 // [ virtual ] class [ static | automatic ] class_identifier [ parameter_port_list ]
@@ -1299,8 +1299,7 @@ static void processClass (tokenInfo *const token)
 	c = skipWhite (vGetc ());
 
 	/* Find class parameters list */
-	processParameterList (token, c);
-	c = skipWhite (vGetc ());
+	c = processParameterList (token, c);
 
 	/* Search for inheritance information */
 	if (readWordToken (token, c))
@@ -1379,7 +1378,7 @@ static void processDesignElement (tokenInfo *const token)
 		c = skipWhite (vGetc ());
 		if (c == '#')	// parameter_port_list
 		{
-			processParameterList (token, c);
+			c = processParameterList (token, c);
 
 			/* Put found parameters in context */
 			verbose ("Putting parameters: %d element(s)\n",
@@ -1392,7 +1391,6 @@ static void processDesignElement (tokenInfo *const token)
 			ptrArrayClear (tagContents);
 			// disable parameter property on parameter declaration statement
 			currentContext->hasParamList = true;
-			c = skipWhite (vGetc ());
 		}
 
 		// skip clocking_event of clocking block


### PR DESCRIPTION
This fix makes input character handling consistent.
Until now, character input processing has been executed in an ad hoc way.

- Each function which executes character input has argument "c" and returns "c".
- It calls skipWhite() before return.

