### PR TITLE
main: add timestamp field for file kind

### DIFF
--- a/Tmain/epoch-field.d/run.sh
+++ b/Tmain/epoch-field.d/run.sh
@@ -1,0 +1,34 @@
+# Copyright: 2020 Masatake YAMATO
+# License: GPL-2
+
+CTAGS=$1
+
+O=/tmp/ctags-tstamp-$$.c
+
+cat > $O <<EOF
+int main (void)
+{
+	return 0;
+}
+EOF
+
+is_json_avaiable()
+{
+	$1 --quiet --options=NONE --with-list-header=no --list-features | grep -q "json"
+}
+
+TZ=UTC+00:00 touch -t '200402291621.42' $O &&
+	$CTAGS --kinds-C= --extras=f --fields=T -o - $O \
+		| sed -e 's/.*\(epoch:.*\)/tags:\1/' &&
+	$CTAGS --kinds-C= --extras=f --fields=T -o - -x --_xformat="xref:epoch:%T" $O &&
+	{
+		if is_json_avaiable $CTAGS; then
+			$CTAGS --kinds-C= --extras=f --fields=T -o - --output-format=json $O \
+				| sed -e 's/.*"epoch": \([0-9]*\).*/json:epoch:\1/'
+		else
+			echo "json:epoch:1078071702"
+		fi
+	}
+s=$?
+rm $O
+exit $s

--- a/Tmain/epoch-field.d/stdout-expected.txt
+++ b/Tmain/epoch-field.d/stdout-expected.txt
@@ -1,0 +1,3 @@
+tags:epoch:1078071702
+xref:epoch:1078071702
+json:epoch:1078071702

--- a/Tmain/extras-field.d/run.sh
+++ b/Tmain/extras-field.d/run.sh
@@ -5,4 +5,3 @@ CTAGS=$1
 
 ${CTAGS} --quiet --options=NONE --fields=+Ere --extras=+qrf -o - input.cpp \
     | sed -e 's|[^	]*\(input.cpp\)|\1|'
-

--- a/Tmain/extras-field.d/run.sh
+++ b/Tmain/extras-field.d/run.sh
@@ -3,5 +3,5 @@
 
 CTAGS=$1
 
-${CTAGS} --quiet --options=NONE --fields=+Ere --extras=+qrf -o - input.cpp \
+${CTAGS} --quiet --options=NONE --fields=+Ere-T --extras=+qrf -o - input.cpp \
     | sed -e 's|[^	]*\(input.cpp\)|\1|'

--- a/Tmain/json-output-format.d/run.sh
+++ b/Tmain/json-output-format.d/run.sh
@@ -7,9 +7,9 @@ CTAGS=$1
 
 if is_feature_available "${CTAGS}" json; then
     {
-	run_with_format json --languages=+man
-	run_with_format json --languages=+man --fields="*"
-	run_with_format json --languages=+man --fields="*" --extras='*'
+	run_with_format json --languages=+man --fields=-T
+	run_with_format json --languages=+man --fields="*"-T
+	run_with_format json --languages=+man --fields="*"-T --extras='*'
     } | cat \
 		| grep -v TAG_PROGRAM_VERSION \
 		| grep -v TAG_OUTPUT_FILESEP  \

--- a/Tmain/json-output-format.d/stdout-expected.txt
+++ b/Tmain/json-output-format.d/stdout-expected.txt
@@ -1,4 +1,4 @@
-# json --languages=+man
+# json --languages=+man --fields=-T
 {"_type": "tag", "name": "Foo", "path": "input.py", "pattern": "/^class Foo:$/", "kind": "class"}
 {"_type": "tag", "name": "N\tA\tM\tE", "path": "input.1", "pattern": "/^.SH \"\tN\tA\tM\tE\t\"$/", "kind": "section"}
 {"_type": "tag", "name": "doIt", "path": "input.py", "pattern": "/^    def doIt():$/", "kind": "member", "scope": "Foo", "scopeKind": "class"}
@@ -6,7 +6,7 @@
 {"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "typeref": "typename:int", "kind": "function"}
 {"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^func main() {$/", "kind": "func", "scope": "main", "scopeKind": "package"}
 {"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^package main$/", "kind": "package"}
-# json --languages=+man --fields=*
+# json --languages=+man --fields=*-T
 {"_type": "tag", "name": "Foo", "path": "input.py", "pattern": "/^class Foo:$/", "access": "public", "inherits": false, "language": "Python", "line": 1, "kind": "class", "roles": "def", "end": 3}
 {"_type": "tag", "name": "N\tA\tM\tE", "path": "input.1", "pattern": "/^.SH \"\tN\tA\tM\tE\t\"$/", "language": "Man", "line": 1, "kind": "section", "roles": "def"}
 {"_type": "tag", "name": "doIt", "path": "input.py", "pattern": "/^    def doIt():$/", "access": "public", "language": "Python", "line": 2, "signature": "()", "kind": "member", "roles": "def", "scope": "Foo", "scopeKind": "class", "end": 3}
@@ -14,7 +14,7 @@
 {"_type": "tag", "name": "main", "path": "input.c", "pattern": "/^main(void)$/", "language": "C", "line": 9, "signature": "(void)", "typeref": "typename:int", "kind": "function", "roles": "def", "end": 12}
 {"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^func main() {$/", "language": "Go", "line": 3, "signature": "()", "kind": "func", "roles": "def", "scope": "main", "scopeKind": "package", "end": 4}
 {"_type": "tag", "name": "main", "path": "input.go", "pattern": "/^package main$/", "language": "Go", "line": 1, "kind": "package", "roles": "def"}
-# json --languages=+man --fields=* --extras=*
+# json --languages=+man --fields=*-T --extras=*
 {"_type": "ptag", "name": "JSON_OUTPUT_VERSION", "path": "0.0", "pattern": "in development"}
 {"_type": "ptag", "name": "TAG_FILE_SORTED", "path": "1", "pattern": "0=unsorted, 1=sorted, 2=foldcase"}
 {"_type": "ptag", "name": "TAG_OUTPUT_EXCMD", "path": "mixed", "pattern": "number, pattern, mixed, or combineV2"}

--- a/Tmain/kinds-all-with-spec.d/run.sh
+++ b/Tmain/kinds-all-with-spec.d/run.sh
@@ -8,9 +8,9 @@ CTAGS=$1
 t ()
 {
 	echo '#' "--all-kinds=$1" 1>&2
-	$CTAGS --quiet --options=NONE -o - --all-kinds="$1" input.c
+	$CTAGS --quiet --options=NONE -o - --all-kinds="$1" --fields=-T input.c
 	echo '#' "--kinds-all=$1" 1>&2
-	$CTAGS --quiet --options=NONE -o - --kinds-all="$1" input.c
+	$CTAGS --quiet --options=NONE -o - --kinds-all="$1" --fields=-T input.c
 }
 
 echo '#' 1>&2
@@ -91,15 +91,15 @@ echo '#' 1>&2
 echo '# Just print the parsed file name' 1>&2
 echo '#' 1>&2
 
-$CTAGS --quiet --options=NONE -o- --all-kinds=F --extras=+f input.c
-$CTAGS --quiet --options=NONE -o- --all-kinds=FF --extras=+f input.c
-$CTAGS --quiet --options=NONE -o- --all-kinds=-F+F --extras=+f input.c
-$CTAGS --quiet --options=NONE -o- --all-kinds='*' --all-kinds=F --extras=+f input.c
+$CTAGS --quiet --options=NONE -o- --all-kinds=F --extras=+f --fields=-T input.c
+$CTAGS --quiet --options=NONE -o- --all-kinds=FF --extras=+f --fields=-T input.c
+$CTAGS --quiet --options=NONE -o- --all-kinds=-F+F --extras=+f --fields=-T input.c
+$CTAGS --quiet --options=NONE -o- --all-kinds='*' --all-kinds=F --extras=+f --fields=-T input.c
 
-$CTAGS --quiet --options=NONE -o- --kinds-all=F --extras=+f input.c
-$CTAGS --quiet --options=NONE -o- --kinds-all=FF --extras=+f input.c
-$CTAGS --quiet --options=NONE -o- --kinds-all=-F+F --extras=+f input.c
-$CTAGS --quiet --options=NONE -o- --kinds-all='*' --kinds-all=F --extras=+f input.c
+$CTAGS --quiet --options=NONE -o- --kinds-all=F --extras=+f --fields=-T input.c
+$CTAGS --quiet --options=NONE -o- --kinds-all=FF --extras=+f --fields=-T input.c
+$CTAGS --quiet --options=NONE -o- --kinds-all=-F+F --extras=+f --fields=-T input.c
+$CTAGS --quiet --options=NONE -o- --kinds-all='*' --kinds-all=F --extras=+f --fields=-T input.c
 
 echo '#' 1>&2
 echo '# The original test cases' 1>&2

--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -1,4 +1,5 @@
 E       UCTAGSextras         no      NONE             s--    no    Extra tag type information
+T       UCTAGSepoch          yes     NONE             -i-    no    the last modified time of the input file (only for F/file kind tag)
 Z       UCTAGSscope          no      NONE             s--    no    [tags output] prepend "scope:" key to s/scope field output, [xref and json output] the same as s/ field
 e       UCTAGSend            no      NONE             -i-    no    end lines of various items
 p       UCTAGSscopeKind      no      NONE             s--    no    [tags output] no effect, [xref and json output] kind of scope in long-name form

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -7,6 +7,7 @@ E	extras	no	NONE	s--	no	Extra tag type information
 K	NONE	no	NONE	s--	no	Kind of tag in long-name form
 R	NONE	no	NONE	s--	no	Marker (R or D) representing whether tag is definition or reference
 S	signature	no	NONE	s--	no	Signature of routine (e.g. prototype or parameter list)
+T	epoch	yes	NONE	-i-	no	the last modified time of the input file (only for F/file kind tag)
 Z	scope	no	NONE	s--	no	[tags output] prepend "scope:" key to s/scope field output, [xref and json output] the same as s/ field
 a	access	no	NONE	s--	no	Access (or export) of class members
 e	end	no	NONE	-i-	no	end lines of various items

--- a/Tmain/ptag-in-optlib-parser.d/stdout-expected.txt
+++ b/Tmain/ptag-in-optlib-parser.d/stdout-expected.txt
@@ -1,5 +1,6 @@
 # BUILTIN
 !_TAG_EXTRA_DESCRIPTION	pseudo	/Include pseudo tags/
+!_TAG_FIELD_DESCRIPTION	epoch	/the last modified time of the input file (only for F\/file kind tag)/
 !_TAG_FIELD_DESCRIPTION	input	/input file/
 !_TAG_FIELD_DESCRIPTION	name	/tag name/
 !_TAG_FIELD_DESCRIPTION	pattern	/pattern/
@@ -19,6 +20,7 @@
 # REGEX
 !_TAG_EXTRA_DESCRIPTION	pseudo	/Include pseudo tags/
 !_TAG_EXTRA_DESCRIPTION!foo	extra	/extra example/
+!_TAG_FIELD_DESCRIPTION	epoch	/the last modified time of the input file (only for F\/file kind tag)/
 !_TAG_FIELD_DESCRIPTION	input	/input file/
 !_TAG_FIELD_DESCRIPTION	name	/tag name/
 !_TAG_FIELD_DESCRIPTION	pattern	/pattern/

--- a/Tmain/xformat-common-fields.d/stdout-expected.txt
+++ b/Tmain/xformat-common-fields.d/stdout-expected.txt
@@ -41,6 +41,11 @@ output: Foo -
 output: doIt ()
 status: 0
 
+field: T
+output: Foo 0
+output: doIt 0
+status: 0
+
 field: Z
 output: Foo 
 output: doIt Foo

--- a/Units/parser-python.r/simple.py.d/args.ctags
+++ b/Units/parser-python.r/simple.py.d/args.ctags
@@ -1,4 +1,4 @@
 --sort=no
 --extras=*-p
---fields=*
 --fields-all=*
+--fields=*-T

--- a/main/entry.c
+++ b/main/entry.c
@@ -203,6 +203,9 @@ extern void makeFileTag (const char *const fileName)
 		tag.extensionFields.endLine = getInputLineNumber ();
 	}
 
+	if (isFieldEnabled (FIELD_EPOCH))
+		tag.extensionFields.epoch = getInputFileMtime ();
+
 	makeTagEntry (&tag);
 }
 

--- a/main/entry.c
+++ b/main/entry.c
@@ -1066,8 +1066,6 @@ static tagEntryInfoX *copyTagEntry (const tagEntryInfo *const tag,
 	slot->name = eStrdup (slot->name);
 	if (slot->extensionFields.access)
 		slot->extensionFields.access = eStrdup (slot->extensionFields.access);
-	if (slot->extensionFields.fileScope)
-		slot->extensionFields.fileScope = eStrdup (slot->extensionFields.fileScope);
 	if (slot->extensionFields.implementation)
 		slot->extensionFields.implementation = eStrdup (slot->extensionFields.implementation);
 	if (slot->extensionFields.inheritance)
@@ -1144,8 +1142,6 @@ static void deleteTagEnry (void *data)
 
 	if (slot->extensionFields.access)
 		eFree ((char *)slot->extensionFields.access);
-	if (slot->extensionFields.fileScope)
-		eFree ((char *)slot->extensionFields.fileScope);
 	if (slot->extensionFields.implementation)
 		eFree ((char *)slot->extensionFields.implementation);
 	if (slot->extensionFields.inheritance)

--- a/main/entry.h
+++ b/main/entry.h
@@ -16,6 +16,7 @@
 #include "types.h"
 
 #include <stdint.h>
+#include <time.h>
 
 #include "field.h"
 #include "xtag.h"
@@ -95,6 +96,7 @@ struct sTagEntryInfo {
 		const char* xpath;
 #endif
 		unsigned long endLine;
+		time_t epoch;
 	} extensionFields;  /* list of extension fields*/
 
 	/* `usedParserFields' tracks how many parser own fields are

--- a/main/entry.h
+++ b/main/entry.h
@@ -67,7 +67,6 @@ struct sTagEntryInfo {
 
 	struct {
 		const char* access;
-		const char* fileScope;
 		const char* implementation;
 		const char* inheritance;
 

--- a/main/field.c
+++ b/main/field.c
@@ -67,6 +67,7 @@ static const char *renderFieldExtras (const tagEntryInfo *const tag, const char 
 static const char *renderFieldXpath (const tagEntryInfo *const tag, const char *value, vString* b);
 static const char *renderFieldScopeKindName(const tagEntryInfo *const tag, const char *value, vString* b);
 static const char *renderFieldEnd (const tagEntryInfo *const tag, const char *value, vString* b);
+static const char *renderFieldEpoch (const tagEntryInfo *const tag, const char *value, vString* b);
 
 static bool doesContainAnyCharInName (const tagEntryInfo *const tag, const char *value, const char *chars);
 static bool doesContainAnyCharInInput (const tagEntryInfo *const tag, const char*value, const char *chars);
@@ -83,6 +84,7 @@ static bool     isSignatureFieldAvailable (const tagEntryInfo *const tag);
 static bool     isExtrasFieldAvailable    (const tagEntryInfo *const tag);
 static bool     isXpathFieldAvailable     (const tagEntryInfo *const tag);
 static bool     isEndFieldAvailable       (const tagEntryInfo *const tag);
+static bool     isEpochAvaiable           (const tagEntryInfo *const tag);
 
 
 #define DEFINE_FIELD(L, N, V, H, DT, RE)				\
@@ -227,6 +229,11 @@ static fieldDefinition fieldDefinitionsUniversal [] = {
 			   isEndFieldAvailable,
 			   FIELDTYPE_INTEGER,
 			   renderFieldEnd, NULL, NULL),
+	DEFINE_FIELD_FULL ('T', "epoch", true,
+					   "the last modified time of the input file (only for F/file kind tag)",
+					   isEpochAvaiable,
+					   FIELDTYPE_INTEGER,
+					   renderFieldEpoch, NULL, NULL),
 };
 
 
@@ -878,6 +885,18 @@ static const char *renderFieldEnd (const tagEntryInfo *const tag,
 		return NULL;
 }
 
+static const char *renderFieldEpoch (const tagEntryInfo *const tag,
+									  const char *value, vString* b)
+{
+#define buf_len 21
+	static char buf[buf_len];
+
+	if (snprintf (buf, buf_len, "%lld", (long long)tag->extensionFields.epoch) > 0)
+		return renderAsIs (b, buf);
+	else
+		return NULL;
+}
+
 static bool     isLanguageFieldAvailable (const tagEntryInfo *const tag)
 {
 	return (tag->langType == LANG_IGNORE)? false: true;
@@ -940,6 +959,13 @@ static bool     isXpathFieldAvailable      (const tagEntryInfo *const tag)
 static bool     isEndFieldAvailable       (const tagEntryInfo *const tag)
 {
 	return (tag->extensionFields.endLine != 0)? true: false;
+}
+
+static bool isEpochAvaiable (const tagEntryInfo *const tag)
+{
+	return (tag->kindIndex == KIND_FILE_INDEX)
+		? true
+		: false;
 }
 
 extern bool isFieldEnabled (fieldType type)

--- a/main/field.h
+++ b/main/field.h
@@ -57,7 +57,8 @@ typedef enum eFieldType { /* extension field content control */
 	FIELD_XPATH,
 	FIELD_SCOPE_KIND_LONG,
 	FIELD_END_LINE,
-	FIELD_BUILTIN_LAST = FIELD_END_LINE,
+	FIELD_EPOCH,
+	FIELD_BUILTIN_LAST = FIELD_EPOCH,
 } fieldType ;
 
 #define fieldDataTypeFalgs "sib" /* used in --list-fields */

--- a/main/read_p.h
+++ b/main/read_p.h
@@ -64,6 +64,8 @@ extern unsigned int getNestedInputBoundaryInfo (unsigned long lineNumber);
 extern const char *getSourceFileTagPath (void);
 extern langType getSourceLanguage (void);
 
+extern time_t getInputFileMtime (void);
+
 /* Bypass: reading from fp in inputFile WITHOUT updating fields in input fields */
 extern char *readLineFromBypass (vString *const vLine, MIOPos location, long *const pSeekValue);
 extern void   pushNarrowedInputStream (

--- a/main/routines.c
+++ b/main/routines.c
@@ -477,6 +477,7 @@ extern fileStatus *eStat (const char *const fileName)
 				file.isSetuid = (bool) ((status.st_mode & S_ISUID) != 0);
 				file.isSetgid = (bool) ((status.st_mode & S_ISGID) != 0);
 				file.size = status.st_size;
+				file.mtime = status.st_mtime;
 			}
 		}
 	}

--- a/main/routines_p.h
+++ b/main/routines_p.h
@@ -68,6 +68,9 @@ typedef struct {
 
 		/* Size of file (pointed to) */
 	unsigned long size;
+
+		/* The last modified time */
+	time_t mtime;
 } fileStatus;
 
 /*

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -313,6 +313,7 @@ static int addExtensionFields (tagWriter *writer, MIO *mio, const tagEntryInfo *
 	length += renderExtensionFieldMaybe (writer, FIELD_EXTRAS, tag, sep, mio);
 	length += renderExtensionFieldMaybe (writer, FIELD_XPATH, tag, sep, mio);
 	length += renderExtensionFieldMaybe (writer, FIELD_END_LINE, tag, sep, mio);
+	length += renderExtensionFieldMaybe (writer, FIELD_EPOCH, tag, sep, mio);
 
 	return length;
 }

--- a/misc/units.py
+++ b/misc/units.py
@@ -486,7 +486,7 @@ def run_tcase(finput, t, name, tclass, category, build_t, extra_inputs):
     #
     # Build cmdline
     #
-    cmdline = [CTAGS, '--verbose', '--options=NONE']
+    cmdline = [CTAGS, '--verbose', '--options=NONE', '--fields=-T']
     if PRETENSE_OPTS != '':
         cmdline += [PRETENSE_OPTS]
     cmdline += ['--optlib-dir=+' + t + '/optlib', '-o', '-']


### PR DESCRIPTION
*The field name is changed from "tstamp" to 'epoch".* 

main,units.py: introduce "epoch:" field for ~f~F/file kind
    
    For implementing the feature "updating the tags file" in the future,
    this change introduces "epoch:", a field which records the last
    modified time of the input file. This field is enabled by default.
    
    Example output:
    
        $ ./ctags --extras=f --kinds-C= -o - main/main.c
        main.c      main/main.c     1;"     F       language:C      epoch:1078071702
    
    The resolution of time is second in the current implementation.
    For Using higher resolution timestamp in the future, ".000000000" is suffixed.
    
    NOTES:
    
    The "fileScope" member of tagEntryInfo structure was not used anywhere in the
    ctags source tree. So this change renames it to "timestamp".
    
    timestamp fields in tags output makes many test cases in Units not work.
    So this change puts "--fileds=-{epoch}" to units.py for turning off
    the field when running "make units".
    
    Signed-off-by: Masatake YAMATO <yamato@redhat.com>
