### PR TITLE
main: attach the last modified time to epcoh: field even for pre opened file

### DIFF
--- a/Tmain/epoch-field.d/run.sh
+++ b/Tmain/epoch-field.d/run.sh
@@ -3,13 +3,23 @@
 
 CTAGS=$1
 
-O=/tmp/ctags-tstamp-$$.c
+O0=/tmp/ctags-tstamp-$$.c
+O1=/tmp/ctags-tstamp-$$.h
+O2=/tmp/ctags-tstamp-$$.m
 
-cat > $O <<EOF
+cat > $O0 <<EOF
 int main (void)
 {
 	return 0;
 }
+EOF
+
+cat > $O1 <<EOF
+extern void foo (void);
+EOF
+
+cat > $O2 <<EOF
+#import <class.h>
 EOF
 
 is_json_avaiable()
@@ -17,18 +27,30 @@ is_json_avaiable()
 	$1 --quiet --options=NONE --with-list-header=no --list-features | grep -q "json"
 }
 
-TZ=UTC+00:00 touch -t '200402291621.42' $O &&
-	$CTAGS --kinds-C= --extras=f --fields=T -o - $O \
-		| sed -e 's/.*\(epoch:.*\)/tags:\1/' &&
-	$CTAGS --kinds-C= --extras=f --fields=T -o - -x --_xformat="xref:epoch:%T" $O &&
-	{
-		if is_json_avaiable $CTAGS; then
-			$CTAGS --kinds-C= --extras=f --fields=T -o - --output-format=json $O \
-				| sed -e 's/.*"epoch": \([0-9]*\).*/json:epoch:\1/'
-		else
-			echo "json:epoch:1078071702"
-		fi
-	}
-s=$?
-rm $O
-exit $s
+run()
+{
+	local o=$1
+	local t=$2
+	shift 2
+	local s
+
+	echo $t
+	TZ=UTC+00:00 touch -t '200402291621.42' $o &&
+		$CTAGS "$@" --kinds-C= --extras=f --fields=T -o - $o \
+			| sed -e 's/.*\(epoch:.*\)/tags:\1/' &&
+		$CTAGS "$@" --kinds-C= --extras=f --fields=T -o - -x --_xformat="xref:epoch:%T" $o &&
+		{
+			if is_json_avaiable $CTAGS; then
+				$CTAGS "$@" --kinds-C= --extras=f --fields=T -o - --output-format=json $o \
+					| sed -e 's/.*"epoch": \([0-9]*\).*/json:epoch:\1/'
+			else
+				echo "json:epoch:1078071702"
+			fi
+		}
+	s=$?
+	rm $o
+	return $s
+}
+
+run $O0 ".c file" && run $O1 ".h file" && run $O2 ".m file" -G
+exit $?

--- a/Tmain/epoch-field.d/stdout-expected.txt
+++ b/Tmain/epoch-field.d/stdout-expected.txt
@@ -1,3 +1,12 @@
+.c file
+tags:epoch:1078071702
+xref:epoch:1078071702
+json:epoch:1078071702
+.h file
+tags:epoch:1078071702
+xref:epoch:1078071702
+json:epoch:1078071702
+.m file
 tags:epoch:1078071702
 xref:epoch:1078071702
 json:epoch:1078071702

--- a/main/read.c
+++ b/main/read.c
@@ -680,7 +680,7 @@ static void rewindInputFile (inputFile *f)
  *  fails, it will display an error message and leave the File.mio set to NULL.
  */
 extern bool openInputFile (const char *const fileName, const langType language,
-			      MIO *mio)
+			      MIO *mio, time_t mtime)
 {
 	const char *const openMode = "rb";
 	bool opened = false;
@@ -726,7 +726,7 @@ extern bool openInputFile (const char *const fileName, const langType language,
 		opened = true;
 
 		if (File.mio == mio)
-			memset (&File.mtime, 0, sizeof (File.mtime));
+			File.mtime = mtime;
 
 		File.bomFound = checkUTF8BOM (File.mio, true);
 

--- a/main/read_p.h
+++ b/main/read_p.h
@@ -52,7 +52,7 @@ extern void freeInputFileResources (void);
    argument. If the 3rd argument is NULL, openInputFile calls getMio
    internally. The 3rd argument is introduced for reusing mio object
    created in parser guessing stage. */
-extern bool openInputFile (const char *const fileName, const langType language, MIO *mio);
+extern bool openInputFile (const char *const fileName, const langType language, MIO *mio, time_t mtime);
 extern MIO *getMio (const char *const fileName, const char *const openMode,
 				    bool memStreamRequired);
 extern void resetInputFile (const langType language);


### PR DESCRIPTION
There are cases that ctags pre-opens an input file for guessing a language for it. e.g. Detecting whether .h file is for for C++ or ObjectiveC.                                                                                 
                                                                                                                                                              
The original code didn't attach the last modified time of the file to "epcoh:" field.                                                                                                                                               
