### PR TITLE
SystemVerilog: refactor readWordToken()

### DIFF
--- a/Units/parser-verilog.r/systemverilog-parameter.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-parameter.d/expected.tags
@@ -50,7 +50,7 @@ A	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$
 Y	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:class.class.generic_decoder
 int_t	input.sv	/^typedef int int_t;$/;"	T	interface:class.class
 user_defined_type_param	input.sv	/^module user_defined_type_param$/;"	m	interface:class.class
-um_code_bits	input.sv	/^  #(int_t num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.user_defined_type_param	parameter:
+num_code_bits	input.sv	/^  #(int_t num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.user_defined_type_param	parameter:
 num_out_bits	input.sv	/^  #(int_t num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.user_defined_type_param
 A	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:class.class.user_defined_type_param
 Y	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:class.class.user_defined_type_param

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -658,13 +658,13 @@ static int vGetc (void)
 	return _vGetc (false);
 }
 
-// [a-zA-Z_`]
-static bool isFirstIdentifierCharacter (const int c)
+// Is the first charactor in an identifier? [a-zA-Z_`]
+static bool isWordToken (const int c)
 {
 	return (isalpha (c) || c == '_' || c == '`');
 }
 
-// [a-zA-Z0-9_`$]
+// Is a charactor in an identifier? [a-zA-Z0-9_`$]
 static bool isIdentifierCharacter (const int c)
 {
 	return (isalnum (c) || c == '_' || c == '`' || c == '$');
@@ -796,7 +796,7 @@ static void _updateKind (tokenInfo *const token)
 /* read an identifier, keyword, number, compiler directive, or macro identifier */
 static bool readWordToken (tokenInfo *const token, int c)
 {
-	if (isFirstIdentifierCharacter (c))
+	if (isWordToken (c))
 	{
 		clearToken (token);
 		do
@@ -822,7 +822,7 @@ static bool isIdentifier (tokenInfo* token)
 			int c = vStringChar (token->name, i);
 			if (i == 0)
 			{
-				if (c == '`' || !isFirstIdentifierCharacter (c))
+				if (c == '`' || !isWordToken (c))
 					return false;
 			}
 			else

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -385,7 +385,6 @@ static bool readWordToken (tokenInfo *const token, int c);
 static int skipBlockName (tokenInfo *const token, int c);
 static int skipDelay(tokenInfo* token, int c);
 static int tagNameList (tokenInfo* token, int c);
-static void updateKind (tokenInfo *const token);
 
 /*
  *   FUNCTION DEFINITIONS
@@ -788,6 +787,12 @@ static int skipMacro (int c)
 	return c;
 }
 
+static void _updateKind (tokenInfo *const token)
+{
+	verilogKind kind = (verilogKind) lookupKeyword (vStringValue (token->name), getInputLanguage () );
+	token->kind = ((kind == K_UNDEFINED) && isIdentifier(token)) ? K_IDENTIFIER : kind;
+}
+
 /* read an identifier, keyword, number, compiler directive, or macro identifier */
 static bool readWordToken (tokenInfo *const token, int c)
 {
@@ -799,7 +804,7 @@ static bool readWordToken (tokenInfo *const token, int c)
 			vStringPut (token->name, c);
 			c = vGetc ();
 		} while (isIdentifierCharacter (c));
-		updateKind (token);
+		_updateKind (token);
 		vUngetc (c);
 		return true;
 	}
@@ -830,17 +835,6 @@ static bool isIdentifier (tokenInfo* token)
 	}
 	else
 		return false;
-}
-
-static verilogKind getKindForToken (tokenInfo *const token)
-{
-	return (verilogKind) lookupKeyword (vStringValue (token->name), getInputLanguage () );
-}
-
-static void updateKind (tokenInfo *const token)
-{
-	verilogKind kind = getKindForToken (token);
-	token->kind = ((kind == K_UNDEFINED) && isIdentifier(token)) ? K_IDENTIFIER : kind;
 }
 
 static void createContext (verilogKind kind, vString* const name)

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1244,24 +1244,27 @@ static int processParameterList (tokenInfo *token, int c)
 		c = skipWhite (vGetc ());
 		if (c == '(')
 		{
-			do
+			c = skipWhite (vGetc ());
+			while (true)
 			{
-				c = skipWhite (vGetc ());
 				if (isWordToken (c))
 				{
-					readWordTokenNoSkip (token, c);	// FIXME
+					c = readWordToken (token, c);
 					verbose ("Found parameter %s\n", vStringValue (token->name));
 					if (token->kind == K_IDENTIFIER)
 					{
-						c = skipWhite (vGetc ());
 						if (c == ',' || c == ')' || c == '=')	// ignore user defined type
 						{
 							tokenInfo *param = dupToken (token);
 							param->kind = K_CONSTANT;
 							param->parameter = parameter;
 							ptrArrayAdd (tagContents, param);
-
-							c = skipExpression (c);
+							if (c == '=')
+								c = skipExpression (vGetc ());
+							else if (c == ',')
+								c = skipWhite (vGetc ());
+							else	// ')'
+								break;
 						}
 					}
 					else if (token->kind == K_PARAMETER)
@@ -1269,12 +1272,12 @@ static int processParameterList (tokenInfo *token, int c)
 					else if (token->kind == K_LOCALPARAM)
 						parameter = false;
 				}
+				else if  (c == ')' || c == EOF)
+					break;
+				else
+					c = skipWhite (vGetc ());
 				// unpacked array is not allowed for a parameter
-				// else if (c == '[') {
-				// 	c =skipDimension(c);
-				// 	vUngetc (c);
-				// }
-			} while (c != ')' && c != EOF);
+			}
 			c = skipWhite (vGetc ());
 		}
 	}

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -764,7 +764,6 @@ static int skipMacro (int c)
 		tokenInfo *token = newToken ();	// don't update token outside
 
 		readWordToken (token, c);
-		updateKind (token);
 		/* Skip compiler directive other than `define */
 		if (token->kind == K_DIRECTIVE)
 		{
@@ -800,6 +799,7 @@ static bool readWordToken (tokenInfo *const token, int c)
 			vStringPut (token->name, c);
 			c = vGetc ();
 		} while (isIdentifierCharacter (c));
+		updateKind (token);
 		vUngetc (c);
 		return true;
 	}
@@ -1189,7 +1189,6 @@ static int processTypedef (tokenInfo *const token, int c)
 	verilogKind kind = K_UNDEFINED;
 	if (readWordToken (token, c))
 	{
-		updateKind (token);
 		c = skipWhite (vGetc ());
 		kind = token->kind;
 	}
@@ -1205,7 +1204,6 @@ static int processTypedef (tokenInfo *const token, int c)
 		case K_STRUCT:
 			if (readWordToken (token, c))
 			{
-				updateKind (token);
 				c = skipWhite (vGetc ());
 				if (token->kind == K_IDENTIFIER && c == ';')
 					currentContext->prototype = true;
@@ -1239,7 +1237,6 @@ static int processParameterList (tokenInfo *token, int c)
 				c = skipWhite (vGetc ());
 				if (readWordToken (token, c))
 				{
-					updateKind (token);
 					verbose ("Found parameter %s\n", vStringValue (token->name));
 					if (token->kind == K_IDENTIFIER)
 					{
@@ -1360,7 +1357,7 @@ static int processDesignElement (tokenInfo *const token, int c)
 
 	if (readWordToken (token, c))
 	{
-		while (getKindForToken (token) == K_IGNORE) // skip static or automatic
+		while (token->kind == K_IGNORE) // skip static or automatic
 		{
 			c = skipWhite (vGetc ());
 			readWordToken (token, c);
@@ -1562,7 +1559,6 @@ static int processType (tokenInfo* token, int c, verilogKind* kind)
 
 		if (!readWordToken (token, c))
 			break;
-		updateKind (token);
 		c = skipWhite (vGetc ());	// read next char
 
 		// fix kind of user defined type
@@ -1777,7 +1773,6 @@ static void findVerilogTags (void)
 			default :
 				if (readWordToken (token, c))
 				{
-					updateKind (token);
 					if (token->kind == K_DIRECTIVE)
 					{
 						// Skip compiler directives which are line-based.


### PR DESCRIPTION
- readWordToken() returns "c" instead of bool value
- updateKind() is merged into readWordToken()
- isFirstIdentifierCharacter() is rename to isWordToken() and is called before readWordToken() is called.

During this refactoring a bug in processParameterList() was found and fixed.