### PR TITLE
Julia: fill scope field for functions

### DIFF
--- a/Units/parser-julia.r/corner_cases.d/expected.tags
+++ b/Units/parser-julia.r/corner_cases.d/expected.tags
@@ -1,19 +1,16 @@
-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
-!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
-Baz.foo	input.jl	/^Baz.foo(x) = 1$/;"	f
 Foo	input.jl	/^abstract type Foo <: Bar end$/;"	t
 Foo	input.jl	/^mutable struct Foo$/;"	s
 Foo	input.jl	/^struct Foo$/;"	s
-Foo.bar	input.jl	/^function Foo.bar(x, y)$/;"	f
 Mod1	input.jl	/^baremodule Mod1$/;"	n
 Mod2	input.jl	/^module Mod2$/;"	n
 Point	input.jl	/^struct Point{T} <: Pointy{T}$/;"	s
 Pointy	input.jl	/^abstract type Pointy{T} end$/;"	t
+bar	input.jl	/^function Foo.bar(x, y)$/;"	f	module:Foo
 cell	input.jl	/^cell(dims::(Integer...)) = Array(Any, convert((Int...), dims))$/;"	f
 elsize	input.jl	/^elsize(::AbstractArray{T}) where {T} = sizeof(T)$/;"	f
 elsize	input.jl	/^function elsize(::AbstractArray{T}) where T$/;"	f
 f	input.jl	/^f(x::FooBar) = x$/;"	f
+foo	input.jl	/^Baz.foo(x) = 1$/;"	f	module:Baz
 foo	input.jl	/^foo(x::(Int,)) = 1$/;"	f
 foo	input.jl	/^function foo()$/;"	f
 foo_bar!	input.jl	/^foo_bar!(x,y) = x + y$/;"	f

--- a/Units/parser-julia.r/function_scope.d/args.ctags
+++ b/Units/parser-julia.r/function_scope.d/args.ctags
@@ -1,0 +1,2 @@
+--fields=+Zs
+--sort=no

--- a/Units/parser-julia.r/function_scope.d/expected.tags
+++ b/Units/parser-julia.r/function_scope.d/expected.tags
@@ -1,0 +1,6 @@
+func1	input.jl	/^function func1(a::Int)$/;"	f
+func2	input.jl	/^function SomeModule.func2(a::Int)$/;"	f	scope:module:SomeModule
+MyModule	input.jl	/^module MyModule$/;"	n
+func3	input.jl	/^function func3(a::Int)$/;"	f	scope:module:MyModule
+func4	input.jl	/^function func4(a::Int)$/;"	f	scope:module:MyModule
+func5	input.jl	/^    function func5(b::Int)$/;"	f	scope:function:func4

--- a/Units/parser-julia.r/function_scope.d/expected.tags
+++ b/Units/parser-julia.r/function_scope.d/expected.tags
@@ -3,4 +3,4 @@ func2	input.jl	/^function SomeModule.func2(a::Int)$/;"	f	scope:module:SomeModule
 MyModule	input.jl	/^module MyModule$/;"	n
 func3	input.jl	/^function func3(a::Int)$/;"	f	scope:module:MyModule
 func4	input.jl	/^function func4(a::Int)$/;"	f	scope:module:MyModule
-func5	input.jl	/^    function func5(b::Int)$/;"	f	scope:function:func4
+func5	input.jl	/^    function func5(b::Int)$/;"	f	scope:function:MyModule.func4

--- a/Units/parser-julia.r/function_scope.d/input.jl
+++ b/Units/parser-julia.r/function_scope.d/input.jl
@@ -1,0 +1,21 @@
+function func1(a::Int)
+    a
+end
+
+function SomeModule.func2(a::Int)
+    a
+end
+
+module MyModule
+function func3(a::Int)
+    a
+end
+
+function func4(a::Int)
+    function func5(b::Int)
+        b
+    end
+    func5(a)
+end
+
+end

--- a/Units/parser-julia.r/julia_test.d/expected.tags
+++ b/Units/parser-julia.r/julia_test.d/expected.tags
@@ -1,7 +1,7 @@
 a	input.jl	/^const a::Int = 'c'  # struct Struct_wrong3 end$/;"	c
 test_macro	input.jl	/^macro test_macro() end$/;"	m
 test_fun	input.jl	/^function test_fun(a::Int, b::T) where #$/;"	f
-Base.ifelse	input.jl	/^function Base.ifelse(a::Int)$/;"	f
+ifelse	input.jl	/^function Base.ifelse(a::Int)$/;"	f	module:Base
 lone_function	input.jl	/^function lone_function end$/;"	f
 run_test	input.jl	/^function run_test(a::T) where T<:Int; a::Int end$/;"	f
 eq	input.jl	/^eq(c=4; b=(1,2,3), c=:a=>5) = a == b$/;"	f

--- a/parsers/julia.c
+++ b/parsers/julia.c
@@ -1046,17 +1046,16 @@ static void parseFunction (lexerState *lexer, vString *scope, int parent_kind)
         }
 
         addTag(name, NULL, vStringValue(arg_list), K_FUNCTION, line, pos, local_scope, local_parent_kind);
-        //addToScope(scope, name);
-        //parseExpr(lexer, true, K_FUNCTION, scope);
+        addToScope(scope, name);
+        parseExpr(lexer, true, K_FUNCTION, scope);
     }
     else if (lexer->cur_token == TOKEN_CLOSE_BLOCK)
     {
         /* Function without method */
         addTag(name, NULL, NULL, K_FUNCTION, line, pos, local_scope, local_parent_kind);
+        /* Go to the closing 'end' keyword */
+        skipUntilEnd(lexer);
     }
-
-    /* Go to the closing 'end' keyword */
-    skipUntilEnd(lexer);
 
     vStringDelete(name);
     vStringDelete(arg_list);

--- a/parsers/julia.c
+++ b/parsers/julia.c
@@ -1383,6 +1383,5 @@ extern parserDefinition* JuliaParser (void)
     def->parser     = findJuliaTags;
     def->keywordTable = JuliaKeywordTable;
     def->keywordCount = ARRAY_SIZE (JuliaKeywordTable);
-    def->useCork    = CORK_QUEUE;
     return def;
 }

--- a/parsers/julia.c
+++ b/parsers/julia.c
@@ -1016,7 +1016,7 @@ static void parseFunction (lexerState *lexer, vString *scope, int parent_kind)
         advanceChar(lexer);
         advanceToken(lexer, true);
     } else {
-        local_scope = scope;
+        local_scope = vStringNewCopy(scope);
         local_parent_kind = parent_kind;
     }
 
@@ -1059,6 +1059,7 @@ static void parseFunction (lexerState *lexer, vString *scope, int parent_kind)
 
     vStringDelete(name);
     vStringDelete(arg_list);
+    vStringDelete(local_scope);
 }
 
 /* Macro format:
@@ -1278,7 +1279,7 @@ static void parseExpr (lexerState *lexer, bool delim, int kind, vString *scope)
 {
     int level = 1;
     size_t old_scope_len;
-    vString *local_scope;
+    vString *local_scope = NULL;
 
     while (lexer->cur_token != TOKEN_EOF)
     {
@@ -1358,6 +1359,7 @@ static void parseExpr (lexerState *lexer, bool delim, int kind, vString *scope)
             break;
         }
     }
+    vStringDelete(local_scope);
 }
 
 static void findJuliaTags (void)

--- a/parsers/julia.c
+++ b/parsers/julia.c
@@ -1279,6 +1279,7 @@ static void parseExpr (lexerState *lexer, bool delim, int kind, vString *scope)
 {
     int level = 1;
     size_t old_scope_len;
+    vString *local_scope;
 
     while (lexer->cur_token != TOKEN_EOF)
     {
@@ -1316,14 +1317,28 @@ static void parseExpr (lexerState *lexer, bool delim, int kind, vString *scope)
                 parseImport(lexer, scope, kind);
                 break;
             case TOKEN_IDENTIFIER:
-                skipWhitespace(lexer, false);
-                if (lexer->first_token && lexer->cur_c == '(')
+                if (lexer->first_token && lexer->cur_c == '.')
                 {
-                    parseShortFunction(lexer, scope, kind);
+                    local_scope = vStringNewCopy(lexer->token_str);
+                    advanceChar(lexer);
+                    advanceToken(lexer, true);
+                    skipWhitespace(lexer, false);
+                    if (lexer->cur_c == '(')
+                    {
+                        parseShortFunction(lexer, local_scope, K_MODULE);
+                    }
                 }
                 else
                 {
-                    advanceToken(lexer, true);
+                    skipWhitespace(lexer, false);
+                    if (lexer->first_token && lexer->cur_c == '(')
+                    {
+                        parseShortFunction(lexer, scope, kind);
+                    }
+                    else
+                    {
+                        advanceToken(lexer, true);
+                    }
                 }
                 break;
             case TOKEN_OPEN_BLOCK:

--- a/parsers/julia.c
+++ b/parsers/julia.c
@@ -1319,7 +1319,11 @@ static void parseExpr (lexerState *lexer, bool delim, int kind, vString *scope)
             case TOKEN_IDENTIFIER:
                 if (lexer->first_token && lexer->cur_c == '.')
                 {
-                    local_scope = vStringNewCopy(lexer->token_str);
+                    if (local_scope == NULL)
+                    {
+                        local_scope = vStringNew();
+                    }
+                    vStringCopy(local_scope, lexer->token_str);
                     advanceChar(lexer);
                     advanceToken(lexer, true);
                     skipWhitespace(lexer, false);


### PR DESCRIPTION
The idea is in the test `function_scope.d`. For a input file like:

``` julia
module MyModule
function func1() end

function func2()
    function func3() end
end

end
```

The `scope` field for the functions should be:

- `func1`: module:MyModule
- `func2`: module:MyModule
- `func3`: function:func2

For now there are some things not working well. I'll write them in code reviews.