### PR TITLE
Kconfig: recognize sourced file name with no quotes

### DIFF
--- a/Units/simple-kconfig.d/expected.tags
+++ b/Units/simple-kconfig.d/expected.tags
@@ -161,3 +161,7 @@ NET_PKTGEN	input-3.kconfig	/^config NET_PKTGEN$/;"	c	menu:Networking options""Ne
 CONFIG_NET_PKTGEN	input-3.kconfig	/^config NET_PKTGEN$/;"	c	menu:Networking options""Network testing	roles:def
 NET_DROP_MONITOR	input-3.kconfig	/^config NET_DROP_MONITOR$/;"	c	menu:Networking options""Network testing	roles:def
 CONFIG_NET_DROP_MONITOR	input-3.kconfig	/^config NET_DROP_MONITOR$/;"	c	menu:Networking options""Network testing	roles:def
+Kconfig.host	input-4.kconfig	/^source Kconfig.host$/;"	k	roles:source
+backends/Kconfig	input-4.kconfig	/^source backends\/Kconfig$/;"	k	roles:source
+accel/Kconfig	input-4.kconfig	/^source accel\/Kconfig$/;"	k	roles:source
+hw/Kconfig	input-4.kconfig	/^source hw\/Kconfig$/;"	k	roles:source

--- a/Units/simple-kconfig.d/input-4.kconfig
+++ b/Units/simple-kconfig.d/input-4.kconfig
@@ -1,0 +1,5 @@
+# Taken from qemu/Kconfig
+source Kconfig.host
+source backends/Kconfig
+source accel/Kconfig
+source hw/Kconfig

--- a/optlib/kconfig.c
+++ b/optlib/kconfig.c
@@ -75,7 +75,7 @@ extern parserDefinition* KconfigParser (void)
 		"m", "{scope=push}{exclusive}", NULL, false},
 		{"^[ \t]*endmenu[ \t]*", "",
 		"", "{scope=pop}{placeholder}{exclusive}", NULL, false},
-		{"^[ \t]*source[ \t]+\"([^\"]+)\"[ \t]*", "\\1",
+		{"^[ \t]*source[ \t]+\"?([^\"]+)\"?[ \t]*", "\\1",
 		"k", "{_role=source}{exclusive}{scope=ref}", NULL, false},
 		{"^[ \t]*choice[ \t]+([A-Za-z0-9_]+)[ \t]*", "\\1",
 		"C", "{scope=push}{exclusive}", NULL, false},

--- a/optlib/kconfig.ctags
+++ b/optlib/kconfig.ctags
@@ -56,7 +56,8 @@
 --regex-Kconfig=/^[ \t]*menu[ \t]+"([^"]+)"[ \t]*/\1/m/{scope=push}{exclusive}
 --regex-Kconfig=/^[ \t]*endmenu[ \t]*//{scope=pop}{placeholder}{exclusive}
 
---regex-Kconfig=/^[ \t]*source[ \t]+"([^"]+)"[ \t]*/\1/k/{_role=source}{exclusive}{scope=ref}
+# Qemu's Kconfig does't use double quotes
+--regex-Kconfig=/^[ \t]*source[ \t]+"?([^"]+)"?[ \t]*/\1/k/{_role=source}{exclusive}{scope=ref}
 
 --regex-Kconfig=/^[ \t]*choice[ \t]+([A-Za-z0-9_]+)[ \t]*/\1/C/{scope=push}{exclusive}
 --regex-Kconfig=/^[ \t]*choice[ \t]*$//C/{_anonymous=choice}{scope=push}{exclusive}


### PR DESCRIPTION
Qemu's minikconf.py doesn't require surrounding a file name with
double quote characters in "source" directive.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>