### PR TITLE
Doc: Restructure "Extending ctags" sections and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,6 @@ The goal of the project is preparing and maintaining common/unified working
 space where people interested in making ctags better can work
 together.
 
-## Getting PACKCC compiler-compiler ##
-
-Packcc is a compiler-compiler; it translates .peg grammar file to .c
-file.  packcc was originally written by Arihiro Yoshida. Its source
-repository is at sourceforge. It seems that packcc at sourceforge is
-not actively maintained. Some derived repositories are at
-github. Currently, our choice is
-https://github.com/enechaev/packcc. It is the most active one in the
-derived repositories.
-
-The source tree of packcc is grafted at misc/packcc directory.
-Building packcc and ctags are integrated in the build-scripts of
-Universal-ctags.
-
 ## The latest build and package ##
 
 If you want to try the latest universal-ctags without building it yourself...

--- a/README.md
+++ b/README.md
@@ -38,23 +38,38 @@ code from GitHub.
 
 ## How to build and install ##
 
-To build with Autotools, see `docs/autotools.rst` for more information.
-(To build on GNU/Linux, Autotools is your choice.)
-To build on Windows, see `docs/windows.rst` for more information.
-To build on OSX, see `docs/osx.rst` for more information.
+To build with Autotools (Autoconf, Automake, and Libtool) on GNU/Linux, OSX, or Windows 10 WSL,
+```
+    $ git clone https://github.com/universal-ctags/ctags.git
+    $ cd ctags
+    $ ./autogen.sh
+    $ ./configure --prefix=/where/you/want # defaults to /usr/local
+    $ make
+    $ make install # may require extra privileges depending on where to install
+```
+
+See
+[`docs/autotools.rst`](https://github.com/universal-ctags/ctags/blob/master/docs/autotools.rst)
+for more information.
+
+To build on Windows, see
+[`docs/windows.rst`](https://github.com/universal-ctags/ctags/blob/master/docs/windows.rst)
+for more information.
+
+To build on OSX, see
+[`docs/osx.rst`](https://github.com/universal-ctags/ctags/blob/master/docs/osx.rst)
+for more information.
 
 ## Manual ##
-Man page (ctags.1) is generated only in Autotools based building process.
-In addition rst2man command is needed.
+Go to https://docs.ctags.io for the preformatted documentations
+of the latest development version.
+See also `*/README.md` on this repository.
 
-rst2man is part of the python-docutils package on Ubuntu.
-
-## Differences ##
+## Differences from exuberant-ctags ##
 
 You may be interested in how universal-ctags is different from
-exuberant-ctags. The critical and attractive changes are explained
-in docs/\*.rst. The preformatted version is available on line,
-https://docs.ctags.io/.
+exuberant-ctags. See [Introduced changes](https://docs.ctags.io/en/latest/news.html)
+on https://docs.ctags.io/ for details.
 
 The most significant incompatible changes:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,10 +16,16 @@ on the tools. When converting rst to man, two backslashes are converted
 into one, however when converting to html, four backslashes are converted
 into one.
 
+##  Generating man pages ##
+
 The files in `man/` directory are generated from the man pages in `../man/`
-directory. Do not edit the files in `man/` directory directly.
+directory. **Do not edit the files in `man/` directory directly.**
+
 Execute the following command in the top directory to update them:
 
 ```sh
 make -C man QUICK=1 update-docs
 ```
+
+To genereate the man pages rst2man command is needed.
+rst2man is part of the python-docutils package on Ubuntu.

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -1,22 +1,14 @@
 =============================================================================
-Extending ctags
+Extending ctags with a parser written in C
 =============================================================================
 
-Exuberant-ctags allows a user to add a new parser to ctags with ``--langdef=<LANG>``
-and ``--regex-<LANG>=...`` options.
-
-Universal-ctags follows and extends the design of Exuberant-ctags in more
-powerful ways, as described in the following chapters.
-
-Universal-ctags encourages users to share the new parsers defined by
-their options. See :ref:`optlib <optlib>` to know how you can share your
-parser definition with others.
-
-Note that some of the new features are experimental, and will be marked as such
-in the documentation.
+.. TODO:
+	describe how to add a parser written in C to ctags.
+	  parserDefinition structure
+	  how to register a parserDefinition function
+	  etc.
 
 .. toctree::
-	:maxdepth: 2
+	:maxdepth: 4
 
-	optlib.rst
 	internal.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,6 +42,7 @@ This is a draft document. Proofreading and pull-requests are welcome!
 	other-projects.rst
 	contributions.rst
 	development-process.rst
+	optlib.rst
 	extending.rst
 	running-multi-parsers.rst
 	tips.rst

--- a/docs/internal.rst
+++ b/docs/internal.rst
@@ -421,3 +421,21 @@ An example can be found in DTS parser:
 
 Setting `requestAutomaticFQTag` to `TRUE` implies setting
 `useCork` to `CORK_QUEUE`.
+
+PACKCC compiler-compiler
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Packcc is a compiler-compiler; it translates .peg grammar file to .c
+file.  packcc was originally written by Arihiro Yoshida. Its source
+repository is at sourceforge. It seems that packcc at sourceforge is
+not actively maintained. Some derived repositories are at
+github. Currently, our choice is
+https://github.com/enechaev/packcc. It is the most active one in the
+derived repositories.
+
+The source tree of packcc is grafted at misc/packcc directory.
+Building packcc and ctags are integrated in the build-scripts of
+Universal-ctags.
+
+.. TODO:
+	refer peg/* as a sample implementation

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -22,6 +22,18 @@ Extending ctags with Regex parser (*optlib*)
 	you want to use permanently. It's really the new language parsers using
 	--regex-<LANG> and such that are about "Extending ctags", no?
 
+Exuberant-ctags allows a user to add a new parser to ctags with ``--langdef=<LANG>``
+and ``--regex-<LANG>=...`` options.
+
+Universal-ctags follows and extends the design of Exuberant-ctags in more
+powerful ways, as described in the following chapters.
+
+Universal-ctags encourages users to share the new parsers defined by
+their options. See :ref:`optlib <optlib>` to know how you can share your
+parser definition with others.
+
+Note that some of the new features are experimental, and will be marked as such
+in the documentation.
 
 Option files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- Restructure "Extending ctags" sections
  - move "Extending ctags with Regex parser" (optlib.rst) to upper level, etc.
- update README.md
  - move PACKCC info to docs/internal.rst, etc.

See each commit message for more information.
