### PR TITLE
build-sys: fixed compilation error in misc/packcc/packcc.c

### DIFF
--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -86,9 +86,9 @@ AS_IF([test -n "$build"],      [ac_build_tool_prefix="$build-"],
 
 AC_LANG_PUSH([C])
 AC_PROG_CC
-AC_PROG_CC_C99
 _AC_COMPILER_EXEEXT
 _AC_COMPILER_OBJEXT
+AC_PROG_CC_C99
 AC_PROG_CPP
 
 dnl Restore the old definitions


### PR DESCRIPTION
`AC_PROG_CC_C99` macro must be placed after `_AC_COMPILER_OBJEXT` macro,
beacuse `AC_PROG_CC_C99` uses the `ac_build_objext` variable, this
variable is assigned by `_AC_COMPILER_OBJEXT`.