### PR TITLE
Cxx,CPreProcessor: limit to use a macro in a recursive macro expansion

### DIFF
--- a/Units/parser-c.r/recursive-macros-2.d/README
+++ b/Units/parser-c.r/recursive-macros-2.d/README
@@ -1,0 +1,2 @@
+typeref field for `p' in expected.tags may be changed when
+the definition for CXX_PARSER_MAXIMUM_MACRO_USE_COUNT is changed.

--- a/Units/parser-c.r/recursive-macros-2.d/args.ctags
+++ b/Units/parser-c.r/recursive-macros-2.d/args.ctags
@@ -1,0 +1,3 @@
+--kinds-C=*
+-D p=a
+-D a=(p+p)

--- a/Units/parser-c.r/recursive-macros-2.d/expected.tags
+++ b/Units/parser-c.r/recursive-macros-2.d/expected.tags
@@ -1,0 +1,2 @@
+dummy	input.c	/^int dummy;$/;"	v	typeref:typename:int
+p	input.c	/^int p;$/;"	v	typeref:typename:int ((((((((+p)+p)+p)+p)+p)+p)+p)+p)

--- a/Units/parser-c.r/recursive-macros-2.d/input.c
+++ b/Units/parser-c.r/recursive-macros-2.d/input.c
@@ -1,0 +1,2 @@
+int p;
+int dummy;

--- a/Units/parser-c.r/recursive-macros.d/args.ctags
+++ b/Units/parser-c.r/recursive-macros.d/args.ctags
@@ -1,0 +1,3 @@
+--kinds-C=*
+-D p=a
+-D a=p+p

--- a/Units/parser-c.r/recursive-macros.d/expected.tags
+++ b/Units/parser-c.r/recursive-macros.d/expected.tags
@@ -1,0 +1,1 @@
+dummy	input.c	/^int dummy;$/;"	v	typeref:typename:int

--- a/Units/parser-c.r/recursive-macros.d/input.c
+++ b/Units/parser-c.r/recursive-macros.d/input.c
@@ -1,0 +1,2 @@
+int p;
+int dummy;

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -448,6 +448,10 @@ extern void cppUngetc (const int c)
 	Cpp.ungetDataSize++;
 }
 
+int cppUngetBufferSize()
+{
+	return Cpp.ungetBufferSize;
+}
 
 /*  This puts an entire string back into the input queue for the input File. */
 void cppUngetString(const char * string,int len)

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -115,9 +115,12 @@ typedef struct sCppMacroReplacementPartInfo {
 typedef struct sCppMacroInfo {
 	bool hasParameterList; /* true if the macro has a trailing () */
 	cppMacroReplacementPartInfo * replacements;
+	int useCount;
+	struct sCppMacroInfo * next;
 } cppMacroInfo;
 
-extern const cppMacroInfo * cppFindMacro (const char *const name);
+extern cppMacroInfo * cppFindMacro (const char *const name);
+extern void cppUngetStringBuiltByMacro (const char * string,int len, cppMacroInfo *macro);
 
 /*
 * Build a replacement string for the specified macro.

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -92,6 +92,7 @@ extern void cppTerminate (void);
 extern void cppBeginStatement (void);
 extern void cppEndStatement (void);
 extern void cppUngetc (const int c);
+extern int cppUngetBufferSize();
 extern void cppUngetString(const char * string,int len);
 extern int cppGetc (void);
 extern const vString * cppGetLastCharOrStringContents (void);


### PR DESCRIPTION
This change limits the usage of a macro definition in a recursive macro expansion up to CXX_PARSER_MAXIMUM_MACRO_USE_COUNT.

This change extends #2780.