### PR TITLE
SystemVerilog: fix ctags --list-kinds-full=SystemVerilog listing

### DIFF
--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -152,7 +152,7 @@ static kindDefinition SystemVerilogKinds [] = {
  { true, 'r', "register",  "variable data types" },
  { true, 't', "task",      "tasks" },
  { true, 'b', "block",     "blocks (begin, fork)" },
- { true, 'i', "instance"   "instances of module or interface" },
+ { true, 'i', "instance",  "instances of module or interface" },
  { true, 'A', "assert",    "assertions (assert, assume, cover, restrict)" },
  { true, 'C', "class",     "classes" },
  { true, 'V', "covergroup","covergroups" },


### PR DESCRIPTION
```
$ ./ctags --list-kinds-full=SystemVerilog
#LETTER NAME                                     ENABLED REFONLY NROLES MASTER DESCRIPTION
A       assert                                   yes     no      0      NONE   assertions (assert, assume, cover, restrict)
...
f       function                                 yes     no      0      NONE   functions
i       instanceinstances of module or interface yes     no      0      NONE   NO DESCRIPTION GIVEN
l       ifclass                                  yes     no      0      NONE   interface class
...
w       member                                   yes     no      0      NONE   struct and union members
$ 
```

The line for instance was broken due to a missing comma.  It has been hidden since #2703.