### PR TITLE
SystemVerilog: fix processAssertion() not to use skipToSemiColon()

### DIFF
--- a/Units/parser-verilog.r/systemverilog-assertion.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-assertion.d/expected.tags
@@ -178,3 +178,7 @@ a1	input.sv	/^    a1: assert property (p1);$/;"	A	module:A
 a2	input.sv	/^    a2: assert property (cb_with_input.p1);$/;"	A	module:A
 a3	input.sv	/^    a3: assert property (p2);$/;"	A	module:A
 a4	input.sv	/^    a4: assert property (cb_without_input.p1);$/;"	A	module:A
+C	input.sv	/^class C;$/;"	C
+check_transfer_size	input.sv	/^  protected function void check_transfer_size();$/;"	f	class:C
+assert_transfer_size	input.sv	/^    assert_transfer_size : assert(trans_collected.size == 1) else begin$/;"	A	function:C.check_transfer_size
+check_transfer_data_size	input.sv	/^  protected function void check_transfer_data_size();$/;"	f	class:C

--- a/Units/parser-verilog.r/systemverilog-assertion.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-assertion.d/expected.tags
@@ -1,13 +1,13 @@
 deferred_immediate_assertions	input.sv	/^initial begin : deferred_immediate_assertions$/;"	b
-immediate_assertion	input.sv	/^    immediate_assertion : assert () task();$/;"	A	block:deferred_immediate_assertions
-immediate_cover	input.sv	/^    immediate_cover     : cover () task();$/;"	A	block:deferred_immediate_assertions
-immediate_assume	input.sv	/^    immediate_assume    : assume () task();$/;"	A	block:deferred_immediate_assertions
-deferred_assertion1	input.sv	/^    deferred_assertion1 : assert #0 () task();$/;"	A	block:deferred_immediate_assertions
-deferred_cover1	input.sv	/^    deferred_cover1     : cover #0 () task();$/;"	A	block:deferred_immediate_assertions
-deferred_assume1	input.sv	/^    deferred_assume1    : assume #0 () task();$/;"	A	block:deferred_immediate_assertions
-deferred_assertion2	input.sv	/^    deferred_assertion2 : assert final () task();$/;"	A	block:deferred_immediate_assertions
-deferred_cover2	input.sv	/^    deferred_cover2     : cover final () task();$/;"	A	block:deferred_immediate_assertions
-deferred_assume2	input.sv	/^    deferred_assume2    : assume final () task();$/;"	A	block:deferred_immediate_assertions
+immediate_assertion	input.sv	/^    immediate_assertion : assert () myTask();$/;"	A	block:deferred_immediate_assertions
+immediate_cover	input.sv	/^    immediate_cover     : cover () myTask();$/;"	A	block:deferred_immediate_assertions
+immediate_assume	input.sv	/^    immediate_assume    : assume () myTask();$/;"	A	block:deferred_immediate_assertions
+deferred_assertion1	input.sv	/^    deferred_assertion1 : assert #0 () myTask();$/;"	A	block:deferred_immediate_assertions
+deferred_cover1	input.sv	/^    deferred_cover1     : cover #0 () myTask();$/;"	A	block:deferred_immediate_assertions
+deferred_assume1	input.sv	/^    deferred_assume1    : assume #0 () myTask();$/;"	A	block:deferred_immediate_assertions
+deferred_assertion2	input.sv	/^    deferred_assertion2 : assert final () myTask();$/;"	A	block:deferred_immediate_assertions
+deferred_cover2	input.sv	/^    deferred_cover2     : cover final () myTask();$/;"	A	block:deferred_immediate_assertions
+deferred_assume2	input.sv	/^    deferred_assume2    : assume final () myTask();$/;"	A	block:deferred_immediate_assertions
 prop1	input.sv	/^property prop1 ($/;"	R
 m	input.sv	/^    local input int m,$/;"	p	property:prop1
 n	input.sv	/^    logic [1:0] n,$/;"	p	property:prop1

--- a/Units/parser-verilog.r/systemverilog-assertion.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-assertion.d/input.sv
@@ -398,3 +398,17 @@ module A;
     a3: assert property (p2);
     a4: assert property (cb_without_input.p1);
 endmodule
+
+// original test
+// excerpt from UVM 1.2:examples/integrated/ubus/sv/ubus_slave_monitor.sv
+class C;
+  protected function void check_transfer_size();
+    assert_transfer_size : assert(trans_collected.size == 1) else begin
+      `uvm_error(get_type_name(),
+        "Invalid transfer size!")
+    end
+  endfunction : check_transfer_size
+
+  // check_transfer_data_size
+  protected function void check_transfer_data_size();
+  endfunction : check_transfer_data_size

--- a/Units/parser-verilog.r/systemverilog-assertion.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-assertion.d/input.sv
@@ -1,13 +1,13 @@
 initial begin : deferred_immediate_assertions
-    immediate_assertion : assert () task();
-    immediate_cover     : cover () task();
-    immediate_assume    : assume () task();
-    deferred_assertion1 : assert #0 () task();
-    deferred_cover1     : cover #0 () task();
-    deferred_assume1    : assume #0 () task();
-    deferred_assertion2 : assert final () task();
-    deferred_cover2     : cover final () task();
-    deferred_assume2    : assume final () task();
+    immediate_assertion : assert () myTask();
+    immediate_cover     : cover () myTask();
+    immediate_assume    : assume () myTask();
+    deferred_assertion1 : assert #0 () myTask();
+    deferred_cover1     : cover #0 () myTask();
+    deferred_assume1    : assume #0 () myTask();
+    deferred_assertion2 : assert final () myTask();
+    deferred_cover2     : cover final () myTask();
+    deferred_assume2    : assume final () myTask();
 end
 
 property prop1 (

--- a/Units/parser-verilog.r/systemverilog-checker.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-checker.d/expected.tags
@@ -62,7 +62,6 @@ check_loop	input.sv	/^                c1 check_loop(posedge clk, in1, in_array[v
 counter_model	input.sv	/^checker counter_model(logic flag);$/;"	H
 flag	input.sv	/^checker counter_model(logic flag);$/;"	p	checker:counter_model
 counter	input.sv	/^    bit [2:0] counter = '0;$/;"	r	checker:counter_model
-counter	input.sv	/^    assert property (@$global_clock counter == 0 |-> flag); \/\/ FIXME$/;"	r	checker:counter_model
 observer_model	input.sv	/^checker observer_model(bit valid, reset);$/;"	H
 valid	input.sv	/^checker observer_model(bit valid, reset);$/;"	p	checker:observer_model
 reset	input.sv	/^checker observer_model(bit valid, reset);$/;"	p	checker:observer_model

--- a/Units/parser-verilog.r/systemverilog-checker.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-checker.d/expected.tags
@@ -8,7 +8,7 @@ c1	input.sv	/^    c1: cover property (!test_sig ##1 test_sig);$/;"	A	checker:my_
 my_check2	input.sv	/^checker my_check2 (logic a, b);$/;"	H
 a	input.sv	/^checker my_check2 (logic a, b);$/;"	p	checker:my_check2
 b	input.sv	/^checker my_check2 (logic a, b);$/;"	p	checker:my_check2
-a1	input.sv	/^    a1: assert #0 ($onehot0({a, b});$/;"	A	checker:my_check2
+a1	input.sv	/^    a1: assert #0 ($onehot0({a, b}));$/;"	A	checker:my_check2
 c1	input.sv	/^    c1: cover #0 (a == 0 && b == 0);$/;"	A	checker:my_check2
 c2	input.sv	/^    c2: cover #0 (a == 1);$/;"	A	checker:my_check2
 c3	input.sv	/^    c3: cover #0 (b == 1);$/;"	A	checker:my_check2
@@ -18,8 +18,8 @@ b	input.sv	/^checker my_check3 (logic a, b, event clock, output bit failure, und
 clock	input.sv	/^checker my_check3 (logic a, b, event clock, output bit failure, undef);$/;"	p	checker:my_check3
 failure	input.sv	/^checker my_check3 (logic a, b, event clock, output bit failure, undef);$/;"	p	checker:my_check3
 undef	input.sv	/^checker my_check3 (logic a, b, event clock, output bit failure, undef);$/;"	p	checker:my_check3
-a1	input.sv	/^    a1: assert property ($onehot0({a, b}) failure = 1'b0; else failure = 1'b1;$/;"	A	checker:my_check3
-a2	input.sv	/^    a2: assert property ($isunknown({a, b}) undef = 1'b0; else undef = 1'b1;$/;"	A	checker:my_check3
+a1	input.sv	/^    a1: assert property ($onehot0({a, b})) failure = 1'b0; else failure = 1'b1;$/;"	A	checker:my_check3
+a2	input.sv	/^    a2: assert property ($isunknown({a, b})) undef = 1'b0; else undef = 1'b1;$/;"	A	checker:my_check3
 my_check4	input.sv	/^checker my_check4 (input logic in,$/;"	H
 in	input.sv	/^checker my_check4 (input logic in,$/;"	p	checker:my_check4
 en	input.sv	/^                   en = 1'b1, \/\/ default value$/;"	p	checker:my_check4

--- a/Units/parser-verilog.r/systemverilog-checker.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-checker.d/input.sv
@@ -16,7 +16,7 @@ endchecker : my_check1
 
 // Simple checker containing deferred assertions
 checker my_check2 (logic a, b);
-    a1: assert #0 ($onehot0({a, b});
+    a1: assert #0 ($onehot0({a, b}));
     c1: cover #0 (a == 0 && b == 0);
     c2: cover #0 (a == 1);
     c3: cover #0 (b == 1);
@@ -25,8 +25,8 @@ endchecker : my_check2
 // Simple checker with output arguments
 checker my_check3 (logic a, b, event clock, output bit failure, undef);
     default clocking @clock; endclocking
-    a1: assert property ($onehot0({a, b}) failure = 1'b0; else failure = 1'b1;
-    a2: assert property ($isunknown({a, b}) undef = 1'b0; else undef = 1'b1;
+    a1: assert property ($onehot0({a, b})) failure = 1'b0; else failure = 1'b1;
+    a2: assert property ($isunknown({a, b})) undef = 1'b0; else undef = 1'b1;
 endchecker : my_check3
 
 // Checker with default input and initialized output arguments

--- a/Units/parser-verilog.r/systemverilog-checker.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-checker.d/input.sv
@@ -105,7 +105,7 @@ checker counter_model(logic flag);
     bit [2:0] counter = '0;
     always_ff @$global_clock
         counter <= counter + 1'b1;
-    assert property (@$global_clock counter == 0 |-> flag); // FIXME
+    assert property (@$global_clock counter == 0 |-> flag);
 endchecker : counter_model
 
 checker observer_model(bit valid, reset);

--- a/Units/parser-verilog.r/systemverilog-covergroup.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-covergroup.d/expected.tags
@@ -1,21 +1,21 @@
 test	input.sv	/^covergroup test;$/;"	V
-immediate_assertion	input.sv	/^    immediate_assertion : assert () task();$/;"	A	covergroup:test
-test.immediate_assertion	input.sv	/^    immediate_assertion : assert () task();$/;"	A	covergroup:test
-immediate_cover	input.sv	/^    immediate_cover     : cover () task();$/;"	A	covergroup:test
-test.immediate_cover	input.sv	/^    immediate_cover     : cover () task();$/;"	A	covergroup:test
-immediate_assume	input.sv	/^    immediate_assume    : assume () task();$/;"	A	covergroup:test
-test.immediate_assume	input.sv	/^    immediate_assume    : assume () task();$/;"	A	covergroup:test
-deferred_assertion1	input.sv	/^    deferred_assertion1 : assert #0 () task();$/;"	A	covergroup:test
-test.deferred_assertion1	input.sv	/^    deferred_assertion1 : assert #0 () task();$/;"	A	covergroup:test
-deferred_cover1	input.sv	/^    deferred_cover1     : cover #0 () task();$/;"	A	covergroup:test
-test.deferred_cover1	input.sv	/^    deferred_cover1     : cover #0 () task();$/;"	A	covergroup:test
-deferred_assume1	input.sv	/^    deferred_assume1    : assume #0 () task();$/;"	A	covergroup:test
-test.deferred_assume1	input.sv	/^    deferred_assume1    : assume #0 () task();$/;"	A	covergroup:test
-deferred_assertion2	input.sv	/^    deferred_assertion2 : assert final () task();$/;"	A	covergroup:test
-test.deferred_assertion2	input.sv	/^    deferred_assertion2 : assert final () task();$/;"	A	covergroup:test
-deferred_cover2	input.sv	/^    deferred_cover2     : cover final () task();$/;"	A	covergroup:test
-test.deferred_cover2	input.sv	/^    deferred_cover2     : cover final () task();$/;"	A	covergroup:test
-deferred_assume2	input.sv	/^    deferred_assume2    : assume final () task();$/;"	A	covergroup:test
-test.deferred_assume2	input.sv	/^    deferred_assume2    : assume final () task();$/;"	A	covergroup:test
+immediate_assertion	input.sv	/^    immediate_assertion : assert () myTask();$/;"	A	covergroup:test
+test.immediate_assertion	input.sv	/^    immediate_assertion : assert () myTask();$/;"	A	covergroup:test
+immediate_cover	input.sv	/^    immediate_cover     : cover () myTask();$/;"	A	covergroup:test
+test.immediate_cover	input.sv	/^    immediate_cover     : cover () myTask();$/;"	A	covergroup:test
+immediate_assume	input.sv	/^    immediate_assume    : assume () myTask();$/;"	A	covergroup:test
+test.immediate_assume	input.sv	/^    immediate_assume    : assume () myTask();$/;"	A	covergroup:test
+deferred_assertion1	input.sv	/^    deferred_assertion1 : assert #0 () myTask();$/;"	A	covergroup:test
+test.deferred_assertion1	input.sv	/^    deferred_assertion1 : assert #0 () myTask();$/;"	A	covergroup:test
+deferred_cover1	input.sv	/^    deferred_cover1     : cover #0 () myTask();$/;"	A	covergroup:test
+test.deferred_cover1	input.sv	/^    deferred_cover1     : cover #0 () myTask();$/;"	A	covergroup:test
+deferred_assume1	input.sv	/^    deferred_assume1    : assume #0 () myTask();$/;"	A	covergroup:test
+test.deferred_assume1	input.sv	/^    deferred_assume1    : assume #0 () myTask();$/;"	A	covergroup:test
+deferred_assertion2	input.sv	/^    deferred_assertion2 : assert final () myTask();$/;"	A	covergroup:test
+test.deferred_assertion2	input.sv	/^    deferred_assertion2 : assert final () myTask();$/;"	A	covergroup:test
+deferred_cover2	input.sv	/^    deferred_cover2     : cover final () myTask();$/;"	A	covergroup:test
+test.deferred_cover2	input.sv	/^    deferred_cover2     : cover final () myTask();$/;"	A	covergroup:test
+deferred_assume2	input.sv	/^    deferred_assume2    : assume final () myTask();$/;"	A	covergroup:test
+test.deferred_assume2	input.sv	/^    deferred_assume2    : assume final () myTask();$/;"	A	covergroup:test
 cg	input.sv	/^covergroup cg @@ ( begin task_end );$/;"	V
 var_to_check_context	input.sv	/^reg var_to_check_context;$/;"	r

--- a/Units/parser-verilog.r/systemverilog-covergroup.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-covergroup.d/input.sv
@@ -1,13 +1,13 @@
 covergroup test;
-    immediate_assertion : assert () task();
-    immediate_cover     : cover () task();
-    immediate_assume    : assume () task();
-    deferred_assertion1 : assert #0 () task();
-    deferred_cover1     : cover #0 () task();
-    deferred_assume1    : assume #0 () task();
-    deferred_assertion2 : assert final () task();
-    deferred_cover2     : cover final () task();
-    deferred_assume2    : assume final () task();
+    immediate_assertion : assert () myTask();
+    immediate_cover     : cover () myTask();
+    immediate_assume    : assume () myTask();
+    deferred_assertion1 : assert #0 () myTask();
+    deferred_cover1     : cover #0 () myTask();
+    deferred_assume1    : assume #0 () myTask();
+    deferred_assertion2 : assert final () myTask();
+    deferred_cover2     : cover final () myTask();
+    deferred_assume2    : assume final () myTask();
 endgroup
 
 covergroup cg @@ ( begin task_end );

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -704,13 +704,10 @@ static int skipDimension (int c)
 	return c;
 }
 
-static int skipToSemiColon (void)
+static int skipToSemiColon (int c)
 {
-	int c;
-	do
-	{
+	while (c != EOF && c != ';')
 		c = vGetc ();
-	} while (c != ';' && c != EOF);
 	return c;	// ';' or EOF
 }
 
@@ -1349,7 +1346,7 @@ static int processAssertion (tokenInfo *const token, int c)
 		vStringCopy (token->name, currentContext->blockName);
 		vStringClear (currentContext->blockName);	// clear block name not to be reused
 		createTag (token, K_ASSERTION);
-		c = skipToSemiColon ();	// FIXME
+		c = skipToSemiColon (c);	// FIXME
 	}
 	return c;
 }
@@ -1427,8 +1424,8 @@ static int skipDelay(tokenInfo* token, int c)
 		c = skipWhite (vGetc ());
 		if (c == '(')
 			c = skipPastMatch ("()");
-		else if (c == ('#')) {
-			c = skipToSemiColon ();	// a dirty hack for "x ##delay1 y[*min:max];"
+		else if (c == '#') {
+			c = skipToSemiColon (vGetc ());	// a dirty hack for "x ##delay1 y[*min:max];"
 		}
 		else	// time literals
 		{
@@ -1670,7 +1667,7 @@ static int findTag (tokenInfo *const token, int c)
 		case K_PORT:
 		case K_REGISTER:
 			if (token->kind == K_PORT && currentContext->kind == K_CLOCKING)
-				c = skipToSemiColon (); // clocking items are not port definitions
+				c = skipToSemiColon (c); // clocking items are not port definitions
 			else
 				c = tagNameList (token, c);
 			break;


### PR DESCRIPTION
A bug in `systemverilog-checker.d/input.sv` which has been marked as FIXME was fixed.