### PR TITLE
Improve recursive macro expansion detection

### DIFF
--- a/Units/parser-c.r/recursive-macros.d/args.ctags
+++ b/Units/parser-c.r/recursive-macros.d/args.ctags
@@ -1,0 +1,3 @@
+--kinds-C=*
+-D p=a
+-D a=p+p

--- a/Units/parser-c.r/recursive-macros.d/expected.tags
+++ b/Units/parser-c.r/recursive-macros.d/expected.tags
@@ -1,0 +1,1 @@
+dummy	input.c	/^int dummy;$/;"	v	typeref:typename:int

--- a/Units/parser-c.r/recursive-macros.d/input.c
+++ b/Units/parser-c.r/recursive-macros.d/input.c
@@ -1,0 +1,2 @@
+int p;
+int dummy;

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -448,6 +448,10 @@ extern void cppUngetc (const int c)
 	Cpp.ungetDataSize++;
 }
 
+int cppUngetBufferSize()
+{
+	return Cpp.ungetBufferSize;
+}
 
 /*  This puts an entire string back into the input queue for the input File. */
 void cppUngetString(const char * string,int len)

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -92,6 +92,7 @@ extern void cppTerminate (void);
 extern void cppBeginStatement (void);
 extern void cppEndStatement (void);
 extern void cppUngetc (const int c);
+extern int cppUngetBufferSize();
 extern void cppUngetString(const char * string,int len);
 extern int cppGetc (void);
 extern const vString * cppGetLastCharOrStringContents (void);


### PR DESCRIPTION
Don't allow the unget buffer to grow too large while expanding macros. This helps with
infinite recursive macro expansions. Fixes #2779 .