### PR TITLE
GitHub Actions: temporarily disable macos-11.0

### DIFF
--- a/.github/workflows/testing-mac.yml
+++ b/.github/workflows/testing-mac.yml
@@ -11,7 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11.0, macos-10.15]
+        # os: [macos-11.0, macos-10.15]
+        os: [macos-10.15]
         compiler: [gcc, clang]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We encounter the same problem reported at
https://github.community/t/macos-11-0-big-sur-builds-stalling-out/153761
.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>