### PR TITLE
appveyor: Revise packaging of debug symbols

### DIFF
--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -194,10 +194,17 @@ copy COPYING package\license > nul
 copy win32\mkstemp\COPYING.MinGW-w64-runtime.txt package\license > nul
 robocopy man package\man *.html > nul
 cd package
-7z a ..\ctags-%ver%-%ARCH%.debug.zip %filelist% %dirlist%
-strip *.exe
+call :strip ctags.exe
+call :strip readtags.exe
 7z a ..\ctags-%ver%-%ARCH%.zip %filelist% %dirlist%
+7z a ..\ctags-%ver%-%ARCH%.debuginfo.zip *.exe.debug
 cd ..
+goto :eof
+
+:strip
+objcopy --only-keep-debug %1 %1.debug
+strip %1
+objcopy --add-gnu-debuglink=%1.debug %1
 goto :eof
 
 

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -194,8 +194,7 @@ copy COPYING package\license > nul
 copy win32\mkstemp\COPYING.MinGW-w64-runtime.txt package\license > nul
 robocopy man package\man *.html > nul
 cd package
-call :strip ctags.exe
-call :strip readtags.exe
+for %%i in (*.exe) do call :strip %%i
 7z a ..\ctags-%ver%-%ARCH%.zip %filelist% %dirlist%
 7z a ..\ctags-%ver%-%ARCH%.debuginfo.zip *.exe.debug
 cd ..


### PR DESCRIPTION
Stop creating a separate debug package which includes whole documents.
Instead, create a package that includes only debug symbols.
Use `objcopy --only-keep-debug` and `objcopy --add-gnu-debuglink` to
extract debug symbols to a separate file.

How to use the debug symbols:
* Extract `*.zip` and `*.debuginfo.zip` in the same directory.
* Also put the ctags source code there.
* Use GDB to debug `ctags.exe`.
  GDB will automatically load the symbols from `ctags.exe.debug`.