### PR TITLE
buildsys;units: fix make check failed on MSYS2 when MSYSTEM=MINGW32 and MSYSTEM=MINGW64

### DIFF
--- a/Tmain/tag-relative-option.d/run.sh
+++ b/Tmain/tag-relative-option.d/run.sh
@@ -34,8 +34,18 @@ fi
     ${CTAGS} $O --_xformat="yes:     $F -> %F"  --tag-relative=yes    $F
     ${CTAGS} $O --_xformat="always:  $F -> %F"  --tag-relative=always $F
 } | {
-	# Normalize driver letter
-    sed -e 's|C:|/c|g'
+    # Normalize Windows driver letter
+    #
+    # comment time:   Sat Feb  6 13:11:44 UTC 2021
+    # comment author: leleliu008@gmail.com
+    #
+    # as far as I know, the most widely used unix-like POSIX-compatible environments on Windows are Cygwin and MSYS2. Actually, MSYS2 is a modified fork of Cygwin. They both provide a command-line tool called cygpath which can be used to convert Windows PATH to UNIX path. There exists other unix-like POSIX-compatible environments on Windows, git-for-windows as an example, but they all based on Cygwin or MSYS2.
+    if command -v cygpath > /dev/null && command -v awk > /dev/null ; then
+        awk '{if ($NF ~ /^[A-Z]:/) { "cygpath "$NF | getline newpath; sub($NF,newpath) } print}'
+    else
+        # \l is a GNU extension. But only Windows's path match [A-Z]: pattern, Cygwin and MSYS2 use GNU sed.
+        sed 's|\([A-Z]\):|/\l\1|'
+    fi
 } | {
 	# Unescape
 	sed -e 's|\\\\|\\|g'


### PR DESCRIPTION
use `cygpath` to convert `Windows path` to `Unix path` if `cygpath` exists.