### PR TITLE
SystemVerilog: port list fix and others

### DIFF
--- a/Units/parser-verilog.r/systemverilog-checker.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-checker.d/expected.tags
@@ -34,8 +34,8 @@ sig	input.sv	/^checker mutex (logic [31:0] sig, event clock, output bit failure)
 clock	input.sv	/^checker mutex (logic [31:0] sig, event clock, output bit failure);$/;"	p	checker:mutex
 failure	input.sv	/^checker mutex (logic [31:0] sig, event clock, output bit failure);$/;"	p	checker:mutex
 m	input.sv	/^module m(wire [31:0] bus, logic clk);$/;"	m
-bus	input.sv	/^module m(wire [31:0] bus, logic clk);$/;"	n	module:m
-clk	input.sv	/^module m(wire [31:0] bus, logic clk);$/;"	n	module:m
+bus	input.sv	/^module m(wire [31:0] bus, logic clk);$/;"	p	module:m
+clk	input.sv	/^module m(wire [31:0] bus, logic clk);$/;"	p	module:m
 res	input.sv	/^    logic res, scan;$/;"	r	module:m
 scan	input.sv	/^    logic res, scan;$/;"	r	module:m
 check_bus	input.sv	/^    mutex check_bus(bus, posedge clk, res);$/;"	i	module:m

--- a/Units/parser-verilog.r/systemverilog-module.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-module.d/expected.tags
@@ -1,14 +1,32 @@
-apb_if	input.sv	/^typedef logic apb_if;$/;"	T
-blk_dut1	input.sv	/^module blk_dut1 (input apb_if    apb, input bit rst); $/;"	m
-apb	input.sv	/^module blk_dut1 (input apb_if    apb, input bit rst); $/;"	p	module:blk_dut1
-rst	input.sv	/^module blk_dut1 (input apb_if    apb, input bit rst); $/;"	p	module:blk_dut1
-blk_dut2	input.sv	/^module blk_dut2 (apb_if    apb, input bit rst);$/;"	m
-apb	input.sv	/^module blk_dut2 (apb_if    apb, input bit rst);$/;"	r	module:blk_dut2
-rst	input.sv	/^module blk_dut2 (apb_if    apb, input bit rst);$/;"	r	module:blk_dut2
-blk_dut3	input.sv	/^module blk_dut3 (logic    apb, input bit rst);$/;"	m
-apb	input.sv	/^module blk_dut3 (logic    apb, input bit rst);$/;"	r	module:blk_dut3
-rst	input.sv	/^module blk_dut3 (logic    apb, input bit rst);$/;"	r	module:blk_dut3
-blk_dut4	input.sv	/^module blk_dut4 #(int BASE_ADDR='h0) (apb_if    apb,$/;"	m
-BASE_ADDR	input.sv	/^module blk_dut4 #(int BASE_ADDR='h0) (apb_if    apb,$/;"	c	module:blk_dut4
-apb	input.sv	/^module blk_dut4 #(int BASE_ADDR='h0) (apb_if    apb,$/;"	r	module:blk_dut4
-rst	input.sv	/^                                     input bit rst);$/;"	r	module:blk_dut4
+user_t	input.sv	/^typedef logic user_t;$/;"	T
+blk_dut1	input.sv	/^module blk_dut1 (input user_t apb, input logic rst); $/;"	m
+apb	input.sv	/^module blk_dut1 (input user_t apb, input logic rst); $/;"	p	module:blk_dut1
+rst	input.sv	/^module blk_dut1 (input user_t apb, input logic rst); $/;"	p	module:blk_dut1
+blk_dut2	input.sv	/^module blk_dut2 (user_t apb, input logic rst);$/;"	m
+apb	input.sv	/^module blk_dut2 (user_t apb, input logic rst);$/;"	p	module:blk_dut2
+rst	input.sv	/^module blk_dut2 (user_t apb, input logic rst);$/;"	p	module:blk_dut2
+blk_dut3	input.sv	/^module blk_dut3 (logic apb, input logic rst);$/;"	m
+apb	input.sv	/^module blk_dut3 (logic apb, input logic rst);$/;"	p	module:blk_dut3
+rst	input.sv	/^module blk_dut3 (logic apb, input logic rst);$/;"	p	module:blk_dut3
+blk_dut4	input.sv	/^module blk_dut4 #(int BASE_ADDR='h0) (user_t apb,$/;"	m
+BASE_ADDR	input.sv	/^module blk_dut4 #(int BASE_ADDR='h0) (user_t apb,$/;"	c	module:blk_dut4
+apb	input.sv	/^module blk_dut4 #(int BASE_ADDR='h0) (user_t apb,$/;"	p	module:blk_dut4
+rst	input.sv	/^                                     input logic rst);$/;"	p	module:blk_dut4
+M1	input.sv	/^module M1;$/;"	m
+M2	input.sv	/^module M2 ();$/;"	m
+M3	input.sv	/^module M3 (a);$/;"	m
+a	input.sv	/^  input a;$/;"	p	module:M3
+M4	input.sv	/^module M4 (a, b);$/;"	m
+a	input.sv	/^  input a, b;$/;"	p	module:M4
+b	input.sv	/^  input a, b;$/;"	p	module:M4
+M5	input.sv	/^module M5 (input user_t a, b);$/;"	m
+a	input.sv	/^module M5 (input user_t a, b);$/;"	p	module:M5
+b	input.sv	/^module M5 (input user_t a, b);$/;"	p	module:M5
+M6	input.sv	/^module M6 (logic a);$/;"	m
+a	input.sv	/^module M6 (logic a);$/;"	p	module:M6
+M7	input.sv	/^module M7 (logic a, output b);$/;"	m
+a	input.sv	/^module M7 (logic a, output b);$/;"	p	module:M7
+b	input.sv	/^module M7 (logic a, output b);$/;"	p	module:M7
+M8	input.sv	/^module M8 (user_t a, b);$/;"	m
+a	input.sv	/^module M8 (user_t a, b);$/;"	p	module:M8
+b	input.sv	/^module M8 (user_t a, b);$/;"	p	module:M8

--- a/Units/parser-verilog.r/systemverilog-module.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-module.d/input.sv
@@ -1,12 +1,45 @@
 // user defined type port
-typedef logic apb_if;
-module blk_dut1 (input apb_if    apb, input bit rst); 
+typedef logic user_t;
+module blk_dut1 (input user_t apb, input logic rst); 
 endmodule
-// FIXME: first port has no direction
-module blk_dut2 (apb_if    apb, input bit rst);
+module blk_dut2 (user_t apb, input logic rst);
 endmodule
-module blk_dut3 (logic    apb, input bit rst);
+module blk_dut3 (logic apb, input logic rst);
 endmodule
-module blk_dut4 #(int BASE_ADDR='h0) (apb_if    apb,
-                                     input bit rst);
+module blk_dut4 #(int BASE_ADDR='h0) (user_t apb,
+                                     input logic rst);
+endmodule
+
+// no port
+module M1;
+endmodule
+
+// no port
+module M2 ();
+endmodule
+
+// non-ANSI
+module M3 (a);
+  input a;
+endmodule
+
+// non-ANSI
+module M4 (a, b);
+  input a, b;
+endmodule
+
+// ANSI
+module M5 (input user_t a, b);
+endmodule
+
+// ANSI
+module M6 (logic a);
+endmodule
+
+// ANSI
+module M7 (logic a, output b);
+endmodule
+
+// ANSI
+module M8 (user_t a, b);
 endmodule

--- a/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
@@ -88,7 +88,10 @@ intf_i	input.sv	/^interface intf_i;$/;"	I
 data_t	input.sv	/^  typedef int data_t;$/;"	T	interface:intf_i
 sub	input.sv	/^module sub(intf_i p);$/;"	m
 p	input.sv	/^module sub(intf_i p);$/;"	r	module:sub
+my_data_t	input.sv	/^  typedef p.data_t my_data_t;$/;"	T	module:sub
 data	input.sv	/^  my_data_t data;$/;"	r	module:sub
+cbs	input.sv	/^module cbs;$/;"	m
+cbs_t	input.sv	/^  typedef p[10].data_t cbs_t;$/;"	T	module:cbs
 user_define_types_1	input.sv	/^module user_define_types_1;$/;"	m
 enum_test	input.sv	/^module enum_test;$/;"	m
 light1	input.sv	/^  enum {red, yellow, green} light1, light2; \/\/ anonymous int type$/;"	E	module:enum_test

--- a/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
@@ -87,7 +87,7 @@ b	input.sv	/^  intP a, b;$/;"	r	module:user_define_types_0
 intf_i	input.sv	/^interface intf_i;$/;"	I
 data_t	input.sv	/^  typedef int data_t;$/;"	T	interface:intf_i
 sub	input.sv	/^module sub(intf_i p);$/;"	m
-p	input.sv	/^module sub(intf_i p);$/;"	r	module:sub
+p	input.sv	/^module sub(intf_i p);$/;"	p	module:sub
 my_data_t	input.sv	/^  typedef p.data_t my_data_t;$/;"	T	module:sub
 data	input.sv	/^  my_data_t data;$/;"	r	module:sub
 cbs	input.sv	/^module cbs;$/;"	m

--- a/Units/parser-verilog.r/systemverilog-net-var.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-net-var.d/input.sv
@@ -145,9 +145,15 @@ interface intf_i;
   typedef int data_t;
 endinterface
 
+// interface based typedef
 module sub(intf_i p);
-  //typedef p.data_t my_data_t; // FIXME: p -> p.data_t?
+  typedef p.data_t my_data_t;
   my_data_t data;
+endmodule
+
+// interface based typedef with constant bit select
+module cbs;
+  typedef p[10].data_t cbs_t;
 endmodule
 
 module user_define_types_1;

--- a/Units/parser-verilog.r/systemverilog-typedef.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-typedef.d/expected.tags
@@ -79,3 +79,5 @@ bar_e.Y	input.sv	/^    Y = 'h0001,$/;"	c	typedef:bar_e
 Z	input.sv	/^    Z = -1$/;"	c	typedef:bar_e
 bar_e.Z	input.sv	/^    Z = -1$/;"	c	typedef:bar_e
 type_class	input.sv	/^typedef classname#(paramvalue) type_class;$/;"	T
+`UVM_CORESERVICE_TYPE	input.sv	/^typedef class `UVM_CORESERVICE_TYPE;$/;"	Q
+`UVM_CORESERVICE_TYPE	input.sv	/^typedef class `UVM_CORESERVICE_TYPE(arg);$/;"	Q

--- a/Units/parser-verilog.r/systemverilog-typedef.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-typedef.d/input.sv
@@ -68,3 +68,7 @@ typedef enum foo_t {
 } bar_e;
 
 typedef classname#(paramvalue) type_class;
+
+// from UVM-1.2
+typedef class `UVM_CORESERVICE_TYPE;
+typedef class `UVM_CORESERVICE_TYPE(arg);

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1172,7 +1172,7 @@ static int processStruct (tokenInfo *const token, int c)
 // data_declaration ::=
 //       [ const ] [ var ] [ static | automatic ] data_type_or_implicit list_of_variable_decl_assignments ;
 //     | typedef data_type type_identifier { [ ... ] } ;
-//     | typedef interface_instance_identifier [ ... ] . type_identifier type_identifier ;
+//     | typedef interface_instance_identifier [ ... ] . type_identifier type_identifier ; // interface based typedef
 //     | typedef [ enum | struct | union | class | interface class ] type_identifier ;
 //     | import < package_import_item > ;
 //     | nettype data_type net_type_identifier [ with [ class_type :: | package_identifier :: | $unit :: ] tf_identifier ] ;
@@ -1205,6 +1205,14 @@ static int processTypedef (tokenInfo *const token, int c)
 			}
 			break;
 		case K_IDENTIFIER:
+			// interface based typedef
+			c = skipDimension (c);
+			if (c == '.')
+			{
+				c = skipWhite (vGetc ());
+				if (isWordToken (c))
+					c = readWordToken (token, c);
+			}
 			if (c == ';')
 				currentContext->prototype = true;
 			break;

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -770,13 +770,6 @@ static int skipMacro (int c)
 			c = skipWhite (c);
 			c = processDefine(token, c);
 		}
-		/* Skip macro or macro functions */
-		else
-		{
-			c = skipWhite (c);	// FIXME: not covered
-			if (c == '(')
-				c = skipPastMatch ("()");
-		}
 		deleteToken (token);
 	}
 	return c;
@@ -1927,12 +1920,6 @@ static void findVerilogTags (void)
 					}
 					else if (token->kind != K_UNDEFINED)
 						c = findTag (token, skipWhite (c));
-					else if (c == '`')	/* Skip macro or macro functions */
-					{
-						c = skipWhite (c);
-						if (c == '(')
-							c = skipPastMatch ("()");
-					}
 				}
 				else
 					c = skipWhite (vGetc ());

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1626,18 +1626,6 @@ static int processType (tokenInfo* token, int c, verilogKind* kind, bool* with)
 	*with = false;
 	do
 	{
-		// [ class_type :: | package_identifier :: | $unit :: ] type_identifier { [ ... ] }
-		if (c == ':')
-		{
-			c = skipWhite (vGetc ());
-			if (c != ':')
-			{
-				verbose ("Unexpected input.\n");
-				vUngetc (c);
-				return ':';
-			}
-			c = skipWhite (vGetc ());
-		}
 		if (c == '.')	// interface_identifier .
 			c = skipWhite (vGetc ());
 		c = skipDimension (c);

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -526,6 +526,13 @@ static void pruneTokens (tokenInfo * token)
 		;
 }
 
+static void swapToken (tokenInfo *t0, tokenInfo *t1)
+{
+	tokenInfo tmp = *t0;
+	*t0 = *t1;
+	*t1 = tmp;
+}
+
 static const char *getNameForKind (const verilogKind kind)
 {
 	if (isInputLanguage (Lang_systemverilog))
@@ -1648,13 +1655,8 @@ static int processType (tokenInfo* token, int c, verilogKind* kind, bool* with)
 		// break on "with"
 		if (token->kind == K_WITH)
 		{
-			// restore tokenSaved to token
-			//   tokenClear() cannot be used to free strings.
-			vStringDelete (token->name);
-			vStringDelete (token->blockName);
-			vStringDelete (token->inheritance);
-			*token = *tokenSaved;
-			eFree (tokenSaved);
+ 			swapToken (token, tokenSaved);
+			deleteToken (tokenSaved);
 			*with = true;	// inform to caller
 			break;
 		}


### PR DESCRIPTION
- fix module port tagging bugs
  - net type and user-defined type ports are tagged as port.
  - correctly distinguishes between ANSI port and non-ANSI port.
  - merge with `processPortList()`
- define `swapToken()` for `K_WITH` handling (proposed by @masatake san)
- fixes for uncovered lines

All high-priority items are implemented by this pull-request.