### PR TITLE
buildsys,units: fix make check failed due to ./misc/units[779]: sytnax error: `"\$file" missing expression operator when running on OpenBSD6.8

### DIFF
--- a/misc/units
+++ b/misc/units
@@ -772,19 +772,11 @@ run_tcase ()
 failure_in_globing ()
 {
     # skip if globing failed, also ignore backup files
-    local file=$1
-    local pat='~$|\*'
-    # use [[ if it is available in the shell implementation.
-    if type '[[' > /dev/null 2>&1; then
-	if [[ "$file" =~ $pat ]]; then
-	    return 0
-	fi
-    else
-	if echo "$file" | grep -q '~$\|\*'; then
-	    return 0
-	fi
-    fi
-    return 1
+    case $1 in
+        *\~)  return 0 ;;
+        *\**) return 0 ;;
+         *)   return 1 ;;
+     esac
 }
 
 run_dir ()


### PR DESCRIPTION
OpenBSD sh has `[[` built-in command, but it does't support `=~` operator.