### PR TITLE
GitHub Actions: run units target on netbsd and openbsd

### DIFF
--- a/.github/workflows/testing-netbsd.yml
+++ b/.github/workflows/testing-netbsd.yml
@@ -1,0 +1,35 @@
+name: run units target on NetBSD
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  testing:
+    runs-on: macos-10.15
+    
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: leleliu008/github-actions-vagrant@v1
+      with:
+        mem: 2048
+        box: generic/netbsd9
+        run: |
+          run sudo pkgin -y install mozilla-rootcerts automake pkg-config
+
+          run sudo mozilla-rootcerts install
+
+          run cc --version
+
+          run ./autogen.sh
+          run ./configure --prefix=/usr
+          run make
+          run sudo make install
+          run file /usr/bin/ctags
+          run ctags --version
+          # bugs to fix
+          #run make check
+          run make roundtrip

--- a/.github/workflows/testing-openbsd.yml
+++ b/.github/workflows/testing-openbsd.yml
@@ -1,0 +1,42 @@
+name: run units target on OpenBSD
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  testing:
+    runs-on: macos-10.15
+    
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: leleliu008/github-actions-vagrant@v1
+      with:
+        mem: 2048
+        box: generic/openbsd6
+        run: |
+          export AUTOCONF_VERSION=2.69
+          export AUTOMAKE_VERSION=1.16
+              
+          export CFLAGS='-I/usr/local/include -L/usr/local/lib'
+              
+          if [ ! -f /usr/local/lib/libiconv.so ] ; then
+            sudo ln -s /usr/local/lib/libiconv.so.* /usr/local/lib/libiconv.so
+          fi
+              
+          run sudo pkg_add automake-1.16.2
+
+          run cc --version
+            
+          run ./autogen.sh
+          run ./configure --prefix=/usr
+          run make
+          run sudo make install
+          run file /usr/bin/ctags
+          run ctags --version
+          # bugs to fix
+          #run make check
+          run make roundtrip


### PR DESCRIPTION
not execute `make check` on `netbsd` and `openbsd`, because `make check` failed on `netbsd` and `openbsd`. I created a new issue([issue-2829](https://github.com/universal-ctags/ctags/issues/2829))