### PR TITLE
circleci: use https for accessing vault centos org

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -233,8 +233,8 @@ jobs:
        - run:
            name: Rearrange CentOS-Base.repo file
            command: |
-             sed -i "s|#baseurl=|baseurl=|g" /etc/yum.repos.d/CentOS-Base.repo
-             sed -i "s|mirrorlist=|#mirrorlist=|g" /etc/yum.repos.d/CentOS-Base.repo
+             sed -i 's|#baseurl=|baseurl=|g' /etc/yum.repos.d/CentOS-Base.repo
+             sed -i 's|mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/CentOS-Base.repo
              sed -i 's|mirror|vault|g' /etc/yum.repos.d/CentOS-Base.repo
        - run:
            name: Install tools for building

--- a/circle.yml
+++ b/circle.yml
@@ -236,6 +236,7 @@ jobs:
              sed -i 's|#baseurl=|baseurl=|g' /etc/yum.repos.d/CentOS-Base.repo
              sed -i 's|mirrorlist=|#mirrorlist=|g' /etc/yum.repos.d/CentOS-Base.repo
              sed -i 's|mirror|vault|g' /etc/yum.repos.d/CentOS-Base.repo
+             sed -i 's|http:|https:|g' /etc/yum.repos.d/CentOS-Base.repo
        - run:
            name: Install tools for building
            command: |


### PR DESCRIPTION
circleci: use https instead of http to access vault.centos.org

It seems that accessing via https is more stable.