### PR TITLE
SystemVerilog: implement unsupported features in processDesignElement()

### DIFF
--- a/Units/parser-verilog.r/systemverilog-covergroup.d/args.ctags
+++ b/Units/parser-verilog.r/systemverilog-covergroup.d/args.ctags
@@ -1,2 +1,2 @@
---extras=+q
 --sort=no
+--kinds-systemverilog=+Q

--- a/Units/parser-verilog.r/systemverilog-covergroup.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-covergroup.d/expected.tags
@@ -1,21 +1,36 @@
-test	input.sv	/^covergroup test;$/;"	V
-immediate_assertion	input.sv	/^    immediate_assertion : assert () myTask();$/;"	A	covergroup:test
-test.immediate_assertion	input.sv	/^    immediate_assertion : assert () myTask();$/;"	A	covergroup:test
-immediate_cover	input.sv	/^    immediate_cover     : cover () myTask();$/;"	A	covergroup:test
-test.immediate_cover	input.sv	/^    immediate_cover     : cover () myTask();$/;"	A	covergroup:test
-immediate_assume	input.sv	/^    immediate_assume    : assume () myTask();$/;"	A	covergroup:test
-test.immediate_assume	input.sv	/^    immediate_assume    : assume () myTask();$/;"	A	covergroup:test
-deferred_assertion1	input.sv	/^    deferred_assertion1 : assert #0 () myTask();$/;"	A	covergroup:test
-test.deferred_assertion1	input.sv	/^    deferred_assertion1 : assert #0 () myTask();$/;"	A	covergroup:test
-deferred_cover1	input.sv	/^    deferred_cover1     : cover #0 () myTask();$/;"	A	covergroup:test
-test.deferred_cover1	input.sv	/^    deferred_cover1     : cover #0 () myTask();$/;"	A	covergroup:test
-deferred_assume1	input.sv	/^    deferred_assume1    : assume #0 () myTask();$/;"	A	covergroup:test
-test.deferred_assume1	input.sv	/^    deferred_assume1    : assume #0 () myTask();$/;"	A	covergroup:test
-deferred_assertion2	input.sv	/^    deferred_assertion2 : assert final () myTask();$/;"	A	covergroup:test
-test.deferred_assertion2	input.sv	/^    deferred_assertion2 : assert final () myTask();$/;"	A	covergroup:test
-deferred_cover2	input.sv	/^    deferred_cover2     : cover final () myTask();$/;"	A	covergroup:test
-test.deferred_cover2	input.sv	/^    deferred_cover2     : cover final () myTask();$/;"	A	covergroup:test
-deferred_assume2	input.sv	/^    deferred_assume2    : assume final () myTask();$/;"	A	covergroup:test
-test.deferred_assume2	input.sv	/^    deferred_assume2    : assume final () myTask();$/;"	A	covergroup:test
-cg	input.sv	/^covergroup cg @@ ( begin task_end );$/;"	V
-var_to_check_context	input.sv	/^reg var_to_check_context;$/;"	r
+C0	input.sv	/^checker C0 (logic clk);$/;"	H
+clk	input.sv	/^checker C0 (logic clk);$/;"	p	checker:C0
+color	input.sv	/^    enum { red, green, blue } color;$/;"	E	checker:C0
+red	input.sv	/^    enum { red, green, blue } color;$/;"	c	enum:C0.color
+green	input.sv	/^    enum { red, green, blue } color;$/;"	c	enum:C0.color
+blue	input.sv	/^    enum { red, green, blue } color;$/;"	c	enum:C0.color
+pixel_adr	input.sv	/^    bit [3:0] pixel_adr, pixel_offset, pixel_hue;$/;"	r	checker:C0
+pixel_offset	input.sv	/^    bit [3:0] pixel_adr, pixel_offset, pixel_hue;$/;"	r	checker:C0
+pixel_hue	input.sv	/^    bit [3:0] pixel_adr, pixel_offset, pixel_hue;$/;"	r	checker:C0
+g2	input.sv	/^    covergroup g2 @(posedge clk);$/;"	V	checker:C0
+xyz	input.sv	/^class xyz;$/;"	C
+m_x	input.sv	/^    bit [3:0] m_x;$/;"	r	class:xyz
+m_y	input.sv	/^    int m_y;$/;"	r	class:xyz
+m_z	input.sv	/^    bit m_z;$/;"	r	class:xyz
+cov1	input.sv	/^    covergroup cov1 @m_z;   \/\/ embedded covergroup$/;"	V	class:xyz
+new	input.sv	/^    function new(); cov1 = new; endfunction$/;"	f	class:xyz
+C1	input.sv	/^checker C1 (logic clk);$/;"	H
+clk	input.sv	/^checker C1 (logic clk);$/;"	p	checker:C1
+v_a	input.sv	/^    bit [9:0] v_a;$/;"	r	checker:C1
+cg	input.sv	/^    covergroup cg @(posedge clk);$/;"	V	checker:C1
+C2	input.sv	/^checker C2 (logic clk);$/;"	H
+clk	input.sv	/^checker C2 (logic clk);$/;"	p	checker:C2
+a	input.sv	/^    bit [3:0] a, b, c;$/;"	r	checker:C2
+b	input.sv	/^    bit [3:0] a, b, c;$/;"	r	checker:C2
+c	input.sv	/^    bit [3:0] a, b, c;$/;"	r	checker:C2
+cov2	input.sv	/^    covergroup cov2 @(posedge clk);$/;"	V	checker:C2
+C3	input.sv	/^checker C3 (logic clk);$/;"	H
+clk	input.sv	/^checker C3 (logic clk);$/;"	p	checker:C3
+p_cg	input.sv	/^    covergroup p_cg with function sample(bit a, int x);$/;"	V	checker:C3
+sample	input.sv	/^    covergroup p_cg with function sample(bit a, int x);$/;"	Q	covergroup:C3.p_cg
+a	input.sv	/^    covergroup p_cg with function sample(bit a, int x);$/;"	p	prototype:C3.p_cg.sample
+x	input.sv	/^    covergroup p_cg with function sample(bit a, int x);$/;"	p	prototype:C3.p_cg.sample
+C4	input.sv	/^checker C4 (logic clk);$/;"	H
+clk	input.sv	/^checker C4 (logic clk);$/;"	p	checker:C4
+cg	input.sv	/^    covergroup cg @@ ( begin task_end );$/;"	V	checker:C4
+var_to_check_context	input.sv	/^    reg var_to_check_context;$/;"	r	checker:C4

--- a/Units/parser-verilog.r/systemverilog-covergroup.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-covergroup.d/input.sv
@@ -1,16 +1,75 @@
-covergroup test;
-    immediate_assertion : assert () myTask();
-    immediate_cover     : cover () myTask();
-    immediate_assume    : assume () myTask();
-    deferred_assertion1 : assert #0 () myTask();
-    deferred_cover1     : cover #0 () myTask();
-    deferred_assume1    : assume #0 () myTask();
-    deferred_assertion2 : assert final () myTask();
-    deferred_cover2     : cover final () myTask();
-    deferred_assume2    : assume final () myTask();
-endgroup
+//
+//  LRM: 19. Functional coverage
+//
+// covergroup is decleared in class, package, or checker
 
-covergroup cg @@ ( begin task_end );
-endgroup
+// 19.3 Defining the coverage model: covergroup
+checker C0 (logic clk);
+    enum { red, green, blue } color;
+    bit [3:0] pixel_adr, pixel_offset, pixel_hue;
 
-reg var_to_check_context;
+    covergroup g2 @(posedge clk);
+        Hue: coverpoint pixel_hue;
+        Offset: coverpoint pixel_offset;
+
+        AxC: cross color, pixel_adr;    // cross 2 variables (implicitly declared
+                                        // coverpoints)
+
+        all: cross color, Hue, Offset;  // cross 1 variable and 2 coverpoints
+    endgroup
+endchecker
+
+// 19.4 Using covergroup in classes
+class xyz;
+    bit [3:0] m_x;
+    int m_y;
+    bit m_z;
+
+    covergroup cov1 @m_z;   // embedded covergroup
+        coverpoint m_x;
+        coverpoint m_y;
+    endgroup
+
+    function new(); cov1 = new; endfunction
+endclass
+
+// 19.5.1 Specifying bins for values
+checker C1 (logic clk);
+    bit [9:0] v_a;
+
+    covergroup cg @(posedge clk);
+        coverpoint v_a
+        {
+            bins a = { [0:63],65 };
+            bins b[] = { [127:150],[148:191] }; // note overlapping values
+            bins c[] = { 200,201,202 };
+            bins d = { [1000:$] };
+            bins others[] = default;
+        }
+    endgroup
+endchecker
+
+// 19.6 Defining cross coverage
+checker C2 (logic clk);
+    bit [3:0] a, b, c;
+    covergroup cov2 @(posedge clk);
+        BC: coverpoint b+c;
+        aXb : cross a, BC;
+    endgroup
+endchecker
+
+// 19.8.1 Overriding the built-in sample method
+checker C3 (logic clk);
+    covergroup p_cg with function sample(bit a, int x);
+        coverpoint x;
+        cross x, a;
+    endgroup : p_cg
+endchecker
+
+// original
+checker C4 (logic clk);
+    covergroup cg @@ ( begin task_end );
+    endgroup
+
+    reg var_to_check_context;
+endchecker

--- a/Units/parser-verilog.r/systemverilog-package.d/args.ctags
+++ b/Units/parser-verilog.r/systemverilog-package.d/args.ctags
@@ -1,3 +1,2 @@
---extras=+q
 --kinds-systemverilog=+Q
 --sort=no

--- a/Units/parser-verilog.r/systemverilog-package.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-package.d/expected.tags
@@ -1,20 +1,47 @@
+ComplexPkg	input.sv	/^package ComplexPkg;$/;"	K
+Complex	input.sv	/^    } Complex;$/;"	T	package:ComplexPkg
+i	input.sv	/^        shortreal i, r;$/;"	w	typedef:ComplexPkg.Complex
+r	input.sv	/^        shortreal i, r;$/;"	w	typedef:ComplexPkg.Complex
+add	input.sv	/^    function Complex add(Complex a, b);$/;"	f	package:ComplexPkg
+a	input.sv	/^    function Complex add(Complex a, b);$/;"	p	function:ComplexPkg.add
+b	input.sv	/^    function Complex add(Complex a, b);$/;"	p	function:ComplexPkg.add
+mul	input.sv	/^    function Complex mul(Complex a, b);$/;"	f	package:ComplexPkg
+a	input.sv	/^    function Complex mul(Complex a, b);$/;"	p	function:ComplexPkg.mul
+b	input.sv	/^    function Complex mul(Complex a, b);$/;"	p	function:ComplexPkg.mul
+p	input.sv	/^package p;$/;"	K
+bool_t	input.sv	/^    typedef enum { FALSE, TRUE } bool_t;$/;"	T	package:p
+FALSE	input.sv	/^    typedef enum { FALSE, TRUE } bool_t;$/;"	c	typedef:p.bool_t
+TRUE	input.sv	/^    typedef enum { FALSE, TRUE } bool_t;$/;"	c	typedef:p.bool_t
+q	input.sv	/^package q;$/;"	K
+teeth_t	input.sv	/^    typedef enum { ORIGINAL, FALSE } teeth_t;$/;"	T	package:q
+ORIGINAL	input.sv	/^    typedef enum { ORIGINAL, FALSE } teeth_t;$/;"	c	typedef:q.teeth_t
+FALSE	input.sv	/^    typedef enum { ORIGINAL, FALSE } teeth_t;$/;"	c	typedef:q.teeth_t
+top1	input.sv	/^module top1 ;$/;"	m
+myteeth	input.sv	/^    teeth_t myteeth;$/;"	r	module:top1
+top2	input.sv	/^module top2 ;$/;"	m
+myteeth	input.sv	/^    teeth_t myteeth;$/;"	r	module:top2
+A	input.sv	/^package A;$/;"	K
+instruction_t	input.sv	/^    } instruction_t;$/;"	T	package:A
+opcode	input.sv	/^        bit [ 7:0] opcode;$/;"	w	typedef:A.instruction_t
+addr	input.sv	/^        bit [23:0] addr;$/;"	w	typedef:A.instruction_t
+B	input.sv	/^package B;$/;"	K
+boolean_t	input.sv	/^    typedef enum bit {FALSE, TRUE} boolean_t;$/;"	T	package:B
+FALSE	input.sv	/^    typedef enum bit {FALSE, TRUE} boolean_t;$/;"	c	typedef:B.boolean_t
+TRUE	input.sv	/^    typedef enum bit {FALSE, TRUE} boolean_t;$/;"	c	typedef:B.boolean_t
+M	input.sv	/^module M import A::instruction_t, B::*;$/;"	m
+WIDTH	input.sv	/^    #(WIDTH = 32)$/;"	c	module:M
+data	input.sv	/^     (input [WIDTH-1:0] data,$/;"	p	module:M
+a	input.sv	/^      input instruction_t a,$/;"	p	module:M
+result	input.sv	/^      output [WIDTH-1:0] result,$/;"	p	module:M
+OK	input.sv	/^      output boolean_t OK$/;"	p	module:M
 MyPackage	input.sv	/^package MyPackage;$/;"	K
 MyData	input.sv	/^    } MyData;$/;"	T	package:MyPackage
-MyPackage.MyData	input.sv	/^    } MyData;$/;"	T	package:MyPackage
 a	input.sv	/^        shortreal a;$/;"	w	typedef:MyPackage.MyData
-MyPackage.MyData.a	input.sv	/^        shortreal a;$/;"	w	typedef:MyPackage.MyData
 b	input.sv	/^        real b;$/;"	w	typedef:MyPackage.MyData
-MyPackage.MyData.b	input.sv	/^        real b;$/;"	w	typedef:MyPackage.MyData
 add	input.sv	/^    function MyData add(MyData x, y);$/;"	f	package:MyPackage
-MyPackage.add	input.sv	/^    function MyData add(MyData x, y);$/;"	f	package:MyPackage
 x	input.sv	/^    function MyData add(MyData x, y);$/;"	p	function:MyPackage.add
-MyPackage.add.x	input.sv	/^    function MyData add(MyData x, y);$/;"	p	function:MyPackage.add
 y	input.sv	/^    function MyData add(MyData x, y);$/;"	p	function:MyPackage.add
-MyPackage.add.y	input.sv	/^    function MyData add(MyData x, y);$/;"	p	function:MyPackage.add
 mul	input.sv	/^    function MyData mul(MyData x, y);$/;"	f	package:MyPackage
-MyPackage.mul	input.sv	/^    function MyData mul(MyData x, y);$/;"	f	package:MyPackage
 x	input.sv	/^    function MyData mul(MyData x, y);$/;"	p	function:MyPackage.mul
-MyPackage.mul.x	input.sv	/^    function MyData mul(MyData x, y);$/;"	p	function:MyPackage.mul
 y	input.sv	/^    function MyData mul(MyData x, y);$/;"	p	function:MyPackage.mul
-MyPackage.mul.y	input.sv	/^    function MyData mul(MyData x, y);$/;"	p	function:MyPackage.mul
 var_to_check_context	input.sv	/^reg var_to_check_context;$/;"	r

--- a/Units/parser-verilog.r/systemverilog-package.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-package.d/input.sv
@@ -1,3 +1,78 @@
+//
+// LRM: 26. Packages
+//
+// 26.2 Package declarations
+package ComplexPkg;
+    typedef struct {
+        shortreal i, r;
+    } Complex;
+
+    function Complex add(Complex a, b);
+        add.r = a.r + b.r;
+        add.i = a.i + b.i;
+    endfunction
+
+    function Complex mul(Complex a, b);
+        mul.r = (a.r * b.r) - (a.i * b.i);
+        mul.i = (a.r * b.i) + (a.i * b.r);
+    endfunction
+endpackage : ComplexPkg
+
+// 26.3 Referencing data in packages
+package p;
+    typedef enum { FALSE, TRUE } bool_t;
+endpackage
+
+package q;
+    typedef enum { ORIGINAL, FALSE } teeth_t;
+endpackage
+
+module top1 ;
+    import p::*;
+    import q::teeth_t;
+
+    teeth_t myteeth;
+
+    initial begin
+        myteeth = q:: FALSE;    // OK:
+        //myteeth = FALSE;        // ERROR: Direct reference to FALSE refers to the
+    end // FALSE enumeration literal imported from p
+endmodule
+
+module top2 ;
+    import p::*;
+    import q::teeth_t, q::ORIGINAL, q::FALSE;
+
+    teeth_t myteeth;
+
+    initial begin
+        myteeth = FALSE; // OK: Direct reference to FALSE refers to the
+    end // FALSE enumeration literal imported from q
+endmodule
+
+// 26.4 Using packages in module headers
+package A;
+    typedef struct {
+        bit [ 7:0] opcode;
+        bit [23:0] addr;
+    } instruction_t;
+endpackage: A
+
+package B;
+    typedef enum bit {FALSE, TRUE} boolean_t;
+endpackage: B
+
+module M import A::instruction_t, B::*;
+    #(WIDTH = 32)
+     (input [WIDTH-1:0] data,
+      input instruction_t a,
+      output [WIDTH-1:0] result,
+      output boolean_t OK
+      );
+    // ...
+endmodule: M
+
+// original
 package MyPackage;
     typedef struct {
         shortreal a;

--- a/Units/parser-verilog.r/systemverilog-parameter.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-parameter.d/expected.tags
@@ -15,109 +15,116 @@ ENCODER_f	input.sv	/^  static function logic [ENCODE_W-1:0] ENCODER_f$/;"	f	clas
 DecodeIn	input.sv	/^      (input logic [DECODE_W-1:0] DecodeIn);$/;"	p	function:C.C.ENCODER_f
 DECODER_f	input.sv	/^  static function logic [DECODE_W-1:0] DECODER_f$/;"	f	class:C.C
 EncodeIn	input.sv	/^      (input logic [ENCODE_W-1:0] EncodeIn);$/;"	p	function:C.C.DECODER_f
-class	input.sv	/^interface class PutImp #(type PUT_T = logic); \/\/ FIXME$/;"	I
-class	input.sv	/^interface class GetImp #(type GET_T = logic); \/\/ FIXME$/;"	I	interface:class
-Fifo	input.sv	/^class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	C	interface:class.class
-T	input.sv	/^class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Fifo	parameter:
-DEPTH	input.sv	/^class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Fifo	parameter:
-myFifo	input.sv	/^  T myFifo[$:DEPTH-1];$/;"	r	class:class.class.Fifo
-put	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored?$/;"	f	class:class.class.Fifo
-a	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored?$/;"	p	function:class.class.Fifo.put
-get	input.sv	/^  virtual function T get(); \/\/ FIXME : to be ignored?$/;"	f	class:class.class.Fifo
-Stack	input.sv	/^class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	C	interface:class.class
-T	input.sv	/^class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Stack	parameter:
-DEPTH	input.sv	/^class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:class.class.Stack	parameter:
-myFifo	input.sv	/^  T myFifo[$:DEPTH-1];$/;"	r	class:class.class.Stack
-put	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored$/;"	f	class:class.class.Stack
-a	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored$/;"	p	function:class.class.Stack.put
-get	input.sv	/^  virtual function T get(); \/\/ FIXME : to be ignored$/;"	f	class:class.class.Stack
-generic_fifo	input.sv	/^module generic_fifo$/;"	m	interface:class.class
-MSB	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:class.class.generic_fifo	parameter:
-LSB	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:class.class.generic_fifo	parameter:
-DEPTH	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:class.class.generic_fifo	parameter:
-in	input.sv	/^   (input  wire [MSB:LSB] in,$/;"	p	module:class.class.generic_fifo
-clk	input.sv	/^    input  wire clk, read, write, reset,$/;"	p	module:class.class.generic_fifo
-read	input.sv	/^    input  wire clk, read, write, reset,$/;"	p	module:class.class.generic_fifo
-write	input.sv	/^    input  wire clk, read, write, reset,$/;"	p	module:class.class.generic_fifo
-reset	input.sv	/^    input  wire clk, read, write, reset,$/;"	p	module:class.class.generic_fifo
-out	input.sv	/^    output logic [MSB:LSB] out,$/;"	p	module:class.class.generic_fifo
-full	input.sv	/^    output logic full, empty );$/;"	p	module:class.class.generic_fifo
-empty	input.sv	/^    output logic full, empty );$/;"	p	module:class.class.generic_fifo
-generic_decoder	input.sv	/^module generic_decoder$/;"	m	interface:class.class
-num_code_bits	input.sv	/^  #(num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.generic_decoder	parameter:
-num_out_bits	input.sv	/^  #(num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.generic_decoder
-A	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:class.class.generic_decoder
-Y	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:class.class.generic_decoder
-int_t	input.sv	/^typedef int int_t;$/;"	T	interface:class.class
-user_defined_type_param	input.sv	/^module user_defined_type_param$/;"	m	interface:class.class
-num_code_bits	input.sv	/^  #(int_t num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.user_defined_type_param	parameter:
-num_out_bits	input.sv	/^  #(int_t num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:class.class.user_defined_type_param
-A	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:class.class.user_defined_type_param
-Y	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:class.class.user_defined_type_param
-L1	input.sv	/^parameter L1 = 0;  \/\/  synonym for the localparam$/;"	c	interface:class.class	parameter:
-module_with_parameter_port_list	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	m	interface:class.class
-P1	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list	parameter:
-P2	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list	parameter:
-L2	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list
-L3	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list
-P3	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list	parameter:
-P4	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:class.class.module_with_parameter_port_list	parameter:
-L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	module:class.class.module_with_parameter_port_list
-L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	module:class.class.module_with_parameter_port_list
-module_with_empty_parameter_port_list	input.sv	/^module module_with_empty_parameter_port_list #()$/;"	m	interface:class.class
-L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	module:class.class.module_with_empty_parameter_port_list
-L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	module:class.class.module_with_empty_parameter_port_list
-module_no_parameter_port_list	input.sv	/^module module_no_parameter_port_list$/;"	m	interface:class.class
-P5	input.sv	/^  parameter  P5 = "parameter";$/;"	c	module:class.class.module_no_parameter_port_list	parameter:
-L8	input.sv	/^  localparam L8 = "local parameter";$/;"	c	module:class.class.module_no_parameter_port_list
-class_with_parameter_port_list	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	C	interface:class.class
-P1	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list	parameter:
-P2	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list	parameter:
-L2	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list
-L3	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list
-P3	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list	parameter:
-P4	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class.class.class_with_parameter_port_list	parameter:
-L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	class:class.class.class_with_parameter_port_list
-L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	class:class.class.class_with_parameter_port_list
-class_with_empty_parameter_port_list	input.sv	/^class class_with_empty_parameter_port_list #();$/;"	C	interface:class.class
-L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	class:class.class.class_with_empty_parameter_port_list
-L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	class:class.class.class_with_empty_parameter_port_list
-class_no_parameter_port_list	input.sv	/^class class_no_parameter_port_list;$/;"	C	interface:class.class
-L8	input.sv	/^  parameter  L8 = "local parameter";  \/\/ synonym for the localparam (class only)$/;"	c	class:class.class.class_no_parameter_port_list
-L9	input.sv	/^  localparam L9 = "local parameter";$/;"	c	class:class.class.class_no_parameter_port_list
-program_with_parameter_port_list	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	P	interface:class.class
-P1	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list	parameter:
-P2	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list	parameter:
-L2	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list
-L3	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list
-P3	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list	parameter:
-P4	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:class.class.program_with_parameter_port_list	parameter:
-L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	program:class.class.program_with_parameter_port_list
-L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	program:class.class.program_with_parameter_port_list
-program_with_empty_parameter_port_list	input.sv	/^program program_with_empty_parameter_port_list #()$/;"	P	interface:class.class
-L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	program:class.class.program_with_empty_parameter_port_list
-L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	program:class.class.program_with_empty_parameter_port_list
-program_no_parameter_port_list	input.sv	/^program program_no_parameter_port_list$/;"	P	interface:class.class
-P5	input.sv	/^  parameter  P5 = "parameter";$/;"	c	program:class.class.program_no_parameter_port_list	parameter:
-L8	input.sv	/^  localparam L8 = "local parameter";$/;"	c	program:class.class.program_no_parameter_port_list
-interface_with_parameter_port_list	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	I	interface:class.class
-P1	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list	parameter:
-P2	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list	parameter:
-L2	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list
-L3	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list
-P3	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list	parameter:
-P4	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:class.class.interface_with_parameter_port_list	parameter:
-L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	interface:class.class.interface_with_parameter_port_list
-L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	interface:class.class.interface_with_parameter_port_list
-interface_with_empty_parameter_port_list	input.sv	/^interface interface_with_empty_parameter_port_list #()$/;"	I	interface:class.class
-L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	interface:class.class.interface_with_empty_parameter_port_list
-L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	interface:class.class.interface_with_empty_parameter_port_list
-interface_no_parameter_port_list	input.sv	/^interface interface_no_parameter_port_list$/;"	I	interface:class.class
-P5	input.sv	/^  parameter  P5 = "parameter";$/;"	c	interface:class.class.interface_no_parameter_port_list	parameter:
-L8	input.sv	/^  localparam L8 = "local parameter";$/;"	c	interface:class.class.interface_no_parameter_port_list
-package_has_no_parameter_port_list	input.sv	/^package package_has_no_parameter_port_list;$/;"	K	interface:class.class
-L1	input.sv	/^  parameter  L1 = "local parameter";$/;"	c	package:class.class.package_has_no_parameter_port_list
-L2	input.sv	/^  localparam L2 = "local parameter";$/;"	c	package:class.class.package_has_no_parameter_port_list
-generate_constructs	input.sv	/^module generate_constructs;$/;"	m	interface:class.class
-L1	input.sv	/^    parameter  L1 = "local parameter";  \/\/ FIXME$/;"	c	module:class.class.generate_constructs	parameter:
-L2	input.sv	/^    localparam L2 = "local parameter";$/;"	c	module:class.class.generate_constructs
+PutImp	input.sv	/^interface class PutImp #(type PUT_T = logic);$/;"	l
+PUT_T	input.sv	/^interface class PutImp #(type PUT_T = logic);$/;"	c	ifclass:PutImp	parameter:
+GetImp	input.sv	/^interface class GetImp #(type GET_T = logic);$/;"	l
+GET_T	input.sv	/^interface class GetImp #(type GET_T = logic);$/;"	c	ifclass:GetImp	parameter:
+Fifo	input.sv	/^class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	C
+T	input.sv	/^class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:Fifo	parameter:
+DEPTH	input.sv	/^class Fifo #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:Fifo	parameter:
+myFifo	input.sv	/^  T myFifo[$:DEPTH-1];$/;"	r	class:Fifo
+put	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored?$/;"	f	class:Fifo
+a	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored?$/;"	p	function:Fifo.put
+get	input.sv	/^  virtual function T get(); \/\/ FIXME : to be ignored?$/;"	f	class:Fifo
+Stack	input.sv	/^class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	C
+T	input.sv	/^class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:Stack	parameter:
+DEPTH	input.sv	/^class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);$/;"	c	class:Stack	parameter:
+myFifo	input.sv	/^  T myFifo[$:DEPTH-1];$/;"	r	class:Stack
+put	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored$/;"	f	class:Stack
+a	input.sv	/^  virtual function void put(T a); \/\/ FIXME : to be ignored$/;"	p	function:Stack.put
+get	input.sv	/^  virtual function T get(); \/\/ FIXME : to be ignored$/;"	f	class:Stack
+IntfA	input.sv	/^interface class IntfA #(type T1 = logic);$/;"	l
+T1	input.sv	/^interface class IntfA #(type T1 = logic);$/;"	c	ifclass:IntfA	parameter:
+T2	input.sv	/^  typedef T1[1:0] T2;$/;"	T	ifclass:IntfA
+IntfB	input.sv	/^interface class IntfB #(type T = bit) extends IntfA #(T);$/;"	l
+T	input.sv	/^interface class IntfB #(type T = bit) extends IntfA #(T);$/;"	c	ifclass:IntfB	parameter:
+generic_fifo	input.sv	/^module generic_fifo$/;"	m
+MSB	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:generic_fifo	parameter:
+LSB	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:generic_fifo	parameter:
+DEPTH	input.sv	/^  #(parameter MSB=3, LSB=0, DEPTH=4) \/\/ these parameters can be redefined$/;"	c	module:generic_fifo	parameter:
+in	input.sv	/^   (input  wire [MSB:LSB] in,$/;"	p	module:generic_fifo
+clk	input.sv	/^    input  wire clk, read, write, reset,$/;"	p	module:generic_fifo
+read	input.sv	/^    input  wire clk, read, write, reset,$/;"	p	module:generic_fifo
+write	input.sv	/^    input  wire clk, read, write, reset,$/;"	p	module:generic_fifo
+reset	input.sv	/^    input  wire clk, read, write, reset,$/;"	p	module:generic_fifo
+out	input.sv	/^    output logic [MSB:LSB] out,$/;"	p	module:generic_fifo
+full	input.sv	/^    output logic full, empty );$/;"	p	module:generic_fifo
+empty	input.sv	/^    output logic full, empty );$/;"	p	module:generic_fifo
+generic_decoder	input.sv	/^module generic_decoder$/;"	m
+num_code_bits	input.sv	/^  #(num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:generic_decoder	parameter:
+num_out_bits	input.sv	/^  #(num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:generic_decoder
+A	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:generic_decoder
+Y	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:generic_decoder
+int_t	input.sv	/^typedef int int_t;$/;"	T
+user_defined_type_param	input.sv	/^module user_defined_type_param$/;"	m
+num_code_bits	input.sv	/^  #(int_t num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:user_defined_type_param	parameter:
+num_out_bits	input.sv	/^  #(int_t num_code_bits = 3, localparam num_out_bits = 1 << num_code_bits)$/;"	c	module:user_defined_type_param
+A	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:user_defined_type_param
+Y	input.sv	/^   (input [num_code_bits-1:0] A, output reg [num_out_bits-1:0] Y);$/;"	p	module:user_defined_type_param
+L1	input.sv	/^parameter L1 = 0;  \/\/  synonym for the localparam$/;"	c	parameter:
+module_with_parameter_port_list	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	m
+P1	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:module_with_parameter_port_list	parameter:
+P2	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:module_with_parameter_port_list	parameter:
+L2	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:module_with_parameter_port_list
+L3	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:module_with_parameter_port_list
+P3	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:module_with_parameter_port_list	parameter:
+P4	input.sv	/^module module_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4/;"	c	module:module_with_parameter_port_list	parameter:
+L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	module:module_with_parameter_port_list
+L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	module:module_with_parameter_port_list
+module_with_empty_parameter_port_list	input.sv	/^module module_with_empty_parameter_port_list #()$/;"	m
+L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	module:module_with_empty_parameter_port_list
+L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	module:module_with_empty_parameter_port_list
+module_no_parameter_port_list	input.sv	/^module module_no_parameter_port_list$/;"	m
+P5	input.sv	/^  parameter  P5 = "parameter";$/;"	c	module:module_no_parameter_port_list	parameter:
+L8	input.sv	/^  localparam L8 = "local parameter";$/;"	c	module:module_no_parameter_port_list
+class_with_parameter_port_list	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	C
+P1	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class_with_parameter_port_list	parameter:
+P2	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class_with_parameter_port_list	parameter:
+L2	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class_with_parameter_port_list
+L3	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class_with_parameter_port_list
+P3	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class_with_parameter_port_list	parameter:
+P4	input.sv	/^class class_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, P4);$/;"	c	class:class_with_parameter_port_list	parameter:
+L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	class:class_with_parameter_port_list
+L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	class:class_with_parameter_port_list
+class_with_empty_parameter_port_list	input.sv	/^class class_with_empty_parameter_port_list #();$/;"	C
+L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	class:class_with_empty_parameter_port_list
+L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	class:class_with_empty_parameter_port_list
+class_no_parameter_port_list	input.sv	/^class class_no_parameter_port_list;$/;"	C
+L8	input.sv	/^  parameter  L8 = "local parameter";  \/\/ synonym for the localparam (class only)$/;"	c	class:class_no_parameter_port_list
+L9	input.sv	/^  localparam L9 = "local parameter";$/;"	c	class:class_no_parameter_port_list
+program_with_parameter_port_list	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	P
+P1	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:program_with_parameter_port_list	parameter:
+P2	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:program_with_parameter_port_list	parameter:
+L2	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:program_with_parameter_port_list
+L3	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:program_with_parameter_port_list
+P3	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:program_with_parameter_port_list	parameter:
+P4	input.sv	/^program program_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter P3, /;"	c	program:program_with_parameter_port_list	parameter:
+L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	program:program_with_parameter_port_list
+L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	program:program_with_parameter_port_list
+program_with_empty_parameter_port_list	input.sv	/^program program_with_empty_parameter_port_list #()$/;"	P
+L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	program:program_with_empty_parameter_port_list
+L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	program:program_with_empty_parameter_port_list
+program_no_parameter_port_list	input.sv	/^program program_no_parameter_port_list$/;"	P
+P5	input.sv	/^  parameter  P5 = "parameter";$/;"	c	program:program_no_parameter_port_list	parameter:
+L8	input.sv	/^  localparam L8 = "local parameter";$/;"	c	program:program_no_parameter_port_list
+interface_with_parameter_port_list	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	I
+P1	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:interface_with_parameter_port_list	parameter:
+P2	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:interface_with_parameter_port_list	parameter:
+L2	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:interface_with_parameter_port_list
+L3	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:interface_with_parameter_port_list
+P3	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:interface_with_parameter_port_list	parameter:
+P4	input.sv	/^interface interface_with_parameter_port_list #(P1, P2, localparam L2 = P1+1, L3=P2*2, parameter /;"	c	interface:interface_with_parameter_port_list	parameter:
+L4	input.sv	/^  parameter  L4 = "local parameter";  \/\/ synonym for the localparam$/;"	c	interface:interface_with_parameter_port_list
+L5	input.sv	/^  localparam L5 = "local parameter";$/;"	c	interface:interface_with_parameter_port_list
+interface_with_empty_parameter_port_list	input.sv	/^interface interface_with_empty_parameter_port_list #()$/;"	I
+L6	input.sv	/^  parameter  L6 = "local parameter";  \/\/ synonym for the localparam$/;"	c	interface:interface_with_empty_parameter_port_list
+L7	input.sv	/^  localparam L7 = "local parameter";$/;"	c	interface:interface_with_empty_parameter_port_list
+interface_no_parameter_port_list	input.sv	/^interface interface_no_parameter_port_list$/;"	I
+P5	input.sv	/^  parameter  P5 = "parameter";$/;"	c	interface:interface_no_parameter_port_list	parameter:
+L8	input.sv	/^  localparam L8 = "local parameter";$/;"	c	interface:interface_no_parameter_port_list
+package_has_no_parameter_port_list	input.sv	/^package package_has_no_parameter_port_list;$/;"	K
+L1	input.sv	/^  parameter  L1 = "local parameter";$/;"	c	package:package_has_no_parameter_port_list
+L2	input.sv	/^  localparam L2 = "local parameter";$/;"	c	package:package_has_no_parameter_port_list
+generate_constructs	input.sv	/^module generate_constructs;$/;"	m
+L1	input.sv	/^    parameter  L1 = "local parameter";  \/\/ FIXME$/;"	c	module:generate_constructs	parameter:
+L2	input.sv	/^    localparam L2 = "local parameter";$/;"	c	module:generate_constructs

--- a/Units/parser-verilog.r/systemverilog-parameter.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-parameter.d/input.sv
@@ -45,11 +45,11 @@ virtual class C#(parameter DECODE_W, parameter ENCODE_W = $clog2(DECODE_W));
 endclass
 
 // LRM 8.26 Interface classes
-interface class PutImp #(type PUT_T = logic); // FIXME
+interface class PutImp #(type PUT_T = logic);
   pure virtual function void put(PUT_T a);
 endclass
 
-interface class GetImp #(type GET_T = logic); // FIXME
+interface class GetImp #(type GET_T = logic);
   pure virtual function GET_T get();
 endclass
 
@@ -72,6 +72,16 @@ class Stack #(type T = logic, int DEPTH = 1) implements PutImp#(T), GetImp#(T);
     get = myFifo.pop_front();
   endfunction
 endclass
+
+// 8.26.3 Type access
+interface class IntfA #(type T1 = logic);
+  typedef T1[1:0] T2;
+  pure virtual function T2 funcA();
+endclass : IntfA
+
+interface class IntfB #(type T = bit) extends IntfA #(T);
+  pure virtual function T2 funcB(); // legal, type T2 is inherited
+endclass : IntfB
 
 // 23.2.3 Parameterized modules
 module generic_fifo

--- a/Units/parser-verilog.r/systemverilog-prototype.d/args.ctags
+++ b/Units/parser-verilog.r/systemverilog-prototype.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-systemverilog=+Q

--- a/Units/parser-verilog.r/systemverilog-prototype.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-prototype.d/expected.tags
@@ -1,0 +1,11 @@
+C	input.sv	/^class C;$/;"	C
+ext_func	input.sv	/^  extern function ext_func ();$/;"	Q	class:C
+ext_pure_virt_task	input.sv	/^  pure virtual task ext_pure_virt_task (x);$/;"	Q	class:C
+x	input.sv	/^  pure virtual task ext_pure_virt_task (x);$/;"	p	prototype:C.ext_pure_virt_task
+fwd_type_class	input.sv	/^  typedef class   fwd_type_class;$/;"	Q	class:C
+foo	input.sv	/^package foo;$/;"	K
+import_func	input.sv	/^  import "DPI-C" context function int import_func (string str);$/;"	Q	package:foo
+str	input.sv	/^  import "DPI-C" context function int import_func (string str);$/;"	p	prototype:foo.import_func
+uvm_object	input.sv	/^  typedef logic uvm_object;$/;"	T	package:foo
+bar	input.sv	/^  function logic bar (uvm_object baz);$/;"	f	package:foo
+baz	input.sv	/^  function logic bar (uvm_object baz);$/;"	p	function:foo.bar

--- a/Units/parser-verilog.r/systemverilog-prototype.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-prototype.d/input.sv
@@ -1,0 +1,15 @@
+// disabled K_PROTOTYPE: don't use "--extras=+q" for coverage
+class C;
+  extern function ext_func ();
+  pure virtual task ext_pure_virt_task (x);
+  typedef class   fwd_type_class;
+endclass
+
+// from UVM-1.2
+package foo;
+  import "DPI-C" context function int import_func (string str);
+  typedef logic uvm_object;
+  function logic bar (uvm_object baz);
+    return 1'b1;
+  endfunction
+endpackage

--- a/Units/parser-verilog.r/systemverilog-task-function.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-task-function.d/expected.tags
@@ -7,16 +7,23 @@ attr	input.sv	/^  task automatic attr ( (* my_attr *) const ref foo, enum { s0, 
 foo	input.sv	/^  task automatic attr ( (* my_attr *) const ref foo, enum { s0, s1 } sel_e );$/;"	p	task:task_func.attr
 sel_e	input.sv	/^  task automatic attr ( (* my_attr *) const ref foo, enum { s0, s1 } sel_e );$/;"	p	task:task_func.attr
 C	input.sv	/^class C;$/;"	C
+foo	input.sv	/^package foo;$/;"	K
+uvm_object	input.sv	/^  typedef logic uvm_object;$/;"	T	package:foo
+bar	input.sv	/^  function logic bar (uvm_object baz);$/;"	f	package:foo
+baz	input.sv	/^  function logic bar (uvm_object baz);$/;"	p	function:foo.bar
 func_test	input.sv	/^class func_test;$/;"	C
-bar	input.sv	/^  function void foo::bar(uvm_object element);$/;"	f	class:func_test.foo
-element	input.sv	/^  function void foo::bar(uvm_object element);$/;"	p	function:func_test.foo.bar
+uvm_object	input.sv	/^  typedef logic uvm_object;$/;"	T	class:func_test
+uvm_comparer	input.sv	/^  typedef logic uvm_comparer;$/;"	T	class:func_test
+uvm_packer	input.sv	/^  typedef logic uvm_packer;$/;"	T	class:func_test
+bar	input.sv	/^  function void foo::bar(uvm_object element);	\/\/ FIXME$/;"	f	class:func_test.foo
+element	input.sv	/^  function void foo::bar(uvm_object element);	\/\/ FIXME$/;"	p	function:func_test.foo.bar
 do_compare	input.sv	/^  function bit do_compare(uvm_object rhs, uvm_comparer comparer);$/;"	f	class:func_test
 rhs	input.sv	/^  function bit do_compare(uvm_object rhs, uvm_comparer comparer);$/;"	p	function:func_test.do_compare
 comparer	input.sv	/^  function bit do_compare(uvm_object rhs, uvm_comparer comparer);$/;"	p	function:func_test.do_compare
 do_pack	input.sv	/^  function void do_pack(uvm_packer packer);$/;"	f	class:func_test
 packer	input.sv	/^  function void do_pack(uvm_packer packer);$/;"	p	function:func_test.do_pack
-get_if	input.sv	/^  function uvm_port_base #(IF) get_if(int index=0);$/;"	f	class:func_test
-index	input.sv	/^  function uvm_port_base #(IF) get_if(int index=0);$/;"	p	function:func_test.get_if
+get_if	input.sv	/^  function uvm_port_base #(IF) get_if(int index=0);	\/\/ FIXME$/;"	f	class:func_test
+index	input.sv	/^  function uvm_port_base #(IF) get_if(int index=0);	\/\/ FIXME$/;"	p	function:func_test.get_if
 bind_vitf	input.sv	/^  function void bind_vitf(virtual wb_if.master sigs);$/;"	f	class:func_test
 sigs	input.sv	/^  function void bind_vitf(virtual wb_if.master sigs);$/;"	p	function:func_test.bind_vitf
 get	input.sv	/^  function string get(string v);$/;"	f	class:func_test

--- a/Units/parser-verilog.r/systemverilog-task-function.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-task-function.d/input.sv
@@ -25,23 +25,32 @@ class C;
 endclass
 
 // from UVM-1.2
-class func_test;
-  // FIXME don't create context
-  // import "DPI-C" context function int uvm_re_match(string re, string str);
+package foo;
+  import "DPI-C" context function int import_func (string str);
+  typedef logic uvm_object;
+  function logic bar (uvm_object baz);
+    return 1'b1;
+  endfunction
+endpackage
 
-  function void foo::bar(uvm_object element);
+class func_test;
+  typedef logic uvm_object;
+  typedef logic uvm_comparer;
+  typedef logic uvm_packer;
+
+  function void foo::bar(uvm_object element);	// FIXME
   endfunction
 
   function bit do_compare(uvm_object rhs, uvm_comparer comparer);
+    foo::bar(rhs);
   endfunction
 
   function void do_pack(uvm_packer packer);
-    always_comb
-      for (int i = 0; i < m_length; i++)
-        ;
+    for (int i = 0; i < 10; i++)
+      ;
   endfunction
 
-  function uvm_port_base #(IF) get_if(int index=0);
+  function uvm_port_base #(IF) get_if(int index=0);	// FIXME
   endfunction
 
   function void bind_vitf(virtual wb_if.master sigs);

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -56,6 +56,7 @@ typedef enum {
 	K_IDENTIFIER,
 	K_LOCALPARAM,
 	K_PARAMETER,
+	K_IMPORT,
 
 	K_UNDEFINED = KEYWORD_NONE,
 	/* the followings items are also used as indices for VerilogKinds[] and SystemVerilogKinds[] */
@@ -224,6 +225,7 @@ static const keywordAssoc KeywordTable [] = {
 	{ "endsequence",   	K_END_DE,    	{ 1, 0 } },
 	{ "enum",          	K_ENUM,      	{ 1, 0 } },
 	{ "extern",        	K_PROTOTYPE, 	{ 1, 0 } },
+	{ "import",        	K_IMPORT,	  	{ 1, 0 } },
 	{ "int",           	K_REGISTER,  	{ 1, 0 } },
 	{ "interconnect",  	K_NET,       	{ 1, 0 } },
 	{ "interface",     	K_INTERFACE, 	{ 1, 0 } },
@@ -1705,6 +1707,7 @@ static int findTag (tokenInfo *const token, int c)
 			c = processStruct (token, c);
 			break;
 		case K_PROTOTYPE:
+		case K_IMPORT:
 			currentContext->prototype = true;
 			break;
 
@@ -1793,6 +1796,9 @@ static void findVerilogTags (void)
 				break;
 			case '@':
 				c = skipClockEvent (token, c);
+				break;
+			case '"':
+				c = skipString (c);
 				break;
 			default :
 				if (isWordToken (c))

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1368,7 +1368,21 @@ static int processDesignElementL (tokenInfo *const token, int c)
 	}
 	createTag (token, kind);	// identifier
 
-	// package_import_declaration : FIXME
+	// skip package_import_declaration
+	if (isWordToken (c))
+	{
+		c = readWordToken (token, c);
+		if (token->kind == K_IMPORT)
+		{
+			c = skipToSemiColon (c);
+			c = skipWhite (vGetc ());	// skip semicolon
+		}
+		else
+		{
+			verbose ("Unexpected input\n");
+			return c;
+		}
+	}
 
 	if (c == '#')	// parameter_port_list
 	{


### PR DESCRIPTION
- processDesignElement() is divided into processDesignElementL() (for module, interface, and program) and processDesignElementS() (for others).
- tagging imported functions is implemented
- skipping package import declaration is implemented
- implement "interface class" support
- implement coverage_event handling
- units tests are heavily updated