### PR TITLE
Julia: correct valgrind error initialization

### DIFF
--- a/Units/parser-julia.r/empty_line.d/expected.tags
+++ b/Units/parser-julia.r/empty_line.d/expected.tags
@@ -1,0 +1,1 @@
+a	input.jl	/^struct a end$/;"	s

--- a/Units/parser-julia.r/empty_line.d/input.jl
+++ b/Units/parser-julia.r/empty_line.d/input.jl
@@ -1,0 +1,2 @@
+
+struct a end

--- a/parsers/julia.c
+++ b/parsers/julia.c
@@ -671,6 +671,7 @@ static int advanceToken (lexerState *lexer, bool skip_whitespace)
     /* the next token is the first token of the line */
     if (lexer->cur_token == TOKEN_NEWLINE ||
         lexer->cur_token == TOKEN_SEMICOLON ||
+        lexer->cur_token == TOKEN_NONE ||
         (lexer->first_token && lexer->cur_token == TOKEN_MACROCALL))
     {
         lexer->first_token = true;
@@ -798,6 +799,7 @@ static void initLexer (lexerState *lexer)
     lexer->token_str = vStringNew();
     lexer->first_token = true;
     lexer->cur_token = TOKEN_NONE;
+    lexer->prev_c = '\0';
 
     if (lexer->cur_c == '#' && lexer->next_c == '!')
     {
@@ -1286,7 +1288,8 @@ static void parseExpr (lexerState *lexer, bool delim, int kind, vString *scope)
         old_scope_len = vStringLength(scope);
         /* Advance token and update if this is a new line */
         while (lexer->cur_token == TOKEN_NEWLINE ||
-               lexer->cur_token == TOKEN_SEMICOLON )
+               lexer->cur_token == TOKEN_SEMICOLON ||
+               lexer->cur_token == TOKEN_NONE )
         {
             advanceToken(lexer, true);
         }


### PR DESCRIPTION
... and treat TOKEN_NONE as a new line token.
rebase of #2787

If the first line is empty, valgrind gives an error.
Short functions defined in the first line are also not parsed, try the following, where fun2 is parsed but not fun1:

fun1(x) = 1
fun2(x) = 2

Solved by initializing the prev_c member to \0 and treating TOKEN_NONE as a new line TOKEN.