### PR TITLE
build-sys: fix configure unary operator expected

### DIFF
--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -41,6 +41,10 @@ AC_REQUIRE([AC_PROG_CC_C99])dnl
 AC_REQUIRE([AC_PROG_CPP])dnl
 AC_REQUIRE([AC_CANONICAL_BUILD])dnl
 
+ac_cv_c_compiler_gnu_saved=$ac_cv_c_compiler_gnu
+
+unset ac_cv_c_compiler_gnu
+
 dnl Use the standard macros, but make them use other variable names
 dnl
 pushdef([ac_cv_prog_CPP], ac_cv_build_prog_CPP)dnl
@@ -127,6 +131,8 @@ popdef([ac_cv_prog_cc_c99])dnl
 popdef([ac_cv_prog_cc_c89])dnl
 popdef([ac_cv_prog_gcc])dnl
 popdef([ac_cv_prog_CPP])dnl
+
+ac_cv_c_compiler_gnu=$ac_cv_c_compiler_gnu_saved
 
 dnl restore global variables ac_ext, ac_cpp, ac_compile,
 dnl ac_link, ac_compiler_gnu (dependant on the current


### PR DESCRIPTION
error message: `./configure: line 5804: test: =: unary operator expected`

this error caused by `ac_cv_c_compiler_gnu` variable is not unset