### PR TITLE
perl: added support for method keyword

### DIFF
--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -419,6 +419,14 @@ static void findPerlTags (void)
 			spaceRequired = true;
 			qualified = true;
 		}
+		else if (strncmp((const char*) cp, "fun", (size_t) 3) == 0)
+		{
+			TRACE("this looks like a sub\n");
+			cp += 3;
+			kind = KIND_PERL_SUBROUTINE;
+			spaceRequired = true;
+			qualified = true;
+		}
 		else if (strncmp((const char*) cp, "use", (size_t) 3) == 0)
 		{
 			cp += 3;

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -411,6 +411,14 @@ static void findPerlTags (void)
 			spaceRequired = true;
 			qualified = true;
 		}
+		else if (strncmp((const char*) cp, "method", (size_t) 6) == 0)
+		{
+			TRACE("this looks like a sub\n");
+			cp += 6;
+			kind = KIND_PERL_SUBROUTINE;
+			spaceRequired = true;
+			qualified = true;
+		}
 		else if (strncmp((const char*) cp, "use", (size_t) 3) == 0)
 		{
 			cp += 3;


### PR DESCRIPTION
I added Perl support for the method keyword used in the Function::Parameters class.