### PR TITLE
Clojure: Fix skipMetadata not called for functions

### DIFF
--- a/Units/parser-clojure.r/clojure-metadata-in-fn.d/expected.tags
+++ b/Units/parser-clojure.r/clojure-metadata-in-fn.d/expected.tags
@@ -1,6 +1,6 @@
-my-fn	./input.clj	/^(defn my-fn [])$/;"	f
-my-hinted-fn	./input.clj	/^(defn my-hinted-fn ^MyReturnType [])$/;"	f
-my-private-fn	./input.clj	/^(defn ^:private my-private-fn [])$/;"	f
-my-private-hinted-fn	./input.clj	/^(defn ^:private my-private-hinted-fn ^MyReturnType [])$/;"	f
-my-public-fn	./input.clj	/^(defn ^{:foo :bar} my-public-fn [])$/;"	f
-so-many-hints	./input.clj	/^(defn ^:private so-many-hints ^MyReturnType$/;"	f
+my-fn	input.clj	/^(defn my-fn [])$/;"	f
+my-hinted-fn	input.clj	/^(defn my-hinted-fn ^MyReturnType [])$/;"	f
+my-private-fn	input.clj	/^(defn ^:private my-private-fn [])$/;"	f
+my-private-hinted-fn	input.clj	/^(defn ^:private my-private-hinted-fn ^MyReturnType [])$/;"	f
+my-public-fn	input.clj	/^(defn ^{:foo :bar} my-public-fn [])$/;"	f
+so-many-hints	input.clj	/^(defn ^:private so-many-hints ^MyReturnType$/;"	f

--- a/Units/parser-clojure.r/clojure-metadata-in-fn.d/expected.tags
+++ b/Units/parser-clojure.r/clojure-metadata-in-fn.d/expected.tags
@@ -1,0 +1,6 @@
+my-fn	./input.clj	/^(defn my-fn [])$/;"	f
+my-hinted-fn	./input.clj	/^(defn my-hinted-fn ^MyReturnType [])$/;"	f
+my-private-fn	./input.clj	/^(defn ^:private my-private-fn [])$/;"	f
+my-private-hinted-fn	./input.clj	/^(defn ^:private my-private-hinted-fn ^MyReturnType [])$/;"	f
+my-public-fn	./input.clj	/^(defn ^{:foo :bar} my-public-fn [])$/;"	f
+so-many-hints	./input.clj	/^(defn ^:private so-many-hints ^MyReturnType$/;"	f

--- a/Units/parser-clojure.r/clojure-metadata-in-fn.d/input.clj
+++ b/Units/parser-clojure.r/clojure-metadata-in-fn.d/input.clj
@@ -1,0 +1,12 @@
+(defn my-fn [])
+
+(defn ^:private my-private-fn [])
+
+(defn ^{:foo :bar} my-public-fn [])
+
+(defn my-hinted-fn ^MyReturnType [])
+
+(defn ^:private my-private-hinted-fn ^MyReturnType [])
+
+(defn ^:private so-many-hints ^MyReturnType
+  [^MyArgType x])

--- a/parsers/clojure.c
+++ b/parsers/clojure.c
@@ -123,6 +123,7 @@ static int makeNamespaceTag (vString * const name, const char *dbp)
 
 static void makeFunctionTag (vString * const name, const char *dbp, int scope_index)
 {
+	dbp = skipMetadata (dbp);
 	functionName (name, dbp);
 	if (vStringLength (name) > 0 && ClojureKinds[K_FUNCTION].enabled)
 	{


### PR DESCRIPTION
Functions can also have metadata, but `skipMetadata` is not called for them. That causes functions like

```clj
(defn ^:private test-fn [])
```

to be parsed as `^:private` instead of `test-fn`. This PR fixes the problem.