### PR TITLE
build-sys: fix configure syntax error near unexpected token `dummy`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,8 @@ AM_SILENT_RULES([yes])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
+m4_ifndef([PKG_CHECK_EXISTS], [m4_fatal([must install pkg-config 0.18 or later before running ./autogen.sh])])
+
 AC_CANONICAL_BUILD
 AC_CANONICAL_HOST
 


### PR DESCRIPTION
add code to configure.ac to check if the `PKG_CHECK_EXISTS` macro is defined. If not defined, a fatal error thrown, tell the user to install pkg-config 0.18 or later.

Note: our project use the `PKG_CHECK_EXISTS` and `PKG_CHECK_MODULES` two macros, these two macros are provided by `pkg.m4` which is installed along with `pkg-config`. the `PKG_CHECK_EXISTS` since `0.18`, the `PKG_CHECK_MODULES` since `0.4`.