### PR TITLE
Julia: correctly recognize Module.@macro as a macro call

### DIFF
--- a/Units/parser-julia.r/scoped_macro.d/args.ctags
+++ b/Units/parser-julia.r/scoped_macro.d/args.ctags
@@ -1,0 +1,2 @@
+--fields=+Zs
+--sort=no

--- a/Units/parser-julia.r/scoped_macro.d/expected.tags
+++ b/Units/parser-julia.r/scoped_macro.d/expected.tags
@@ -1,0 +1,10 @@
+fun1	input.jl	/^@eval fun1(x) = $a$/;"	f
+fun2	input.jl	/^Base.@eval fun2(x) = $a$/;"	f
+fun3	input.jl	/^@eval function fun3(x)$/;"	f
+fun4	input.jl	/^Base.@eval function fun4(x)$/;"	f
+Test1	input.jl	/^@eval struct Test1$/;"	s
+a	input.jl	/^    a::$T$/;"	g	scope:struct:Test1
+Test2	input.jl	/^Base.@eval struct Test2$/;"	s
+a	input.jl	/^    a::$T$/;"	g	scope:struct:Test2
+macro1	input.jl	/^@eval macro macro1(x)$/;"	m
+macro2	input.jl	/^Base.@eval macro macro2(x)$/;"	m

--- a/Units/parser-julia.r/scoped_macro.d/input.jl
+++ b/Units/parser-julia.r/scoped_macro.d/input.jl
@@ -1,0 +1,23 @@
+@eval fun1(x) = $a
+Base.@eval fun2(x) = $a
+
+@eval function fun3(x)
+    $a
+end
+Base.@eval function fun4(x)
+    $a
+end
+
+@eval struct Test1
+    a::$T
+end
+Base.@eval struct Test2
+    a::$T
+end
+
+@eval macro macro1(x)
+    $a
+end
+Base.@eval macro macro2(x)
+    $a
+end


### PR DESCRIPTION
```julia
@eval fun1(x) = $a
Base.@eval fun2(x) = $a
```
`fun2` is not recognized as a short function, because `Base.@eval` is not recognized as a macro (with scope).

(currently `fun1` is also not parsed but it will be corrected by #2790).

~~This is a work in progress, it should be implemented using the new cork system introduced by #2763.~~
It is working now!