### PR TITLE
Inko: rename "object" keyword to "class"

### DIFF
--- a/Units/parser-inko.r/everything.d/expected.tags
+++ b/Units/parser-inko.r/everything.d/expected.tags
@@ -1,15 +1,15 @@
-A	input.inko	/^object A$/;"	o
-@number	input.inko	/^  @number: X$/;"	a	object:A
-in_a	input.inko	/^  def in_a {$/;"	m	object:A
+A	input.inko	/^class A$/;"	o
+@number	input.inko	/^  @number: X$/;"	a	class:A
+in_a	input.inko	/^  def in_a {$/;"	m	class:A
 another	input.inko	/^  def another {}$/;"	m
 foo	input.inko	/^def foo {}$/;"	m
-B	input.inko	/^object B {$/;"	o
-in_b	input.inko	/^  def in_b {$/;"	m	object:B
+B	input.inko	/^class B {$/;"	o
+in_b	input.inko	/^  def in_b {$/;"	m	class:B
 global	input.inko	/^def global {}$/;"	m
 SomeTrait	input.inko	/^trait SomeTrait {$/;"	t
 required_method	input.inko	/^  def required_method$/;"	m	trait:SomeTrait
-Socket	input.inko	/^object Socket {$/;"	o
-quack	input.inko	/^  def quack {}$/;"	m	object:Socket
+Socket	input.inko	/^class Socket {$/;"	o
+quack	input.inko	/^  def quack {}$/;"	m	class:Socket
 Socket	input.inko	/^impl Bar for Socket {$/;"	r	implements:Bar
 moo	input.inko	/^  def moo !! Integer {}$/;"	m	reopen:Socket
 Chickens	input.inko	/^impl Chickens {$/;"	r

--- a/Units/parser-inko.r/everything.d/input.inko
+++ b/Units/parser-inko.r/everything.d/input.inko
@@ -1,6 +1,6 @@
 { 20 }
 
-object A
+class A
 {
   @number: X
 
@@ -13,7 +13,7 @@ object A
 
 def foo {}
 
-object B {
+class B {
   def in_b {
     { 10  }
   }
@@ -26,7 +26,7 @@ trait SomeTrait {
   def required_method
 }
 
-object Socket {
+class Socket {
   def quack {}
 }
 

--- a/Units/parser-inko.r/methods.d/expected.tags
+++ b/Units/parser-inko.r/methods.d/expected.tags
@@ -1,7 +1,7 @@
-A	input.inko	/^object A {$/;"	o
-method_a	input.inko	/^  def method_a {}$/;"	m	object:A
-B	input.inko	/^object B {$/;"	o
-method_b	input.inko	/^  def method_b {}$/;"	m	object:B
+A	input.inko	/^class A {$/;"	o
+method_a	input.inko	/^  def method_a {}$/;"	m	class:A
+B	input.inko	/^class B {$/;"	o
+method_b	input.inko	/^  def method_b {}$/;"	m	class:B
 +	input.inko	/^def + {}$/;"	m
 -	input.inko	/^def - {}$/;"	m
 *	input.inko	/^def * {}$/;"	m

--- a/Units/parser-inko.r/methods.d/input.inko
+++ b/Units/parser-inko.r/methods.d/input.inko
@@ -1,8 +1,8 @@
-object A {
+class A {
   def method_a {}
 }
 
-object B {
+class B {
   def method_b {}
 }
 

--- a/Units/parser-inko.r/objects.d/expected.tags
+++ b/Units/parser-inko.r/objects.d/expected.tags
@@ -1,4 +1,4 @@
-A	input.inko	/^object A {}$/;"	o
-B	input.inko	/^object B {}$/;"	o
-C	input.inko	/^object C {$/;"	o
-@foo	input.inko	/^  @foo: X$/;"	a	object:C
+A	input.inko	/^class A {}$/;"	o
+B	input.inko	/^class B {}$/;"	o
+C	input.inko	/^class C {$/;"	o
+@foo	input.inko	/^  @foo: X$/;"	a	class:C

--- a/Units/parser-inko.r/objects.d/input.inko
+++ b/Units/parser-inko.r/objects.d/input.inko
@@ -1,6 +1,6 @@
-object A {}
-object B {}
+class A {}
+class B {}
 
-object C {
+class C {
   @foo: X
 }

--- a/Units/parser-inko.r/strings.d/expected.tags
+++ b/Units/parser-inko.r/strings.d/expected.tags
@@ -1,1 +1,1 @@
-Foo	input.inko	/^object Foo {}$/;"	o
+Foo	input.inko	/^class Foo {}$/;"	o

--- a/Units/parser-inko.r/strings.d/input.inko
+++ b/Units/parser-inko.r/strings.d/input.inko
@@ -1,12 +1,12 @@
 'foo'
 'let A = 10'
-'object B {}'
+'class B {}'
 'trait C {}'
 "trait D {}"
 
-'foo \' object AA {}'
-"foo \" object AA {}"
+'foo \' class AA {}'
+"foo \" class AA {}"
 
 `trait Hello {}`
 
-object Foo {}
+class Foo {}

--- a/optlib/inko.c
+++ b/optlib/inko.c
@@ -12,7 +12,7 @@ static void initializeInkoParser (const langType language)
 {
 
 	addLanguageRegexTable (language, "toplevel");
-	addLanguageRegexTable (language, "object");
+	addLanguageRegexTable (language, "class");
 	addLanguageRegexTable (language, "trait");
 	addLanguageRegexTable (language, "method");
 	addLanguageRegexTable (language, "comment");
@@ -35,8 +35,8 @@ static void initializeInkoParser (const langType language)
 	                               "^#",
 	                               "", "", "{tenter=comment}", NULL);
 	addLanguageTagMultiTableRegex (language, "toplevel",
-	                               "^[[:blank:]]*object[[:blank:]]+",
-	                               "", "", "{tenter=object}", NULL);
+	                               "^[[:blank:]]*class[[:blank:]]+",
+	                               "", "", "{tenter=class}", NULL);
 	addLanguageTagMultiTableRegex (language, "toplevel",
 	                               "^[[:blank:]]*trait[[:blank:]]+",
 	                               "", "", "{tenter=trait}", NULL);
@@ -61,13 +61,13 @@ static void initializeInkoParser (const langType language)
 	addLanguageTagMultiTableRegex (language, "toplevel",
 	                               "^.",
 	                               "", "", "", NULL);
-	addLanguageTagMultiTableRegex (language, "object",
+	addLanguageTagMultiTableRegex (language, "class",
 	                               "^([A-Z][a-zA-Z0-9_?]*)[^{]*",
 	                               "\\1", "o", "{scope=push}", NULL);
-	addLanguageTagMultiTableRegex (language, "object",
+	addLanguageTagMultiTableRegex (language, "class",
 	                               "^\\{",
 	                               "", "", "{tleave}", NULL);
-	addLanguageTagMultiTableRegex (language, "object",
+	addLanguageTagMultiTableRegex (language, "class",
 	                               "^.",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "trait",
@@ -155,7 +155,7 @@ extern parserDefinition* InkoParser (void)
 
 	static kindDefinition InkoKindTable [] = {
 		{
-		  true, 'o', "object", "Object definition",
+		  true, 'o', "class", "Class definition",
 		},
 		{
 		  true, 'm', "method", "Method definition",
@@ -170,7 +170,7 @@ extern parserDefinition* InkoParser (void)
 		  true, 'c', "constant", "Constant definition",
 		},
 		{
-		  true, 'r', "reopen", "Reopen object",
+		  true, 'r', "reopen", "Reopen class",
 		},
 	};
 	static fieldDefinition InkoFieldTable [] = {

--- a/optlib/inko.ctags
+++ b/optlib/inko.ctags
@@ -22,19 +22,19 @@
 
 --langdef=Inko
 --map-Inko=+.inko
---kinddef-Inko=o,object,Object definition
+--kinddef-Inko=o,class,Class definition
 --kinddef-Inko=m,method,Method definition
 --kinddef-Inko=t,trait,Trait definition
 --kinddef-Inko=a,attribute,Attribute definition
 --kinddef-Inko=c,constant,Constant definition
---kinddef-Inko=r,reopen,Reopen object
+--kinddef-Inko=r,reopen,Reopen class
 
 --_fielddef-Inko=implements,Trait being implemented
 
 --fields-Inko=+{implements}
 
 --_tabledef-Inko=toplevel
---_tabledef-Inko=object
+--_tabledef-Inko=class
 --_tabledef-Inko=trait
 --_tabledef-Inko=method
 --_tabledef-Inko=comment
@@ -62,7 +62,7 @@
 --_mtable-regex-Inko=tstring/.//
 
 --_mtable-regex-Inko=toplevel/#//{tenter=comment}
---_mtable-regex-Inko=toplevel/[[:blank:]]*object[[:blank:]]+//{tenter=object}
+--_mtable-regex-Inko=toplevel/[[:blank:]]*class[[:blank:]]+//{tenter=class}
 --_mtable-regex-Inko=toplevel/[[:blank:]]*trait[[:blank:]]+//{tenter=trait}
 --_mtable-regex-Inko=toplevel/[[:blank:]]*def[[:blank:]]+//{tenter=method}
 --_mtable-regex-Inko=toplevel/[[:blank:]]*impl[[:blank:]]+//{tenter=impl}
@@ -72,9 +72,9 @@
 --_mtable-regex-Inko=toplevel/(@[a-zA-Z0-9_]+):/\1/a/{scope=ref}
 --_mtable-regex-Inko=toplevel/.//
 
---_mtable-regex-Inko=object/([A-Z][a-zA-Z0-9_?]*)[^{]*/\1/o/{scope=push}
---_mtable-regex-Inko=object/\{//{tleave}
---_mtable-regex-Inko=object/.//
+--_mtable-regex-Inko=class/([A-Z][a-zA-Z0-9_?]*)[^{]*/\1/o/{scope=push}
+--_mtable-regex-Inko=class/\{//{tleave}
+--_mtable-regex-Inko=class/.//
 
 --_mtable-regex-Inko=trait/([A-Z][a-zA-Z0-9_?]*)[^{]*/\1/t/{scope=push}
 --_mtable-regex-Inko=trait/\{//{tleave}


### PR DESCRIPTION
The "object" keyword has been renamed to "class". This commit updates
all Inko tests and the parser to match this change.