### PR TITLE
Julia: correct bugs with struct constructor

### DIFF
--- a/Units/parser-julia.r/parametric_constructor.d/expected.tags
+++ b/Units/parser-julia.r/parametric_constructor.d/expected.tags
@@ -1,0 +1,8 @@
+OurRational	input.jl	/^struct OurRational{T<:Integer} <: Real$/;"	s
+OurRational{Int16}	input.jl	/^OurRational{Int16}(num::T, den::T) where T<:Integer = new(num, den)$/;"	f
+OurRational{Int64}	input.jl	/^    OurRational{Int64}(num::T, den::T, test::T) where T<:Integer = new(num, den, test)$/;"	f	struct:OurRational
+OurRational{Int8}	input.jl	/^    OurRational{Int8}(num::T, den::T) where T<:Integer = new(convert(Int8, num), convert(Int8, d/;"	f	struct:OurRational
+OurRational{T}	input.jl	/^    function OurRational{T}(num::T, den::T) where T<:Integer$/;"	f	struct:OurRational
+den	input.jl	/^    den::T$/;"	g	struct:OurRational
+num	input.jl	/^    num::T$/;"	g	struct:OurRational
+test	input.jl	/^    test::T$/;"	g	struct:OurRational

--- a/Units/parser-julia.r/parametric_constructor.d/input.jl
+++ b/Units/parser-julia.r/parametric_constructor.d/input.jl
@@ -1,0 +1,28 @@
+struct OurRational{T<:Integer} <: Real
+    "Numerator"
+    num::T
+
+    "Denominator"
+    den::T
+
+    OurRational{Int8}(num::T, den::T) where T<:Integer = new(convert(Int8, num), convert(Int8, den))
+
+    """
+    Parametric inner constructor
+    """
+    function OurRational{T}(num::T, den::T) where T<:Integer
+        if num == 0 && den == 0
+            error("invalid rational: 0//0")
+        end
+        g = gcd(den, num)
+        num = div(num, g)
+        den = div(den, g)
+        new(num, den)
+    end
+
+    test::T
+
+    OurRational{Int64}(num::T, den::T, test::T) where T<:Integer = new(num, den, test)
+end
+
+OurRational{Int16}(num::T, den::T) where T<:Integer = new(num, den)

--- a/Units/parser-julia.r/parametric_constructor.d/input.jl
+++ b/Units/parser-julia.r/parametric_constructor.d/input.jl
@@ -14,6 +14,10 @@ struct OurRational{T<:Integer} <: Real
         if num == 0 && den == 0
             error("invalid rational: 0//0")
         end
+        # Bug with short function misidentification of == and =>
+        length(num) == 0
+        length(den) => 0
+        
         g = gcd(den, num)
         num = div(num, g)
         den = div(den, g)

--- a/parsers/julia.c
+++ b/parsers/julia.c
@@ -1072,12 +1072,16 @@ static void parseFunction (lexerState *lexer, vString *scope, int parent_kind)
     if (lexer->cur_token != TOKEN_IDENTIFIER)
     {
         return;
-    } else if (lexer->cur_c == '.') {
+    }
+    else if (lexer->cur_c == '.')
+    {
         local_scope = vStringNewCopy(lexer->token_str);
         local_parent_kind = K_MODULE;
         advanceChar(lexer);
         advanceToken(lexer, true, false);
-    } else {
+    }
+    else
+    {
         local_scope = vStringNewCopy(scope);
         local_parent_kind = parent_kind;
     }

--- a/parsers/julia.c
+++ b/parsers/julia.c
@@ -1033,10 +1033,10 @@ static void parseShortFunction (lexerState *lexer, vString *scope, int parent_ki
         advanceToken(lexer, true, false);
     }
 
-    /* scan equal sign */
-    if (lexer->cur_token != '=' &&
-        lexer->cur_c != '=' &&
-        lexer->cur_c != '>')
+    /* scan equal sign, ignore `==` and `=>` */
+    if (!(lexer->cur_token == '=' &&
+          lexer->cur_c != '=' &&
+          lexer->cur_c != '>'))
     {
         vStringDelete(name);
         vStringDelete(arg_list);


### PR DESCRIPTION
Correct three bugs with functions and constructors:
- `lenght(a) == 0` was recognized as a short function definition.
- Parametric constructors with `function` keyword were not recognized, like `function MyStruct{Int}(x) ... end`
- Inner constructors inside `struct` defined below a constructor with the `function` keyword had incorrect scope, it was considered to be below the constructor with `function`.
- [EDIT] Outer constructor, like parametric short function `func{Int}(x) = 0`, was not recognized as a short function.