### PR TITLE
php: Fix support for PHP 7.2+ trailing comma in grouped use statements

### DIFF
--- a/Units/parser-php.r/php-use.d/expected.tags
+++ b/Units/parser-php.r/php-use.d/expected.tags
@@ -24,6 +24,7 @@ NS30	input.php	/^  use NS2\\{NS30, NS31\\Cls4};$/;"	a	typeref:unknown:NS2\\NS30
 NSCls	input.php	/^  use NS\\Iface as NSIface, NS\\Cls as NSCls;$/;"	a	namespace:NS2	typeref:unknown:NS\\Cls
 NSIface	input.php	/^  use NS\\Iface as NSIface, NS\\Cls as NSCls;$/;"	a	namespace:NS2	typeref:unknown:NS\\Iface
 NameSpaceTreePointO	input.php	/^  use NS2\\{NS30 as NameSpaceTreePointO, NS31\\Cls4 as ClassFour};$/;"	a	typeref:unknown:NS2\\NS30
+NameSpaceTreePointZero	input.php	/^  use NS2\\{NS30 as NameSpaceTreePointZero,};$/;"	a	typeref:unknown:NS2\\NS30
 SomeAliasedNS	input.php	/^  use NS as SomeAliasedNS;$/;"	a	typeref:unknown:NS
 cls	input.php	/^  $cls = new Cls2;$/;"	v
 cls	input.php	/^  $cls = new Cls;$/;"	v

--- a/Units/parser-php.r/php-use.d/input.php
+++ b/Units/parser-php.r/php-use.d/input.php
@@ -57,6 +57,7 @@ namespace {
   use NS2\{Cls as NS2Cls, Iface};
   use NS2\{NS30, NS31\Cls4};
   use NS2\{NS30 as NameSpaceTreePointO, NS31\Cls4 as ClassFour};
+  use NS2\{NS30 as NameSpaceTreePointZero,};
   
   $cls = new Cls;
   echo $cls::CONST, "\n";

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -1557,6 +1557,9 @@ static bool parseUse (tokenInfo *const token)
 		if (readNext)
 		{
 			readToken (token);
+			/* in case of a trailing comma (or an empty group) */
+			if (token->type == TOKEN_CLOSE_CURLY)
+				break;
 			readQualifiedName (token, refName, nameToken);
 		}
 


### PR DESCRIPTION
https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.trailing-comma-in-grouped-namespaces