### PR TITLE
docs: updates of ctags(1) and docs/ updates

### DIFF
--- a/docs/contributions.rst
+++ b/docs/contributions.rst
@@ -84,10 +84,6 @@ Defining kinds is the most important task in writing a new parser.
 Once a kind is introduced, we cannot change it because it breaks
 tags file compatibility.
 
-If you are not interested in designing kinds because you are an
-emacs user and use just TAGS output, there are two choices:
-TBW.
-
 See :ref:`tag_entries` in :ref:`ctags(1) <ctags(1)>` for more details of kinds
 and roles.
 
@@ -95,11 +91,6 @@ Scope information and full qualified tags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Optional.
-TBW.
-
-Adding a new field
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 TBW.
 
 Developing a parser

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -4,12 +4,6 @@
 Extending ctags with a parser written in C
 =============================================================================
 
-.. TODO:
-	describe how to add a parser written in C to ctags.
-	  parserDefinition structure
-	  how to register a parserDefinition function
-	  etc.
-
 This chapter describes how to add a parser in C and the internal API of
 Universal Ctags.
 

--- a/docs/internal.rst
+++ b/docs/internal.rst
@@ -425,20 +425,21 @@ An example can be found in DTS parser:
 Setting `requestAutomaticFQTag` to `TRUE` implies setting
 `useCork` to `CORK_QUEUE`.
 
-PACKCC compiler-compiler
+PackCC compiler-compiler
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Packcc is a compiler-compiler; it translates .peg grammar file to .c
-file.  packcc was originally written by Arihiro Yoshida. Its source
-repository is at sourceforge. It seems that packcc at sourceforge is
+PackCC is a compiler-compiler; it translates .peg grammar file to .c
+file.  PackCC was originally written by Arihiro Yoshida. Its source
+repository is at sourceforge. It seems that PackCC at sourceforge is
 not actively maintained. Some derived repositories are at
 github. Currently, our choice is
 https://github.com/enechaev/packcc. It is the most active one in the
 derived repositories.
 
-The source tree of packcc is grafted at misc/packcc directory.
-Building packcc and ctags are integrated in the build-scripts of
+The source tree of PackCC is grafted at misc/packcc directory.
+Building PackCC and ctags are integrated in the build-scripts of
 Universal Ctags.
 
-.. TODO:
-	refer peg/* as a sample implementation
+Refer `peg/valink.peg
+<https://github.com/universal-ctags/ctags/blob/master/peg/varlink.peg>`_ as a
+sample of a parser using PackCC.

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -205,6 +205,22 @@ Input/Output File Options
 	esoteric and is disabled by default. This option must appear before
 	the first file name.
 
+``--filter-terminator=string``
+	Specifies a string to print to standard output following the tags for
+	each file name parsed when the ``--filter`` option is enabled. This may
+	permit an application reading the output of ctags
+	to determine when the output for each file is finished.
+
+	Note that if the
+	file name read is a directory and ``--recurse`` is enabled, this string will
+	be printed only once at the end of all tags found for by descending
+	the directory. This string will always be separated from the last tag
+	line for the file by its terminating newline.
+
+	This option is quite
+	esoteric and is empty by default. This option must appear before
+	the first file name.
+
 ``--links[=yes|no]``
 	Indicates whether symbolic links (if supported) should be followed.
 	When disabled, symbolic links are ignored. This option is on by default.
@@ -283,24 +299,6 @@ Input/Output File Options
 
 Output Format Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``--filter-terminator=string``
-	Specifies a string to print to standard output following the tags for
-	each file name parsed when the ``--filter`` option is enabled. This may
-	permit an application reading the output of ctags
-	to determine when the output for each file is finished.
-
-	Note that if the
-	file name read is a directory and ``--recurse`` is enabled, this string will
-	be printed only once at the end of all tags found for by descending
-	the directory. This string will always be separated from the last tag
-	line for the file by its terminating newline.
-
-	This option is quite
-	esoteric and is empty by default. This option must appear before
-	the first file name.
-
-.. TODO: Shall we move this after "--filter"?
-
 ``--format=level``
 	Change the format of the output tag file. Currently the only valid
 	values for level are 1 or 2. Level 1 specifies the original tag file
@@ -649,8 +647,6 @@ See "`TAG ENTRIES`_" about fields, kinds, roles, and extras.
 	(i.e. ``--fields-all=``), all fields are disabled. These two combinations
 	are useful for testing.
 
-	.. TODO: "to all languages;" instead of "to all fields;" ???
-
 ``--kinds-<LANG>=[+|-]kinds|*``
 	Specifies a list of language-specific kinds of tags (or kinds) to
 	include in the output file for a particular language, where *<LANG>* is
@@ -683,6 +679,9 @@ See "`TAG ENTRIES`_" about fields, kinds, roles, and extras.
 
 ``--<LANG>-kinds=[+|-]kinds|*``
 	This option is obsolete. Use ``--kinds-<LANG>=...`` instead.
+
+..	COMMENT:
+	``--param-<LANG>:name=argument`` is moved to "Language Specific Options"
 
 ``--pattern-length-limit=N``
 	Truncate patterns of tag entries after '``N``' characters. Disable by setting to 0
@@ -757,18 +756,30 @@ See "`TAG ENTRIES`_" about fields, kinds, roles, and extras.
 	(e.g.  ``--roles-all.*=*`` or ``--roles-all.*=``).
 
 ``--tag-relative[=yes|no|always|never]``
-	The ``yes`` value indicates that the file paths recorded in the tag file should be
-	relative to the directory containing the tag file, rather than relative
-	to the current directory, unless the files supplied on the command line
-	are specified with absolute paths. This option must appear before the
+	Specifies how the file paths recorded in the tag file.
+	This option must appear before the
 	first file name. The default is ``yes`` when running in etags mode (see
 	the ``-e`` option), ``no`` otherwise.
-	The ``always`` value indicates the recorded file paths should be relative
-	even if source file names are passed in with absolute paths.
-	The ``never`` value indicates the recorded file paths should be absolute
-	even if source file names are passed in with relative paths.
 
-	.. TODO: make as a definition list
+	``yes``
+		indicates that the file paths recorded in the tag file should be
+		*relative to the directory containing the tag file*
+		unless the files supplied on the command line
+		are specified with absolute paths.
+
+	``no``
+		indicates that the file paths recorded in the tag file should be
+		*relative to the current directory*
+		unless the files supplied on the command line
+		are specified with absolute paths.
+
+	``always``
+		indicates the recorded file paths should be relative
+		even if source file names are passed in with absolute paths.
+
+	``never``
+		indicates the recorded file paths should be absolute
+		even if source file names are passed in with relative paths.
 
 ``--use-slash-as-filename-separator[=yes|no]``
 	Uses slash ('``/``') character as filename separators instead of backslash
@@ -1249,8 +1260,6 @@ Listing Options
 
 	ENABLED
 		Whether the kind is enabled or not. It takes ``yes`` or ``no``.
-		(Currently all roles are enabled. An option for disabling
-		a specified role is not implemented yet.)
 
 	DESCRIPTION
 		Human readable description for the role.
@@ -1528,8 +1537,6 @@ conditions.  "interpreter" testing is enabled only when a file is an
 executable or the ``--guess-language-eagerly`` (``-G`` in short) option is
 given. The other heuristic tests are enabled only when ``-G`` option is
 given.
-
-.. TODO: move the paragraph above to the beginning of this section.
 
 The ``--print-language`` option can be used just to print the results of
 parser selections for given files instead of generating a tags file.

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -19,7 +19,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The *ctags* and *etags* programs
+The *ctags* and *etags* (see ``-e`` option) programs
 (hereinafter collectively referred to as ctags,
 except where distinguished) generate an index (or "tag") file for a
 variety of *language objects* found in *source file(s)*. This tag file allows
@@ -117,7 +117,7 @@ List options
 ~~~~~~~~~~~~
 
 Universal Ctags introduces many ``--list-...`` options that provide
-the internal data of Universal Ctags (See :ref:`option_listing`). Both users and client tools may
+the internal data of Universal Ctags (See "`Listing Options`_"). Both users and client tools may
 use the data. ``--with-list-header`` and ``--machinable`` options
 adjust the output of the most of ``--list-...`` options.
 
@@ -191,11 +191,7 @@ Input/Output File Options
 
 	For an example, you want ctags to ignore all files
 	under ``foo`` directory except ``foo/main.c``, use the following command
-	line: ``--exclude=foo/* --exclude-exception=foo/main.c``. Don't forget
-	shell quoting for '``*``'.
-
-.. TODO: Which shell requires the quoting?
-   At least bash does not require quoting unless directory `--exclude=foo' exists.
+	line: ``--exclude=foo/* --exclude-exception=foo/main.c``.
 
 ``--filter[=yes|no]``
 	Makes ctags behave as a filter, reading source
@@ -522,6 +518,8 @@ Language Selection and Mapping Options
 
 Tags File Contents Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+See "`TAG ENTRIES`_" about fields, kinds, roles, and extras.
+
 ``--excmd=type``
 	Determines the type of ``EX`` command used to locate tags in the source
 	file. [Ignored in etags mode]
@@ -619,7 +617,7 @@ Tags File Contents Options
 
 ``--fields=[+|-]flags|*``
 	Specifies which available extension fields are to be included in
-	the tag entries (see "`TAG FILE FORMAT`_" section, and "`Fields`_"
+	the tag entries (see "`TAG FILE FORMAT`_" section, and "`Extension fields`_"
 	subsection, for more information).
 
 	The parameter ``flags`` is a set of one-letter or long-name flags,
@@ -685,12 +683,6 @@ Tags File Contents Options
 
 ``--<LANG>-kinds=[+|-]kinds|*``
 	This option is obsolete. Use ``--kinds-<LANG>=...`` instead.
-
-``--param-<LANG>:name=argument``
-	Set <LANG> specific parameter. Available parameters can be listed with
-	``--list-params``.
-
-	.. TODO: add description of "parameter".
 
 ``--pattern-length-limit=N``
 	Truncate patterns of tag entries after '``N``' characters. Disable by setting to 0
@@ -1035,7 +1027,7 @@ Listing Options
 
 ``--list-fields[=language|all]``
 	Lists the fields recognized for either the specified *language* or
-	*all* languages. See "`Fields`_" subsection to know what are fields.
+	*all* languages. See "`Extension fields`_" subsection to know what are fields.
 	``all`` is used as default value if the option argument is omitted.
 
 	.. TODO? xref output
@@ -1191,7 +1183,7 @@ Listing Options
 	This option does not work with ``--machinable`` nor
 	``--with-list-header``.
 
-	.. TODO: ".. may be used in many other options...": I don't think it is``all`` worth to be described.
+	.. TODO: ".. may be used in many other options...": I don't think it is worth to be described.
 
 ``--list-map-extensions[=language|all]``
 	Lists the file extensions which associate a file
@@ -1442,15 +1434,6 @@ is given or not.)
 
 .. TODO: all heuristics??? To be confirmed.
 
-.. options should be revised here
-	``--map-<LANG>`` (done)
-	``--langmap=map[,map[...]]`` (done)
-	``--language-force=language`` (done)
-	``--languages=[+|-]list`` (done)
-	``--list-maps[=language|all]`` (done)
-	``--list-map-extensions`` (done)
-	``--list-map-patterns`` (done)
-
 Heuristically guessing
 ..........................
 
@@ -1565,8 +1548,11 @@ Examples:
 TAG FILE FORMAT
 ---------------
 
+This section describes the tag file format briefly.  See :ref:`tags(5) <tags(5)>` and
+:ref:`ctags-client-tools(7) <ctags-client-tools(7)>` for more details.
+
 When not running in etags mode, each entry in the tag file consists of a
-separate line, each looking like this in the most general case:
+separate line, each looking like this, called *regular tags*, in the most general case:
 
 ::
 
@@ -1574,19 +1560,35 @@ separate line, each looking like this in the most general case:
 
 The fields and separators of these lines are specified as follows:
 
-	1.	tag name
-	2.	single tab character
-	3.	name of the file in which the object associated with the tag is located
-	4.	single tab character
-	5.	EX command used to locate the tag within the file; generally a
-		search pattern (either /pattern/ or ?pattern?) or line number (see
-		``--excmd``). Tag file format 2 (see ``--format``) extends this EX command
-		under certain circumstances to include a set of extension fields
-		(described below) embedded in an EX comment immediately appended
-		to the EX command, which leaves it backward-compatible with original
-		vi(1) implementations.
+	1.	``tag_name``: tag name
+	2.	``<TAB>``: single tab character
+	3.	``file_name``: name of the file in which the object associated with the tag is located
+	4.	``<TAB>``: single tab character
+	5.	``ex_cmd``: EX command used to locate the tag within the file; generally a
+		search pattern (either ``/pattern/`` or ``?pattern?``) or line number (see
+		``--excmd=type`` option).
+	6.	``;"<TAB>extension_fields``: a set of extension fields. See
+		"`Extension fields`_" for more details.
 
-A few special tags are written into the tag file for internal purposes.
+		Tag file format 2 (see ``--format``) extends the EX command
+		to include the extension fields embedded in an EX comment immediately appended
+		to the EX command, which leaves it backward-compatible with original
+		``vi(1)`` implementations.
+
+A few special tags, called *pseudo tags*, are written into the tag file for internal purposes.
+
+::
+
+	!_TAG_FILE_FORMAT       2       /extended format; --format=1 will not append ;" to lines/
+	!_TAG_FILE_SORTED       1       /0=unsorted, 1=sorted, 2=foldcase/
+	...
+
+``--pseudo-tags=[+|-]ptag|*`` option enables or disables emitting pseudo-tags.
+
+See the output of ``ctags --list-pseudo-tags`` for the list of
+the kinds.
+See also :ref:`tags(5) <tags(5)>` and :ref:`ctags-client-tools(7) <ctags-client-tools(7)>` for more details of the pseudo tags.
+
 These tags are composed in such a way that they always sort to the top of
 the file. Therefore, the first two characters of these tags are used a magic
 number to detect a tag file for purposes of determining whether a
@@ -1596,9 +1598,8 @@ Note that the name of each source file will be recorded in the tag file
 exactly as it appears on the command line. Therefore, if the path you
 specified on the command line was relative to the current directory, then
 it will be recorded in that same manner in the tag file. See, however,
-the ``--tag-relative`` option for how this behavior can be modified.
-
-.. _tag_entries:
+the ``--tag-relative[=yes|no|always|never]`` option for how this behavior can be
+modified.
 
 TAG ENTRIES
 -----------
@@ -1614,24 +1615,14 @@ objects: places where named language objects *are used*. However, support
 for generating reference tags is new and limited to specific areas of
 specific languages in the current version.
 
-Fields
-~~~~~~
+Extension fields
+~~~~~~~~~~~~~~~~
 
-A tag can record various information, called *fields*. The
-essential fields are: *name* of language objects, *input*,
-*pattern*, and *line*. ``input:`` is the name of source file where
-``name:`` is defined or referenced. ``pattern:`` can be used to search
-the *name* in ``input:``. *line* is the line number where
-``name:`` is defined or referenced in ``input:``.
-
-ctags offers extension fields. See also the
-descriptions of ``--list-fields`` option and ``--fields`` option.
+A tag can record various information, called *extension fields*.
 
 Extension fields are tab-separated key-value pairs appended to the end of
 the EX command as a comment, as described above. These key value pairs
-appear in the general form ``key:value``. Their presence in the lines of the
-tag file are controlled by the ``--fields`` option. The possible keys and
-the meaning of their values are as follows:
+appear in the general form ``key:value``.
 
 In addition, information on the scope of the tag definition may be
 available, with the key portion equal to some language-dependent construct
@@ -1640,78 +1631,83 @@ This scope entry indicates the scope in which the tag was found.
 For example, a tag generated for a C structure member would have a scope
 looking like ``struct:myStruct``.
 
-The meaning of major fields is as follows (one-letter flag/long-name flag):
+``--fields=[+|-]flags|*`` and ``--fields-<LANG>=[+|-]flags|*`` options specifies
+which available extension fields are to be included in the tag entries.
+
+See the output of ``ctags --list-fields`` for the list of
+extension fields.
+The essential fields are ``name``, ``input``, ``pattern``, and ``line``.
+The meaning of major fields is as follows (long-name flag/one-letter flag):
 
 ``access``/``a``
-	Access (or export) of class members
-
 	Indicates the visibility of this class member, where value is specific
 	to the language.
 
 ``end``/``e``
-	End lines of various items
+	Indicates the line number of the end lines of the language object.
+
+``extras``/``E``
+	Extra tag type information. See "`Extras`_" for details.
 
 ``file``/``f``
-	File-restricted scoping. Enabled by default.
-
 	Indicates that the tag has file-limited visibility. This key has no
-	corresponding value.
+	corresponding value. Enabled by default.
 
 ``implementation``/``m``
-	Implementation information
-
 	When present, this indicates a limited implementation (abstract vs.
 	concrete) of a routine or class, where value is specific to the
 	language (``virtual`` or ``pure virtual`` for C++; ``abstract`` for Java).
 
 ``inherits``/``i``
-	Inheritance information.
-
-	When present, value. is a comma-separated list of classes from which
+	When present, value is a comma-separated list of classes from which
 	this class is derived (i.e. inherits from).
 
+``input``/``F``
+	The name of source file where ``name`` is defined or referenced.
+
 ``k``
-	Kind of tag as one-letter. Enabled by default.
-	Exceptionally this has no long-name.
+	`Kind <Kinds>`_ of tag as one-letter. Enabled by default.
+	This field has no long-name.
 	See also ``kind``/``z`` flag.
 
 ``K``
-	Kind of tag as long-name.
-	Exceptionally this has no long-name.
+	`Kind <Kinds>`_ of tag as long-name.
+	This field has no long-name.
 	See also ``kind``/``z`` flag.
 
 ``kind``/``z``
-	Include the ``kind:`` key in kind field.  See also ``k`` and ``K`` flags.
+	Include the ``kind:`` key in `kind field <Kinds>`_.  See also ``k`` and ``K`` flags.
 
 ``language``/``l``
 	Language of source file containing tag
 
 ``line``/``n``
-	Line number of tag definition
+	The line number where ``name`` is defined or referenced in ``input``.
+
+``name``/``N``
+	The name of language objects.
+
+``pattern``/``P``
+	Can be used to search the ``name`` in ``input``
 
 ``roles``/``r``
-	Roles assigned to the tag.
-	For a definition tag, this field takes ``def`` as a value.
+	Roles assigned to the tag. See "`Roles`_" for more details.
 
 ``s``
 	Scope of tag definition. Enabled by default.
-	Exceptionally this has no long-name.
-	See also ``Z`` flag.
+	This field has no long-name.
+	See also ``scope``/``Z`` flag.
 
-	.. TODO? implement "scope" of Z/scope flag.
-
-``Z``
-	Include the ``scope:`` key in scope field.
-	Exceptionally this has no long-name.  See also ``s`` flag.
+``scope``/``Z``
+	Prepend the ``scope:`` key to scope (``s``) field.
+	See also ``s`` flag.
 
 ``scopeKind``/``p``
 	Kind of scope as long-name
 
 ``signature``/``S``
-	Signature of routine (e.g. prototype or parameter list)
-
 	When present, value is a language-dependent representation of the
-	signature of a routine. A routine signature in its complete form
+	signature of a routine (e.g. prototype or parameter list). A routine signature in its complete form
 	specifies the return type of a routine and its formal argument list.
 	This extension field is presently supported only for C-based
 	languages and does not include the return type.
@@ -1721,26 +1717,41 @@ The meaning of major fields is as follows (one-letter flag/long-name flag):
 	callable like function as ``typeref:`` field.
 	Enabled by default.
 
-Check the output of the ``--list-fields`` option for the other minor
-fields.
-
 Kinds
-~~~~~~
+......
 
-``kind:`` is a field which represents the *kind* of language object
+``kind`` is a field which represents the *kind* of language object
 specified by a tag. Kinds used and defined are very different between
 parsers. For example, C language defines ``macro``, ``function``,
-``variable``, ``typedef``, etc. See also the descriptions of
-``--list-kinds-full`` option and ``--kinds-<LANG>`` option.
+``variable``, ``typedef``, etc.
 
-Indicates the type, or kind, of tag. Its value is either one of the
-corresponding one-letter flags described under the various
-``--kinds-<LANG>`` options above, or a long-name flag. It is permitted
+``--kinds-<LANG>=[+|-]kinds|*`` option specifies a list of language-specific
+kinds of tags (or kinds) to include in the output file for a particular
+language.
+
+See the output of ``ctags --list-kinds-full`` for the complete
+list of the kinds.
+
+Its value is either one of the
+corresponding one-letter flags or a long-name flag. It is permitted
 (and is, in fact, the default) for the key portion of this field to be
-omitted. The optional behaviors are controlled with the ``--fields`` option.
+omitted. The optional behaviors are controlled with the ``--fields`` option as follows.
+
+.. code-block:: console
+
+	$ ctags -o - kinds.c
+	foo     kinds.c /^int foo() {$/;"       f       typeref:typename:int
+	$ ctags --fields=+k -o - kinds.c
+	foo     kinds.c /^int foo() {$/;"       f       typeref:typename:int
+	$ ctags --fields=+K -o - kinds.c
+	foo     kinds.c /^int foo() {$/;"       function        typeref:typename:int
+	$ ctags --fields=+z -o - kinds.c
+	foo     kinds.c /^int foo() {$/;"       kind:f  typeref:typename:int
+	$ ctags --fields=+zK -o - kinds.c
+	foo     kinds.c /^int foo() {$/;"       kind:function   typeref:typename:int
 
 Roles
-~~~~~~
+......
 
 *Role* is a newly introduced concept in Universal Ctags. Role is a
 concept associated with reference tags, and is not implemented widely yet.
@@ -1754,15 +1765,35 @@ kind. In other words, the ``kind`` field identifies the *what* of the language
 object, whereas the ``roles`` field identifies the *how* of a referenced language
 object. Roles are only used with specific kinds.
 
-For example, for the source file used for demonstrating in the "`Extras`_"
-subsection, ``Baz`` is tagged as a reference tag with kind ``package`` and with
-role ``imported``. Another example is for a C++ ``header`` kind tag, generated by
-``#include`` statements: the ``roles:system`` or ``roles:local`` fields will be
-added depending on whether the include file name begins with '``<``' or not.
+For a definition tag, this field takes ``def`` as a value.
 
-See also the descriptions of ``--list-roles`` and ``--roles-<LANG>.<KIND>=``
-options.
+For example, ``Baz`` is tagged as a reference tag with kind ``package`` and with
+role ``imported`` with the following code.
 
+.. code-block:: java
+
+	package Bar;
+	import Baz;
+
+	class Foo {
+			// ...
+	}
+
+.. code-block:: console
+
+	$ ctags --fields=+KEr -uo - roles.java
+	Bar     roles.java     /^package Bar;$/;"      package roles:def
+	Foo     roles.java     /^class Foo {$/;"       class   roles:def
+	$ ctags --fields=+EKr --extras=+r -uo - roles.java
+	Bar     roles.java     /^package Bar;$/;"      package roles:def
+	Baz     roles.java     /^import Baz;$/;"       package roles:imported  extras:reference
+	Foo     roles.java     /^class Foo {$/;"       class   roles:def
+
+``--roles-<LANG>.<KIND>=[+|-]roles|*`` option specifies a list of kind-specific
+roles of tags to include in the output file for a particular language.
+
+Inquire the output of ``ctags --list-roles`` for the list of
+roles.
 
 Extras
 ~~~~~~
@@ -1775,18 +1806,18 @@ name, or for tagging something not associated with a language object. A typical
 extra tag is ``qualified``, which tags a language object with a
 class-qualified or scope-qualified name.
 
-Inquire the output of ``--list-extras`` option for the other minor
-extras.
+``--extra=[+|-]flags|*`` and ``--extras-<LANG>=[+|-]flags|*`` options specifies
+whether to include extra tag entries for certain kinds of information.
 
-See also the descriptions of ``--list-extras`` option and ``--extras``
-option in "`OPTIONS`_".
+Inquire the output of ``ctags --list-extras`` for the list of extras.
+The meaning of major extras is as follows (long-name flag/one-letter flag):
 
-The meaning of major extras is as follows (one-letter flag/long-name flag):
-
-none/``anonymous``
+``anonymous``/none
 	Include an entry for the language object that has no name like lambda
 	function. This extra has no one-letter flag and is enabled by
-	default. The extra tag is useful as a placeholder to fill scope fields
+	default.
+
+	The extra tag is useful as a placeholder to fill scope fields
 	for language objects defined in a language object with no name.
 
 	.. code-block:: C
@@ -1801,12 +1832,13 @@ none/``anonymous``
 	ctags generates an anonymous extra tag for the struct
 	and fills the scope fields with the name of the extra tag.
 
-	.. code-block:: tags
+	.. code-block:: console
 
+		$ ctags --fields=-f -uo - input.c
 		__anon9f26d2460108	input.c	/^struct {$/;"	s
-		p	input.c	/^} p = { .x = 0.0, .y = 0.0 };$/;"	v	typeref:struct:__anon9f26d2460108
 		x	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
 		y	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
+		p	input.c	/^} p = { .x = 0.0, .y = 0.0 };$/;"	v	typeref:struct:__anon9f26d2460108
 
 	The above tag output has ``__anon9f26d2460108`` as an anonymous extra tag.
 	The typeref field of '``p``' also receives the benefit of it.
@@ -1815,11 +1847,28 @@ none/``anonymous``
 	Indicates whether tags scoped only for a single file (i.e. tags which
 	cannot be seen outside of the file in which they are defined, such as
 	language objects with ``static`` modifier of C language) should be included
-	in the output. See also the ``-h`` option. This option is enabled by
-	default. This is the replacement for ``--file-scope`` option of
-	Exuberant Ctags.
+	in the output. See also the ``-h`` option.
 
-	.. TODO: "This option" is ambiguous. fileScope Extra Tag or -h option?
+	This extra tag is enabled by default. Add ``--extras=-F`` option not to
+	output tags scoped only for a single-file. This is the replacement for
+	``--file-scope`` option of Exuberant Ctags.
+
+	.. code-block:: c
+
+		static int f() {
+			return 0;
+		}
+		int g() {
+			return 0;
+		}
+
+	.. code-block:: console
+
+		$ ctags -uo - filescope.c
+		f       filescope.c     /^static int f() {$/;"  f       typeref:typename:int    file:
+		g       filescope.c     /^int g() {$/;" f       typeref:typename:int
+		$ ctags --extras=-F -uo - filescope.c
+		g       filescope.c     /^int g() {$/;" f       typeref:typename:int
 
 ``inputFile``/``f``
 	Include an entry for the base file name of every source file
@@ -1831,7 +1880,7 @@ none/``anonymous``
 	attached to the tag. (However, ctags omits the ``end:`` field
 	if no newline is in the file like an empty file.)
 
-	By default, ctags doesn't create the ``f/inputFile`` extra
+	By default, ctags doesn't create the ``inputFile``/``f`` extra
 	tag for the source file when ctags doesn't find a parser
 	for it. Enabling ``Unknown`` parser with ``--languages=+Unknown`` forces
 	ctags to create the extra tags for any source files.
@@ -1868,20 +1917,52 @@ none/``anonymous``
 
 	.. code-block:: Java
 
-		package Bar;
-		import Baz;
+		class point {
+			double x;
+		};
 
-		class Foo {
-			// ...
-		}
-
-	For the above source file, ctags tags ``Bar`` and ``Foo`` by
+	For the above source file, ctags tags ``point`` and ``x`` by
 	default.  If the ``qualified`` extra is enabled from the command line
-	(``--extras=+q``), then ``Bar.Foo`` is also tagged even though the string
-	``Bar.Foo`` is not in the source code.
+	(``--extras=+q``), then ``point.x`` is also tagged even though the string
+	"``point.x``" is not in the source code.
+
+	.. code-block:: console
+
+		$ ctags --fields=+K -uo - qualified.java
+		point   qualified.java  /^class point {$/;"     class
+		x       qualified.java  /^      double x;$/;"   field   class:point
+		$ ctags --fields=+K --extras=+q -uo - qualified.java
+		point   qualified.java  /^class point {$/;"     class
+		x       qualified.java  /^      double x;$/;"   field   class:point
+		point.x qualified.java  /^      double x;$/;"   field   class:point
 
 ``reference``/``r``
 	Include reference tags. See "`TAG ENTRIES`_" about reference tags.
+
+	The following example demonstrates the ``reference`` extra tag.
+
+	.. code-block:: c
+
+		#include <stdio.h>
+		#include "utils.h"
+		#define X
+		#undef X
+
+	The ``roles:system`` or ``roles:local`` fields will be
+	added depending on whether the include file name begins with '``<``' or not.
+
+	``#define X`` emits a definition tag. On the other hand ``#undef X`` emits a
+	reference tag.
+
+	.. code-block:: console
+
+		$ ctags --fields=+EKr -uo - inc.c
+		X       inc.c   /^#define X$/;" macro   file:   roles:def       extras:fileScope
+		$ ctags --fields=+EKr --extras=+r -uo - inc.c
+		stdio.h inc.c   /^#include <stdio.h>/;" header  roles:system    extras:reference
+		utils.h inc.c   /^#include "utils.h"/;" header  roles:local     extras:reference
+		X       inc.c   /^#define X$/;" macro   file:   roles:def       extras:fileScope
+		X       inc.c   /^#undef X$/;"  macro   file:   roles:undef     extras:fileScope,reference
 
 Language-specific fields and extras
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1890,18 +1971,9 @@ Exuberant Ctags has the concept of *fields* and *extras*. They are common
 between parsers of different languages. Universal Ctags extends this concept
 by providing language-specific fields and extras.
 
-.. options should be explained and revised here
-   ``--list-languages`` (done)
-   ``--list-kinds``     (done)
-   ``--list-kinds-full``(done)
-   ``--list-fields``    (done)
-   ``--list-extras``    (done)
-   ``--list-roles``     (done)
-   ``--kinds-<LANG>=``  (done)
-   ``--fields=``        (done)
-   ``--fields-<LANG>``  (done)
-   ``--extras=``        (done)
-   ``--extras-<LANG>=`` (done)
+.. Note: kinds are language-specific since e-ctags. roles are new to u-ctags.
+
+.. TODO: move the following "Hot to ..." sections to FAQ man page when available
 
 HOW TO USE WITH VI
 ------------------
@@ -1980,8 +2052,6 @@ identical to the line containing the tag. The following example
 demonstrates this condition:
 
 .. code-block:: C
-	:linenos:
-	:emphasize-lines: 1,5
 
 	int variable;
 
@@ -1994,8 +2064,8 @@ demonstrates this condition:
 
 Depending upon which editor you use and where in the code you happen to be,
 it is possible that the search pattern may locate the local parameter
-declaration on the line 5 before it finds the actual global variable definition
-on the line 1, since the lines (and therefore their search patterns) are
+declaration before it finds the actual global variable definition,
+since the lines (and therefore their search patterns) are
 identical.
 
 This can be avoided by use of the ``--excmd=n`` option.

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -595,97 +595,6 @@ Tags File Contents Options
 	extras`_" about the concept). Use ``--extras-<LANG>=`` option for
 	controlling them.
 
-	.. TODO: move the following list to "Extras"
-
-	The meaning of major extras is as follows (one-letter flag/long-name flag):
-
-	none/``anonymous``
-		Include an entry for the language object that has no name like lambda
-		function. This extra has no one-letter flag and is enabled by
-		default. The extra tag is useful as a placeholder to fill scope fields
-		for language objects defined in a language object with no name.
-
-		.. code-block:: C
-
-			struct {
-				double x, y;
-			} p = { .x = 0.0, .y = 0.0 };
-
-		'``x``' and '``y``' are the members of a structure. When filling the scope
-		fields for them, ctags has trouble because the struct
-		where '``x``' and '``y``' belong to has no name. For overcoming the trouble,
-		ctags generates an anonymous extra tag for the struct
-		and fills the scope fields with the name of the extra tag.
-
-		.. code-block:: tags
-
-			__anon9f26d2460108	input.c	/^struct {$/;"	s
-			p	input.c	/^} p = { .x = 0.0, .y = 0.0 };$/;"	v	typeref:struct:__anon9f26d2460108
-			x	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
-			y	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
-
-		The above tag output has ``__anon9f26d2460108`` as an anonymous extra tag.
-		The typeref field of '``p``' also receives the benefit of it.
-
-	``F``/``fileScope``
-		Indicates whether tags scoped only for a single file (i.e. tags which
-		cannot be seen outside of the file in which they are defined, such as
-		language objects with ``static`` modifier of C language) should be included
-		in the output. See also the ``-h`` option. This option is enabled by
-		default. This is the replacement for ``--file-scope`` option of
-		Exuberant Ctags.
-
-		.. TODO: "This option" is ambiguous. fileScope Extra Tag or -h option?
-
-	``f``/``inputFile``
-		Include an entry for the base file name of every source file
-		(e.g. ``example.c``), which addresses the first line of the file.
-		This flag is the replacement for ``--file-tags`` hidden option of
-		Exuberant Ctags.
-
-		If the ``end:`` field is enabled, the end line number of the file can be
-		attached to the tag. (However, ctags omits the ``end:`` field
-		if no newline is in the file like an empty file.)
-
-		By default, ctags doesn't create the ``f/inputFile`` extra
-		tag for the source file when ctags doesn't find a parser
-		for it. Enabling ``Unknown`` parser with ``--languages=+Unknown`` forces
-		ctags to create the extra tags for any source files.
-
-		The etags mode enables the ``Unknown`` parser implicitly.
-
-	``p``/``pseudo``
-		Include pseudo-tags. Enabled by default unless the tag file is
-		written to standard output. See :ref:`ctags-client-tools(7) <ctags-client-tools(7)>` about
-		the detail of pseudo-tags.
-
-	``q``/``qualified``
-		Include an extra class-qualified or namespace-qualified tag entry
-		for each tag which is a member of a class or a namespace.
-
-		This may allow easier location of a specific tags when
-		multiple occurrences of a tag name occur in the tag file.
-		Note, however, that this could potentially more than double
-		the size of the tag file.
-
-		The actual form of the qualified tag depends upon the language
-		from which the tag was derived (using a form that is most
-		natural for how qualified calls are specified in the
-		language). For C++ and Perl, it is in the form
-		``class::member``; for Eiffel and Java, it is in the form
-		``class.member``.
-
-		Note: Using backslash characters as separators forming
-		qualified name in PHP. However, in tags output of
-		Universal Ctags, a backslash character in a name is escaped
-		with a backslash character. See :ref:`tags(5) <tags(5)>` about the escaping.
-
-	``r``/``reference``
-		Include reference tags. See "`TAG ENTRIES`_" about reference tags.
-
-	Inquire the output of ``--list-extras`` option for the other minor
-	extras.
-
 ``--extras-<LANG>=[+|-]flags|*``
 	Specifies whether to include extra tag entries for certain kinds of
 	information for language *<LANG>*. Universal Ctags
@@ -729,73 +638,6 @@ Tags File Contents Options
 	controlling them.
 
 	.. TODO: Confirm the description above is correct.
-
-	.. TODO: move the following list to "Fields"
-
-	The meaning of major fields is as follows (one-letter flag/long-name flag):
-
-	``a``/``access``
-		Access (or export) of class members
-
-	``e``/``end``
-		End lines of various items
-
-	``f``/``file``
-		File-restricted scoping. Enabled by default.
-
-	``i``/``inherits``
-		Inheritance information.
-
-	``k``
-		Kind of tag as one-letter. Enabled by default.
-		Exceptionally this has no long-name.
-		See also ``z``/``kind`` flag.
-
-	``K``
-		Kind of tag as long-name.
-		Exceptionally this has no long-name.
-		See also ``z``/``kind`` flag.
-
-	``l``/``language``
-		Language of source file containing tag
-
-	``m``/``implementation``
-		Implementation information
-
-	``n``/``line``
-		Line number of tag definition
-
-	``p``/``scopeKind``
-		Kind of scope as long-name
-
-	``r``/``roles``
-		Roles assigned to the tag.
-		For a definition tag, this field takes ``def`` as a value.
-
-	``s``
-		Scope of tag definition. Enabled by default.
-		Exceptionally this has no long-name.
-		See also ``Z`` flag.
-
-		.. TODO? implement "scope" of Z/scope flag.
-
-	``S``/``signature``
-		Signature of routine (e.g. prototype or parameter list)
-
-	``t``/``typeref``
-		Type and name of a variable, typedef, or return type of
-		callable like function as ``typeref:`` field.
-		Enabled by default.
-
-	``z``/``kind``
-		Include the ``kind:`` key in kind field.  See also ``k`` and ``K`` flags.
-
-	``Z``
-		Include the ``scope:`` key in scope field.
-		Exceptionally this has no long-name.  See also ``s`` flag.
-
-	Check the output of the ``--list-fields`` option for the other minor
-	fields.
 
 ``--fields-<LANG>=[+|-]flags|*``
 	Specifies which language-specific fields are to be included in
@@ -1720,124 +1562,6 @@ Examples:
 
 ``NONE`` means that ctags does not select any parser for the file.
 
-.. _tag_entries:
-
-TAG ENTRIES
------------
-
-A tag is an index for a language object. The concept of a tag and related
-items in Exuberant Ctags are refined and extended in Universal Ctags.
-
-A tag is categorized into *definition tags* or *reference tags*.
-In general, Exuberant Ctags only tags *definitions* of
-language objects: places where newly named language objects *are introduced*.
-Universal Ctags, on the other hand, can also tag *references* of language
-objects: places where named language objects *are used*. However, support
-for generating reference tags is new and limited to specific areas of
-specific languages in the current version.
-
-
-Fields
-~~~~~~
-
-A tag can record various information, called *fields*. The
-essential fields are: *name* of language objects, *input*,
-*pattern*, and *line*. ``input:`` is the name of source file where
-``name:`` is defined or referenced. ``pattern:`` can be used to search
-the *name* in ``input:``. *line* is the line number where
-``name:`` is defined or referenced in ``input:``.
-
-ctags offers extension fields. See also the
-descriptions of ``--list-fields`` option and ``--fields`` option.
-
-
-Kinds
-~~~~~~
-
-``kind:`` is a field which represents the *kind* of language object
-specified by a tag. Kinds used and defined are very different between
-parsers. For example, C language defines ``macro``, ``function``,
-``variable``, ``typedef``, etc. See also the descriptions of
-``--list-kinds-full`` option and ``--kinds-<LANG>`` option.
-
-
-Extras
-~~~~~~
-
-Generally, ctags tags only language objects appearing
-in source files, as is. In other words, a value for a ``name:`` field
-should be found on the source file associated with the ``name:``. An
-``extra`` type tag (*extra*) is for tagging a language object with a processed
-name, or for tagging something not associated with a language object. A typical
-extra tag is ``qualified``, which tags a language object with a
-class-qualified or scope-qualified name.
-
-The following example demonstrates the ``qualified`` extra tag.
-
-.. code-block:: Java
-
-	package Bar;
-	import Baz;
-
-	class Foo {
-		// ...
-	}
-
-For the above source file, ctags tags ``Bar`` and ``Foo`` by
-default.  If the ``qualified`` extra is enabled from the command line
-(``--extras=+q``), then ``Bar.Foo`` is also tagged even though the string
-``Bar.Foo`` is not in the source code.
-
-See also the descriptions of ``--list-extras`` option and ``--extras``
-option in "`OPTIONS`_".
-
-
-Roles
-~~~~~~
-
-*Role* is a newly introduced concept in Universal Ctags. Role is a
-concept associated with reference tags, and is not implemented widely yet.
-
-As described previously in "`Kinds`_", the ``kind`` field represents the type
-of language object specified with a tag, such as a function vs. a variable.
-Specific kinds are defined for reference tags, such as the C++ kind ``header`` for
-header file, or Java kind ``package`` for package statements. For such reference
-kinds, a ``roles`` field can be added to distinguish the role of the reference
-kind. In other words, the ``kind`` field identifies the *what* of the language
-object, whereas the ``roles`` field identifies the *how* of a referenced language
-object. Roles are only used with specific kinds.
-
-For example, for the source file used for demonstrating in the "`Extras`_"
-subsection, ``Baz`` is tagged as a reference tag with kind ``package`` and with
-role ``imported``. Another example is for a C++ ``header`` kind tag, generated by
-``#include`` statements: the ``roles:system`` or ``roles:local`` fields will be
-added depending on whether the include file name begins with '``<``' or not.
-
-See also the descriptions of ``--list-roles`` and ``--roles-<LANG>.<KIND>=``
-options.
-
-
-Language-specific fields and extras
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Exuberant Ctags has the concept of *fields* and *extras*. They are common
-between parsers of different languages. Universal Ctags extends this concept
-by providing language-specific fields and extras.
-
-.. options should be explained and revised here
-   ``--list-languages`` (done)
-   ``--list-kinds``     (done)
-   ``--list-kinds-full``(done)
-   ``--list-fields``    (done)
-   ``--list-extras``    (done)
-   ``--list-roles``     (done)
-   ``--kinds-<LANG>=``  (done)
-   ``--fields=``        (done)
-   ``--fields-<LANG>``  (done)
-   ``--extras=``        (done)
-   ``--extras-<LANG>=`` (done)
-
-
 TAG FILE FORMAT
 ---------------
 
@@ -1874,44 +1598,40 @@ specified on the command line was relative to the current directory, then
 it will be recorded in that same manner in the tag file. See, however,
 the ``--tag-relative`` option for how this behavior can be modified.
 
+.. _tag_entries:
+
+TAG ENTRIES
+-----------
+
+A tag is an index for a language object. The concept of a tag and related
+items in Exuberant Ctags are refined and extended in Universal Ctags.
+
+A tag is categorized into *definition tags* or *reference tags*.
+In general, Exuberant Ctags only tags *definitions* of
+language objects: places where newly named language objects *are introduced*.
+Universal Ctags, on the other hand, can also tag *references* of language
+objects: places where named language objects *are used*. However, support
+for generating reference tags is new and limited to specific areas of
+specific languages in the current version.
+
+Fields
+~~~~~~
+
+A tag can record various information, called *fields*. The
+essential fields are: *name* of language objects, *input*,
+*pattern*, and *line*. ``input:`` is the name of source file where
+``name:`` is defined or referenced. ``pattern:`` can be used to search
+the *name* in ``input:``. *line* is the line number where
+``name:`` is defined or referenced in ``input:``.
+
+ctags offers extension fields. See also the
+descriptions of ``--list-fields`` option and ``--fields`` option.
+
 Extension fields are tab-separated key-value pairs appended to the end of
 the EX command as a comment, as described above. These key value pairs
 appear in the general form ``key:value``. Their presence in the lines of the
 tag file are controlled by the ``--fields`` option. The possible keys and
 the meaning of their values are as follows:
-
-.. Q: this list is very out-of-date. Should we just say "use --list-fields"?
-
-access
-	Indicates the visibility of this class member, where value is specific
-	to the language.
-
-file
-	Indicates that the tag has file-limited visibility. This key has no
-	corresponding value.
-
-kind
-	Indicates the type, or kind, of tag. Its value is either one of the
-	corresponding one-letter flags described under the various
-	``--kinds-<LANG>`` options above, or a long-name flag. It is permitted
-	(and is, in fact, the default) for the key portion of this field to be
-	omitted. The optional behaviors are controlled with the ``--fields`` option.
-
-implementation
-	When present, this indicates a limited implementation (abstract vs.
-	concrete) of a routine or class, where value is specific to the
-	language (``virtual`` or ``pure virtual`` for C++; ``abstract`` for Java).
-
-inherits
-	When present, value. is a comma-separated list of classes from which
-	this class is derived (i.e. inherits from).
-
-signature
-	When present, value is a language-dependent representation of the
-	signature of a routine. A routine signature in its complete form
-	specifies the return type of a routine and its formal argument list.
-	This extension field is presently supported only for C-based
-	languages and does not include the return type.
 
 In addition, information on the scope of the tag definition may be
 available, with the key portion equal to some language-dependent construct
@@ -1920,6 +1640,268 @@ This scope entry indicates the scope in which the tag was found.
 For example, a tag generated for a C structure member would have a scope
 looking like ``struct:myStruct``.
 
+The meaning of major fields is as follows (one-letter flag/long-name flag):
+
+``access``/``a``
+	Access (or export) of class members
+
+	Indicates the visibility of this class member, where value is specific
+	to the language.
+
+``end``/``e``
+	End lines of various items
+
+``file``/``f``
+	File-restricted scoping. Enabled by default.
+
+	Indicates that the tag has file-limited visibility. This key has no
+	corresponding value.
+
+``implementation``/``m``
+	Implementation information
+
+	When present, this indicates a limited implementation (abstract vs.
+	concrete) of a routine or class, where value is specific to the
+	language (``virtual`` or ``pure virtual`` for C++; ``abstract`` for Java).
+
+``inherits``/``i``
+	Inheritance information.
+
+	When present, value. is a comma-separated list of classes from which
+	this class is derived (i.e. inherits from).
+
+``k``
+	Kind of tag as one-letter. Enabled by default.
+	Exceptionally this has no long-name.
+	See also ``kind``/``z`` flag.
+
+``K``
+	Kind of tag as long-name.
+	Exceptionally this has no long-name.
+	See also ``kind``/``z`` flag.
+
+``kind``/``z``
+	Include the ``kind:`` key in kind field.  See also ``k`` and ``K`` flags.
+
+``language``/``l``
+	Language of source file containing tag
+
+``line``/``n``
+	Line number of tag definition
+
+``roles``/``r``
+	Roles assigned to the tag.
+	For a definition tag, this field takes ``def`` as a value.
+
+``s``
+	Scope of tag definition. Enabled by default.
+	Exceptionally this has no long-name.
+	See also ``Z`` flag.
+
+	.. TODO? implement "scope" of Z/scope flag.
+
+``Z``
+	Include the ``scope:`` key in scope field.
+	Exceptionally this has no long-name.  See also ``s`` flag.
+
+``scopeKind``/``p``
+	Kind of scope as long-name
+
+``signature``/``S``
+	Signature of routine (e.g. prototype or parameter list)
+
+	When present, value is a language-dependent representation of the
+	signature of a routine. A routine signature in its complete form
+	specifies the return type of a routine and its formal argument list.
+	This extension field is presently supported only for C-based
+	languages and does not include the return type.
+
+``typeref``/``t``
+	Type and name of a variable, typedef, or return type of
+	callable like function as ``typeref:`` field.
+	Enabled by default.
+
+Check the output of the ``--list-fields`` option for the other minor
+fields.
+
+Kinds
+~~~~~~
+
+``kind:`` is a field which represents the *kind* of language object
+specified by a tag. Kinds used and defined are very different between
+parsers. For example, C language defines ``macro``, ``function``,
+``variable``, ``typedef``, etc. See also the descriptions of
+``--list-kinds-full`` option and ``--kinds-<LANG>`` option.
+
+Indicates the type, or kind, of tag. Its value is either one of the
+corresponding one-letter flags described under the various
+``--kinds-<LANG>`` options above, or a long-name flag. It is permitted
+(and is, in fact, the default) for the key portion of this field to be
+omitted. The optional behaviors are controlled with the ``--fields`` option.
+
+Roles
+~~~~~~
+
+*Role* is a newly introduced concept in Universal Ctags. Role is a
+concept associated with reference tags, and is not implemented widely yet.
+
+As described previously in "`Kinds`_", the ``kind`` field represents the type
+of language object specified with a tag, such as a function vs. a variable.
+Specific kinds are defined for reference tags, such as the C++ kind ``header`` for
+header file, or Java kind ``package`` for package statements. For such reference
+kinds, a ``roles`` field can be added to distinguish the role of the reference
+kind. In other words, the ``kind`` field identifies the *what* of the language
+object, whereas the ``roles`` field identifies the *how* of a referenced language
+object. Roles are only used with specific kinds.
+
+For example, for the source file used for demonstrating in the "`Extras`_"
+subsection, ``Baz`` is tagged as a reference tag with kind ``package`` and with
+role ``imported``. Another example is for a C++ ``header`` kind tag, generated by
+``#include`` statements: the ``roles:system`` or ``roles:local`` fields will be
+added depending on whether the include file name begins with '``<``' or not.
+
+See also the descriptions of ``--list-roles`` and ``--roles-<LANG>.<KIND>=``
+options.
+
+
+Extras
+~~~~~~
+
+Generally, ctags tags only language objects appearing
+in source files, as is. In other words, a value for a ``name:`` field
+should be found on the source file associated with the ``name:``. An
+``extra`` type tag (*extra*) is for tagging a language object with a processed
+name, or for tagging something not associated with a language object. A typical
+extra tag is ``qualified``, which tags a language object with a
+class-qualified or scope-qualified name.
+
+Inquire the output of ``--list-extras`` option for the other minor
+extras.
+
+See also the descriptions of ``--list-extras`` option and ``--extras``
+option in "`OPTIONS`_".
+
+The meaning of major extras is as follows (one-letter flag/long-name flag):
+
+none/``anonymous``
+	Include an entry for the language object that has no name like lambda
+	function. This extra has no one-letter flag and is enabled by
+	default. The extra tag is useful as a placeholder to fill scope fields
+	for language objects defined in a language object with no name.
+
+	.. code-block:: C
+
+		struct {
+			double x, y;
+		} p = { .x = 0.0, .y = 0.0 };
+
+	'``x``' and '``y``' are the members of a structure. When filling the scope
+	fields for them, ctags has trouble because the struct
+	where '``x``' and '``y``' belong to has no name. For overcoming the trouble,
+	ctags generates an anonymous extra tag for the struct
+	and fills the scope fields with the name of the extra tag.
+
+	.. code-block:: tags
+
+		__anon9f26d2460108	input.c	/^struct {$/;"	s
+		p	input.c	/^} p = { .x = 0.0, .y = 0.0 };$/;"	v	typeref:struct:__anon9f26d2460108
+		x	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
+		y	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
+
+	The above tag output has ``__anon9f26d2460108`` as an anonymous extra tag.
+	The typeref field of '``p``' also receives the benefit of it.
+
+``fileScope``/``F``
+	Indicates whether tags scoped only for a single file (i.e. tags which
+	cannot be seen outside of the file in which they are defined, such as
+	language objects with ``static`` modifier of C language) should be included
+	in the output. See also the ``-h`` option. This option is enabled by
+	default. This is the replacement for ``--file-scope`` option of
+	Exuberant Ctags.
+
+	.. TODO: "This option" is ambiguous. fileScope Extra Tag or -h option?
+
+``inputFile``/``f``
+	Include an entry for the base file name of every source file
+	(e.g. ``example.c``), which addresses the first line of the file.
+	This flag is the replacement for ``--file-tags`` hidden option of
+	Exuberant Ctags.
+
+	If the ``end:`` field is enabled, the end line number of the file can be
+	attached to the tag. (However, ctags omits the ``end:`` field
+	if no newline is in the file like an empty file.)
+
+	By default, ctags doesn't create the ``f/inputFile`` extra
+	tag for the source file when ctags doesn't find a parser
+	for it. Enabling ``Unknown`` parser with ``--languages=+Unknown`` forces
+	ctags to create the extra tags for any source files.
+
+	The etags mode enables the ``Unknown`` parser implicitly.
+
+``pseudo``/``p``
+	Include pseudo-tags. Enabled by default unless the tag file is
+	written to standard output. See :ref:`ctags-client-tools(7) <ctags-client-tools(7)>` about
+	the detail of pseudo-tags.
+
+``qualified``/``q``
+	Include an extra class-qualified or namespace-qualified tag entry
+	for each tag which is a member of a class or a namespace.
+
+	This may allow easier location of a specific tags when
+	multiple occurrences of a tag name occur in the tag file.
+	Note, however, that this could potentially more than double
+	the size of the tag file.
+
+	The actual form of the qualified tag depends upon the language
+	from which the tag was derived (using a form that is most
+	natural for how qualified calls are specified in the
+	language). For C++ and Perl, it is in the form
+	``class::member``; for Eiffel and Java, it is in the form
+	``class.member``.
+
+	Note: Using backslash characters as separators forming
+	qualified name in PHP. However, in tags output of
+	Universal Ctags, a backslash character in a name is escaped
+	with a backslash character. See :ref:`tags(5) <tags(5)>` about the escaping.
+
+	The following example demonstrates the ``qualified`` extra tag.
+
+	.. code-block:: Java
+
+		package Bar;
+		import Baz;
+
+		class Foo {
+			// ...
+		}
+
+	For the above source file, ctags tags ``Bar`` and ``Foo`` by
+	default.  If the ``qualified`` extra is enabled from the command line
+	(``--extras=+q``), then ``Bar.Foo`` is also tagged even though the string
+	``Bar.Foo`` is not in the source code.
+
+``reference``/``r``
+	Include reference tags. See "`TAG ENTRIES`_" about reference tags.
+
+Language-specific fields and extras
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Exuberant Ctags has the concept of *fields* and *extras*. They are common
+between parsers of different languages. Universal Ctags extends this concept
+by providing language-specific fields and extras.
+
+.. options should be explained and revised here
+   ``--list-languages`` (done)
+   ``--list-kinds``     (done)
+   ``--list-kinds-full``(done)
+   ``--list-fields``    (done)
+   ``--list-extras``    (done)
+   ``--list-roles``     (done)
+   ``--kinds-<LANG>=``  (done)
+   ``--fields=``        (done)
+   ``--fields-<LANG>``  (done)
+   ``--extras=``        (done)
+   ``--extras-<LANG>=`` (done)
 
 HOW TO USE WITH VI
 ------------------

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -55,7 +55,7 @@ describes how the capability is extended.
 
 Newly introduced experimental features are not explained here. If you
 are interested in such features and ctags internals,
-visit https://docs.ctags.io/en/latest/.
+visit https://docs.ctags.io/.
 
 
 COMMAND LINE INTERFACE
@@ -117,7 +117,7 @@ List options
 ~~~~~~~~~~~~
 
 Universal Ctags introduces many ``--list-...`` options that provide
-the internal data of Universal Ctags. Both users and client tools may
+the internal data of Universal Ctags (See :ref:`option_listing`). Both users and client tools may
 use the data. ``--with-list-header`` and ``--machinable`` options
 adjust the output of the most of ``--list-...`` options.
 
@@ -158,7 +158,9 @@ Input/Output File Options
 	will be compared against both the complete path (e.g.
 	``some/path/base.ext``) and the base name (e.g. ``base.ext``) of the file, thus
 	allowing patterns which match a given file name irrespective of its
-	path, or match only a specific path. If appropriate support is available
+	path, or match only a specific path.
+
+	If appropriate support is available
 	from the runtime library of your C compiler, then pattern may
 	contain the usual shell wildcards (not regular expressions) common on
 	Unix (be sure to quote the option parameter to protect the wildcards from
@@ -192,6 +194,9 @@ Input/Output File Options
 	line: ``--exclude=foo/* --exclude-exception=foo/main.c``. Don't forget
 	shell quoting for '``*``'.
 
+.. TODO: Which shell requires the quoting?
+   At least bash does not require quoting unless directory `--exclude=foo' exists.
+
 ``--filter[=yes|no]``
 	Makes ctags behave as a filter, reading source
 	file names from standard input and printing their tags to standard
@@ -214,25 +219,33 @@ Input/Output File Options
 
 ``--recurse[=yes|no]``
 	Recurse into directories encountered in the list of supplied files.
+
 	If the list of supplied files is empty and no file list is specified with
 	the ``-L`` option, then the current directory (i.e. '``.``') is assumed.
-	Symbolic links are followed by default. If you don't like these behaviors, either
+	Symbolic links are followed by default (See ``--links`` option). If you don't like these behaviors, either
 	explicitly specify the files or pipe the output of ``find(1)`` into
-	``ctags -L -`` instead. Note: This option is not supported on
-	all platforms at present. It is available if the output of the ``--help``
-	option includes this option. See, also, the ``--exclude`` and
+	``ctags -L -`` instead. See, also, the ``--exclude`` and
 	``--maxdepth`` to limit recursion.
+
+	Note: This option is not supported on
+	all platforms at present. It is available if the output of the ``--help``
+	option includes this option.
+
+.. TODO(code): --list-features option should support this.
 
 ``-R``
 	Equivalent to ``--recurse``.
 
 ``-L file``
 	Read from file a list of file names for which tags should be generated.
+
 	If file is specified as '``-``', then file names are read from standard
 	input. File names read using this option are processed following file
 	names appearing on the command line. Options are also accepted in this
 	input. If this option is specified more than once, only the last will
-	apply. Note: file is read in line-oriented mode, where a new line is
+	apply.
+
+	Note: file is read in line-oriented mode, where a new line is
 	the only delimiter and non-trailing white space is considered significant,
 	in order that file names containing spaces may be supplied
 	(however, trailing white space is stripped from lines); this can affect
@@ -250,7 +263,9 @@ Input/Output File Options
 ``-f tagfile``
 	Use the name specified by tagfile for the tag file (default is "``tags``",
 	or "``TAGS``" when running in etags mode). If tagfile is specified as '``-``',
-	then the tags are written to standard output instead. ctags
+	then the tags are written to standard output instead.
+
+	ctags
 	will stubbornly refuse to take orders if tagfile exists and
 	its first line contains something other than a valid tags line. This
 	will save your neck if you mistakenly type ``ctags -f
@@ -259,7 +274,9 @@ Input/Output File Options
 	file name which begins with a '``-``' (dash) character, since this most
 	likely means that you left out the tag file name and this option tried to
 	grab the next option as the file name. If you really want to name your
-	output tag file ``-ugly``, specify it as ``-f ./-ugly``. This option must
+	output tag file ``-ugly``, specify it as ``-f ./-ugly``.
+
+	This option must
 	appear before the first file name. If this option is specified more
 	than once, only the last will apply.
 
@@ -274,13 +291,19 @@ Output Format Options
 	Specifies a string to print to standard output following the tags for
 	each file name parsed when the ``--filter`` option is enabled. This may
 	permit an application reading the output of ctags
-	to determine when the output for each file is finished. Note that if the
+	to determine when the output for each file is finished.
+
+	Note that if the
 	file name read is a directory and ``--recurse`` is enabled, this string will
 	be printed only once at the end of all tags found for by descending
 	the directory. This string will always be separated from the last tag
-	line for the file by its terminating newline. This option is quite
+	line for the file by its terminating newline.
+
+	This option is quite
 	esoteric and is empty by default. This option must appear before
 	the first file name.
+
+.. TODO: Shall we move this after "--filter"?
 
 ``--format=level``
 	Change the format of the output tag file. Currently the only valid
@@ -316,7 +339,9 @@ Output Format Options
 	the output includes: the tag name; the kind of tag; the line number,
 	file name, and source line (with extra white space condensed) of the
 	file which defines the tag. No tag file is written and all options
-	affecting tag file output will be ignored. Example applications for this
+	affecting tag file output will be ignored.
+
+	Example applications for this
 	feature are generating a listing of all functions located in a source
 	file (e.g. ``ctags -x --kinds-c=f file``), or generating
 	a list of all externally visible global variables located in a source
@@ -363,17 +388,17 @@ Output Format Options
 
 Language Selection and Mapping Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``--language-force=language``
+``--language-force=language|auto``
 	By default, ctags automatically selects the language
 	of a source file, ignoring those files whose language cannot be
-	determined (see "`Determining file language`_", above). This option forces the specified
+	determined (see "`Determining file language`_"). This option forces the specified
 	*language* (case-insensitive; either built-in or user-defined) to be used
 	for every supplied file instead of automatically selecting the language
 	based upon its extension. In addition, the special value ``auto`` indicates
 	that the language should be automatically selected (which effectively
 	disables this option).
 
-``--languages=[+|-]list``
+``--languages=[+|-]list|all``
 	Specifies the languages for which tag generation is enabled, with *list*
 	containing a comma-separated list of language names (case-insensitive;
 	either built-in or user-defined). If the first language of *list* is not
@@ -526,7 +551,7 @@ Tags File Contents Options
 		jumps to some tags to miss the target definition by one or more
 		lines. Basically, this option is best used when the source code
 		to which it is applied is not subject to change. Selecting this
-		option type causes the following options to be ignored: ``-BF``.
+		option type causes the following options to be ignored: ``-B``, ``-F``.
 
 	``pattern``
 		Use only search patterns for all tags, rather than the line numbers
@@ -536,12 +561,13 @@ Tags File Contents Options
 
 	``mixed``
 		In this mode, patterns are generally used with a few exceptions.
-		For C, line numbers are used for macro definition tags. This was
-		the default format generated by the original ctags and is, therefore,
-		retained as the default for this option. For Fortran, line numbers
+		For C, line numbers are used for macro definition tags. For Fortran, line numbers
 		are used for common blocks because their corresponding source lines
 		are generally identical, making pattern searches useless
 		for finding all matches.
+
+		This was the default format generated by the original ctags and is,
+		therefore, retained as the default for this option.
 
 	``combine``
 		Concatenate the line number and pattern with a semicolon in between.
@@ -568,6 +594,8 @@ Tags File Contents Options
 	supports language-specific extras. (See "`Language-specific fields and
 	extras`_" about the concept). Use ``--extras-<LANG>=`` option for
 	controlling them.
+
+	.. TODO: move the following list to "Extras"
 
 	The meaning of major extras is as follows (one-letter flag/long-name flag):
 
@@ -603,9 +631,11 @@ Tags File Contents Options
 		Indicates whether tags scoped only for a single file (i.e. tags which
 		cannot be seen outside of the file in which they are defined, such as
 		language objects with ``static`` modifier of C language) should be included
-		in the output. See, also, the ``-h`` option. This option is enabled by
+		in the output. See also the ``-h`` option. This option is enabled by
 		default. This is the replacement for ``--file-scope`` option of
 		Exuberant Ctags.
+
+		.. TODO: "This option" is ambiguous. fileScope Extra Tag or -h option?
 
 	``f``/``inputFile``
 		Include an entry for the base file name of every source file
@@ -614,13 +644,13 @@ Tags File Contents Options
 		Exuberant Ctags.
 
 		If the ``end:`` field is enabled, the end line number of the file can be
-		attached to the tag. (However, @CTAGS_NAME_EXAMPLE@ omits the ``end:`` field
+		attached to the tag. (However, ctags omits the ``end:`` field
 		if no newline is in the file like an empty file.)
 
-		By default, @CTAGS_NAME_EXAMPLE@ doesn't create the ``f/inputFile`` extra
-		tag for the source file when @CTAGS_NAME_EXAMPLE@ doesn't find a parser
+		By default, ctags doesn't create the ``f/inputFile`` extra
+		tag for the source file when ctags doesn't find a parser
 		for it. Enabling ``Unknown`` parser with ``--languages=+Unknown`` forces
-		@CTAGS_NAME_EXAMPLE@ to create the extra tags for any source files.
+		ctags to create the extra tags for any source files.
 
 		The etags mode enables the ``Unknown`` parser implicitly.
 
@@ -680,12 +710,12 @@ Tags File Contents Options
 
 ``--fields=[+|-]flags|*``
 	Specifies which available extension fields are to be included in
-	the tag entries (see "`TAG FILE FORMAT`_" second, and "`Fields`_"
-	subsection , for more information).
+	the tag entries (see "`TAG FILE FORMAT`_" section, and "`Fields`_"
+	subsection, for more information).
 
-	The parameter ``flags`` is a set of one-letter flags (and/or long-name flags),
+	The parameter ``flags`` is a set of one-letter or long-name flags,
 	each representing one type of extension field to include.
-	Each letter or group of letters may be preceded by either '``+``' to add it
+	Each flag or group of flags may be preceded by either '``+``' to add it
 	to the default set, or '``-``' to exclude it. In the absence of any
 	preceding '``+``' or '``-``' sign, only those fields explicitly listed in flags
 	will be included in the output (i.e. overriding the default set). All
@@ -698,6 +728,9 @@ Tags File Contents Options
 	extras`_" about the concept). Use ``--fields-<LANG>=`` option for
 	controlling them.
 
+	.. TODO: Confirm the description above is correct.
+
+	.. TODO: move the following list to "Fields"
 
 	The meaning of major fields is as follows (one-letter flag/long-name flag):
 
@@ -715,12 +748,12 @@ Tags File Contents Options
 
 	``k``
 		Kind of tag as one-letter. Enabled by default.
-		Exceptionally this has no field name.
+		Exceptionally this has no long-name.
 		See also ``z``/``kind`` flag.
 
 	``K``
 		Kind of tag as long-name.
-		Exceptionally this has no field name.
+		Exceptionally this has no long-name.
 		See also ``z``/``kind`` flag.
 
 	``l``/``language``
@@ -741,7 +774,7 @@ Tags File Contents Options
 
 	``s``
 		Scope of tag definition. Enabled by default.
-		Exceptionally this has no name.
+		Exceptionally this has no long-name.
 		See also ``Z`` flag.
 
 		.. TODO? implement "scope" of Z/scope flag.
@@ -750,16 +783,16 @@ Tags File Contents Options
 		Signature of routine (e.g. prototype or parameter list)
 
 	``t``/``typeref``
-		Type and name of a variable, typedef or return type of
+		Type and name of a variable, typedef, or return type of
 		callable like function as ``typeref:`` field.
 		Enabled by default.
 
 	``z``/``kind``
-		Include the ``kind:`` key in kind field
+		Include the ``kind:`` key in kind field.  See also ``k`` and ``K`` flags.
 
 	``Z``
 		Include the ``scope:`` key in scope field.
-		Exceptionally this has no name.
+		Exceptionally this has no long-name.  See also ``s`` flag.
 
 	Check the output of the ``--list-fields`` option for the other minor
 	fields.
@@ -773,15 +806,17 @@ Tags File Contents Options
 	Specify ``all`` as *<LANG>* to apply the parameter ``flags`` to all
 	languages; all fields are enabled with specifying '``*``' as the
 	parameter flags. If specifying nothing as the parameter ``flags``
-	(``--fields-all=``), all fields are disabled. These two combinations
+	(i.e. ``--fields-all=``), all fields are disabled. These two combinations
 	are useful for testing.
+
+	.. TODO: "to all languages;" instead of "to all fields;" ???
 
 ``--kinds-<LANG>=[+|-]kinds|*``
 	Specifies a list of language-specific kinds of tags (or kinds) to
 	include in the output file for a particular language, where *<LANG>* is
 	case-insensitive and is one of the built-in language names (see the
 	``--list-languages`` option for a complete list). The parameter ``kinds`` is a group
-	of one-letter flags (and/or long-name flags) designating kinds of tags (particular to the language)
+	of one-letter or long-name flags designating kinds of tags (particular to the language)
 	to either include or exclude from the output. The specific sets of
 	flags recognized for each language, their meanings and defaults may be
 	list using the ``--list-kinds-full`` option. Each letter or group of letters
@@ -813,9 +848,11 @@ Tags File Contents Options
 	Set <LANG> specific parameter. Available parameters can be listed with
 	``--list-params``.
 
+	.. TODO: add description of "parameter".
+
 ``--pattern-length-limit=N``
-	Cutoff patterns of tag entries after '``N``' characters. Disable by setting to 0
-	(default is 96). Specifying 0 as *N* results no truncation.
+	Truncate patterns of tag entries after '``N``' characters. Disable by setting to 0
+	(default is 96).
 
 	An input source file with long lines and multiple tag matches per
 	line can generate an excessively large tags file with an
@@ -835,7 +872,7 @@ Tags File Contents Options
 	should however be rare, and in the worse case will lead to including
 	up to an extra 3 bytes above the limit.
 
-``--pseudo-tags=[+|-]ptag``, ``--pseudo-tags=*``
+``--pseudo-tags=[+|-]ptag|*``
 	Enable/disable emitting pseudo-tag named ``ptag``.
 	If '``*``' is given, enable emitting all pseudo-tags.
 
@@ -856,13 +893,13 @@ Tags File Contents Options
 
 		$ ctags --fields='{line}{end}' -o - hello.c
 		main	hello.c	/^main(int argc, char **argv)$/;"	f	line:3	end:6
-		$ ctags --put-field-prefix --fields='{line}{end}' -o - /tmp/hello.c
-		main	/tmp/hello.c	/^main(int argc, char **argv)$/;"	f	line:3	UCTAGSend:6
+		$ ctags --put-field-prefix --fields='{line}{end}' -o - hello.c
+		main	hello.c	/^main(int argc, char **argv)$/;"	f	line:3	UCTAGSend:6
 
 	In the above example, the prefix is put to ``end`` field which is
 	newly introduced in Universal Ctags.
 
-``--roles-<LANG>.<KIND>=[+|-]roles``, ``--roles-<LANG>.<KIND>=*|``
+``--roles-<LANG>.<KIND>=[+|-]roles|*``
 	Specifies a list of kind-specific roles of tags to include in the
 	output file for a particular language.
 	*<KIND>* specifies the kind where the ``roles`` are defined.
@@ -897,9 +934,11 @@ Tags File Contents Options
 	The ``never`` value indicates the recorded file paths should be absolute
 	even if source file names are passed in with relative paths.
 
+	.. TODO: make as a definition list
+
 ``--use-slash-as-filename-separator[=yes|no]``
-	Uses slash character as filename separators instead of backslash
-	character when printing ``input:`` field.
+	Uses slash ('``/``') character as filename separators instead of backslash
+	('``\``') character when printing ``input:`` field.
 	This option is available on MSWindows only.
 	The default is ``yes`` for the default "u-ctags" output format, and
 	``no`` for the other formats.
@@ -913,6 +952,9 @@ Tags File Contents Options
 
 Option File Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. TODO: merge some of description in option-file.rst into FILE or a dedicated
+	section
+
 ``--options=pathname``
 	Read additional options from file or directory.
 
@@ -928,30 +970,33 @@ Option File Options
 	As a special case, if ``--options=NONE`` is specified as the first
 	option on the command line, preloading is disabled; the option
 	will disable the automatic reading of any configuration options
-	from either a file or the environment (see "`FILES`_").
+	from either a file or the environment variable (see "`FILES`_").
 
 ``--options-maybe=pathname``
 	Same as ``--options`` but doesn't cause an error if file
 	(or directory) specified with ``pathname`` doesn't exist.
 
 ``--optlib-dir=[+]directory``
-	Add an optlib ``directory`` to or reset optlib path list.
+	Add an optlib ``directory`` to or reset the optlib path list.
 	By default, the optlib path list is empty.
 
 optlib Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+See :ref:`ctags-optlib(7) <ctags-optlib(7)>` for details of each option.
+
 ``--kinddef-<LANG>=letter,name,description``
 	Define a kind for *<LANG>*.
 	Don't be confused this with ``--kinds-<LANG>``.
 
 ``--langdef=name``
-	See :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
+	Defines a new user-defined language, ``name``, to be parsed with regular
+	expressions.
 
 ``--mline-regex-<LANG>=/line_pattern/name_pattern/[flags]``
-	Define multiline regular expression for locating tags in specific language.
+	Define multi-line regular expression for locating tags in specific language.
 
 ``--regex-<LANG>=/regexp/replacement/[kind-spec/][flags]``
-	See :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
+	Define single-line regular expression for locating tags in specific language.
 
 .. _option_lang_specific:
 
@@ -961,17 +1006,21 @@ Language Specific Options
 	Indicates a preference as to whether code within an ``#if 0`` branch of a
 	preprocessor conditional should be examined for non-macro tags (macro
 	tags are always included). Because the intent of this construct is to
-	disable code, the default value of this option is ``no``. Note that this
+	disable code, the default value of this option is ``no`` (disabled).
+
+	Note that this
 	indicates a preference only and does not guarantee skipping code within
 	an ``#if 0`` branch, since the fall-back algorithm used to generate
 	tags when preprocessor conditionals are too complex follows all branches
-	of a conditional. This option is disabled by default.
+	of a conditional.
 
 ``--line-directives[=yes|no]``
 	Specifies whether ``#line`` directives should be recognized. These are
-	present in the output of preprocessors and contain the line number, and
+	present in the output of a preprocessor and contain the line number, and
 	possibly the file name, of the original source file(s) from which the
-	preprocessor output file was generated. When enabled, this option will
+	preprocessor output file was generated. This option is off by default.
+
+	When enabled, this option will
 	cause ctags to generate tag entries marked with the
 	file names and line numbers of their locations original source file(s),
 	instead of their actual locations in the preprocessor output. The actual
@@ -979,7 +1028,9 @@ Language Specific Options
 	components as the preprocessor output file, since it is assumed that
 	the original source files are located relative to the preprocessor
 	output file (unless, of course, the ``#line`` directive specifies an
-	absolute path). This option is off by default. Note: This option is generally
+	absolute path).
+
+	Note: This option is generally
 	only useful when used together with the ``--excmd=number`` (``-n``) option.
 	Also, you may have to use either the ``--langmap`` or ``--language-force`` option
 	if the extension of the preprocessor output file is not known to
@@ -997,20 +1048,26 @@ Language Specific Options
 	Specifies a list of file extensions, separated by periods, which are
 	to be interpreted as include (or header) files. To indicate files having
 	no extension, use a period not followed by a non-period character
-	(e.g. '``.``', ``..x``, ``.x.``). This option only affects how the scoping of
+	(e.g. '``.``', ``..x``, ``.x.``).
+
+	This option only affects how the scoping of
 	particular kinds of tags are interpreted (i.e. whether or not they are
 	considered as globally visible or visible only within the file in which
 	they are defined); it does not map the extension to any particular
 	language. Any tag which is located in a non-include file and cannot be
 	seen (e.g. linked to) from another file is considered to have file-limited
 	(e.g. static) scope. No kind of tag appearing in an include file
-	will be considered to have file-limited scope. If the first character
-	in the list is a plus sign, then the extensions in the list will be
+	will be considered to have file-limited scope.
+
+	If the first character in the list is '``+``', then the extensions in the list will be
 	appended to the current list; otherwise, the list will replace the
 	current list. See, also, the ``F/fileScope`` flag of ``--extras`` option.
+
 	The default list is
 	``.h.H.hh.hpp.hxx.h++.inc.def``. To restore the default list, specify ``-h``
-	default. Note that if an extension supplied to this option is not
+	default.
+
+	Note that if an extension supplied to this option is not
 	already mapped to a particular language (see "`Determining file language`_", above),
 	you will also need to use either the ``--langmap`` or ``--language-force`` option.
 
@@ -1019,21 +1076,29 @@ Language Specific Options
 	parsing C and C++ source files. This option is specifically provided
 	to handle special cases arising through the use of preprocessor macros.
 	When the identifiers listed are simple identifiers, these identifiers
-	will be ignored during parsing of the source files. If an identifier is
+	will be ignored during parsing of the source files.
+
+	If an identifier is
 	suffixed with a '``+``' character, ctags will also
 	ignore any parenthesis-enclosed argument list which may immediately
-	follow the identifier in the source files. If two identifiers are
+	follow the identifier in the source files.
+
+	If two identifiers are
 	separated with the '``=``' character, the first identifiers is replaced by
 	the second identifiers for parsing purposes. The list of identifiers may
 	be supplied directly on the command line or read in from a separate file.
+
 	If the first character of identifier-list is '``@``', '``.``' or a pathname
 	separator ('``/``' or '``\``'), or the first two characters specify a drive
 	letter (e.g. ``C:``), the parameter identifier-list will be interpreted as
 	a filename from which to read a list of identifiers, one per input line.
+
 	Otherwise, identifier-list is a list of identifiers (or identifier
 	pairs) to be specially handled, each delimited by either a comma or
 	by white space (in which case the list should be quoted to keep the
-	entire list as one command line argument). Multiple ``-I`` options may be
+	entire list as one command line argument).
+
+	Multiple ``-I`` options may be
 	supplied. To clear the list of ignore identifiers, supply a single
 	dash ('``-``') for identifier-list.
 
@@ -1105,7 +1170,7 @@ Listing Options
 	language.  These option takes one-letter flag or long-name flag as a parameter
 	for specifying an extra.
 
-	The meaning of columns are as follows:
+	The meaning of columns in output are as follows:
 
 	LETTER
 		One-letter flag. '``-``' means the extra does not have one-letter flag.
@@ -1133,9 +1198,9 @@ Listing Options
 
 	.. TODO? xref output
 
-	A field can be enabled or disabled with ``--fields=`` for common
-	fields in all languages, or ``--fields-<LANG>=`` for the specified
-	language.  These option takes one-letter flags and/or long-name flags
+	A field can be enabled or disabled with ``--fields=`` option for common
+	fields in all languages, or ``--fields-<LANG>=`` option for the specified
+	language.  These options take one-letter flags and/or long-name flags
 	as a parameter for specifying fields.
 
 	The meaning of columns are as follows:
@@ -1154,7 +1219,7 @@ Listing Options
 		``NONE`` means the extra is common in parsers.
 
 	JSTYPE
-		Json type used in printing the value of field when ``--output-format=json``
+		JSON type used in printing the value of field when ``--output-format=json``
 		is specified.
 
 		Following characters are used for representing types.
@@ -1170,7 +1235,9 @@ Listing Options
 		``--output-format=json`` are still experimental.
 
 	FIXED
-	   Whether this field can be disabled or not. Some fields are printed always
+	   Whether this field can be disabled or not.
+
+	   Some fields are printed always
 	   in tags output. They have ``yes`` as the value for this column.
 
 	DESCRIPTION
@@ -1264,6 +1331,8 @@ Listing Options
 		Though ``local`` kind of C language is enabled/disabled. If you swap the languages, you
 		see the same result.
 
+		.. TODO: need a reference to "master parser"
+
 	DESCRIPTION
 		Human readable description for the kind.
 
@@ -1280,6 +1349,8 @@ Listing Options
 	This option does not work with ``--machinable`` nor
 	``--with-list-header``.
 
+	.. TODO: ".. may be used in many other options...": I don't think it is``all`` worth to be described.
+
 ``--list-map-extensions[=language|all]``
 	Lists the file extensions which associate a file
 	name with a language for either the specified *language* or *all*
@@ -1295,8 +1366,7 @@ Listing Options
 ``--list-maps[=language|all]``
 	Lists file name patterns and the file extensions which associate a file
 	name with a language for either the specified *language* or *all*
-	languages, and then exits. See the ``--langmap`` option, and
-	"`Determining file language`_", above.
+	languages, and then exits.
 	``all`` is used as default value if the option argument is omitted.
 
 	To list the file extensions or file name patterns individually, use
@@ -1309,6 +1379,7 @@ Listing Options
 ``--list-mline-regex-flags``
 	Output list of flags which can be used in a multiline regex parser
 	definition.
+	See :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
 
 ``--list-params[=language|all]``
 	Lists the parameters for either the specified *language* or *all*
@@ -1319,11 +1390,13 @@ Listing Options
 	Output list of pseudo-tags.
 
 ``--list-regex-flags``
+	Lists the flags that can be used in ``--regex-<LANG>`` option.
 	See :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
 
 ``--list-roles[=language|all[.kinds]]``
 	List the roles for either the specified *language* or *all* languages.
 	``all`` is used as default value if the option argument is omitted.
+
 	If the parameter ``kinds`` is given after the parameter
 	``language`` or ``all`` with concatenating with '``.``', list only roles
 	defined in the kinds. Both one-letter flags and long name flags surrounded
@@ -1342,7 +1415,7 @@ Listing Options
 
 	ENABLED
 		Whether the kind is enabled or not. It takes ``yes`` or ``no``.
-		(Currently all roles are enabled. No option for disabling
+		(Currently all roles are enabled. An option for disabling
 		a specified role is not implemented yet.)
 
 	DESCRIPTION
@@ -1374,8 +1447,8 @@ Miscellaneous Options
 	Equivalent to ``--help``.
 
 ``--help-full``
-	Prints to standard output a detailed usage description about experimental
-	features, and then exits. Visit https://docs.ctags.io/en/latest/ for information
+	Prints to standard output a detailed usage description including experimental
+	features, and then exits. Visit https://docs.ctags.io/ for information
 	about the latest exciting experimental features.
 
 ``--license``
@@ -1435,6 +1508,11 @@ parses through the file and adds an entry to the tag file for each
 language object it is written to handle. See "`TAG FILE FORMAT`_", below,
 for details on these entries.
 
+Notes for C/C++ Parser
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. TODO: move the following description to parser-cxx.rst.
+
 This implementation of ctags imposes no formatting
 requirements on C code as do legacy implementations. Older implementations
 of ctags tended to rely upon certain formatting assumptions in order to
@@ -1490,10 +1568,10 @@ removing identical tag lines.
 .. _guessing:
 
 Determining file language
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 File name mapping
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+..........................
 
 Unless the ``--language-force`` option is specified, the language of each source
 file is automatically selected based upon a *mapping* of file names to
@@ -1502,8 +1580,7 @@ the ``--list-maps`` option and may be changed using the ``--langmap`` or
 ``--map-<LANG>`` options.
 
 If the name of a file is not mapped to a language, ctags tries
-to heuristically guess the language for the file by inspecting its content. See
-"`Determining file language`_".
+to heuristically guess the language for the file by inspecting its content.
 
 All files that have no file name mapping and no guessed parser are
 ignored. This permits running ctags on all files in
@@ -1512,7 +1589,7 @@ all files in an entire source directory tree
 (e.g. ``ctags -R``), since only those files whose
 names are mapped to languages will be scanned.
 
-The same extensions are mapped to multiple parsers. For example, ``.h``
+An extension may be mapped to multiple parsers. For example, ``.h``
 are mapped to C++, C and ObjectiveC. These mappings can cause
 issues. ctags tries to select the proper parser
 for the source file by applying heuristics to its content, however
@@ -1520,6 +1597,8 @@ it is not perfect.  In case of issues one can use ``--language-force=language``,
 ``--langmap=map[,map[...]]``, or the ``--map-<LANG>=-pattern|extension``
 options. (Some of the heuristics are applied whether ``--guess-language-eagerly``
 is given or not.)
+
+.. TODO: all heuristics??? To be confirmed.
 
 .. options should be revised here
 	``--map-<LANG>`` (done)
@@ -1531,7 +1610,7 @@ is given or not.)
 	``--list-map-patterns`` (done)
 
 Heuristically guessing
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+..........................
 
 If ctags cannot select a parser from the mapping of file names,
 various heuristic tests are conducted to determine the language:
@@ -1553,12 +1632,14 @@ template file name testing
 	parser. However, ``sh`` is listed as an alias for ``shell``, therefore
 	ctags selects the "shell" parser for the file.
 
-	An exception is ``env``. If ``env`` is specified, ctags
+	An exception is ``env``. If ``env`` is specified (for example
+	``#!/usr/bin/env python``), ctags
 	reads more lines to find real interpreter specification.
 
 	To display the list of aliases, use ``--list-aliases`` option.
-	To add/remove an item to/from the list, use the
-	``--alias-<LANG>=[+|-]aliasPattern`` option.
+	To add an item to the list or to remove an item from the list, use the
+	``--alias-<LANG>=+aliasPattern`` or ``--alias-<LANG>=-aliasPattern`` option
+	respectively.
 
 "zsh autoload tag" testing
 	If the first line starts with ``#compdef`` or ``#autoload``,
@@ -1623,6 +1704,8 @@ executable or the ``--guess-language-eagerly`` (``-G`` in short) option is
 given. The other heuristic tests are enabled only when ``-G`` option is
 given.
 
+.. TODO: move the paragraph above to the beginning of this section.
+
 The ``--print-language`` option can be used just to print the results of
 parser selections for given files instead of generating a tags file.
 
@@ -1647,9 +1730,9 @@ items in Exuberant Ctags are refined and extended in Universal Ctags.
 
 A tag is categorized into *definition tags* or *reference tags*.
 In general, Exuberant Ctags only tags *definitions* of
-language objects: places where newly named language objects are introduced.
+language objects: places where newly named language objects *are introduced*.
 Universal Ctags, on the other hand, can also tag *references* of language
-objects: places where named language objects are used. However, support
+objects: places where named language objects *are used*. However, support
 for generating reference tags is new and limited to specific areas of
 specific languages in the current version.
 
@@ -1761,7 +1844,9 @@ TAG FILE FORMAT
 When not running in etags mode, each entry in the tag file consists of a
 separate line, each looking like this in the most general case:
 
-tag_name<TAB>file_name<TAB>ex_cmd;"<TAB>extension_fields
+::
+
+	tag_name<TAB>file_name<TAB>ex_cmd;"<TAB>extension_fields
 
 The fields and separators of these lines are specified as follows:
 
@@ -1884,9 +1969,12 @@ HOW TO USE WITH NEDIT
 ---------------------
 
 NEdit version 5.1 and later can handle the new extended tag file format
-(see ``--format``). To make NEdit use the tag file, select "File->Load Tags
-File". To jump to the definition for a tag, highlight the word, then press
-``Ctrl-D``. NEdit 5.1 can read multiple tag files from different
+(see ``--format``).
+
+* To make NEdit use the tag file, select "File->Load Tags File".
+* To jump to the definition for a tag, highlight the word, then press ``Ctrl-D``.
+
+NEdit 5.1 can read multiple tag files from different
 directories. Setting the X resource ``nedit.tagFile`` to the name of a tag
 file instructs NEdit to automatically load that tag file at startup time.
 
@@ -1910,6 +1998,8 @@ identical to the line containing the tag. The following example
 demonstrates this condition:
 
 .. code-block:: C
+	:linenos:
+	:emphasize-lines: 1,5
 
 	int variable;
 
@@ -1922,8 +2012,10 @@ demonstrates this condition:
 
 Depending upon which editor you use and where in the code you happen to be,
 it is possible that the search pattern may locate the local parameter
-declaration in foo() before it finds the actual global variable definition,
-since the lines (and therefore their search patterns are identical).
+declaration on the line 5 before it finds the actual global variable definition
+on the line 1, since the lines (and therefore their search patterns) are
+identical.
+
 This can be avoided by use of the ``--excmd=n`` option.
 
 
@@ -1931,6 +2023,8 @@ BUGS
 ----
 
 ctags has more options than ``ls(1)``.
+
+.. TODO: move the following paragraph to parser-cxx.rst.
 
 When parsing a C++ member function definition (e.g. ``className::function``),
 ctags cannot determine whether the scope specifier
@@ -1953,7 +2047,10 @@ ENVIRONMENT VARIABLES
 	starts, after the configuration files listed in FILES, below, are read,
 	but before any command line options are read. Options appearing on
 	the command line will override options specified in this variable.
-	Only options will be read from this variable. Note that all white space
+
+	Only options will be read from this variable.
+
+	Note that all white space
 	in this variable is considered a separator, making it impossible to pass
 	an option parameter containing an embedded space. If this is a problem,
 	use a configuration file instead.
@@ -1964,17 +2061,21 @@ ENVIRONMENT VARIABLES
 	found, etags will try to use ``CTAGS`` instead.
 
 ``TMPDIR``
-	On Unix-like hosts where ``mkstemp()`` is available, the value of this
+	On Unix-like hosts where ``mkstemp(3)`` is available, the value of this
 	variable specifies the directory in which to place temporary files.
 	This can be useful if the size of a temporary file becomes too large
 	to fit on the partition holding the default temporary directory
-	defined at compilation time. ctags creates temporary
+	defined at compilation time.
+
+	ctags creates temporary
 	files only if either (1) an emacs-style tag file is being
 	generated, (2) the tag file is being sent to standard output, or
 	(3) the program was compiled to use an internal sort algorithm to sort
-	the tag files instead of the ``sort`` utility of the operating system.
-	If the ``sort`` utility of the operating system is being used, it will
-	generally observe this variable also. Note that if ctags
+	the tag files instead of the ``sort(1)`` utility of the operating system.
+	If the ``sort(1)`` utility of the operating system is being used, it will
+	generally observe this variable also.
+
+	Note that if ctags
 	is setuid, the value of ``TMPDIR`` will be ignored.
 
 
@@ -1993,31 +2094,38 @@ FILES
 
 ``ctags.d/*.ctags``
 
-	If any of these configuration files exist, each will be expected to
-	contain a set of default options which are read in the order listed
-	when ctags starts, but before the ``CTAGS`` environment
-	variable is read or any command line options are read. This makes it
-	possible to set up personal or project-level defaults. It
-	is possible to compile ctags to read an additional
-	configuration file before any of those shown above, which will be
-	indicated if the output produced by the ``--version`` option lists the
-	``custom-conf`` feature. Options appearing in the ``CTAGS`` environment
-	variable or on the command line will override options specified in these
-	files. Only options will be read from these files. Note that the option
-	files are read in line-oriented mode in which spaces are significant
-	(since shell quoting is not possible) but spaces at the beginning
-	of a line are ignored. Each line of the file is read as
-	one command line parameter (as if it were quoted with single quotes).
-	Therefore, use new lines to indicate separate command-line arguments.
-	A line starting with '``#``' is treated as a comment.
-
-	``*.ctags`` files in a directory are loaded in alphabetical order.
-
 ``tags``
 	The default tag file created by ctags.
 
 ``TAGS``
 	The default tag file created by etags.
+
+	If any of these configuration files exist, each will be expected to
+	contain a set of default options which are read in the order listed
+	when ctags starts, but before the ``CTAGS`` environment
+	variable is read or any command line options are read. This makes it
+	possible to set up personal or project-level defaults.
+
+	It
+	is possible to compile ctags to read an additional
+	configuration file before any of those shown above, which will be
+	indicated if the output produced by the ``--version`` option lists the
+	``custom-conf`` feature.
+
+	Options appearing in the ``CTAGS`` environment
+	variable or on the command line will override options specified in these
+	files. Only options will be read from these files.
+
+	Note that the option
+	files are read in line-oriented mode in which spaces are significant
+	(since shell quoting is not possible) but spaces at the beginning
+	of a line are ignored. Each line of the file is read as
+	one command line parameter (as if it were quoted with single quotes).
+	Therefore, use new lines to indicate separate command-line arguments.
+
+	A line starting with '``#``' is treated as a comment.
+
+	``*.ctags`` files in a directory are loaded in alphabetical order.
 
 
 SEE ALSO
@@ -2039,14 +2147,11 @@ See :ref:`ctags-lang-python(7) <ctags-lang-python(7)>` about python input specif
 See :ref:`readtags(1) <readtags(1)>` about a client tool for binary searching a
 name in a sorted tags file.
 
-The official Universal Ctags web site at:
-
-https://ctags.io/
+The official Universal Ctags web site at: https://ctags.io/
 
 Also ex(1), vi(1), elvis, or, better yet, vim, the official editor of ctags.
-For more information on vim, see the VIM Pages web site at:
 
-https://www.vim.org/
+For more information on vim, see the VIM Pages web site at: https://www.vim.org/
 
 
 AUTHOR
@@ -2076,11 +2181,10 @@ CREDITS
 This version of ctags (Universal Ctags) derived from
 the repository, known as fishman-ctags, started by Reza Jelveh.
 
+The fishman-ctags was derived from Exuberant Ctags.
+
 Some parsers are taken from ``tagmanager`` of the Geany (https://www.geany.org/)
 project.
-
-
-The fishman-ctags was derived from Exuberant Ctags.
 
 Exuberant Ctags was originally derived from and
 inspired by the ctags program by Steve Kirkendall <kirkenda@cs.pdx.edu>

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -19,12 +19,12 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **ctags** and **etags** programs
+The *ctags* and *etags* programs
 (hereinafter collectively referred to as ctags,
 except where distinguished) generate an index (or "tag") file for a
-variety of **language objects** found in **source file(s)**. This tag file allows
+variety of *language objects* found in *source file(s)*. This tag file allows
 these items to be quickly and easily located by a text editor or other
-utilities (**client tools**). A **tag** signifies a language object for which an index entry is
+utilities (*client tools*). A *tag* signifies a language object for which an index entry is
 available (or, alternatively, the index entry created for that object).
 
 Alternatively, ctags can generate a cross reference
@@ -37,14 +37,14 @@ jump to the file and line which defines the name. See the manual of your
 favorite editor about utilizing ctags command and
 the tag index files in the editor.
 
-ctags is capable of generating different **kinds** of tags
-for each of many different **languages**. For a complete list of supported
+ctags is capable of generating different *kinds* of tags
+for each of many different *languages*. For a complete list of supported
 languages, the names by which they are recognized, and the kinds of tags
 which are generated for each, see the ``--list-languages`` and ``--list-kinds-full``
 options.
 
-This man page describes **Universal Ctags**, an implementation of ctags
-derived from **Exuberant Ctags**. The major incompatible changes between
+This man page describes *Universal Ctags*, an implementation of ctags
+derived from *Exuberant Ctags*. The major incompatible changes between
 Universal Ctags and Exuberant Ctags are enumerated in
 :ref:`ctags-incompatibilities(7) <ctags-incompatibilities(7)>`.
 
@@ -63,7 +63,7 @@ COMMAND LINE INTERFACE
 
 Despite the wealth of available options, defaults are set so that
 ctags is most commonly executed without any options (e.g.
-"ctags \*", or "ctags -R"), which will
+"``ctags *``", or "``ctags -R``"), which will
 create a tag file in the current directory for all recognized source
 files. The options described below are provided merely to allow custom
 tailoring to meet special needs.
@@ -72,13 +72,13 @@ Note that spaces separating the single-letter options from their parameters
 are optional.
 
 Note also that the boolean parameters to the long form options (those
-beginning with "--" and that take a "[=yes|no]" parameter) may be omitted,
-in which case "=yes" is implied. (e.g. ``--sort`` is equivalent to ``--sort=yes``).
-Note further that "=1", "=on", and "=true" are considered synonyms for "=yes",
-and that "=0", "=off", and "=false" are considered synonyms for "=no".
+beginning with "``--``" and that take a "``[=yes|no]``" parameter) may be omitted,
+in which case "``=yes``" is implied. (e.g. "``--sort``" is equivalent to "``--sort=yes``").
+Note further that "``=1``", "``=on``", and "``=true``" are considered synonyms for "``=yes``",
+and that "``=0``", "``=off``", and "``=false``" are considered synonyms for "``=no``".
 
 Some options are either ignored or useful only when used while running in
-etags mode (see -e option). Such options will be noted.
+etags mode (see ``-e`` option). Such options will be noted.
 
 Most options may appear anywhere on the command line, affecting only those
 files which follow the option. A few options, however, must appear
@@ -124,7 +124,7 @@ adjust the output of the most of ``--list-...`` options.
 The default setting (``--with-list-header=yes`` and ``--machinable=no``)
 is for using interactively from a terminal. The header that explains
 the meaning of columns is simply added to the output, and each column is
-aligned in all lines. The header line starts with a hash ('#') character.
+aligned in all lines. The header line starts with a hash ('``#``') character.
 
 For scripting in a client tool, ``--with-list-header=no`` and
 ``--machinable=yes`` may be useful. The header is not added to the
@@ -156,20 +156,20 @@ Input/Output File Options
 	be specified as many times as desired. For each file name considered
 	by ctags, each pattern specified using this option
 	will be compared against both the complete path (e.g.
-	some/path/base.ext) and the base name (e.g. base.ext) of the file, thus
+	``some/path/base.ext``) and the base name (e.g. ``base.ext``) of the file, thus
 	allowing patterns which match a given file name irrespective of its
 	path, or match only a specific path. If appropriate support is available
 	from the runtime library of your C compiler, then pattern may
 	contain the usual shell wildcards (not regular expressions) common on
 	Unix (be sure to quote the option parameter to protect the wildcards from
 	being expanded by the shell before being passed to ctags;
-	also be aware that wildcards can match the slash character, '/').
+	also be aware that wildcards can match the slash character, '``/``').
 	You can determine if shell wildcards are available on your platform by
 	examining the output of the ``--list-features`` option, which will include
-	"wildcards" in the compiled feature list; otherwise, pattern is matched
+	``wildcards`` in the compiled feature list; otherwise, pattern is matched
 	against file names using a simple textual comparison.
 
-	If pattern begins with the character '@', then the rest of the string
+	If pattern begins with the character '``@``', then the rest of the string
 	is interpreted as a file name from which to read exclusion patterns,
 	one per line. If pattern is empty, the list of excluded patterns is
 	cleared.
@@ -187,10 +187,10 @@ Input/Output File Options
 	affects the files and directories that are excluded by the pattern
 	specified with ``--exclude=`` option.
 
-	For an example, you want @CTAGS_NAME_EXAMPLE@ to ignore all files
-	under "foo" directory except "foo/main.c", use the following command
-	line: "--exclude=foo/* --exclude-exception=foo/main.c". Don't forget
-	shell quoting for '*'.
+	For an example, you want ctags to ignore all files
+	under ``foo`` directory except ``foo/main.c``, use the following command
+	line: ``--exclude=foo/* --exclude-exception=foo/main.c``. Don't forget
+	shell quoting for '``*``'.
 
 ``--filter[=yes|no]``
 	Makes ctags behave as a filter, reading source
@@ -215,10 +215,10 @@ Input/Output File Options
 ``--recurse[=yes|no]``
 	Recurse into directories encountered in the list of supplied files.
 	If the list of supplied files is empty and no file list is specified with
-	the -L option, then the current directory (i.e. ".") is assumed.
-	Symbolic links are followed. If you don't like these behaviors, either
-	explicitly specify the files or pipe the output of find(1) into
-	ctags -L- instead. Note: This option is not supported on
+	the ``-L`` option, then the current directory (i.e. '``.``') is assumed.
+	Symbolic links are followed by default. If you don't like these behaviors, either
+	explicitly specify the files or pipe the output of ``find(1)`` into
+	``ctags -L -`` instead. Note: This option is not supported on
 	all platforms at present. It is available if the output of the ``--help``
 	option includes this option. See, also, the ``--exclude`` and
 	``--maxdepth`` to limit recursion.
@@ -228,7 +228,7 @@ Input/Output File Options
 
 ``-L file``
 	Read from file a list of file names for which tags should be generated.
-	If file is specified as "-", then file names are read from standard
+	If file is specified as '``-``', then file names are read from standard
 	input. File names read using this option are processed following file
 	names appearing on the command line. Options are also accepted in this
 	input. If this option is specified more than once, only the last will
@@ -241,25 +241,25 @@ Input/Output File Options
 ``--append[=yes|no]``
 	Indicates whether tags generated from the specified files should be
 	appended to those already present in the tag file or should replace them.
-	This option is "no" by default. This option must appear before the
+	This option is ``no`` by default. This option must appear before the
 	first file name.
 
 ``-a``
 	Equivalent to ``--append``.
 
 ``-f tagfile``
-	Use the name specified by tagfile for the tag file (default is "tags",
-	or "TAGS" when running in etags mode). If tagfile is specified as "-",
+	Use the name specified by tagfile for the tag file (default is "``tags``",
+	or "``TAGS``" when running in etags mode). If tagfile is specified as '``-``',
 	then the tags are written to standard output instead. ctags
 	will stubbornly refuse to take orders if tagfile exists and
 	its first line contains something other than a valid tags line. This
-	will save your neck if you mistakenly type "ctags -f
-	\*.c", which would otherwise overwrite your first C file with the tags
+	will save your neck if you mistakenly type ``ctags -f
+	*.c``, which would otherwise overwrite your first C file with the tags
 	generated by the rest! It will also refuse to accept a multi-character
-	file name which begins with a '-' (dash) character, since this most
+	file name which begins with a '``-``' (dash) character, since this most
 	likely means that you left out the tag file name and this option tried to
 	grab the next option as the file name. If you really want to name your
-	output tag file "-ugly", specify it as "./-ugly". This option must
+	output tag file ``-ugly``, specify it as ``-f ./-ugly``. This option must
 	appear before the first file name. If this option is specified more
 	than once, only the last will apply.
 
@@ -287,15 +287,15 @@ Output Format Options
 	values for level are 1 or 2. Level 1 specifies the original tag file
 	format and level 2 specifies a new extended format containing extension
 	fields (but in a manner which retains backward-compatibility with
-	original vi(1) implementations). The default level is 2. This option
+	original ``vi(1)`` implementations). The default level is 2. This option
 	must appear before the first file name. [Ignored in etags mode]
 
 ``--output-format=u-ctags|e-ctags|etags|xref|json``
-	Specify the output format. The default is "u-ctags".
-	See :ref:`tags(5) <tags(5)>` for "u-ctags" and "e-ctags".
-	See ``-e`` for "etags", and ``-x`` for "xref".
-	"json" is experimental format, and available only if
-	the ctags executable is built with libjansson.
+	Specify the output format. The default is ``u-ctags``.
+	See :ref:`tags(5) <tags(5)>` for ``u-ctags`` and ``e-ctags``.
+	See ``-e`` for ``etags``, and ``-x`` for ``xref``.
+	``json`` is experimental format, and available only if
+	the ctags executable is built with ``libjansson``.
 	This option must appear before the first file name.
 
 .. TODO: convert output-json.rst to ctags-json-output.1.rst (ctags-json-output(1)).
@@ -318,19 +318,19 @@ Output Format Options
 	file which defines the tag. No tag file is written and all options
 	affecting tag file output will be ignored. Example applications for this
 	feature are generating a listing of all functions located in a source
-	file (e.g. "ctags -x --kinds-c=f file"), or generating
+	file (e.g. ``ctags -x --kinds-c=f file``), or generating
 	a list of all externally visible global variables located in a source
-	file (e.g. "ctags -x --kinds-c=v --extras=-F file").
+	file (e.g. ``ctags -x --kinds-c=v --extras=-F file``).
 	This option must appear before the first file name.
 
 ``--sort[=yes|no|foldcase]``
 	Indicates whether the tag file should be sorted on the tag name
-	(default is yes). Note that the original vi(1) required sorted tags.
+	(default is yes). Note that the original ``vi(1)`` required sorted tags.
 	The foldcase value specifies case insensitive (or case-folded) sorting.
 	Fast binary searches of tag files sorted with case-folding will require
 	special support from tools using tag files, such as that found in the
 	ctags readtags library, or Vim version 6.2 or higher
-	(using "set ignorecase"). This option must appear before the first file
+	(using ``set ignorecase``). This option must appear before the first file
 	name. [Ignored in etags mode]
 
 ``-u``
@@ -347,7 +347,7 @@ Output Format Options
 	encoding to the encoding specified by ``--output-encoding=encoding``.
 
 ``--input-encoding-<LANG>=encoding``
-	Specifies a specific input encoding for ``LANG``. It overrides the global
+	Specifies a specific input encoding for *<LANG>*. It overrides the global
 	default value given with ``--input-encoding``.
 
 ``--output-encoding=encoding``
@@ -357,7 +357,7 @@ Output Format Options
 
 	In addition ``encoding`` is specified at the top the tags file as the
 	value for the ``TAG_FILE_ENCODING`` pseudo-tag. The default value of
-	``encoding`` is UTF-8.
+	``encoding`` is ``UTF-8``.
 
 .. _option_lang_mapping:
 
@@ -369,7 +369,7 @@ Language Selection and Mapping Options
 	determined (see "`Determining file language`_", above). This option forces the specified
 	*language* (case-insensitive; either built-in or user-defined) to be used
 	for every supplied file instead of automatically selecting the language
-	based upon its extension. In addition, the special value "auto" indicates
+	based upon its extension. In addition, the special value ``auto`` indicates
 	that the language should be automatically selected (which effectively
 	disables this option).
 
@@ -377,11 +377,11 @@ Language Selection and Mapping Options
 	Specifies the languages for which tag generation is enabled, with *list*
 	containing a comma-separated list of language names (case-insensitive;
 	either built-in or user-defined). If the first language of *list* is not
-	preceded by either a '+' or '-', the current list (the current settings
+	preceded by either a '``+``' or '``-``', the current list (the current settings
 	of enabled/disabled languages managed in ctags internally)
-	will be cleared before adding or removing the languages in *list*. Until a '-' is
+	will be cleared before adding or removing the languages in *list*. Until a '``-``' is
 	encountered, each language in the *list* will be added to the current list.
-	As either the '+' or '-' is encountered in the *list*, the languages
+	As either the '``+``' or '``-``' is encountered in the *list*, the languages
 	following it are added or removed from the current list, respectively.
 	Thus, it becomes simple to replace the current list with a new one, or
 	to add or remove languages from the current list.
@@ -392,7 +392,7 @@ Language Selection and Mapping Options
 	languages, including user-defined languages, are enabled unless explicitly
 	disabled using this option. Language names included in list may be any
 	built-in language or one previously defined with ``--langdef``. The default
-	is "all", which is also accepted as a valid argument. See the
+	is ``all``, which is also accepted as a valid argument. See the
 	``--list-languages`` option for a list of the all (built-in and user-defined)
 	language names.
 
@@ -400,16 +400,16 @@ Language Selection and Mapping Options
 	specified with different arguments multiple times in a command line.
 
 ``--alias-<LANG>=[+|-]aliasPattern``
-	Adds ('+') or removes ('-') an alias pattern to a language specified
+	Adds ('``+``') or removes ('``-``') an alias pattern to a language specified
 	with *<LANG>*. ctags refers to the alias pattern in
 	"`Determining file language`_" stage.
 
-	The parameter aliasPattern is not a list. Use this option multiple
+	The parameter ``aliasPattern`` is not a list. Use this option multiple
 	times in a command line to add or remove multiple alias
 	patterns.
 
-	To restore the default language aliases, specify "default" as the
-	parameter aliasPattern. Using "all" for *<LANG>* has meaning in
+	To restore the default language aliases, specify ``default`` as the
+	parameter aliasPattern. Using ``all`` for *<LANG>* has meaning in
 	following two cases:
 
 	``--alias-all=``
@@ -428,11 +428,11 @@ Language Selection and Mapping Options
 ``--langmap=map[,map[...]]``
 	Controls how file names are mapped to languages (see the ``--list-maps``
 	option). Each comma-separated *map* consists of the language name (either
-	a built-in or user-defined language), a colon, and a list of **file
-	extensions** and/or **file name patterns**. A file extension is specified by
-	preceding the extension with a period (e.g. ".c"). A file name pattern
+	a built-in or user-defined language), a colon, and a list of *file
+	extensions* and/or *file name patterns*. A file extension is specified by
+	preceding the extension with a period (e.g. ``.c``). A file name pattern
 	is specified by enclosing the pattern in parentheses (e.g.
-	"([Mm]akefile)").
+	``([Mm]akefile)``).
 
 	If appropriate support is available from the runtime
 	library of your C compiler, then the file name pattern may contain the usual
@@ -440,7 +440,7 @@ Language Selection and Mapping Options
 	protect the wildcards from being expanded by the shell before being
 	passed to ctags). You can determine if shell wildcards
 	are available on your platform by examining the output of the
-	``--list-features`` option, which will include "wildcards" in the compiled
+	``--list-features`` option, which will include ``wildcards`` in the compiled
 	feature list; otherwise, the file name patterns are matched against
 	file names using a simple textual comparison.
 
@@ -448,24 +448,24 @@ Language Selection and Mapping Options
 	it will first be unmapped from any other languages. (``--map-<LANG>``
 	option provides more fine-grained control.)
 
-	If the first character in a map is a plus sign ('+'), then the extensions and
+	If the first character in a map is a plus sign ('``+``'), then the extensions and
 	file name patterns in that map will be appended to the current map
 	for that language; otherwise, the map will replace the current map.
-	For example, to specify that only files with extensions of .c and .x are
-	to be treated as C language files, use "--langmap=c:.c.x"; to also add
-	files with extensions of .j as Java language files, specify
-	"--langmap=c:.c.x,java:+.j". To map makefiles (e.g. files named either
-	"Makefile", "makefile", or having the extension ".mak") to a language
-	called "make", specify "--langmap=make:([Mm]akefile).mak". To map files
+	For example, to specify that only files with extensions of ``.c`` and ``.x`` are
+	to be treated as C language files, use ``--langmap=c:.c.x``; to also add
+	files with extensions of ``.j`` as Java language files, specify
+	``--langmap=c:.c.x,java:+.j``. To map makefiles (e.g. files named either
+	``Makefile``, ``makefile``, or having the extension ``.mak``) to a language
+	called ``make``, specify ``--langmap=make:([Mm]akefile).mak``. To map files
 	having no extension, specify a period not followed by a non-period
-	character (e.g. ".", "..x", ".x.").
+	character (e.g. '``.``', ``..x``, ``.x.``).
 
 	To clear the mapping for a
 	particular language (thus inhibiting automatic generation of tags for
-	that language), specify an empty extension list (e.g. "--langmap=fortran:").
+	that language), specify an empty extension list (e.g. ``--langmap=fortran:``).
 	To restore the default language mappings for a particular language,
-	supply the keyword "default" for the mapping. To specify restore the
-	default language mappings for all languages, specify "--langmap=default".
+	supply the keyword ``default`` for the mapping. To specify restore the
+	default language mappings for all languages, specify ``--langmap=default``.
 
 	Note that file name patterns are tested before file extensions when inferring
 	the language of a file. This order of Universal Ctags is different from
@@ -481,12 +481,12 @@ Language Selection and Mapping Options
 	``--langmap`` option handle only *1:1 map*, only one language
 	mapping to one file name pattern or file extension.  A typical N:1
 	map is seen in C++ and ObjectiveC language; both languages have
-	a map to ".h" as a file extension.
+	a map to ``.h`` as a file extension.
 
-	A file extension is specified by preceding the extension with a period (e.g. ".c").
+	A file extension is specified by preceding the extension with a period (e.g. ``.c``).
 	A file name pattern is specified by enclosing the pattern in parentheses (e.g.
-	"([Mm]akefile)"). A prefixed plus ('+') sign is for adding, and
-	minus ('-') is for removing. No prefix means replacing the map of *<LANG>*.
+	``([Mm]akefile)``). A prefixed plus ('``+``') sign is for adding, and
+	minus ('``-``') is for removing. No prefix means replacing the map of *<LANG>*.
 
 	Unlike ``--langmap``, *extension* (or *pattern*) is not a list.
 	``--map-<LANG>`` takes one *extension* (or *pattern*). However,
@@ -498,20 +498,20 @@ Language Selection and Mapping Options
 Tags File Contents Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``--excmd=type``
-	Determines the type of EX command used to locate tags in the source
+	Determines the type of ``EX`` command used to locate tags in the source
 	file. [Ignored in etags mode]
 
-	The valid values for type (either the entire word or the first letter
+	The valid values for *type* (either the entire word or the first letter
 	is accepted) are:
 
-	number
+	``number``
 		Use only line numbers in the tag file for locating tags. This has
 		four advantages:
 
 		1.	Significantly reduces the size of the resulting tag file.
 		2.	Eliminates failures to find tags because the line defining the
 			tag has changed, causing the pattern match to fail (note that
-			some editors, such as vim, are able to recover in many such
+			some editors, such as ``vim``, are able to recover in many such
 			instances).
 		3.	Eliminates finding identical matching, but incorrect, source
 			lines (see "`BUGS`_").
@@ -528,13 +528,13 @@ Tags File Contents Options
 		to which it is applied is not subject to change. Selecting this
 		option type causes the following options to be ignored: ``-BF``.
 
-	pattern
+	``pattern``
 		Use only search patterns for all tags, rather than the line numbers
 		usually used for macro definitions. This has the advantage of
 		not referencing obsolete line numbers when lines have been added or
 		removed since the tag file was generated.
 
-	mixed
+	``mixed``
 		In this mode, patterns are generally used with a few exceptions.
 		For C, line numbers are used for macro definition tags. This was
 		the default format generated by the original ctags and is, therefore,
@@ -543,7 +543,7 @@ Tags File Contents Options
 		are generally identical, making pattern searches useless
 		for finding all matches.
 
-	combine
+	``combine``
 		Concatenate the line number and pattern with a semicolon in between.
 
 ``-n``
@@ -558,10 +558,10 @@ Tags File Contents Options
 
 	The parameter flags is a set of one-letter flags (and/or long-name flags), each
 	representing one kind of extra tag entry to include in the tag file.
-	If flags is preceded by either the '+' or '-' character, the effect of
+	If flags is preceded by either the '``+``' or '``-``' character, the effect of
 	each flag is added to, or removed from, those currently enabled;
 	otherwise the flags replace any current settings. All entries are
-	included  if '*' is given.
+	included  if '``*``' is given.
 
 	This ``--extras=`` option is for controlling extras common in all
 	languages (or language-independent extras).  Universal Ctags also
@@ -571,7 +571,7 @@ Tags File Contents Options
 
 	The meaning of major extras is as follows (one-letter flag/long-name flag):
 
-	/anonymous
+	none/``anonymous``
 		Include an entry for the language object that has no name like lambda
 		function. This extra has no one-letter flag and is enabled by
 		default. The extra tag is useful as a placeholder to fill scope fields
@@ -583,9 +583,9 @@ Tags File Contents Options
 				double x, y;
 			} p = { .x = 0.0, .y = 0.0 };
 
-		"x" and "y" are the members of a structure. When filling the scope
+		'``x``' and '``y``' are the members of a structure. When filling the scope
 		fields for them, ctags has trouble because the struct
-		where "x" and "y" belong to has no name. For overcoming the trouble,
+		where '``x``' and '``y``' belong to has no name. For overcoming the trouble,
 		ctags generates an anonymous extra tag for the struct
 		and fills the scope fields with the name of the extra tag.
 
@@ -596,20 +596,20 @@ Tags File Contents Options
 			x	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
 			y	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
 
-		The above tag output has "__anon9f26d2460108" as an anonymous extra tag.
-		The typeref field of "p" also receives the benefit of it.
+		The above tag output has ``__anon9f26d2460108`` as an anonymous extra tag.
+		The typeref field of '``p``' also receives the benefit of it.
 
-	F/fileScope
+	``F``/``fileScope``
 		Indicates whether tags scoped only for a single file (i.e. tags which
 		cannot be seen outside of the file in which they are defined, such as
-		language objects with "static" modifier of C language) should be included
+		language objects with ``static`` modifier of C language) should be included
 		in the output. See, also, the ``-h`` option. This option is enabled by
 		default. This is the replacement for ``--file-scope`` option of
 		Exuberant Ctags.
 
-	f/inputFile
+	``f``/``inputFile``
 		Include an entry for the base file name of every source file
-		(e.g. "example.c"), which addresses the first line of the file.
+		(e.g. ``example.c``), which addresses the first line of the file.
 		This flag is the replacement for ``--file-tags`` hidden option of
 		Exuberant Ctags.
 
@@ -617,19 +617,19 @@ Tags File Contents Options
 		attached to the tag. (However, @CTAGS_NAME_EXAMPLE@ omits the ``end:`` field
 		if no newline is in the file like an empty file.)
 
-		By default, @CTAGS_NAME_EXAMPLE@ doesn't create the "f/inputFile" extra
+		By default, @CTAGS_NAME_EXAMPLE@ doesn't create the ``f/inputFile`` extra
 		tag for the source file when @CTAGS_NAME_EXAMPLE@ doesn't find a parser
-		for it. Enabling "Unknown" parser with "--languages=+Unknown" forces
+		for it. Enabling ``Unknown`` parser with ``--languages=+Unknown`` forces
 		@CTAGS_NAME_EXAMPLE@ to create the extra tags for any source files.
 
-		The etags mode enables the "Unknown" parser implicitly.
+		The etags mode enables the ``Unknown`` parser implicitly.
 
-	p/pseudo
+	``p``/``pseudo``
 		Include pseudo-tags. Enabled by default unless the tag file is
 		written to standard output. See :ref:`ctags-client-tools(7) <ctags-client-tools(7)>` about
 		the detail of pseudo-tags.
 
-	q/qualified
+	``q``/``qualified``
 		Include an extra class-qualified or namespace-qualified tag entry
 		for each tag which is a member of a class or a namespace.
 
@@ -642,15 +642,15 @@ Tags File Contents Options
 		from which the tag was derived (using a form that is most
 		natural for how qualified calls are specified in the
 		language). For C++ and Perl, it is in the form
-		"class::member"; for Eiffel and Java, it is in the form
-		"class.member".
+		``class::member``; for Eiffel and Java, it is in the form
+		``class.member``.
 
 		Note: Using backslash characters as separators forming
 		qualified name in PHP. However, in tags output of
 		Universal Ctags, a backslash character in a name is escaped
 		with a backslash character. See :ref:`tags(5) <tags(5)>` about the escaping.
 
-	r/reference
+	``r``/``reference``
 		Include reference tags. See "`TAG ENTRIES`_" about reference tags.
 
 	Inquire the output of ``--list-extras`` option for the other minor
@@ -658,18 +658,18 @@ Tags File Contents Options
 
 ``--extras-<LANG>=[+|-]flags|*``
 	Specifies whether to include extra tag entries for certain kinds of
-	information for language <LANG>. Universal Ctags
+	information for language *<LANG>*. Universal Ctags
 	introduces language-specific extras. See "`Language-specific fields and
 	extras`_" about the concept. This option is for controlling them.
 
-	Specifies "all" as <LANG> to apply the parameter flags to all
-	languages; all extras are enabled with specifying '*' as the
+	Specifies ``all`` as *<LANG>* to apply the parameter flags to all
+	languages; all extras are enabled with specifying '``*``' as the
 	parameter flags. If specifying nothing as the parameter flags
 	(``--extras-all=``), all extras are disabled. These two combinations
 	are useful for testing.
 
 	Check the output of the ``--list-extras=<LANG>`` option for the
-	extras of specific language <LANG>.
+	extras of specific language *<LANG>*.
 
 ``--extra=[+|-]flags|*``
 	Equivalent to ``--extras=[+|-]flags|*``, which was introduced to
@@ -683,13 +683,13 @@ Tags File Contents Options
 	the tag entries (see "`TAG FILE FORMAT`_" second, and "`Fields`_"
 	subsection , for more information).
 
-	The parameter flags is a set of one-letter flags (and/or long-name flags),
+	The parameter ``flags`` is a set of one-letter flags (and/or long-name flags),
 	each representing one type of extension field to include.
-	Each letter or group of letters may be preceded by either '+' to add it
-	to the default set, or '-' to exclude it. In the absence of any
-	preceding '+' or '-' sign, only those fields explicitly listed in flags
+	Each letter or group of letters may be preceded by either '``+``' to add it
+	to the default set, or '``-``' to exclude it. In the absence of any
+	preceding '``+``' or '``-``' sign, only those fields explicitly listed in flags
 	will be included in the output (i.e. overriding the default set). All
-	fields are included if '*' is given. This option is ignored if the
+	fields are included if '``*``' is given. This option is ignored if the
 	option ``--format=1`` (legacy tag file format) has been specified.
 
 	This ``--fields=`` option is for controlling fields common in all
@@ -701,64 +701,64 @@ Tags File Contents Options
 
 	The meaning of major fields is as follows (one-letter flag/long-name flag):
 
-	a/access
+	``a``/``access``
 		Access (or export) of class members
 
-	e/end
+	``e``/``end``
 		End lines of various items
 
-	f/file
+	``f``/``file``
 		File-restricted scoping. Enabled by default.
 
-	i/inherits
+	``i``/``inherits``
 		Inheritance information.
 
-	k
+	``k``
 		Kind of tag as one-letter. Enabled by default.
 		Exceptionally this has no field name.
-		See also z/kind flag.
+		See also ``z``/``kind`` flag.
 
-	K
+	``K``
 		Kind of tag as long-name.
 		Exceptionally this has no field name.
-		See also z/kind flag.
+		See also ``z``/``kind`` flag.
 
-	l/language
+	``l``/``language``
 		Language of source file containing tag
 
-	m/implementation
+	``m``/``implementation``
 		Implementation information
 
-	n/line
+	``n``/``line``
 		Line number of tag definition
 
-	p/scopeKind
+	``p``/``scopeKind``
 		Kind of scope as long-name
 
-	r/roles
+	``r``/``roles``
 		Roles assigned to the tag.
-		For a definition tag, this field takes "def" as a value.
+		For a definition tag, this field takes ``def`` as a value.
 
-	s
+	``s``
 		Scope of tag definition. Enabled by default.
 		Exceptionally this has no name.
-		See also Z flag.
+		See also ``Z`` flag.
 
 		.. TODO? implement "scope" of Z/scope flag.
 
-	S/signature
+	``S``/``signature``
 		Signature of routine (e.g. prototype or parameter list)
 
-	t/typeref
+	``t``/``typeref``
 		Type and name of a variable, typedef or return type of
-		callable like function as "typeref:" field.
+		callable like function as ``typeref:`` field.
 		Enabled by default.
 
-	z/kind
-		Include the "kind:" key in kind field
+	``z``/``kind``
+		Include the ``kind:`` key in kind field
 
-	Z
-		Include the "scope:" key in scope field.
+	``Z``
+		Include the ``scope:`` key in scope field.
 		Exceptionally this has no name.
 
 	Check the output of the ``--list-fields`` option for the other minor
@@ -770,41 +770,41 @@ Tags File Contents Options
 	supports language-specific fields. (See "`Language-specific fields and
 	extras`_" about the concept). This option is for controlling them.
 
-	Specify "all" as <LANG> to apply the parameter flags to all
-	fields; all fields are enabled with specifying '*' as the
-	parameter flags. If specifying nothing as the parameter flags
+	Specify ``all`` as *<LANG>* to apply the parameter ``flags`` to all
+	languages; all fields are enabled with specifying '``*``' as the
+	parameter flags. If specifying nothing as the parameter ``flags``
 	(``--fields-all=``), all fields are disabled. These two combinations
 	are useful for testing.
 
 ``--kinds-<LANG>=[+|-]kinds|*``
 	Specifies a list of language-specific kinds of tags (or kinds) to
-	include in the output file for a particular language, where <LANG> is
+	include in the output file for a particular language, where *<LANG>* is
 	case-insensitive and is one of the built-in language names (see the
-	``--list-languages`` option for a complete list). The parameter kinds is a group
+	``--list-languages`` option for a complete list). The parameter ``kinds`` is a group
 	of one-letter flags (and/or long-name flags) designating kinds of tags (particular to the language)
 	to either include or exclude from the output. The specific sets of
 	flags recognized for each language, their meanings and defaults may be
 	list using the ``--list-kinds-full`` option. Each letter or group of letters
-	may be preceded by either '+' to add it to, or '-' to remove it from,
-	the default set. In the absence of any preceding '+' or '-' sign, only
+	may be preceded by either '``+``' to add it to, or '``-``' to remove it from,
+	the default set. In the absence of any preceding '``+``' or '``-``' sign, only
 	those kinds explicitly listed in kinds will be included in the output
 	(i.e. overriding the default for the specified language).
 
-	Specify '*' as the parameter to include all kinds implemented
-	in <LANG> in the output. Furthermore if "all" is given as <LANG>,
-	specification of the parameter kinds affects all languages defined
-	in ctags. Giving "all" makes sense only when '*' or
-	'F' is given as the parameter kinds.
+	Specify '``*``' as the parameter to include all kinds implemented
+	in *<LANG>* in the output. Furthermore if ``all`` is given as *<LANG>*,
+	specification of the parameter ``kinds`` affects all languages defined
+	in ctags. Giving ``all`` makes sense only when '``*``' or
+	'``F``' is given as the parameter ``kinds``.
 
 	As an example for the C language, in order to add prototypes and
 	external variable declarations to the default set of tag kinds,
-	but exclude macros, use "--kinds-c=+px-d"; to include only tags for
-	functions, use "--kinds-c=f".
+	but exclude macros, use ``--kinds-c=+px-d``; to include only tags for
+	functions, use ``--kinds-c=f``.
 
 	Some kinds of C and C++ languages are synchronized; enabling
 	(or disabling) a kind in one language enables the kind having
 	the same one-letter and long-name in the other language. See also the
-	description of MASTER column of ``--list-kinds-full``.
+	description of ``MASTER`` column of ``--list-kinds-full``.
 
 ``--<LANG>-kinds=[+|-]kinds|*``
 	This option is obsolete. Use ``--kinds-<LANG>=...`` instead.
@@ -814,7 +814,7 @@ Tags File Contents Options
 	``--list-params``.
 
 ``--pattern-length-limit=N``
-	Cutoff patterns of tag entries after N characters. Disable by setting to 0
+	Cutoff patterns of tag entries after '``N``' characters. Disable by setting to 0
 	(default is 96). Specifying 0 as *N* results no truncation.
 
 	An input source file with long lines and multiple tag matches per
@@ -836,11 +836,11 @@ Tags File Contents Options
 	up to an extra 3 bytes above the limit.
 
 ``--pseudo-tags=[+|-]ptag``, ``--pseudo-tags=*``
-	Enable/disable emitting pseudo-tag named ptag.
-	If \* is given, enable emitting all pseudo-tags.
+	Enable/disable emitting pseudo-tag named ``ptag``.
+	If '``*``' is given, enable emitting all pseudo-tags.
 
 ``--put-field-prefix``
-	Put "UCTAGS" as prefix for the name of fields newly introduced in
+	Put ``UCTAGS`` as prefix for the name of fields newly introduced in
 	Universal Ctags.
 
 	Some fields are newly introduced in Universal Ctags and more will
@@ -859,56 +859,56 @@ Tags File Contents Options
 		$ ctags --put-field-prefix --fields='{line}{end}' -o - /tmp/hello.c
 		main	/tmp/hello.c	/^main(int argc, char **argv)$/;"	f	line:3	UCTAGSend:6
 
-	In the above example, the prefix is put to "end" field which is
+	In the above example, the prefix is put to ``end`` field which is
 	newly introduced in Universal Ctags.
 
 ``--roles-<LANG>.<KIND>=[+|-]roles``, ``--roles-<LANG>.<KIND>=*|``
-    Specifies a list of kind-specific roles of tags to include in the
+	Specifies a list of kind-specific roles of tags to include in the
 	output file for a particular language.
-	<KIND> specifies the kind where the role is defined.
-	<LANG> specifies the language where the kind is defined.
-	Each role in roles must be surrounded by braces (e.g. "{system}"
+	*<KIND>* specifies the kind where the ``roles`` are defined.
+	*<LANG>* specifies the language where the kind is defined.
+	Each role in ``roles`` must be surrounded by braces (e.g. ``{system}``
 	for a role named "system").
 
-	Like ``--kinds-<LANG>`` option, '+' is for adding the role to the
-	list, and '-' is for removing from the list. '*' is for including
+	Like ``--kinds-<LANG>`` option, '``+``' is for adding the role to the
+	list, and '``-``' is for removing from the list. '``*``' is for including
 	all roles of the kind to the list. 	The option with no argument
 	makes the list empty.
 
 	Both a one-letter flag or a long name flag surrounded by braces are
-	acceptable for specifying a kind (e.g. "--roles-C.h=+{system}{local}"
-	or "--roles-C.{header}=+{system}{local}").  '*' can be used for <KIND>
+	acceptable for specifying a kind (e.g. ``--roles-C.h=+{system}{local}``
+	or ``--roles-C.{header}=+{system}{local}``).  '``*``' can be used for *<KIND>*
 	only for adding/removing all roles of all kinds in a language to/from
-	the list (e.g.  "--roles-C.*=*" or "--roles-C.*=").
+	the list (e.g.  ``--roles-C.*=*`` or ``--roles-C.*=``).
 
-	"all" can be used for <LANG> only for adding/removing all roles of
+	``all`` can be used for *<LANG>* only for adding/removing all roles of
 	all kinds in all languages to/from the list
-	(e.g.  "--roles-all.*=*" or "--roles-all.*=").
+	(e.g.  ``--roles-all.*=*`` or ``--roles-all.*=``).
 
 ``--tag-relative[=yes|no|always|never]``
-	The yes value indicates that the file paths recorded in the tag file should be
+	The ``yes`` value indicates that the file paths recorded in the tag file should be
 	relative to the directory containing the tag file, rather than relative
 	to the current directory, unless the files supplied on the command line
 	are specified with absolute paths. This option must appear before the
-	first file name. The default is yes when running in etags mode (see
-	the ``-e`` option), no otherwise.
-	The always value indicates the recorded file paths should be relative
+	first file name. The default is ``yes`` when running in etags mode (see
+	the ``-e`` option), ``no`` otherwise.
+	The ``always`` value indicates the recorded file paths should be relative
 	even if source file names are passed in with absolute paths.
-	The never value indicates the recorded file paths should be absolute
+	The ``never`` value indicates the recorded file paths should be absolute
 	even if source file names are passed in with relative paths.
 
 ``--use-slash-as-filename-separator[=yes|no]``
 	Uses slash character as filename separators instead of backslash
 	character when printing ``input:`` field.
 	This option is available on MSWindows only.
-	The default is yes for the default "u-ctags" output format, and
-	no for the other formats.
+	The default is ``yes`` for the default "u-ctags" output format, and
+	``no`` for the other formats.
 
 ``-B``
-	Use backward searching patterns (e.g. ?pattern?). [Ignored in etags mode]
+	Use backward searching patterns (e.g. ``?pattern?``). [Ignored in etags mode]
 
 ``-F``
-	Use forward searching patterns (e.g. /pattern/) (default). [Ignored
+	Use forward searching patterns (e.g. ``/pattern/``) (default). [Ignored
 	in etags mode]
 
 Option File Options
@@ -916,33 +916,33 @@ Option File Options
 ``--options=pathname``
 	Read additional options from file or directory.
 
-	ctags searches *pathname* in optlib path list
+	ctags searches ``pathname`` in the optlib path list
 	first. If ctags cannot find a file or directory
 	in the list, ctags reads a file or directory
-	at the specified *pathname*.
+	at the specified ``pathname``.
 
 	If a file is specified, it should contain one option per line. If
-	a directory is specified, files suffixed with ".ctags" under it
+	a directory is specified, files suffixed with ``.ctags`` under it
 	are read in alphabetical order.
 
-	As a special case, if "--options=NONE" is specified as the first
+	As a special case, if ``--options=NONE`` is specified as the first
 	option on the command line, preloading is disabled; the option
 	will disable the automatic reading of any configuration options
 	from either a file or the environment (see "`FILES`_").
 
 ``--options-maybe=pathname``
 	Same as ``--options`` but doesn't cause an error if file
-	(or directory) specified with *pathname* doesn't exist.
+	(or directory) specified with ``pathname`` doesn't exist.
 
 ``--optlib-dir=[+]directory``
-	Add an optlib *directory* to or reset **optlib** path list.
+	Add an optlib ``directory`` to or reset optlib path list.
 	By default, the optlib path list is empty.
 
 optlib Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``--kinddef-<LANG>=letter,name,description``
-	See :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
-	Be not confused this with ``--kinds-<LANG>``.
+	Define a kind for *<LANG>*.
+	Don't be confused this with ``--kinds-<LANG>``.
 
 ``--langdef=name``
 	See :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
@@ -958,17 +958,17 @@ optlib Options
 Language Specific Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``--if0[=yes|no]``
-	Indicates a preference as to whether code within an "#if 0" branch of a
+	Indicates a preference as to whether code within an ``#if 0`` branch of a
 	preprocessor conditional should be examined for non-macro tags (macro
 	tags are always included). Because the intent of this construct is to
-	disable code, the default value of this option is no. Note that this
+	disable code, the default value of this option is ``no``. Note that this
 	indicates a preference only and does not guarantee skipping code within
-	an "#if 0" branch, since the fall-back algorithm used to generate
+	an ``#if 0`` branch, since the fall-back algorithm used to generate
 	tags when preprocessor conditionals are too complex follows all branches
 	of a conditional. This option is disabled by default.
 
 ``--line-directives[=yes|no]``
-	Specifies whether "#line" directives should be recognized. These are
+	Specifies whether ``#line`` directives should be recognized. These are
 	present in the output of preprocessors and contain the line number, and
 	possibly the file name, of the original source file(s) from which the
 	preprocessor output file was generated. When enabled, this option will
@@ -978,7 +978,7 @@ Language Specific Options
 	file names placed into the tag file will have the same leading path
 	components as the preprocessor output file, since it is assumed that
 	the original source files are located relative to the preprocessor
-	output file (unless, of course, the #line directive specifies an
+	output file (unless, of course, the ``#line`` directive specifies an
 	absolute path). This option is off by default. Note: This option is generally
 	only useful when used together with the ``--excmd=number`` (``-n``) option.
 	Also, you may have to use either the ``--langmap`` or ``--language-force`` option
@@ -997,7 +997,7 @@ Language Specific Options
 	Specifies a list of file extensions, separated by periods, which are
 	to be interpreted as include (or header) files. To indicate files having
 	no extension, use a period not followed by a non-period character
-	(e.g. ".", "..x", ".x."). This option only affects how the scoping of
+	(e.g. '``.``', ``..x``, ``.x.``). This option only affects how the scoping of
 	particular kinds of tags are interpreted (i.e. whether or not they are
 	considered as globally visible or visible only within the file in which
 	they are defined); it does not map the extension to any particular
@@ -1007,9 +1007,9 @@ Language Specific Options
 	will be considered to have file-limited scope. If the first character
 	in the list is a plus sign, then the extensions in the list will be
 	appended to the current list; otherwise, the list will replace the
-	current list. See, also, the "F/fileScope" flag of ``--extras`` option.
+	current list. See, also, the ``F/fileScope`` flag of ``--extras`` option.
 	The default list is
-	".h.H.hh.hpp.hxx.h++.inc.def". To restore the default list, specify ``-h``
+	``.h.H.hh.hpp.hxx.h++.inc.def``. To restore the default list, specify ``-h``
 	default. Note that if an extension supplied to this option is not
 	already mapped to a particular language (see "`Determining file language`_", above),
 	you will also need to use either the ``--langmap`` or ``--language-force`` option.
@@ -1020,22 +1020,22 @@ Language Specific Options
 	to handle special cases arising through the use of preprocessor macros.
 	When the identifiers listed are simple identifiers, these identifiers
 	will be ignored during parsing of the source files. If an identifier is
-	suffixed with a '+' character, ctags will also
+	suffixed with a '``+``' character, ctags will also
 	ignore any parenthesis-enclosed argument list which may immediately
 	follow the identifier in the source files. If two identifiers are
-	separated with the '=' character, the first identifiers is replaced by
+	separated with the '``=``' character, the first identifiers is replaced by
 	the second identifiers for parsing purposes. The list of identifiers may
 	be supplied directly on the command line or read in from a separate file.
-	If the first character of identifier-list is '@', '.' or a pathname
-	separator (``'/'`` or ``'\'``), or the first two characters specify a drive
-	letter (e.g. "C:"), the parameter identifier-list will be interpreted as
+	If the first character of identifier-list is '``@``', '``.``' or a pathname
+	separator ('``/``' or '``\``'), or the first two characters specify a drive
+	letter (e.g. ``C:``), the parameter identifier-list will be interpreted as
 	a filename from which to read a list of identifiers, one per input line.
 	Otherwise, identifier-list is a list of identifiers (or identifier
 	pairs) to be specially handled, each delimited by either a comma or
 	by white space (in which case the list should be quoted to keep the
 	entire list as one command line argument). Multiple ``-I`` options may be
 	supplied. To clear the list of ignore identifiers, supply a single
-	dash ("-") for identifier-list.
+	dash ('``-``') for identifier-list.
 
 	This feature is useful when preprocessor macros are used in such a way
 	that they cause syntactic confusion due to their presence. Indeed,
@@ -1047,9 +1047,9 @@ Language Specific Options
 
 		int foo ARGDECL4(void *, ptr, long int, nbytes)
 
-	In the above example, the macro "ARGDECL4" would be mistakenly
+	In the above example, the macro ``ARGDECL4`` would be mistakenly
 	interpreted to be the name of the function instead of the correct name
-	of "foo". Specifying "-I ARGDECL4" results in the correct behavior.
+	of ``foo``. Specifying ``-I ARGDECL4`` results in the correct behavior.
 
 	.. code-block:: C
 
@@ -1062,7 +1062,7 @@ Language Specific Options
 	much like a K&R style function parameter declaration). In fact, this
 	seeming function definition could possibly even cause the rest of the
 	file to be skipped over while trying to complete the definition.
-	Specifying "-I MODULE_VERSION+" would avoid such a problem.
+	Specifying ``-I MODULE_VERSION+`` would avoid such a problem.
 
 	.. code-block:: C
 
@@ -1070,21 +1070,25 @@ Language Specific Options
 			// your content here
 		};
 
-	The example above uses "CLASS" as a preprocessor macro which expands to
-	something different for each platform. For instance CLASS may be
-	defined as "class __declspec(dllexport)" on Win32 platforms and simply
-	"class" on UNIX. Normally, the absence of the C++ keyword "class"
+	The example above uses ``CLASS`` as a preprocessor macro which expands to
+	something different for each platform. For instance ``CLASS`` may be
+	defined as ``class __declspec(dllexport)`` on Win32 platforms and simply
+	``class`` on UNIX. Normally, the absence of the C++ keyword ``class``
 	would cause the source file to be incorrectly parsed. Correct behavior
-	can be restored by specifying "-I CLASS=class".
+	can be restored by specifying ``-I CLASS=class``.
 
-.. _option_listing:
+``--param-<LANG>:name=argument``
+	Set *<LANG>* specific parameter. Available parameters can be listed with
+	``--list-params``.
+
+	.. TODO: add description of "parameter".
 
 Listing Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``--list-aliases[=language|all]``
-	Lists the aliases for either the specified *language* or **all**
+	Lists the aliases for either the specified ``language`` or ``all``
 	languages, and then exits.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 	The aliases are used when heuristically testing a language parser for a
 	source file.
 
@@ -1093,8 +1097,8 @@ Listing Options
 
 ``--list-extras[=language|all]``
 	Lists the extras recognized for either the specified *language* or
-	**all** languages. See "`Extras`_" subsection to know what are extras.
-	**all** is used as default value if the option argument is omitted.
+	*all* languages. See "`Extras`_" subsection to know what are extras.
+	``all`` is used as default value if the option argument is omitted.
 
 	An extra can be enabled or disabled with ``--extras=`` for common
 	extras in all languages, or ``--extras-<LANG>=`` for the specified
@@ -1104,17 +1108,17 @@ Listing Options
 	The meaning of columns are as follows:
 
 	LETTER
-		One-letter flag. '-' means the extra does not have one-letter flag.
+		One-letter flag. '``-``' means the extra does not have one-letter flag.
 
 	NAME
 		Long-name flag. The long-name is used in ``extras:`` field.
 
 	ENABLED
-		Whether the extra is enabled or not. It takes "yes" or "no".
+		Whether the extra is enabled or not. It takes ``yes`` or ``no``.
 
 	LANGUAGE
 		The name of language if the extra is owned by a parser.
-		"NONE" means the extra is common in parsers.
+		``NONE`` means the extra is common in parsers.
 
 	DESCRIPTION
 		Human readable description for the extra.
@@ -1124,8 +1128,8 @@ Listing Options
 
 ``--list-fields[=language|all]``
 	Lists the fields recognized for either the specified *language* or
-	**all** languages. See "`Fields`_" subsection to know what are fields.
-	**all** is used as default value if the option argument is omitted.
+	*all* languages. See "`Fields`_" subsection to know what are fields.
+	``all`` is used as default value if the option argument is omitted.
 
 	.. TODO? xref output
 
@@ -1137,37 +1141,37 @@ Listing Options
 	The meaning of columns are as follows:
 
 	LETTER
-		One-letter flag. '-' means the field does not have one-letter flag.
+		One-letter flag. '``-``' means the field does not have one-letter flag.
 
 	NAME
 		Long-name of field.
 
 	ENABLED
-		Whether the field is enabled or not. It takes "yes" or "no".
+		Whether the field is enabled or not. It takes ``yes`` or ``no``.
 
 	LANGUAGE
 		The name of language if the field is owned by a parser.
-		"NONE" means the extra is common in parsers.
+		``NONE`` means the extra is common in parsers.
 
 	JSTYPE
-		Json type used in printing the value of field when "--output-format=json"
+		Json type used in printing the value of field when ``--output-format=json``
 		is specified.
 
 		Following characters are used for representing types.
 
-		s
+		``s``
 			string
-		i
+		``i``
 			integer
-		b
+		``b``
 			boolean (true or false)
 
 		The representation of this field and the output format used in
-		"--output-format=json" are still experimental.
+		``--output-format=json`` are still experimental.
 
 	FIXED
 	   Whether this field can be disabled or not. Some fields are printed always
-	   in tags output. They have "yes" as the value for this column.
+	   in tags output. They have ``yes`` as the value for this column.
 
 	DESCRIPTION
 		Human readable description for the field.
@@ -1179,7 +1183,7 @@ Listing Options
 	This option prints only LETTER, DESCRIPTION, and ENABLED fields
 	of ``--list-kinds-full`` output. However, the presentation of
 	ENABLED column is different from that of ``--list-kinds-full``
-	option; "[off]" follows after description if the kind is disabled,
+	option; ``[off]`` follows after description if the kind is disabled,
 	and nothing follows	if enabled. The most of all kinds are enabled
 	by default.
 
@@ -1193,9 +1197,9 @@ Listing Options
 
 ``--list-kinds-full[=language|all]``
 	Lists the tag kinds recognized for either the specified *language*
-	or **all** languages, and then exits. See "`Kinds`_" subsection to
+	or *all* languages, and then exits. See "`Kinds`_" subsection to
 	learn what kinds are.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 
 	Each kind of tag recorded in the tag file is represented by a
 	one-letter flag, or a long-name flag. They are also used to filter the tags
@@ -1212,7 +1216,7 @@ Listing Options
 
 	NAME
 		The long-name flag of the kind. This can be used as the alternative
-		to the one-letter flag described above. If enabling 'K' field with
+		to the one-letter flag described above. If enabling ``K`` field with
 		``--fields=+K``, ctags uses long-names instead of
 		one-letters in tags output. To enable/disable a kind with
 		``--kinds-<LANG>`` option, long-name surrounded by braces instead
@@ -1220,11 +1224,11 @@ Listing Options
 		unique in a language.
 
 	ENABLED
-		Whether the kind is enabled or not. It takes "yes" or "no".
+		Whether the kind is enabled or not. It takes ``yes`` or ``no``.
 
 	REFONLY
 		Whether the kind is specialized for reference tagging or not.
-		If the column is "yes", the kind is for reference tagging, and
+		If the column is ``yes``, the kind is for reference tagging, and
 		it is never used for definition tagging. See also "`TAG ENTRIES`_".
 
 	NROLES
@@ -1242,7 +1246,7 @@ Listing Options
 		C++. Enabling/disabling kindX in C language enables/disables a
 		kind in C++ language having the same long-name flag with kindX. To
 		emulate this behavior in Universal Ctags, a concept named
-		"master parser" is introduced. Enabling/disabling some kinds
+		*master parser* is introduced. Enabling/disabling some kinds
 		are synchronized under the control of a master language.
 
 		.. code-block:: console
@@ -1256,8 +1260,8 @@ Listing Options
 			#LANGUAGE  LETTER NAME   ENABLED REFONLY NROLES MASTER DESCRIPTION
 			C++        l      local  no      no      0      C      local variables
 
-		You see "ENABLED" field of "local" kind of C++ language is changed
-		Though "local" kind of C language is enabled/disabled. If you swap the languages, you
+		You see ``ENABLED`` field of ``local`` kind of C++ language is changed
+		Though ``local`` kind of C language is enabled/disabled. If you swap the languages, you
 		see the same result.
 
 	DESCRIPTION
@@ -1269,7 +1273,7 @@ Listing Options
 	used in many other options like ``--language-force``,
 	``--languages``, ``--kinds-<LANG>``, ``--regex-<LANG>``, and so on.
 
-	Each language listed is disabled if followed by "[disabled]".
+	Each language listed is disabled if followed by ``[disabled]``.
 	To use the parser for such a language, specify the language as an
 	argument of ``--languages=+`` option.
 
@@ -1278,22 +1282,22 @@ Listing Options
 
 ``--list-map-extensions[=language|all]``
 	Lists the file extensions which associate a file
-	name with a language for either the specified *language* or **all**
+	name with a language for either the specified *language* or *all*
 	languages, and then exits.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 
 ``--list-map-patterns[=language|all]``
 	Lists the file name patterns which associate a file
-	name with a language for either the specified *language* or **all**
+	name with a language for either the specified *language* or *all*
 	languages, and then exits.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 
 ``--list-maps[=language|all]``
 	Lists file name patterns and the file extensions which associate a file
-	name with a language for either the specified *language* or **all**
+	name with a language for either the specified *language* or *all*
 	languages, and then exits. See the ``--langmap`` option, and
 	"`Determining file language`_", above.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 
 	To list the file extensions or file name patterns individually, use
 	``--list-map-extensions`` or ``--list-map-patterns`` option.
@@ -1307,9 +1311,9 @@ Listing Options
 	definition.
 
 ``--list-params[=language|all]``
-	Lists the parameters for either the specified *language* or **all**
+	Lists the parameters for either the specified *language* or *all*
 	languages, and then exits.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 
 ``--list-pseudo-tags``
 	Output list of pseudo-tags.
@@ -1318,10 +1322,10 @@ Listing Options
 	See :ref:`ctags-optlib(7) <ctags-optlib(7)>`.
 
 ``--list-roles[=language|all[.kinds]]``
-	List the roles for either the specified *language* or **all** languages.
-	**all** is used as default value if the option argument is omitted.
-	If the parameter kinds is given after the parameter
-	*language* or **all** with concatenating with '.', list only roles
+	List the roles for either the specified *language* or *all* languages.
+	``all`` is used as default value if the option argument is omitted.
+	If the parameter ``kinds`` is given after the parameter
+	``language`` or ``all`` with concatenating with '``.``', list only roles
 	defined in the kinds. Both one-letter flags and long name flags surrounded
 	by braces are acceptable as the parameter kinds.
 
@@ -1337,7 +1341,7 @@ Listing Options
 		The long-name flag of the role.
 
 	ENABLED
-		Whether the kind is enabled or not. It takes "yes" or "no".
+		Whether the kind is enabled or not. It takes ``yes`` or ``no``.
 		(Currently all roles are enabled. No option for disabling
 		a specified role is not implemented yet.)
 
@@ -1346,8 +1350,8 @@ Listing Options
 
 ``--list-subparsers[=baselang|all]``
 	Lists the subparsers for a base language for either the specified
-	*baselang* or **all** languages, and then exits.
-	**all** is used as default value if the option argument is omitted.
+	*baselang* or *all* languages, and then exits.
+	``all`` is used as default value if the option argument is omitted.
 
 ``--machinable[=yes|no]``
 	Use tab character as separators for ``--list-`` option output.  It
@@ -1381,14 +1385,14 @@ Miscellaneous Options
 	Just prints the language parsers for specified source files, and then exits.
 
 ``--quiet[=yes|no]``
-	Write fewer messages (default is no).
+	Write fewer messages (default is ``no``).
 
 ``--totals[=yes|no|extra]``
 	Prints statistics about the source files read and the tag file written
 	during the current invocation of ctags. This option
 	is off by default. This option must appear before the first file name.
 
-	The extra value prints parser specific statistics for parsers
+	The ``extra`` value prints parser specific statistics for parsers
 	gathering such information.
 
 ``--verbose[=yes|no]``
@@ -1399,7 +1403,7 @@ Miscellaneous Options
 	from the configuration files (see "`FILES`_", below) and the CTAGS
 	environment variable. However, if this option is the first argument on
 	the command line, it will take effect before any options are read from
-	these sources. The default is no.
+	these sources. The default is ``no``.
 
 ``-V``
 	Equivalent to ``--verbose``.
@@ -1416,8 +1420,8 @@ Obsoleted Options
 	ctags of SVR4 Unix.
 
 ``--file-scope[=yes|no]``
-	This options is removed. Use "--extras=[+|-]F" or
-	"--extras=[+|-]{fileScope}" instead.
+	This options is removed. Use ``--extras=[+|-]F`` or
+	``--extras=[+|-]{fileScope}`` instead.
 
 OPERATIONAL DETAILS
 -------------------
@@ -1440,7 +1444,7 @@ In general, ctags tries to be smart about conditional
 preprocessor directives. If a preprocessor conditional is encountered
 within a statement which defines a tag, ctags follows
 only the first branch of that conditional (except in the special case of
-"#if 0", in which case it follows only the last branch). The reason for
+``#if 0``, in which case it follows only the last branch). The reason for
 this is that failing to pursue only one branch can result in ambiguous
 syntax, as in the following example:
 
@@ -1463,7 +1467,7 @@ generally due to complicated and inconsistent pairing within the
 conditionals, ctags will retry the file using a
 different heuristic which does not selectively follow conditional
 preprocessor branches, but instead falls back to relying upon a closing
-brace ("}") in column 1 as indicating the end of a block once any brace
+brace ('``}``') in column 1 as indicating the end of a block once any brace
 imbalance results from following a #if conditional branch.
 
 ctags will also try to specially handle arguments lists
@@ -1472,7 +1476,7 @@ conditional construct::
 
 	extern void foo __ARGS((int one, char two));
 
-Any name immediately preceding the "((" will be automatically ignored and
+Any name immediately preceding the '``((``' will be automatically ignored and
 the previous name will be used.
 
 C++ operator definitions are specially handled. In order for consistency
@@ -1492,7 +1496,7 @@ File name mapping
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Unless the ``--language-force`` option is specified, the language of each source
-file is automatically selected based upon a **mapping** of file names to
+file is automatically selected based upon a *mapping* of file names to
 languages. The mappings in effect for each language may be displayed using
 the ``--list-maps`` option and may be changed using the ``--langmap`` or
 ``--map-<LANG>`` options.
@@ -1503,12 +1507,12 @@ to heuristically guess the language for the file by inspecting its content. See
 
 All files that have no file name mapping and no guessed parser are
 ignored. This permits running ctags on all files in
-either a single directory (e.g.  "ctags \*"), or on
+either a single directory (e.g.  ``ctags *``), or on
 all files in an entire source directory tree
-(e.g. "ctags -R"), since only those files whose
+(e.g. ``ctags -R``), since only those files whose
 names are mapped to languages will be scanned.
 
-The same extensions are mapped to multiple parsers. For example, ".h"
+The same extensions are mapped to multiple parsers. For example, ``.h``
 are mapped to C++, C and ObjectiveC. These mappings can cause
 issues. ctags tries to select the proper parser
 for the source file by applying heuristics to its content, however
@@ -1533,23 +1537,23 @@ If ctags cannot select a parser from the mapping of file names,
 various heuristic tests are conducted to determine the language:
 
 template file name testing
-	If the file name has an ".in" extension, ctags applies
+	If the file name has an ``.in`` extension, ctags applies
 	the mapping to the file name without the extension. For example,
-	"config.h" is tested for a file named "config.h.in".
+	``config.h`` is tested for a file named ``config.h.in``.
 
 "interpreter" testing
-	The first line of the file is checked to see if the file is a "#!"
+	The first line of the file is checked to see if the file is a ``#!``
 	script for a recognized language. ctags looks for
 	a parser having the same name.
 
 	If ctags finds no such parser,
 	ctags looks for the name in alias lists. For
-	example, consider if the first line is "#!/bin/sh".  Though
+	example, consider if the first line is ``#!/bin/sh``.  Though
 	ctags has a "shell" parser, it doesn't have a "sh"
-	parser. However, "sh" is listed as an alias for "shell", therefore
+	parser. However, ``sh`` is listed as an alias for ``shell``, therefore
 	ctags selects the "shell" parser for the file.
 
-	An exception is "env". If "env" is specified, ctags
+	An exception is ``env``. If ``env`` is specified, ctags
 	reads more lines to find real interpreter specification.
 
 	To display the list of aliases, use ``--list-aliases`` option.
@@ -1557,7 +1561,7 @@ template file name testing
 	``--alias-<LANG>=[+|-]aliasPattern`` option.
 
 "zsh autoload tag" testing
-	If the first line starts with "#compdef" or "#autoload",
+	If the first line starts with ``#compdef`` or ``#autoload``,
 	ctags regards the line as "zsh".
 
 "emacs mode at the first line" testing
@@ -1566,7 +1570,7 @@ template file name testing
 	and utilize the marker for the mode selection. This heuristic test does
 	the same as what Emacs does.
 
-	ctags treats *MODE* as a name of interpreter and applies the same
+	ctags treats ``MODE`` as a name of interpreter and applies the same
 	rule of "interpreter" testing if the first line has one of
 	the following patterns::
 
@@ -1582,7 +1586,7 @@ template file name testing
 	Emacs editor recognizes another marker at the end of file as a
 	mode specifier. This heuristic test does the same as what Emacs does.
 
-	ctags treats *MODE* as a name of an interpreter and applies the same
+	ctags treats ``MODE`` as a name of an interpreter and applies the same
 	rule of "interpreter" heuristic testing, if the lines at the tail of the file
 	have the following pattern::
 
@@ -1596,7 +1600,7 @@ template file name testing
 
 "vim modeline" testing
 	Like the modeline of the Emacs editor, Vim editor has the same concept.
-	ctags treats *TYPE* as a name of interpreter and applies the same
+	ctags treats ``TYPE`` as a name of interpreter and applies the same
 	rule of "interpreter" heuristic testing if the last 5 lines of the file
 	have one of the following patterns::
 
@@ -1609,7 +1613,7 @@ template file name testing
 		ft=TYPE
 
 "PHP marker" testing
-	If the first line is started with "<?php",
+	If the first line is started with ``<?php``,
 	ctags regards the line as "php".
 
 Looking into the file contents is a more expensive operation than file
@@ -1641,7 +1645,7 @@ TAG ENTRIES
 A tag is an index for a language object. The concept of a tag and related
 items in Exuberant Ctags are refined and extended in Universal Ctags.
 
-A tag is categorized into **definition tags** or **reference tags**.
+A tag is categorized into *definition tags* or *reference tags*.
 In general, Exuberant Ctags only tags *definitions* of
 language objects: places where newly named language objects are introduced.
 Universal Ctags, on the other hand, can also tag *references* of language
@@ -1653,11 +1657,11 @@ specific languages in the current version.
 Fields
 ~~~~~~
 
-A tag can record various information, called **fields**. The
-essential fields are: **name** of language objects, **input**,
-**pattern**, and **line**. ``input:`` is the name of source file where
+A tag can record various information, called *fields*. The
+essential fields are: *name* of language objects, *input*,
+*pattern*, and *line*. ``input:`` is the name of source file where
 ``name:`` is defined or referenced. ``pattern:`` can be used to search
-the **name** in ``input:``. **line** is the line number where
+the *name* in ``input:``. *line* is the line number where
 ``name:`` is defined or referenced in ``input:``.
 
 ctags offers extension fields. See also the
@@ -1669,8 +1673,8 @@ Kinds
 
 ``kind:`` is a field which represents the *kind* of language object
 specified by a tag. Kinds used and defined are very different between
-parsers. For example, C language defines "macro", "function",
-"variable", "typedef", etc. See also the descriptions of
+parsers. For example, C language defines ``macro``, ``function``,
+``variable``, ``typedef``, etc. See also the descriptions of
 ``--list-kinds-full`` option and ``--kinds-<LANG>`` option.
 
 
@@ -1680,12 +1684,12 @@ Extras
 Generally, ctags tags only language objects appearing
 in source files, as is. In other words, a value for a ``name:`` field
 should be found on the source file associated with the ``name:``. An
-"extra" type tag (*extra*) is for tagging a language object with a processed
+``extra`` type tag (*extra*) is for tagging a language object with a processed
 name, or for tagging something not associated with a language object. A typical
-extra tag is "qualified", which tags a language object with a
+extra tag is ``qualified``, which tags a language object with a
 class-qualified or scope-qualified name.
 
-The following example demonstrates the "qualified" extra tag.
+The following example demonstrates the ``qualified`` extra tag.
 
 .. code-block:: Java
 
@@ -1696,10 +1700,10 @@ The following example demonstrates the "qualified" extra tag.
 		// ...
 	}
 
-For the above source file, ctags tags "Bar" and "Foo" by
-default.  If the "qualified" extra is enabled from the command line
-(``--extras=+q``), then "Bar.Foo" is also tagged even though the string
-"Bar.Foo" is not in the source code.
+For the above source file, ctags tags ``Bar`` and ``Foo`` by
+default.  If the ``qualified`` extra is enabled from the command line
+(``--extras=+q``), then ``Bar.Foo`` is also tagged even though the string
+``Bar.Foo`` is not in the source code.
 
 See also the descriptions of ``--list-extras`` option and ``--extras``
 option in "`OPTIONS`_".
@@ -1711,20 +1715,20 @@ Roles
 *Role* is a newly introduced concept in Universal Ctags. Role is a
 concept associated with reference tags, and is not implemented widely yet.
 
-As described previously in "Kinds", the "kind" field represents the type
+As described previously in "`Kinds`_", the ``kind`` field represents the type
 of language object specified with a tag, such as a function vs. a variable.
-Specific kinds are defined for reference tags, such as the C++ kind "header" for
-header file, or Java kind "package" for package statements. For such reference
-kinds, a "roles" field can be added to distinguish the role of the reference
-kind. In other words, the "kind" field identifies the "what" of the language
-object, whereas the "roles" field identifies the "how" of a referenced language
+Specific kinds are defined for reference tags, such as the C++ kind ``header`` for
+header file, or Java kind ``package`` for package statements. For such reference
+kinds, a ``roles`` field can be added to distinguish the role of the reference
+kind. In other words, the ``kind`` field identifies the *what* of the language
+object, whereas the ``roles`` field identifies the *how* of a referenced language
 object. Roles are only used with specific kinds.
 
 For example, for the source file used for demonstrating in the "`Extras`_"
-subsection, "Baz" is tagged as a reference tag with kind "package" and with
-role "imported". Another example is for a C++ "header" kind tag, generated by
-"#include" statements: the ``roles:system`` or ``roles:local`` fields will be
-added depending on whether the include file name begins with "<" or not.
+subsection, ``Baz`` is tagged as a reference tag with kind ``package`` and with
+role ``imported``. Another example is for a C++ ``header`` kind tag, generated by
+``#include`` statements: the ``roles:system`` or ``roles:local`` fields will be
+added depending on whether the include file name begins with '``<``' or not.
 
 See also the descriptions of ``--list-roles`` and ``--roles-<LANG>.<KIND>=``
 options.
@@ -1733,7 +1737,7 @@ options.
 Language-specific fields and extras
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Exuberant Ctags has the concept of "fields" and "extras". They are common
+Exuberant Ctags has the concept of *fields* and *extras*. They are common
 between parsers of different languages. Universal Ctags extends this concept
 by providing language-specific fields and extras.
 
@@ -1787,7 +1791,7 @@ the ``--tag-relative`` option for how this behavior can be modified.
 
 Extension fields are tab-separated key-value pairs appended to the end of
 the EX command as a comment, as described above. These key value pairs
-appear in the general form "key:value". Their presence in the lines of the
+appear in the general form ``key:value``. Their presence in the lines of the
 tag file are controlled by the ``--fields`` option. The possible keys and
 the meaning of their values are as follows:
 
@@ -1811,7 +1815,7 @@ kind
 implementation
 	When present, this indicates a limited implementation (abstract vs.
 	concrete) of a routine or class, where value is specific to the
-	language ("virtual" or "pure virtual" for C++; "abstract" for Java).
+	language (``virtual`` or ``pure virtual`` for C++; ``abstract`` for Java).
 
 inherits
 	When present, value. is a comma-separated list of classes from which
@@ -1829,48 +1833,48 @@ available, with the key portion equal to some language-dependent construct
 name and its value the name declared for that construct in the program.
 This scope entry indicates the scope in which the tag was found.
 For example, a tag generated for a C structure member would have a scope
-looking like "struct:myStruct".
+looking like ``struct:myStruct``.
 
 
 HOW TO USE WITH VI
 ------------------
 
-Vi will, by default, expect a tag file by the name "tags" in the current
+Vi will, by default, expect a tag file by the name ``tags`` in the current
 directory. Once the tag file is built, the following commands exercise
 the tag indexing feature:
 
-vi -t tag
-	Start vi and position the cursor at the file and line where "tag"
+``vi -t tag``
+	Start vi and position the cursor at the file and line where ``tag``
 	is defined.
 
-:ta tag
+``:ta tag``
 	Find a tag.
 
-Ctrl-]
+``Ctrl-]``
 	Find the tag under the cursor.
 
-Ctrl-T
+``Ctrl-T``
 	Return to previous location before jump to tag (not widely implemented).
 
 
 HOW TO USE WITH GNU EMACS
 -------------------------
 
-Emacs will, by default, expect a tag file by the name "TAGS" in the
+Emacs will, by default, expect a tag file by the name ``TAGS`` in the
 current directory. Once the tag file is built, the following commands
 exercise the tag indexing feature:
 
-M-x visit-tags-table <RET> FILE <RET>
-	Select the tag file, "FILE", to use.
+``M-x visit-tags-table <RET> FILE <RET>``
+	Select the tag file, ``FILE``, to use.
 
-M-. [TAG] <RET>
+``M-. [TAG] <RET>``
 	Find the first definition of TAG. The default tag is the identifier
 	under the cursor.
 
-M-*
-	Pop back to where you previously invoked "M-.".
+``M-*``
+	Pop back to where you previously invoked ``M-.``.
 
-C-u M-.
+``C-u M-.``
 	Find the next definition for the last tag.
 
 For more commands, see the Tags topic in the Emacs info document.
@@ -1882,8 +1886,8 @@ HOW TO USE WITH NEDIT
 NEdit version 5.1 and later can handle the new extended tag file format
 (see ``--format``). To make NEdit use the tag file, select "File->Load Tags
 File". To jump to the definition for a tag, highlight the word, then press
-Ctrl-D. NEdit 5.1 can read multiple tag files from different
-directories. Setting the X resource nedit.tagFile to the name of a tag
+``Ctrl-D``. NEdit 5.1 can read multiple tag files from different
+directories. Setting the X resource ``nedit.tagFile`` to the name of a tag
 file instructs NEdit to automatically load that tag file at startup time.
 
 
@@ -1926,9 +1930,9 @@ This can be avoided by use of the ``--excmd=n`` option.
 BUGS
 ----
 
-ctags has more options than ls(1).
+ctags has more options than ``ls(1)``.
 
-When parsing a C++ member function definition (e.g. "className::function"),
+When parsing a C++ member function definition (e.g. ``className::function``),
 ctags cannot determine whether the scope specifier
 is a class name or a namespace specifier and always lists it as a class name
 in the scope portion of the extension fields. Also, if a C++ function
@@ -1936,14 +1940,14 @@ is defined outside of the class declaration (the usual case), the access
 specification (i.e. public, protected, or private) and implementation
 information (e.g. virtual, pure virtual) contained in the function
 declaration are not known when the tag is generated for the function
-definition. It will, however be available for prototypes (e.g. "--kinds-c++=+p").
+definition. It will, however be available for prototypes (e.g. ``--kinds-c++=+p``).
 
 No qualified tags are generated for language objects inherited into a class.
 
 ENVIRONMENT VARIABLES
 ---------------------
 
-CTAGS
+``CTAGS``
 	If this environment variable exists, it will be expected to contain a
 	set of default options which are read when ctags
 	starts, after the configuration files listed in FILES, below, are read,
@@ -1954,13 +1958,13 @@ CTAGS
 	an option parameter containing an embedded space. If this is a problem,
 	use a configuration file instead.
 
-ETAGS
-	Similar to the CTAGS variable above, this variable, if found, will be
+``ETAGS``
+	Similar to the ``CTAGS`` variable above, this variable, if found, will be
 	read when etags starts. If this variable is not
-	found, etags will try to use CTAGS instead.
+	found, etags will try to use ``CTAGS`` instead.
 
-TMPDIR
-	On Unix-like hosts where mkstemp() is available, the value of this
+``TMPDIR``
+	On Unix-like hosts where ``mkstemp()`` is available, the value of this
 	variable specifies the directory in which to place temporary files.
 	This can be useful if the size of a temporary file becomes too large
 	to fit on the partition holding the default temporary directory
@@ -1968,35 +1972,36 @@ TMPDIR
 	files only if either (1) an emacs-style tag file is being
 	generated, (2) the tag file is being sent to standard output, or
 	(3) the program was compiled to use an internal sort algorithm to sort
-	the tag files instead of the sort utility of the operating system.
-	If the sort utility of the operating system is being used, it will
+	the tag files instead of the ``sort`` utility of the operating system.
+	If the ``sort`` utility of the operating system is being used, it will
 	generally observe this variable also. Note that if ctags
-	is setuid, the value of TMPDIR will be ignored.
+	is setuid, the value of ``TMPDIR`` will be ignored.
 
 
 FILES
 -----
 
-$XDG_CONFIG_HOME/ctags/\*.ctags, or $HOME/.config/ctags/\*.ctags if $XDG_CONFIG_HOME is not defined
+``$XDG_CONFIG_HOME/ctags/*.ctags``, or ``$HOME/.config/ctags/*.ctags`` if
+``$XDG_CONFIG_HOME`` is not defined
 (on other than MSWindows)
 
-$HOME/.ctags.d/\*.ctags
+``$HOME/.ctags.d/*.ctags``
 
-$HOMEDRIVE$HOMEPATH/ctags.d/\*.ctags (on MSWindows only)
+``$HOMEDRIVE$HOMEPATH/ctags.d/*.ctags`` (on MSWindows only)
 
-.ctags.d/\*.ctags
+``.ctags.d/*.ctags``
 
-ctags.d/\*.ctags
+``ctags.d/*.ctags``
 
 	If any of these configuration files exist, each will be expected to
 	contain a set of default options which are read in the order listed
-	when ctags starts, but before the CTAGS environment
+	when ctags starts, but before the ``CTAGS`` environment
 	variable is read or any command line options are read. This makes it
 	possible to set up personal or project-level defaults. It
 	is possible to compile ctags to read an additional
 	configuration file before any of those shown above, which will be
 	indicated if the output produced by the ``--version`` option lists the
-	"custom-conf" feature. Options appearing in the CTAGS environment
+	``custom-conf`` feature. Options appearing in the ``CTAGS`` environment
 	variable or on the command line will override options specified in these
 	files. Only options will be read from these files. Note that the option
 	files are read in line-oriented mode in which spaces are significant
@@ -2004,14 +2009,14 @@ ctags.d/\*.ctags
 	of a line are ignored. Each line of the file is read as
 	one command line parameter (as if it were quoted with single quotes).
 	Therefore, use new lines to indicate separate command-line arguments.
-	A line starting with '#' is treated as a comment.
+	A line starting with '``#``' is treated as a comment.
 
-	\*.ctags files in a directory are loaded in alphabetical order.
+	``*.ctags`` files in a directory are loaded in alphabetical order.
 
-tags
+``tags``
 	The default tag file created by ctags.
 
-TAGS
+``TAGS``
 	The default tag file created by etags.
 
 
@@ -2069,9 +2074,9 @@ service to humanity."
 CREDITS
 -------
 This version of ctags (Universal Ctags) derived from
-the repository, known as **fishman-ctags**, started by Reza Jelveh.
+the repository, known as fishman-ctags, started by Reza Jelveh.
 
-Some parsers are taken from **tagmanager** of **Geany** (https://www.geany.org/)
+Some parsers are taken from ``tagmanager`` of the Geany (https://www.geany.org/)
 project.
 
 

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -10,13 +10,7 @@ Extending ctags with Regex parser (*optlib*)
 	:local:
 
 .. TODO:
-	review extras, fields, and roles sections
-	possibly restructure this file's section ordering
-	add documentation for --_mtable-extend-<LANG>
-	add documentation for tjump, treset, tquit flags
 	add a section on debugging
-	add a section on langdef base parser flag, including
-		shared/dedicated/bidirectional directions
 
 Exuberant Ctags allows a user to add a new parser to ctags with ``--langdef=<LANG>``
 and ``--regex-<LANG>=...`` options.
@@ -1540,8 +1534,6 @@ following input file::
 Defining a subparser
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. TODO upper level?
-
 Basic
 .........................................................................
 
@@ -1754,135 +1746,3 @@ To add your optlib file, ``foo.ctags``, into ``ctags`` do the following steps;
 
 You are encouraged to submit your :file:`.ctags` file to our repository on
 github through a pull request. See :ref:`contributions` for more details.
-
-.. TODO: the following section is a duplicate of "Contribution" chatper and has
-   less information than it.  To be removed.
-
-.. _submitting_optlib:
-
-Submitting an optlib file to the Universal Ctags project
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You are encouraged to submit your :file:`.ctags` file to our repository on
-github through a pull request.
-
-Universal Ctags provides a facility for "Option library".
-Read ":ref:`option_files`" about the concept and usage first.
-
-Here I will explain how to merge your .ctags into Universal Ctags as
-part of the option library. Here I assume you consider contributing
-an option library in which a regex-based language parser is defined.
-
-First you need your option library (which you have seen in this part of the
-guide).  See `How to Add Support for a New Language to Exuberant Ctags
-(EXTENDING)`_ to learn how to write a regex-based language parser in C.
-
-In this section I explain what to do after you have your parser.
-
-Like in the link, I use Swine as the name of programming language that
-the parser deals with. Assume source files written in Swine language have a
-suffix *.swn*. The file name of the option library is *swine.ctags*.
-
-.. _`How to Add Support for a New Language to Exuberant Ctags (EXTENDING)`: http://ctags.sourceforge.net/EXTENDING.html
-
-Copyright notice, contact mail address and license term
-......................................................................
-
-Put these information at the header of *swine.ctags*.
-
-An example taken from *data/optlib/ctags.ctags* ::
-
-	#
-	#
-	#  Copyright (c) 2014, Red Hat, Inc.
-	#  Copyright (c) 2014, Masatake YAMATO
-	#
-	#  Author: Masatake YAMATO <yamato@redhat.com>
-	#
-	# This program is free software; you can redistribute it and/or
-	# modify it under the terms of the GNU General Public License
-	# as published by the Free Software Foundation; either version 2
-	# of the License, or (at your option) any later version.
-	#
-	# This program is distributed in the hope that it will be useful,
-	# but WITHOUT ANY WARRANTY; without even the implied warranty of
-	# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-	# GNU General Public License for more details.
-	#
-	# You should have received a copy of the GNU General Public License
-	# along with this program; if not, write to the Free Software
-	# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
-	# USA.
-	#
-	#
-	...
-
-"GPL version 2 or later version" is needed here. The Option library is not
-linked to ``ctags`` command. However, I have written a translator which
-generates *.c* file from a given option file. Said translator is called
-``optlib2c`` and can be found in ``misc/optlib2c`` from the source tree. As
-result the *.c* file is built into ``ctags`` command. In such a case "GPL
-version 2 or later version" is be required.
-
-*Units* test cases
-......................................................................
-
-We, Universal Ctags developers don't have enough time to learn all
-languages supported by ``ctags``. In other word, we cannot review the
-code. Only test cases help us to know whether a contributed option
-library works well or not. We may reject any contribution without
-a test case.
-
-Read "Using *Units*" about how to write *Units* test cases.  Do not write one
-big test case: smaller cases are helpful to know about the intent of the
-contributor. For example:
-
-* *Units/sh-alias.d*
-* *Units/sh-comments.d*
-* *Units/sh-quotes.d*
-* *Units/sh-statements.d*
-
-are good example of small test cases.
-Big test cases are acceptable if smaller test cases exist.
-
-See also *parser-m4.r/m4-simple.d* especially *parser-m4.r/m4-simple.d/args.ctags*.
-Your test cases need ``ctags`` having already loaded your option
-library, swine.ctags. You must specify loading it in the
-test case own *args.ctags*.
-
-Assume your test name is *swine-simile.d*. Put ``--option=swine`` in
-*Units/swine-simile.d/args.ctags*.
-
-Incorporating your parser to ctags build process
-......................................................................
-
-Add your optlib file, *swine.ctags* to ``OPTLIB2C_INPUT`` variable of
-+*makefiles/optlib2c_input.mak* in Universal Ctags source tree.
-
-
-Verification
-......................................................................
-
-Let's verify all your work here.
-
-1. Run the tests and check whether your test case is passed or failed::
-
-	$ make units
-
-2. Verify your files are installed as expected::
-
-	$ mkdir /tmp/tmp
-	$ ./configure --prefix=/tmp/tmp
-	$ make
-	$ make install
-	$ /tmp/tmp/ctags -o - --languages=Swine something_input.swn
-
-
-Pull-request
-......................................................................
-
-Please, consider submitting your well written optlib parser to
-Universal Ctags. Your *.ctags* is a treasure and can be shared as a
-first class software component in Universal Ctags.
-
-Pull-requests are welcome.

--- a/docs/other-projects.rst
+++ b/docs/other-projects.rst
@@ -52,10 +52,13 @@ Software using ctags
 	.. TODO: Is Pygments using ctags? To be move moved to other section?
 
 	Pygments is a generic syntax highlighter.
+
 	It can utilize tags file
 	as input for making hyperlinks. However, Pygments just looks
 	at names and lines in tags file. scopes and kinds are not
-	used.
+	used.  See `here
+	<https://pygments-doc.readthedocs.io/en/latest/formatters/html.html>`_ for
+	details.
 
 	As far as I (Masatake YAMATO) tried, using Pygments from ctags
 	is not so useful. There are critical gap between ctags and Pygments.
@@ -72,6 +75,9 @@ Software using ctags
 	A person at GNU global project proposed an extension for the tags file
 	format: See `this ticket
 	<https://sourceforge.net/p/ctags/mailman/message/30020186/>`_ for details.
+
+	See also `'Source code reading' related sites
+	<https://www.gnu.org/software/global/links.html>`_.
 
 `GNU Source-highlight <https://www.gnu.org/software/src-highlite/>`_
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -243,10 +243,8 @@ message, too. What we should do?
 In such a case, merge as usually but use *.b* as suffix for
 the directory of test case instead of *.d*.
 
-*Unix/css-singlequote-in-comment-issue2.b* is an example
-of *.b* suffix usage.
-
-.. TODO: Now we only have Units/parser-css.r/css-singlequote-in-comment-issue2.d/
+``parser-autoconf.r/nested-block.ac.b/`` is an example
+of ``.b``*`` suffix usage.
 
 When you run test.units target, you will see::
 
@@ -351,16 +349,21 @@ The file name rule is suggested by Maxime Coste <frrrwww@gmail.com>.
 Reviewing the result of Units test
 ------------------------------------------------------------
 
-Try misc/review. [TBW]
+Try misc/review.
 
-..	semifuzz.rst
+.. code-block:: console
+
+    $ misc/review --help
+    Usage:
+            misc/review          help|--help|-h                 show this message
+            misc/review          [list] [-b]                    list failed Units and Tmain
+                                 -b                             list .b (known bug) marked cases
+            misc/review          inspect [-b]                   inspect difference interactively
+                                 -b                             inspect .b (known bug) marked cases
+    $
 
 Semi-fuzz(*Fuzz*) testing
 ---------------------------------------------------------------------
-
-:Maintainer: Masatake YAMATO <yamato@redhat.com>
-
-----
 
 Unexpected input can lead ctags to enter an infinite loop. The fuzz
 target tries to identify these conditions by passing
@@ -411,14 +414,8 @@ As the same as units target, this semi-fuzz test target also calls
 *misc/units shrink* when a test case is failed. See "*Units* test facility"
 about the shrunk result.
 
-..	noise.rst
-
 *Noise* testing
 ---------------------------------------------------------------------
-
-:Maintainer: Masatake YAMATO <yamato@redhat.com>
-
------
 
 After enjoying developing Semi-fuzz testing, I'm looking for a more unfair
 approach. Run
@@ -427,22 +424,14 @@ approach. Run
 
 	$ make noise LANGUAGES=LANG1[,LANG2,...]
 
-It takes a long time, especially with ``VG=1``, so this cannot be run
-under Travis CI. However, it is a good idea to run it locally.
-
 The noise target generates test cases by inserting or deleting one
 character to the test cases of *Units*.
 
-TBW
-
-..	chop.rst
+It takes a long time, even without ``VG=1``, so this cannot be run
+under Travis CI. However, it is a good idea to run it locally.
 
 *Chop* and *slap* testing
 ---------------------------------------------------------------------
-
-:Maintainer: Masatake YAMATO <yamato@redhat.com>
-
-----
 
 After reviving many bug reports, we recognized some of them spot
 unexpected EOF. The chop target was developed based on this recognition.
@@ -466,10 +455,6 @@ from head.
 
 Input validation for *Units*
 ---------------------------------------------------------------------
-
-:Maintainer: Masatake YAMATO <yamato@redhat.com>
-
-----
 
 We have to maintain parsers for languages that we don't know well.  We
 don't have enough time to learn the languages.

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -55,7 +55,7 @@ describes how the capability is extended.
 
 Newly introduced experimental features are not explained here. If you
 are interested in such features and @CTAGS_NAME_EXECUTABLE@ internals,
-visit https://docs.ctags.io/en/latest/.
+visit https://docs.ctags.io/.
 
 
 COMMAND LINE INTERFACE
@@ -117,7 +117,7 @@ List options
 ~~~~~~~~~~~~
 
 Universal Ctags introduces many ``--list-...`` options that provide
-the internal data of Universal Ctags. Both users and client tools may
+the internal data of Universal Ctags (See :ref:`option_listing`). Both users and client tools may
 use the data. ``--with-list-header`` and ``--machinable`` options
 adjust the output of the most of ``--list-...`` options.
 
@@ -158,7 +158,9 @@ Input/Output File Options
 	will be compared against both the complete path (e.g.
 	``some/path/base.ext``) and the base name (e.g. ``base.ext``) of the file, thus
 	allowing patterns which match a given file name irrespective of its
-	path, or match only a specific path. If appropriate support is available
+	path, or match only a specific path.
+
+	If appropriate support is available
 	from the runtime library of your C compiler, then pattern may
 	contain the usual shell wildcards (not regular expressions) common on
 	Unix (be sure to quote the option parameter to protect the wildcards from
@@ -192,6 +194,9 @@ Input/Output File Options
 	line: ``--exclude=foo/* --exclude-exception=foo/main.c``. Don't forget
 	shell quoting for '``*``'.
 
+.. TODO: Which shell requires the quoting?
+   At least bash does not require quoting unless directory `--exclude=foo' exists.
+
 ``--filter[=yes|no]``
 	Makes @CTAGS_NAME_EXECUTABLE@ behave as a filter, reading source
 	file names from standard input and printing their tags to standard
@@ -214,25 +219,33 @@ Input/Output File Options
 
 ``--recurse[=yes|no]``
 	Recurse into directories encountered in the list of supplied files.
+
 	If the list of supplied files is empty and no file list is specified with
 	the ``-L`` option, then the current directory (i.e. '``.``') is assumed.
-	Symbolic links are followed by default. If you don't like these behaviors, either
+	Symbolic links are followed by default (See ``--links`` option). If you don't like these behaviors, either
 	explicitly specify the files or pipe the output of ``find(1)`` into
-	``@CTAGS_NAME_EXECUTABLE@ -L -`` instead. Note: This option is not supported on
-	all platforms at present. It is available if the output of the ``--help``
-	option includes this option. See, also, the ``--exclude`` and
+	``@CTAGS_NAME_EXECUTABLE@ -L -`` instead. See, also, the ``--exclude`` and
 	``--maxdepth`` to limit recursion.
+
+	Note: This option is not supported on
+	all platforms at present. It is available if the output of the ``--help``
+	option includes this option.
+
+.. TODO(code): --list-features option should support this.
 
 ``-R``
 	Equivalent to ``--recurse``.
 
 ``-L file``
 	Read from file a list of file names for which tags should be generated.
+
 	If file is specified as '``-``', then file names are read from standard
 	input. File names read using this option are processed following file
 	names appearing on the command line. Options are also accepted in this
 	input. If this option is specified more than once, only the last will
-	apply. Note: file is read in line-oriented mode, where a new line is
+	apply.
+
+	Note: file is read in line-oriented mode, where a new line is
 	the only delimiter and non-trailing white space is considered significant,
 	in order that file names containing spaces may be supplied
 	(however, trailing white space is stripped from lines); this can affect
@@ -250,7 +263,9 @@ Input/Output File Options
 ``-f tagfile``
 	Use the name specified by tagfile for the tag file (default is "``tags``",
 	or "``TAGS``" when running in etags mode). If tagfile is specified as '``-``',
-	then the tags are written to standard output instead. @CTAGS_NAME_EXECUTABLE@
+	then the tags are written to standard output instead.
+
+	@CTAGS_NAME_EXECUTABLE@
 	will stubbornly refuse to take orders if tagfile exists and
 	its first line contains something other than a valid tags line. This
 	will save your neck if you mistakenly type ``@CTAGS_NAME_EXECUTABLE@ -f
@@ -259,7 +274,9 @@ Input/Output File Options
 	file name which begins with a '``-``' (dash) character, since this most
 	likely means that you left out the tag file name and this option tried to
 	grab the next option as the file name. If you really want to name your
-	output tag file ``-ugly``, specify it as ``-f ./-ugly``. This option must
+	output tag file ``-ugly``, specify it as ``-f ./-ugly``.
+
+	This option must
 	appear before the first file name. If this option is specified more
 	than once, only the last will apply.
 
@@ -274,13 +291,19 @@ Output Format Options
 	Specifies a string to print to standard output following the tags for
 	each file name parsed when the ``--filter`` option is enabled. This may
 	permit an application reading the output of @CTAGS_NAME_EXECUTABLE@
-	to determine when the output for each file is finished. Note that if the
+	to determine when the output for each file is finished.
+
+	Note that if the
 	file name read is a directory and ``--recurse`` is enabled, this string will
 	be printed only once at the end of all tags found for by descending
 	the directory. This string will always be separated from the last tag
-	line for the file by its terminating newline. This option is quite
+	line for the file by its terminating newline.
+
+	This option is quite
 	esoteric and is empty by default. This option must appear before
 	the first file name.
+
+.. TODO: Shall we move this after "--filter"?
 
 ``--format=level``
 	Change the format of the output tag file. Currently the only valid
@@ -316,7 +339,9 @@ Output Format Options
 	the output includes: the tag name; the kind of tag; the line number,
 	file name, and source line (with extra white space condensed) of the
 	file which defines the tag. No tag file is written and all options
-	affecting tag file output will be ignored. Example applications for this
+	affecting tag file output will be ignored.
+
+	Example applications for this
 	feature are generating a listing of all functions located in a source
 	file (e.g. ``@CTAGS_NAME_EXECUTABLE@ -x --kinds-c=f file``), or generating
 	a list of all externally visible global variables located in a source
@@ -363,17 +388,17 @@ Output Format Options
 
 Language Selection and Mapping Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``--language-force=language``
+``--language-force=language|auto``
 	By default, @CTAGS_NAME_EXECUTABLE@ automatically selects the language
 	of a source file, ignoring those files whose language cannot be
-	determined (see "`Determining file language`_", above). This option forces the specified
+	determined (see "`Determining file language`_"). This option forces the specified
 	*language* (case-insensitive; either built-in or user-defined) to be used
 	for every supplied file instead of automatically selecting the language
 	based upon its extension. In addition, the special value ``auto`` indicates
 	that the language should be automatically selected (which effectively
 	disables this option).
 
-``--languages=[+|-]list``
+``--languages=[+|-]list|all``
 	Specifies the languages for which tag generation is enabled, with *list*
 	containing a comma-separated list of language names (case-insensitive;
 	either built-in or user-defined). If the first language of *list* is not
@@ -526,7 +551,7 @@ Tags File Contents Options
 		jumps to some tags to miss the target definition by one or more
 		lines. Basically, this option is best used when the source code
 		to which it is applied is not subject to change. Selecting this
-		option type causes the following options to be ignored: ``-BF``.
+		option type causes the following options to be ignored: ``-B``, ``-F``.
 
 	``pattern``
 		Use only search patterns for all tags, rather than the line numbers
@@ -536,12 +561,13 @@ Tags File Contents Options
 
 	``mixed``
 		In this mode, patterns are generally used with a few exceptions.
-		For C, line numbers are used for macro definition tags. This was
-		the default format generated by the original ctags and is, therefore,
-		retained as the default for this option. For Fortran, line numbers
+		For C, line numbers are used for macro definition tags. For Fortran, line numbers
 		are used for common blocks because their corresponding source lines
 		are generally identical, making pattern searches useless
 		for finding all matches.
+
+		This was the default format generated by the original ctags and is,
+		therefore, retained as the default for this option.
 
 	``combine``
 		Concatenate the line number and pattern with a semicolon in between.
@@ -568,6 +594,8 @@ Tags File Contents Options
 	supports language-specific extras. (See "`Language-specific fields and
 	extras`_" about the concept). Use ``--extras-<LANG>=`` option for
 	controlling them.
+
+	.. TODO: move the following list to "Extras"
 
 	The meaning of major extras is as follows (one-letter flag/long-name flag):
 
@@ -603,9 +631,11 @@ Tags File Contents Options
 		Indicates whether tags scoped only for a single file (i.e. tags which
 		cannot be seen outside of the file in which they are defined, such as
 		language objects with ``static`` modifier of C language) should be included
-		in the output. See, also, the ``-h`` option. This option is enabled by
+		in the output. See also the ``-h`` option. This option is enabled by
 		default. This is the replacement for ``--file-scope`` option of
 		Exuberant Ctags.
+
+		.. TODO: "This option" is ambiguous. fileScope Extra Tag or -h option?
 
 	``f``/``inputFile``
 		Include an entry for the base file name of every source file
@@ -614,13 +644,13 @@ Tags File Contents Options
 		Exuberant Ctags.
 
 		If the ``end:`` field is enabled, the end line number of the file can be
-		attached to the tag. (However, @CTAGS_NAME_EXAMPLE@ omits the ``end:`` field
+		attached to the tag. (However, @CTAGS_NAME_EXECUTABLE@ omits the ``end:`` field
 		if no newline is in the file like an empty file.)
 
-		By default, @CTAGS_NAME_EXAMPLE@ doesn't create the ``f/inputFile`` extra
-		tag for the source file when @CTAGS_NAME_EXAMPLE@ doesn't find a parser
+		By default, @CTAGS_NAME_EXECUTABLE@ doesn't create the ``f/inputFile`` extra
+		tag for the source file when @CTAGS_NAME_EXECUTABLE@ doesn't find a parser
 		for it. Enabling ``Unknown`` parser with ``--languages=+Unknown`` forces
-		@CTAGS_NAME_EXAMPLE@ to create the extra tags for any source files.
+		@CTAGS_NAME_EXECUTABLE@ to create the extra tags for any source files.
 
 		The etags mode enables the ``Unknown`` parser implicitly.
 
@@ -680,12 +710,12 @@ Tags File Contents Options
 
 ``--fields=[+|-]flags|*``
 	Specifies which available extension fields are to be included in
-	the tag entries (see "`TAG FILE FORMAT`_" second, and "`Fields`_"
-	subsection , for more information).
+	the tag entries (see "`TAG FILE FORMAT`_" section, and "`Fields`_"
+	subsection, for more information).
 
-	The parameter ``flags`` is a set of one-letter flags (and/or long-name flags),
+	The parameter ``flags`` is a set of one-letter or long-name flags,
 	each representing one type of extension field to include.
-	Each letter or group of letters may be preceded by either '``+``' to add it
+	Each flag or group of flags may be preceded by either '``+``' to add it
 	to the default set, or '``-``' to exclude it. In the absence of any
 	preceding '``+``' or '``-``' sign, only those fields explicitly listed in flags
 	will be included in the output (i.e. overriding the default set). All
@@ -698,6 +728,9 @@ Tags File Contents Options
 	extras`_" about the concept). Use ``--fields-<LANG>=`` option for
 	controlling them.
 
+	.. TODO: Confirm the description above is correct.
+
+	.. TODO: move the following list to "Fields"
 
 	The meaning of major fields is as follows (one-letter flag/long-name flag):
 
@@ -715,12 +748,12 @@ Tags File Contents Options
 
 	``k``
 		Kind of tag as one-letter. Enabled by default.
-		Exceptionally this has no field name.
+		Exceptionally this has no long-name.
 		See also ``z``/``kind`` flag.
 
 	``K``
 		Kind of tag as long-name.
-		Exceptionally this has no field name.
+		Exceptionally this has no long-name.
 		See also ``z``/``kind`` flag.
 
 	``l``/``language``
@@ -741,7 +774,7 @@ Tags File Contents Options
 
 	``s``
 		Scope of tag definition. Enabled by default.
-		Exceptionally this has no name.
+		Exceptionally this has no long-name.
 		See also ``Z`` flag.
 
 		.. TODO? implement "scope" of Z/scope flag.
@@ -750,16 +783,16 @@ Tags File Contents Options
 		Signature of routine (e.g. prototype or parameter list)
 
 	``t``/``typeref``
-		Type and name of a variable, typedef or return type of
+		Type and name of a variable, typedef, or return type of
 		callable like function as ``typeref:`` field.
 		Enabled by default.
 
 	``z``/``kind``
-		Include the ``kind:`` key in kind field
+		Include the ``kind:`` key in kind field.  See also ``k`` and ``K`` flags.
 
 	``Z``
 		Include the ``scope:`` key in scope field.
-		Exceptionally this has no name.
+		Exceptionally this has no long-name.  See also ``s`` flag.
 
 	Check the output of the ``--list-fields`` option for the other minor
 	fields.
@@ -773,15 +806,17 @@ Tags File Contents Options
 	Specify ``all`` as *<LANG>* to apply the parameter ``flags`` to all
 	languages; all fields are enabled with specifying '``*``' as the
 	parameter flags. If specifying nothing as the parameter ``flags``
-	(``--fields-all=``), all fields are disabled. These two combinations
+	(i.e. ``--fields-all=``), all fields are disabled. These two combinations
 	are useful for testing.
+
+	.. TODO: "to all languages;" instead of "to all fields;" ???
 
 ``--kinds-<LANG>=[+|-]kinds|*``
 	Specifies a list of language-specific kinds of tags (or kinds) to
 	include in the output file for a particular language, where *<LANG>* is
 	case-insensitive and is one of the built-in language names (see the
 	``--list-languages`` option for a complete list). The parameter ``kinds`` is a group
-	of one-letter flags (and/or long-name flags) designating kinds of tags (particular to the language)
+	of one-letter or long-name flags designating kinds of tags (particular to the language)
 	to either include or exclude from the output. The specific sets of
 	flags recognized for each language, their meanings and defaults may be
 	list using the ``--list-kinds-full`` option. Each letter or group of letters
@@ -813,9 +848,11 @@ Tags File Contents Options
 	Set <LANG> specific parameter. Available parameters can be listed with
 	``--list-params``.
 
+	.. TODO: add description of "parameter".
+
 ``--pattern-length-limit=N``
-	Cutoff patterns of tag entries after '``N``' characters. Disable by setting to 0
-	(default is 96). Specifying 0 as *N* results no truncation.
+	Truncate patterns of tag entries after '``N``' characters. Disable by setting to 0
+	(default is 96).
 
 	An input source file with long lines and multiple tag matches per
 	line can generate an excessively large tags file with an
@@ -835,7 +872,7 @@ Tags File Contents Options
 	should however be rare, and in the worse case will lead to including
 	up to an extra 3 bytes above the limit.
 
-``--pseudo-tags=[+|-]ptag``, ``--pseudo-tags=*``
+``--pseudo-tags=[+|-]ptag|*``
 	Enable/disable emitting pseudo-tag named ``ptag``.
 	If '``*``' is given, enable emitting all pseudo-tags.
 
@@ -856,13 +893,13 @@ Tags File Contents Options
 
 		$ @CTAGS_NAME_EXECUTABLE@ --fields='{line}{end}' -o - hello.c
 		main	hello.c	/^main(int argc, char **argv)$/;"	f	line:3	end:6
-		$ @CTAGS_NAME_EXECUTABLE@ --put-field-prefix --fields='{line}{end}' -o - /tmp/hello.c
-		main	/tmp/hello.c	/^main(int argc, char **argv)$/;"	f	line:3	UCTAGSend:6
+		$ @CTAGS_NAME_EXECUTABLE@ --put-field-prefix --fields='{line}{end}' -o - hello.c
+		main	hello.c	/^main(int argc, char **argv)$/;"	f	line:3	UCTAGSend:6
 
 	In the above example, the prefix is put to ``end`` field which is
 	newly introduced in Universal Ctags.
 
-``--roles-<LANG>.<KIND>=[+|-]roles``, ``--roles-<LANG>.<KIND>=*|``
+``--roles-<LANG>.<KIND>=[+|-]roles|*``
 	Specifies a list of kind-specific roles of tags to include in the
 	output file for a particular language.
 	*<KIND>* specifies the kind where the ``roles`` are defined.
@@ -897,9 +934,11 @@ Tags File Contents Options
 	The ``never`` value indicates the recorded file paths should be absolute
 	even if source file names are passed in with relative paths.
 
+	.. TODO: make as a definition list
+
 ``--use-slash-as-filename-separator[=yes|no]``
-	Uses slash character as filename separators instead of backslash
-	character when printing ``input:`` field.
+	Uses slash ('``/``') character as filename separators instead of backslash
+	('``\``') character when printing ``input:`` field.
 	This option is available on MSWindows only.
 	The default is ``yes`` for the default "u-ctags" output format, and
 	``no`` for the other formats.
@@ -913,6 +952,9 @@ Tags File Contents Options
 
 Option File Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. TODO: merge some of description in option-file.rst into FILE or a dedicated
+	section
+
 ``--options=pathname``
 	Read additional options from file or directory.
 
@@ -928,30 +970,33 @@ Option File Options
 	As a special case, if ``--options=NONE`` is specified as the first
 	option on the command line, preloading is disabled; the option
 	will disable the automatic reading of any configuration options
-	from either a file or the environment (see "`FILES`_").
+	from either a file or the environment variable (see "`FILES`_").
 
 ``--options-maybe=pathname``
 	Same as ``--options`` but doesn't cause an error if file
 	(or directory) specified with ``pathname`` doesn't exist.
 
 ``--optlib-dir=[+]directory``
-	Add an optlib ``directory`` to or reset optlib path list.
+	Add an optlib ``directory`` to or reset the optlib path list.
 	By default, the optlib path list is empty.
 
 optlib Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+See ctags-optlib(7) for details of each option.
+
 ``--kinddef-<LANG>=letter,name,description``
 	Define a kind for *<LANG>*.
 	Don't be confused this with ``--kinds-<LANG>``.
 
 ``--langdef=name``
-	See ctags-optlib(7).
+	Defines a new user-defined language, ``name``, to be parsed with regular
+	expressions.
 
 ``--mline-regex-<LANG>=/line_pattern/name_pattern/[flags]``
-	Define multiline regular expression for locating tags in specific language.
+	Define multi-line regular expression for locating tags in specific language.
 
 ``--regex-<LANG>=/regexp/replacement/[kind-spec/][flags]``
-	See ctags-optlib(7).
+	Define single-line regular expression for locating tags in specific language.
 
 .. _option_lang_specific:
 
@@ -961,17 +1006,21 @@ Language Specific Options
 	Indicates a preference as to whether code within an ``#if 0`` branch of a
 	preprocessor conditional should be examined for non-macro tags (macro
 	tags are always included). Because the intent of this construct is to
-	disable code, the default value of this option is ``no``. Note that this
+	disable code, the default value of this option is ``no`` (disabled).
+
+	Note that this
 	indicates a preference only and does not guarantee skipping code within
 	an ``#if 0`` branch, since the fall-back algorithm used to generate
 	tags when preprocessor conditionals are too complex follows all branches
-	of a conditional. This option is disabled by default.
+	of a conditional.
 
 ``--line-directives[=yes|no]``
 	Specifies whether ``#line`` directives should be recognized. These are
-	present in the output of preprocessors and contain the line number, and
+	present in the output of a preprocessor and contain the line number, and
 	possibly the file name, of the original source file(s) from which the
-	preprocessor output file was generated. When enabled, this option will
+	preprocessor output file was generated. This option is off by default.
+
+	When enabled, this option will
 	cause @CTAGS_NAME_EXECUTABLE@ to generate tag entries marked with the
 	file names and line numbers of their locations original source file(s),
 	instead of their actual locations in the preprocessor output. The actual
@@ -979,7 +1028,9 @@ Language Specific Options
 	components as the preprocessor output file, since it is assumed that
 	the original source files are located relative to the preprocessor
 	output file (unless, of course, the ``#line`` directive specifies an
-	absolute path). This option is off by default. Note: This option is generally
+	absolute path).
+
+	Note: This option is generally
 	only useful when used together with the ``--excmd=number`` (``-n``) option.
 	Also, you may have to use either the ``--langmap`` or ``--language-force`` option
 	if the extension of the preprocessor output file is not known to
@@ -997,20 +1048,26 @@ Language Specific Options
 	Specifies a list of file extensions, separated by periods, which are
 	to be interpreted as include (or header) files. To indicate files having
 	no extension, use a period not followed by a non-period character
-	(e.g. '``.``', ``..x``, ``.x.``). This option only affects how the scoping of
+	(e.g. '``.``', ``..x``, ``.x.``).
+
+	This option only affects how the scoping of
 	particular kinds of tags are interpreted (i.e. whether or not they are
 	considered as globally visible or visible only within the file in which
 	they are defined); it does not map the extension to any particular
 	language. Any tag which is located in a non-include file and cannot be
 	seen (e.g. linked to) from another file is considered to have file-limited
 	(e.g. static) scope. No kind of tag appearing in an include file
-	will be considered to have file-limited scope. If the first character
-	in the list is a plus sign, then the extensions in the list will be
+	will be considered to have file-limited scope.
+
+	If the first character in the list is '``+``', then the extensions in the list will be
 	appended to the current list; otherwise, the list will replace the
 	current list. See, also, the ``F/fileScope`` flag of ``--extras`` option.
+
 	The default list is
 	``.h.H.hh.hpp.hxx.h++.inc.def``. To restore the default list, specify ``-h``
-	default. Note that if an extension supplied to this option is not
+	default.
+
+	Note that if an extension supplied to this option is not
 	already mapped to a particular language (see "`Determining file language`_", above),
 	you will also need to use either the ``--langmap`` or ``--language-force`` option.
 
@@ -1019,21 +1076,29 @@ Language Specific Options
 	parsing C and C++ source files. This option is specifically provided
 	to handle special cases arising through the use of preprocessor macros.
 	When the identifiers listed are simple identifiers, these identifiers
-	will be ignored during parsing of the source files. If an identifier is
+	will be ignored during parsing of the source files.
+
+	If an identifier is
 	suffixed with a '``+``' character, @CTAGS_NAME_EXECUTABLE@ will also
 	ignore any parenthesis-enclosed argument list which may immediately
-	follow the identifier in the source files. If two identifiers are
+	follow the identifier in the source files.
+
+	If two identifiers are
 	separated with the '``=``' character, the first identifiers is replaced by
 	the second identifiers for parsing purposes. The list of identifiers may
 	be supplied directly on the command line or read in from a separate file.
+
 	If the first character of identifier-list is '``@``', '``.``' or a pathname
 	separator ('``/``' or '``\``'), or the first two characters specify a drive
 	letter (e.g. ``C:``), the parameter identifier-list will be interpreted as
 	a filename from which to read a list of identifiers, one per input line.
+
 	Otherwise, identifier-list is a list of identifiers (or identifier
 	pairs) to be specially handled, each delimited by either a comma or
 	by white space (in which case the list should be quoted to keep the
-	entire list as one command line argument). Multiple ``-I`` options may be
+	entire list as one command line argument).
+
+	Multiple ``-I`` options may be
 	supplied. To clear the list of ignore identifiers, supply a single
 	dash ('``-``') for identifier-list.
 
@@ -1105,7 +1170,7 @@ Listing Options
 	language.  These option takes one-letter flag or long-name flag as a parameter
 	for specifying an extra.
 
-	The meaning of columns are as follows:
+	The meaning of columns in output are as follows:
 
 	LETTER
 		One-letter flag. '``-``' means the extra does not have one-letter flag.
@@ -1133,9 +1198,9 @@ Listing Options
 
 	.. TODO? xref output
 
-	A field can be enabled or disabled with ``--fields=`` for common
-	fields in all languages, or ``--fields-<LANG>=`` for the specified
-	language.  These option takes one-letter flags and/or long-name flags
+	A field can be enabled or disabled with ``--fields=`` option for common
+	fields in all languages, or ``--fields-<LANG>=`` option for the specified
+	language.  These options take one-letter flags and/or long-name flags
 	as a parameter for specifying fields.
 
 	The meaning of columns are as follows:
@@ -1154,7 +1219,7 @@ Listing Options
 		``NONE`` means the extra is common in parsers.
 
 	JSTYPE
-		Json type used in printing the value of field when ``--output-format=json``
+		JSON type used in printing the value of field when ``--output-format=json``
 		is specified.
 
 		Following characters are used for representing types.
@@ -1170,7 +1235,9 @@ Listing Options
 		``--output-format=json`` are still experimental.
 
 	FIXED
-	   Whether this field can be disabled or not. Some fields are printed always
+	   Whether this field can be disabled or not.
+
+	   Some fields are printed always
 	   in tags output. They have ``yes`` as the value for this column.
 
 	DESCRIPTION
@@ -1264,6 +1331,8 @@ Listing Options
 		Though ``local`` kind of C language is enabled/disabled. If you swap the languages, you
 		see the same result.
 
+		.. TODO: need a reference to "master parser"
+
 	DESCRIPTION
 		Human readable description for the kind.
 
@@ -1280,6 +1349,8 @@ Listing Options
 	This option does not work with ``--machinable`` nor
 	``--with-list-header``.
 
+	.. TODO: ".. may be used in many other options...": I don't think it is``all`` worth to be described.
+
 ``--list-map-extensions[=language|all]``
 	Lists the file extensions which associate a file
 	name with a language for either the specified *language* or *all*
@@ -1295,8 +1366,7 @@ Listing Options
 ``--list-maps[=language|all]``
 	Lists file name patterns and the file extensions which associate a file
 	name with a language for either the specified *language* or *all*
-	languages, and then exits. See the ``--langmap`` option, and
-	"`Determining file language`_", above.
+	languages, and then exits.
 	``all`` is used as default value if the option argument is omitted.
 
 	To list the file extensions or file name patterns individually, use
@@ -1309,6 +1379,7 @@ Listing Options
 ``--list-mline-regex-flags``
 	Output list of flags which can be used in a multiline regex parser
 	definition.
+	See ctags-optlib(7).
 
 ``--list-params[=language|all]``
 	Lists the parameters for either the specified *language* or *all*
@@ -1319,11 +1390,13 @@ Listing Options
 	Output list of pseudo-tags.
 
 ``--list-regex-flags``
+	Lists the flags that can be used in ``--regex-<LANG>`` option.
 	See ctags-optlib(7).
 
 ``--list-roles[=language|all[.kinds]]``
 	List the roles for either the specified *language* or *all* languages.
 	``all`` is used as default value if the option argument is omitted.
+
 	If the parameter ``kinds`` is given after the parameter
 	``language`` or ``all`` with concatenating with '``.``', list only roles
 	defined in the kinds. Both one-letter flags and long name flags surrounded
@@ -1342,7 +1415,7 @@ Listing Options
 
 	ENABLED
 		Whether the kind is enabled or not. It takes ``yes`` or ``no``.
-		(Currently all roles are enabled. No option for disabling
+		(Currently all roles are enabled. An option for disabling
 		a specified role is not implemented yet.)
 
 	DESCRIPTION
@@ -1374,8 +1447,8 @@ Miscellaneous Options
 	Equivalent to ``--help``.
 
 ``--help-full``
-	Prints to standard output a detailed usage description about experimental
-	features, and then exits. Visit https://docs.ctags.io/en/latest/ for information
+	Prints to standard output a detailed usage description including experimental
+	features, and then exits. Visit https://docs.ctags.io/ for information
 	about the latest exciting experimental features.
 
 ``--license``
@@ -1435,6 +1508,11 @@ parses through the file and adds an entry to the tag file for each
 language object it is written to handle. See "`TAG FILE FORMAT`_", below,
 for details on these entries.
 
+Notes for C/C++ Parser
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. TODO: move the following description to parser-cxx.rst.
+
 This implementation of @CTAGS_NAME_EXECUTABLE@ imposes no formatting
 requirements on C code as do legacy implementations. Older implementations
 of ctags tended to rely upon certain formatting assumptions in order to
@@ -1490,10 +1568,10 @@ removing identical tag lines.
 .. _guessing:
 
 Determining file language
---------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 File name mapping
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+..........................
 
 Unless the ``--language-force`` option is specified, the language of each source
 file is automatically selected based upon a *mapping* of file names to
@@ -1502,8 +1580,7 @@ the ``--list-maps`` option and may be changed using the ``--langmap`` or
 ``--map-<LANG>`` options.
 
 If the name of a file is not mapped to a language, @CTAGS_NAME_EXECUTABLE@ tries
-to heuristically guess the language for the file by inspecting its content. See
-"`Determining file language`_".
+to heuristically guess the language for the file by inspecting its content.
 
 All files that have no file name mapping and no guessed parser are
 ignored. This permits running @CTAGS_NAME_EXECUTABLE@ on all files in
@@ -1512,7 +1589,7 @@ all files in an entire source directory tree
 (e.g. ``@CTAGS_NAME_EXECUTABLE@ -R``), since only those files whose
 names are mapped to languages will be scanned.
 
-The same extensions are mapped to multiple parsers. For example, ``.h``
+An extension may be mapped to multiple parsers. For example, ``.h``
 are mapped to C++, C and ObjectiveC. These mappings can cause
 issues. @CTAGS_NAME_EXECUTABLE@ tries to select the proper parser
 for the source file by applying heuristics to its content, however
@@ -1520,6 +1597,8 @@ it is not perfect.  In case of issues one can use ``--language-force=language``,
 ``--langmap=map[,map[...]]``, or the ``--map-<LANG>=-pattern|extension``
 options. (Some of the heuristics are applied whether ``--guess-language-eagerly``
 is given or not.)
+
+.. TODO: all heuristics??? To be confirmed.
 
 .. options should be revised here
 	``--map-<LANG>`` (done)
@@ -1531,7 +1610,7 @@ is given or not.)
 	``--list-map-patterns`` (done)
 
 Heuristically guessing
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+..........................
 
 If @CTAGS_NAME_EXECUTABLE@ cannot select a parser from the mapping of file names,
 various heuristic tests are conducted to determine the language:
@@ -1553,12 +1632,14 @@ template file name testing
 	parser. However, ``sh`` is listed as an alias for ``shell``, therefore
 	@CTAGS_NAME_EXECUTABLE@ selects the "shell" parser for the file.
 
-	An exception is ``env``. If ``env`` is specified, @CTAGS_NAME_EXECUTABLE@
+	An exception is ``env``. If ``env`` is specified (for example
+	``#!/usr/bin/env python``), @CTAGS_NAME_EXECUTABLE@
 	reads more lines to find real interpreter specification.
 
 	To display the list of aliases, use ``--list-aliases`` option.
-	To add/remove an item to/from the list, use the
-	``--alias-<LANG>=[+|-]aliasPattern`` option.
+	To add an item to the list or to remove an item from the list, use the
+	``--alias-<LANG>=+aliasPattern`` or ``--alias-<LANG>=-aliasPattern`` option
+	respectively.
 
 "zsh autoload tag" testing
 	If the first line starts with ``#compdef`` or ``#autoload``,
@@ -1623,6 +1704,8 @@ executable or the ``--guess-language-eagerly`` (``-G`` in short) option is
 given. The other heuristic tests are enabled only when ``-G`` option is
 given.
 
+.. TODO: move the paragraph above to the beginning of this section.
+
 The ``--print-language`` option can be used just to print the results of
 parser selections for given files instead of generating a tags file.
 
@@ -1647,9 +1730,9 @@ items in Exuberant Ctags are refined and extended in Universal Ctags.
 
 A tag is categorized into *definition tags* or *reference tags*.
 In general, Exuberant Ctags only tags *definitions* of
-language objects: places where newly named language objects are introduced.
+language objects: places where newly named language objects *are introduced*.
 Universal Ctags, on the other hand, can also tag *references* of language
-objects: places where named language objects are used. However, support
+objects: places where named language objects *are used*. However, support
 for generating reference tags is new and limited to specific areas of
 specific languages in the current version.
 
@@ -1761,7 +1844,9 @@ TAG FILE FORMAT
 When not running in etags mode, each entry in the tag file consists of a
 separate line, each looking like this in the most general case:
 
-tag_name<TAB>file_name<TAB>ex_cmd;"<TAB>extension_fields
+::
+
+	tag_name<TAB>file_name<TAB>ex_cmd;"<TAB>extension_fields
 
 The fields and separators of these lines are specified as follows:
 
@@ -1884,9 +1969,12 @@ HOW TO USE WITH NEDIT
 ---------------------
 
 NEdit version 5.1 and later can handle the new extended tag file format
-(see ``--format``). To make NEdit use the tag file, select "File->Load Tags
-File". To jump to the definition for a tag, highlight the word, then press
-``Ctrl-D``. NEdit 5.1 can read multiple tag files from different
+(see ``--format``).
+
+* To make NEdit use the tag file, select "File->Load Tags File".
+* To jump to the definition for a tag, highlight the word, then press ``Ctrl-D``.
+
+NEdit 5.1 can read multiple tag files from different
 directories. Setting the X resource ``nedit.tagFile`` to the name of a tag
 file instructs NEdit to automatically load that tag file at startup time.
 
@@ -1910,6 +1998,8 @@ identical to the line containing the tag. The following example
 demonstrates this condition:
 
 .. code-block:: C
+	:linenos:
+	:emphasize-lines: 1,5
 
 	int variable;
 
@@ -1922,8 +2012,10 @@ demonstrates this condition:
 
 Depending upon which editor you use and where in the code you happen to be,
 it is possible that the search pattern may locate the local parameter
-declaration in foo() before it finds the actual global variable definition,
-since the lines (and therefore their search patterns are identical).
+declaration on the line 5 before it finds the actual global variable definition
+on the line 1, since the lines (and therefore their search patterns) are
+identical.
+
 This can be avoided by use of the ``--excmd=n`` option.
 
 
@@ -1931,6 +2023,8 @@ BUGS
 ----
 
 @CTAGS_NAME_EXECUTABLE@ has more options than ``ls(1)``.
+
+.. TODO: move the following paragraph to parser-cxx.rst.
 
 When parsing a C++ member function definition (e.g. ``className::function``),
 @CTAGS_NAME_EXECUTABLE@ cannot determine whether the scope specifier
@@ -1953,7 +2047,10 @@ ENVIRONMENT VARIABLES
 	starts, after the configuration files listed in FILES, below, are read,
 	but before any command line options are read. Options appearing on
 	the command line will override options specified in this variable.
-	Only options will be read from this variable. Note that all white space
+
+	Only options will be read from this variable.
+
+	Note that all white space
 	in this variable is considered a separator, making it impossible to pass
 	an option parameter containing an embedded space. If this is a problem,
 	use a configuration file instead.
@@ -1964,17 +2061,21 @@ ENVIRONMENT VARIABLES
 	found, @ETAGS_NAME_EXECUTABLE@ will try to use ``CTAGS`` instead.
 
 ``TMPDIR``
-	On Unix-like hosts where ``mkstemp()`` is available, the value of this
+	On Unix-like hosts where ``mkstemp(3)`` is available, the value of this
 	variable specifies the directory in which to place temporary files.
 	This can be useful if the size of a temporary file becomes too large
 	to fit on the partition holding the default temporary directory
-	defined at compilation time. @CTAGS_NAME_EXECUTABLE@ creates temporary
+	defined at compilation time.
+
+	@CTAGS_NAME_EXECUTABLE@ creates temporary
 	files only if either (1) an emacs-style tag file is being
 	generated, (2) the tag file is being sent to standard output, or
 	(3) the program was compiled to use an internal sort algorithm to sort
-	the tag files instead of the ``sort`` utility of the operating system.
-	If the ``sort`` utility of the operating system is being used, it will
-	generally observe this variable also. Note that if @CTAGS_NAME_EXECUTABLE@
+	the tag files instead of the ``sort(1)`` utility of the operating system.
+	If the ``sort(1)`` utility of the operating system is being used, it will
+	generally observe this variable also.
+
+	Note that if @CTAGS_NAME_EXECUTABLE@
 	is setuid, the value of ``TMPDIR`` will be ignored.
 
 
@@ -1993,31 +2094,38 @@ FILES
 
 ``ctags.d/*.ctags``
 
-	If any of these configuration files exist, each will be expected to
-	contain a set of default options which are read in the order listed
-	when @CTAGS_NAME_EXECUTABLE@ starts, but before the ``CTAGS`` environment
-	variable is read or any command line options are read. This makes it
-	possible to set up personal or project-level defaults. It
-	is possible to compile @CTAGS_NAME_EXECUTABLE@ to read an additional
-	configuration file before any of those shown above, which will be
-	indicated if the output produced by the ``--version`` option lists the
-	``custom-conf`` feature. Options appearing in the ``CTAGS`` environment
-	variable or on the command line will override options specified in these
-	files. Only options will be read from these files. Note that the option
-	files are read in line-oriented mode in which spaces are significant
-	(since shell quoting is not possible) but spaces at the beginning
-	of a line are ignored. Each line of the file is read as
-	one command line parameter (as if it were quoted with single quotes).
-	Therefore, use new lines to indicate separate command-line arguments.
-	A line starting with '``#``' is treated as a comment.
-
-	``*.ctags`` files in a directory are loaded in alphabetical order.
-
 ``tags``
 	The default tag file created by @CTAGS_NAME_EXECUTABLE@.
 
 ``TAGS``
 	The default tag file created by @ETAGS_NAME_EXECUTABLE@.
+
+	If any of these configuration files exist, each will be expected to
+	contain a set of default options which are read in the order listed
+	when @CTAGS_NAME_EXECUTABLE@ starts, but before the ``CTAGS`` environment
+	variable is read or any command line options are read. This makes it
+	possible to set up personal or project-level defaults.
+
+	It
+	is possible to compile @CTAGS_NAME_EXECUTABLE@ to read an additional
+	configuration file before any of those shown above, which will be
+	indicated if the output produced by the ``--version`` option lists the
+	``custom-conf`` feature.
+
+	Options appearing in the ``CTAGS`` environment
+	variable or on the command line will override options specified in these
+	files. Only options will be read from these files.
+
+	Note that the option
+	files are read in line-oriented mode in which spaces are significant
+	(since shell quoting is not possible) but spaces at the beginning
+	of a line are ignored. Each line of the file is read as
+	one command line parameter (as if it were quoted with single quotes).
+	Therefore, use new lines to indicate separate command-line arguments.
+
+	A line starting with '``#``' is treated as a comment.
+
+	``*.ctags`` files in a directory are loaded in alphabetical order.
 
 
 SEE ALSO
@@ -2039,14 +2147,11 @@ See ctags-lang-python(7) about python input specific notes.
 See readtags(1) about a client tool for binary searching a
 name in a sorted tags file.
 
-The official Universal Ctags web site at:
-
-https://ctags.io/
+The official Universal Ctags web site at: https://ctags.io/
 
 Also ex(1), vi(1), elvis, or, better yet, vim, the official editor of ctags.
-For more information on vim, see the VIM Pages web site at:
 
-https://www.vim.org/
+For more information on vim, see the VIM Pages web site at: https://www.vim.org/
 
 
 AUTHOR
@@ -2076,11 +2181,10 @@ CREDITS
 This version of @CTAGS_NAME_EXECUTABLE@ (Universal Ctags) derived from
 the repository, known as fishman-ctags, started by Reza Jelveh.
 
+The fishman-ctags was derived from Exuberant Ctags.
+
 Some parsers are taken from ``tagmanager`` of the Geany (https://www.geany.org/)
 project.
-
-
-The fishman-ctags was derived from Exuberant Ctags.
 
 Exuberant Ctags was originally derived from and
 inspired by the ctags program by Steve Kirkendall <kirkenda@cs.pdx.edu>

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -191,11 +191,7 @@ Input/Output File Options
 
 	For an example, you want @CTAGS_NAME_EXECUTABLE@ to ignore all files
 	under ``foo`` directory except ``foo/main.c``, use the following command
-	line: ``--exclude=foo/* --exclude-exception=foo/main.c``. Don't forget
-	shell quoting for '``*``'.
-
-.. TODO: Which shell requires the quoting?
-   At least bash does not require quoting unless directory `--exclude=foo' exists.
+	line: ``--exclude=foo/* --exclude-exception=foo/main.c``.
 
 ``--filter[=yes|no]``
 	Makes @CTAGS_NAME_EXECUTABLE@ behave as a filter, reading source
@@ -207,6 +203,22 @@ Input/Output File Options
 	any file supplied using the ``-L`` option. When this option is enabled,
 	the options ``-f``, ``-o``, and ``--totals`` are ignored. This option is quite
 	esoteric and is disabled by default. This option must appear before
+	the first file name.
+
+``--filter-terminator=string``
+	Specifies a string to print to standard output following the tags for
+	each file name parsed when the ``--filter`` option is enabled. This may
+	permit an application reading the output of @CTAGS_NAME_EXECUTABLE@
+	to determine when the output for each file is finished.
+
+	Note that if the
+	file name read is a directory and ``--recurse`` is enabled, this string will
+	be printed only once at the end of all tags found for by descending
+	the directory. This string will always be separated from the last tag
+	line for the file by its terminating newline.
+
+	This option is quite
+	esoteric and is empty by default. This option must appear before
 	the first file name.
 
 ``--links[=yes|no]``
@@ -287,24 +299,6 @@ Input/Output File Options
 
 Output Format Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``--filter-terminator=string``
-	Specifies a string to print to standard output following the tags for
-	each file name parsed when the ``--filter`` option is enabled. This may
-	permit an application reading the output of @CTAGS_NAME_EXECUTABLE@
-	to determine when the output for each file is finished.
-
-	Note that if the
-	file name read is a directory and ``--recurse`` is enabled, this string will
-	be printed only once at the end of all tags found for by descending
-	the directory. This string will always be separated from the last tag
-	line for the file by its terminating newline.
-
-	This option is quite
-	esoteric and is empty by default. This option must appear before
-	the first file name.
-
-.. TODO: Shall we move this after "--filter"?
-
 ``--format=level``
 	Change the format of the output tag file. Currently the only valid
 	values for level are 1 or 2. Level 1 specifies the original tag file
@@ -653,8 +647,6 @@ See "`TAG ENTRIES`_" about fields, kinds, roles, and extras.
 	(i.e. ``--fields-all=``), all fields are disabled. These two combinations
 	are useful for testing.
 
-	.. TODO: "to all languages;" instead of "to all fields;" ???
-
 ``--kinds-<LANG>=[+|-]kinds|*``
 	Specifies a list of language-specific kinds of tags (or kinds) to
 	include in the output file for a particular language, where *<LANG>* is
@@ -687,6 +679,9 @@ See "`TAG ENTRIES`_" about fields, kinds, roles, and extras.
 
 ``--<LANG>-kinds=[+|-]kinds|*``
 	This option is obsolete. Use ``--kinds-<LANG>=...`` instead.
+
+..	COMMENT:
+	``--param-<LANG>:name=argument`` is moved to "Language Specific Options"
 
 ``--pattern-length-limit=N``
 	Truncate patterns of tag entries after '``N``' characters. Disable by setting to 0
@@ -761,18 +756,30 @@ See "`TAG ENTRIES`_" about fields, kinds, roles, and extras.
 	(e.g.  ``--roles-all.*=*`` or ``--roles-all.*=``).
 
 ``--tag-relative[=yes|no|always|never]``
-	The ``yes`` value indicates that the file paths recorded in the tag file should be
-	relative to the directory containing the tag file, rather than relative
-	to the current directory, unless the files supplied on the command line
-	are specified with absolute paths. This option must appear before the
+	Specifies how the file paths recorded in the tag file.
+	This option must appear before the
 	first file name. The default is ``yes`` when running in etags mode (see
 	the ``-e`` option), ``no`` otherwise.
-	The ``always`` value indicates the recorded file paths should be relative
-	even if source file names are passed in with absolute paths.
-	The ``never`` value indicates the recorded file paths should be absolute
-	even if source file names are passed in with relative paths.
 
-	.. TODO: make as a definition list
+	``yes``
+		indicates that the file paths recorded in the tag file should be
+		*relative to the directory containing the tag file*
+		unless the files supplied on the command line
+		are specified with absolute paths.
+
+	``no``
+		indicates that the file paths recorded in the tag file should be
+		*relative to the current directory*
+		unless the files supplied on the command line
+		are specified with absolute paths.
+
+	``always``
+		indicates the recorded file paths should be relative
+		even if source file names are passed in with absolute paths.
+
+	``never``
+		indicates the recorded file paths should be absolute
+		even if source file names are passed in with relative paths.
 
 ``--use-slash-as-filename-separator[=yes|no]``
 	Uses slash ('``/``') character as filename separators instead of backslash
@@ -1253,8 +1260,6 @@ Listing Options
 
 	ENABLED
 		Whether the kind is enabled or not. It takes ``yes`` or ``no``.
-		(Currently all roles are enabled. An option for disabling
-		a specified role is not implemented yet.)
 
 	DESCRIPTION
 		Human readable description for the role.
@@ -1532,8 +1537,6 @@ conditions.  "interpreter" testing is enabled only when a file is an
 executable or the ``--guess-language-eagerly`` (``-G`` in short) option is
 given. The other heuristic tests are enabled only when ``-G`` option is
 given.
-
-.. TODO: move the paragraph above to the beginning of this section.
 
 The ``--print-language`` option can be used just to print the results of
 parser selections for given files instead of generating a tags file.

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -19,7 +19,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The *@CTAGS_NAME_EXECUTABLE@* and *@ETAGS_NAME_EXECUTABLE@* programs
+The *@CTAGS_NAME_EXECUTABLE@* and *@ETAGS_NAME_EXECUTABLE@* (see ``-e`` option) programs
 (hereinafter collectively referred to as @CTAGS_NAME_EXECUTABLE@,
 except where distinguished) generate an index (or "tag") file for a
 variety of *language objects* found in *source file(s)*. This tag file allows
@@ -117,7 +117,7 @@ List options
 ~~~~~~~~~~~~
 
 Universal Ctags introduces many ``--list-...`` options that provide
-the internal data of Universal Ctags (See :ref:`option_listing`). Both users and client tools may
+the internal data of Universal Ctags (See "`Listing Options`_"). Both users and client tools may
 use the data. ``--with-list-header`` and ``--machinable`` options
 adjust the output of the most of ``--list-...`` options.
 
@@ -522,6 +522,8 @@ Language Selection and Mapping Options
 
 Tags File Contents Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+See "`TAG ENTRIES`_" about fields, kinds, roles, and extras.
+
 ``--excmd=type``
 	Determines the type of ``EX`` command used to locate tags in the source
 	file. [Ignored in etags mode]
@@ -619,7 +621,7 @@ Tags File Contents Options
 
 ``--fields=[+|-]flags|*``
 	Specifies which available extension fields are to be included in
-	the tag entries (see "`TAG FILE FORMAT`_" section, and "`Fields`_"
+	the tag entries (see "`TAG FILE FORMAT`_" section, and "`Extension fields`_"
 	subsection, for more information).
 
 	The parameter ``flags`` is a set of one-letter or long-name flags,
@@ -685,12 +687,6 @@ Tags File Contents Options
 
 ``--<LANG>-kinds=[+|-]kinds|*``
 	This option is obsolete. Use ``--kinds-<LANG>=...`` instead.
-
-``--param-<LANG>:name=argument``
-	Set <LANG> specific parameter. Available parameters can be listed with
-	``--list-params``.
-
-	.. TODO: add description of "parameter".
 
 ``--pattern-length-limit=N``
 	Truncate patterns of tag entries after '``N``' characters. Disable by setting to 0
@@ -1035,7 +1031,7 @@ Listing Options
 
 ``--list-fields[=language|all]``
 	Lists the fields recognized for either the specified *language* or
-	*all* languages. See "`Fields`_" subsection to know what are fields.
+	*all* languages. See "`Extension fields`_" subsection to know what are fields.
 	``all`` is used as default value if the option argument is omitted.
 
 	.. TODO? xref output
@@ -1191,7 +1187,7 @@ Listing Options
 	This option does not work with ``--machinable`` nor
 	``--with-list-header``.
 
-	.. TODO: ".. may be used in many other options...": I don't think it is``all`` worth to be described.
+	.. TODO: ".. may be used in many other options...": I don't think it is worth to be described.
 
 ``--list-map-extensions[=language|all]``
 	Lists the file extensions which associate a file
@@ -1442,15 +1438,6 @@ is given or not.)
 
 .. TODO: all heuristics??? To be confirmed.
 
-.. options should be revised here
-	``--map-<LANG>`` (done)
-	``--langmap=map[,map[...]]`` (done)
-	``--language-force=language`` (done)
-	``--languages=[+|-]list`` (done)
-	``--list-maps[=language|all]`` (done)
-	``--list-map-extensions`` (done)
-	``--list-map-patterns`` (done)
-
 Heuristically guessing
 ..........................
 
@@ -1565,8 +1552,11 @@ Examples:
 TAG FILE FORMAT
 ---------------
 
+This section describes the tag file format briefly.  See tags(5) and
+ctags-client-tools(7) for more details.
+
 When not running in etags mode, each entry in the tag file consists of a
-separate line, each looking like this in the most general case:
+separate line, each looking like this, called *regular tags*, in the most general case:
 
 ::
 
@@ -1574,19 +1564,35 @@ separate line, each looking like this in the most general case:
 
 The fields and separators of these lines are specified as follows:
 
-	1.	tag name
-	2.	single tab character
-	3.	name of the file in which the object associated with the tag is located
-	4.	single tab character
-	5.	EX command used to locate the tag within the file; generally a
-		search pattern (either /pattern/ or ?pattern?) or line number (see
-		``--excmd``). Tag file format 2 (see ``--format``) extends this EX command
-		under certain circumstances to include a set of extension fields
-		(described below) embedded in an EX comment immediately appended
-		to the EX command, which leaves it backward-compatible with original
-		vi(1) implementations.
+	1.	``tag_name``: tag name
+	2.	``<TAB>``: single tab character
+	3.	``file_name``: name of the file in which the object associated with the tag is located
+	4.	``<TAB>``: single tab character
+	5.	``ex_cmd``: EX command used to locate the tag within the file; generally a
+		search pattern (either ``/pattern/`` or ``?pattern?``) or line number (see
+		``--excmd=type`` option).
+	6.	``;"<TAB>extension_fields``: a set of extension fields. See
+		"`Extension fields`_" for more details.
 
-A few special tags are written into the tag file for internal purposes.
+		Tag file format 2 (see ``--format``) extends the EX command
+		to include the extension fields embedded in an EX comment immediately appended
+		to the EX command, which leaves it backward-compatible with original
+		``vi(1)`` implementations.
+
+A few special tags, called *pseudo tags*, are written into the tag file for internal purposes.
+
+::
+
+	!_TAG_FILE_FORMAT       2       /extended format; --format=1 will not append ;" to lines/
+	!_TAG_FILE_SORTED       1       /0=unsorted, 1=sorted, 2=foldcase/
+	...
+
+``--pseudo-tags=[+|-]ptag|*`` option enables or disables emitting pseudo-tags.
+
+See the output of ``@CTAGS_NAME_EXECUTABLE@ --list-pseudo-tags`` for the list of
+the kinds.
+See also tags(5) and ctags-client-tools(7) for more details of the pseudo tags.
+
 These tags are composed in such a way that they always sort to the top of
 the file. Therefore, the first two characters of these tags are used a magic
 number to detect a tag file for purposes of determining whether a
@@ -1596,9 +1602,8 @@ Note that the name of each source file will be recorded in the tag file
 exactly as it appears on the command line. Therefore, if the path you
 specified on the command line was relative to the current directory, then
 it will be recorded in that same manner in the tag file. See, however,
-the ``--tag-relative`` option for how this behavior can be modified.
-
-.. _tag_entries:
+the ``--tag-relative[=yes|no|always|never]`` option for how this behavior can be
+modified.
 
 TAG ENTRIES
 -----------
@@ -1614,24 +1619,14 @@ objects: places where named language objects *are used*. However, support
 for generating reference tags is new and limited to specific areas of
 specific languages in the current version.
 
-Fields
-~~~~~~
+Extension fields
+~~~~~~~~~~~~~~~~
 
-A tag can record various information, called *fields*. The
-essential fields are: *name* of language objects, *input*,
-*pattern*, and *line*. ``input:`` is the name of source file where
-``name:`` is defined or referenced. ``pattern:`` can be used to search
-the *name* in ``input:``. *line* is the line number where
-``name:`` is defined or referenced in ``input:``.
-
-@CTAGS_NAME_EXECUTABLE@ offers extension fields. See also the
-descriptions of ``--list-fields`` option and ``--fields`` option.
+A tag can record various information, called *extension fields*.
 
 Extension fields are tab-separated key-value pairs appended to the end of
 the EX command as a comment, as described above. These key value pairs
-appear in the general form ``key:value``. Their presence in the lines of the
-tag file are controlled by the ``--fields`` option. The possible keys and
-the meaning of their values are as follows:
+appear in the general form ``key:value``.
 
 In addition, information on the scope of the tag definition may be
 available, with the key portion equal to some language-dependent construct
@@ -1640,78 +1635,83 @@ This scope entry indicates the scope in which the tag was found.
 For example, a tag generated for a C structure member would have a scope
 looking like ``struct:myStruct``.
 
-The meaning of major fields is as follows (one-letter flag/long-name flag):
+``--fields=[+|-]flags|*`` and ``--fields-<LANG>=[+|-]flags|*`` options specifies
+which available extension fields are to be included in the tag entries.
+
+See the output of ``@CTAGS_NAME_EXECUTABLE@ --list-fields`` for the list of
+extension fields.
+The essential fields are ``name``, ``input``, ``pattern``, and ``line``.
+The meaning of major fields is as follows (long-name flag/one-letter flag):
 
 ``access``/``a``
-	Access (or export) of class members
-
 	Indicates the visibility of this class member, where value is specific
 	to the language.
 
 ``end``/``e``
-	End lines of various items
+	Indicates the line number of the end lines of the language object.
+
+``extras``/``E``
+	Extra tag type information. See "`Extras`_" for details.
 
 ``file``/``f``
-	File-restricted scoping. Enabled by default.
-
 	Indicates that the tag has file-limited visibility. This key has no
-	corresponding value.
+	corresponding value. Enabled by default.
 
 ``implementation``/``m``
-	Implementation information
-
 	When present, this indicates a limited implementation (abstract vs.
 	concrete) of a routine or class, where value is specific to the
 	language (``virtual`` or ``pure virtual`` for C++; ``abstract`` for Java).
 
 ``inherits``/``i``
-	Inheritance information.
-
-	When present, value. is a comma-separated list of classes from which
+	When present, value is a comma-separated list of classes from which
 	this class is derived (i.e. inherits from).
 
+``input``/``F``
+	The name of source file where ``name`` is defined or referenced.
+
 ``k``
-	Kind of tag as one-letter. Enabled by default.
-	Exceptionally this has no long-name.
+	`Kind <Kinds>`_ of tag as one-letter. Enabled by default.
+	This field has no long-name.
 	See also ``kind``/``z`` flag.
 
 ``K``
-	Kind of tag as long-name.
-	Exceptionally this has no long-name.
+	`Kind <Kinds>`_ of tag as long-name.
+	This field has no long-name.
 	See also ``kind``/``z`` flag.
 
 ``kind``/``z``
-	Include the ``kind:`` key in kind field.  See also ``k`` and ``K`` flags.
+	Include the ``kind:`` key in `kind field <Kinds>`_.  See also ``k`` and ``K`` flags.
 
 ``language``/``l``
 	Language of source file containing tag
 
 ``line``/``n``
-	Line number of tag definition
+	The line number where ``name`` is defined or referenced in ``input``.
+
+``name``/``N``
+	The name of language objects.
+
+``pattern``/``P``
+	Can be used to search the ``name`` in ``input``
 
 ``roles``/``r``
-	Roles assigned to the tag.
-	For a definition tag, this field takes ``def`` as a value.
+	Roles assigned to the tag. See "`Roles`_" for more details.
 
 ``s``
 	Scope of tag definition. Enabled by default.
-	Exceptionally this has no long-name.
-	See also ``Z`` flag.
+	This field has no long-name.
+	See also ``scope``/``Z`` flag.
 
-	.. TODO? implement "scope" of Z/scope flag.
-
-``Z``
-	Include the ``scope:`` key in scope field.
-	Exceptionally this has no long-name.  See also ``s`` flag.
+``scope``/``Z``
+	Prepend the ``scope:`` key to scope (``s``) field.
+	See also ``s`` flag.
 
 ``scopeKind``/``p``
 	Kind of scope as long-name
 
 ``signature``/``S``
-	Signature of routine (e.g. prototype or parameter list)
-
 	When present, value is a language-dependent representation of the
-	signature of a routine. A routine signature in its complete form
+	signature of a routine (e.g. prototype or parameter list). A routine signature in its complete form
 	specifies the return type of a routine and its formal argument list.
 	This extension field is presently supported only for C-based
 	languages and does not include the return type.
@@ -1721,26 +1721,41 @@ The meaning of major fields is as follows (one-letter flag/long-name flag):
 	callable like function as ``typeref:`` field.
 	Enabled by default.
 
-Check the output of the ``--list-fields`` option for the other minor
-fields.
-
 Kinds
-~~~~~~
+......
 
-``kind:`` is a field which represents the *kind* of language object
+``kind`` is a field which represents the *kind* of language object
 specified by a tag. Kinds used and defined are very different between
 parsers. For example, C language defines ``macro``, ``function``,
-``variable``, ``typedef``, etc. See also the descriptions of
-``--list-kinds-full`` option and ``--kinds-<LANG>`` option.
+``variable``, ``typedef``, etc.
 
-Indicates the type, or kind, of tag. Its value is either one of the
-corresponding one-letter flags described under the various
-``--kinds-<LANG>`` options above, or a long-name flag. It is permitted
+``--kinds-<LANG>=[+|-]kinds|*`` option specifies a list of language-specific
+kinds of tags (or kinds) to include in the output file for a particular
+language.
+
+See the output of ``@CTAGS_NAME_EXECUTABLE@ --list-kinds-full`` for the complete
+list of the kinds.
+
+Its value is either one of the
+corresponding one-letter flags or a long-name flag. It is permitted
 (and is, in fact, the default) for the key portion of this field to be
-omitted. The optional behaviors are controlled with the ``--fields`` option.
+omitted. The optional behaviors are controlled with the ``--fields`` option as follows.
+
+.. code-block:: console
+
+	$ ctags -o - kinds.c
+	foo     kinds.c /^int foo() {$/;"       f       typeref:typename:int
+	$ ctags --fields=+k -o - kinds.c
+	foo     kinds.c /^int foo() {$/;"       f       typeref:typename:int
+	$ ctags --fields=+K -o - kinds.c
+	foo     kinds.c /^int foo() {$/;"       function        typeref:typename:int
+	$ ctags --fields=+z -o - kinds.c
+	foo     kinds.c /^int foo() {$/;"       kind:f  typeref:typename:int
+	$ ctags --fields=+zK -o - kinds.c
+	foo     kinds.c /^int foo() {$/;"       kind:function   typeref:typename:int
 
 Roles
-~~~~~~
+......
 
 *Role* is a newly introduced concept in Universal Ctags. Role is a
 concept associated with reference tags, and is not implemented widely yet.
@@ -1754,15 +1769,35 @@ kind. In other words, the ``kind`` field identifies the *what* of the language
 object, whereas the ``roles`` field identifies the *how* of a referenced language
 object. Roles are only used with specific kinds.
 
-For example, for the source file used for demonstrating in the "`Extras`_"
-subsection, ``Baz`` is tagged as a reference tag with kind ``package`` and with
-role ``imported``. Another example is for a C++ ``header`` kind tag, generated by
-``#include`` statements: the ``roles:system`` or ``roles:local`` fields will be
-added depending on whether the include file name begins with '``<``' or not.
+For a definition tag, this field takes ``def`` as a value.
 
-See also the descriptions of ``--list-roles`` and ``--roles-<LANG>.<KIND>=``
-options.
+For example, ``Baz`` is tagged as a reference tag with kind ``package`` and with
+role ``imported`` with the following code.
 
+.. code-block:: java
+
+	package Bar;
+	import Baz;
+
+	class Foo {
+			// ...
+	}
+
+.. code-block:: console
+
+	$ ctags --fields=+KEr -uo - roles.java
+	Bar     roles.java     /^package Bar;$/;"      package roles:def
+	Foo     roles.java     /^class Foo {$/;"       class   roles:def
+	$ ctags --fields=+EKr --extras=+r -uo - roles.java
+	Bar     roles.java     /^package Bar;$/;"      package roles:def
+	Baz     roles.java     /^import Baz;$/;"       package roles:imported  extras:reference
+	Foo     roles.java     /^class Foo {$/;"       class   roles:def
+
+``--roles-<LANG>.<KIND>=[+|-]roles|*`` option specifies a list of kind-specific
+roles of tags to include in the output file for a particular language.
+
+Inquire the output of ``@CTAGS_NAME_EXECUTABLE@ --list-roles`` for the list of
+roles.
 
 Extras
 ~~~~~~
@@ -1775,18 +1810,18 @@ name, or for tagging something not associated with a language object. A typical
 extra tag is ``qualified``, which tags a language object with a
 class-qualified or scope-qualified name.
 
-Inquire the output of ``--list-extras`` option for the other minor
-extras.
+``--extra=[+|-]flags|*`` and ``--extras-<LANG>=[+|-]flags|*`` options specifies
+whether to include extra tag entries for certain kinds of information.
 
-See also the descriptions of ``--list-extras`` option and ``--extras``
-option in "`OPTIONS`_".
+Inquire the output of ``@CTAGS_NAME_EXECUTABLE@ --list-extras`` for the list of extras.
+The meaning of major extras is as follows (long-name flag/one-letter flag):
 
-The meaning of major extras is as follows (one-letter flag/long-name flag):
-
-none/``anonymous``
+``anonymous``/none
 	Include an entry for the language object that has no name like lambda
 	function. This extra has no one-letter flag and is enabled by
-	default. The extra tag is useful as a placeholder to fill scope fields
+	default.
+
+	The extra tag is useful as a placeholder to fill scope fields
 	for language objects defined in a language object with no name.
 
 	.. code-block:: C
@@ -1801,12 +1836,13 @@ none/``anonymous``
 	@CTAGS_NAME_EXECUTABLE@ generates an anonymous extra tag for the struct
 	and fills the scope fields with the name of the extra tag.
 
-	.. code-block:: tags
+	.. code-block:: console
 
+		$ ctags --fields=-f -uo - input.c
 		__anon9f26d2460108	input.c	/^struct {$/;"	s
-		p	input.c	/^} p = { .x = 0.0, .y = 0.0 };$/;"	v	typeref:struct:__anon9f26d2460108
 		x	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
 		y	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
+		p	input.c	/^} p = { .x = 0.0, .y = 0.0 };$/;"	v	typeref:struct:__anon9f26d2460108
 
 	The above tag output has ``__anon9f26d2460108`` as an anonymous extra tag.
 	The typeref field of '``p``' also receives the benefit of it.
@@ -1815,11 +1851,28 @@ none/``anonymous``
 	Indicates whether tags scoped only for a single file (i.e. tags which
 	cannot be seen outside of the file in which they are defined, such as
 	language objects with ``static`` modifier of C language) should be included
-	in the output. See also the ``-h`` option. This option is enabled by
-	default. This is the replacement for ``--file-scope`` option of
-	Exuberant Ctags.
+	in the output. See also the ``-h`` option.
 
-	.. TODO: "This option" is ambiguous. fileScope Extra Tag or -h option?
+	This extra tag is enabled by default. Add ``--extras=-F`` option not to
+	output tags scoped only for a single-file. This is the replacement for
+	``--file-scope`` option of Exuberant Ctags.
+
+	.. code-block:: c
+
+		static int f() {
+			return 0;
+		}
+		int g() {
+			return 0;
+		}
+
+	.. code-block:: console
+
+		$ ctags -uo - filescope.c
+		f       filescope.c     /^static int f() {$/;"  f       typeref:typename:int    file:
+		g       filescope.c     /^int g() {$/;" f       typeref:typename:int
+		$ ctags --extras=-F -uo - filescope.c
+		g       filescope.c     /^int g() {$/;" f       typeref:typename:int
 
 ``inputFile``/``f``
 	Include an entry for the base file name of every source file
@@ -1831,7 +1884,7 @@ none/``anonymous``
 	attached to the tag. (However, @CTAGS_NAME_EXECUTABLE@ omits the ``end:`` field
 	if no newline is in the file like an empty file.)
 
-	By default, @CTAGS_NAME_EXECUTABLE@ doesn't create the ``f/inputFile`` extra
+	By default, @CTAGS_NAME_EXECUTABLE@ doesn't create the ``inputFile``/``f`` extra
 	tag for the source file when @CTAGS_NAME_EXECUTABLE@ doesn't find a parser
 	for it. Enabling ``Unknown`` parser with ``--languages=+Unknown`` forces
 	@CTAGS_NAME_EXECUTABLE@ to create the extra tags for any source files.
@@ -1868,20 +1921,52 @@ none/``anonymous``
 
 	.. code-block:: Java
 
-		package Bar;
-		import Baz;
+		class point {
+			double x;
+		};
 
-		class Foo {
-			// ...
-		}
-
-	For the above source file, @CTAGS_NAME_EXECUTABLE@ tags ``Bar`` and ``Foo`` by
+	For the above source file, @CTAGS_NAME_EXECUTABLE@ tags ``point`` and ``x`` by
 	default.  If the ``qualified`` extra is enabled from the command line
-	(``--extras=+q``), then ``Bar.Foo`` is also tagged even though the string
-	``Bar.Foo`` is not in the source code.
+	(``--extras=+q``), then ``point.x`` is also tagged even though the string
+	"``point.x``" is not in the source code.
+
+	.. code-block:: console
+
+		$ ctags --fields=+K -uo - qualified.java
+		point   qualified.java  /^class point {$/;"     class
+		x       qualified.java  /^      double x;$/;"   field   class:point
+		$ ctags --fields=+K --extras=+q -uo - qualified.java
+		point   qualified.java  /^class point {$/;"     class
+		x       qualified.java  /^      double x;$/;"   field   class:point
+		point.x qualified.java  /^      double x;$/;"   field   class:point
 
 ``reference``/``r``
 	Include reference tags. See "`TAG ENTRIES`_" about reference tags.
+
+	The following example demonstrates the ``reference`` extra tag.
+
+	.. code-block:: c
+
+		#include <stdio.h>
+		#include "utils.h"
+		#define X
+		#undef X
+
+	The ``roles:system`` or ``roles:local`` fields will be
+	added depending on whether the include file name begins with '``<``' or not.
+
+	``#define X`` emits a definition tag. On the other hand ``#undef X`` emits a
+	reference tag.
+
+	.. code-block:: console
+
+		$ ctags --fields=+EKr -uo - inc.c
+		X       inc.c   /^#define X$/;" macro   file:   roles:def       extras:fileScope
+		$ ctags --fields=+EKr --extras=+r -uo - inc.c
+		stdio.h inc.c   /^#include <stdio.h>/;" header  roles:system    extras:reference
+		utils.h inc.c   /^#include "utils.h"/;" header  roles:local     extras:reference
+		X       inc.c   /^#define X$/;" macro   file:   roles:def       extras:fileScope
+		X       inc.c   /^#undef X$/;"  macro   file:   roles:undef     extras:fileScope,reference
 
 Language-specific fields and extras
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1890,18 +1975,9 @@ Exuberant Ctags has the concept of *fields* and *extras*. They are common
 between parsers of different languages. Universal Ctags extends this concept
 by providing language-specific fields and extras.
 
-.. options should be explained and revised here
-   ``--list-languages`` (done)
-   ``--list-kinds``     (done)
-   ``--list-kinds-full``(done)
-   ``--list-fields``    (done)
-   ``--list-extras``    (done)
-   ``--list-roles``     (done)
-   ``--kinds-<LANG>=``  (done)
-   ``--fields=``        (done)
-   ``--fields-<LANG>``  (done)
-   ``--extras=``        (done)
-   ``--extras-<LANG>=`` (done)
+.. Note: kinds are language-specific since e-ctags. roles are new to u-ctags.
+
+.. TODO: move the following "Hot to ..." sections to FAQ man page when available
 
 HOW TO USE WITH VI
 ------------------
@@ -1980,8 +2056,6 @@ identical to the line containing the tag. The following example
 demonstrates this condition:
 
 .. code-block:: C
-	:linenos:
-	:emphasize-lines: 1,5
 
 	int variable;
 
@@ -1994,8 +2068,8 @@ demonstrates this condition:
 
 Depending upon which editor you use and where in the code you happen to be,
 it is possible that the search pattern may locate the local parameter
-declaration on the line 5 before it finds the actual global variable definition
-on the line 1, since the lines (and therefore their search patterns) are
+declaration before it finds the actual global variable definition,
+since the lines (and therefore their search patterns) are
 identical.
 
 This can be avoided by use of the ``--excmd=n`` option.

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -595,97 +595,6 @@ Tags File Contents Options
 	extras`_" about the concept). Use ``--extras-<LANG>=`` option for
 	controlling them.
 
-	.. TODO: move the following list to "Extras"
-
-	The meaning of major extras is as follows (one-letter flag/long-name flag):
-
-	none/``anonymous``
-		Include an entry for the language object that has no name like lambda
-		function. This extra has no one-letter flag and is enabled by
-		default. The extra tag is useful as a placeholder to fill scope fields
-		for language objects defined in a language object with no name.
-
-		.. code-block:: C
-
-			struct {
-				double x, y;
-			} p = { .x = 0.0, .y = 0.0 };
-
-		'``x``' and '``y``' are the members of a structure. When filling the scope
-		fields for them, @CTAGS_NAME_EXECUTABLE@ has trouble because the struct
-		where '``x``' and '``y``' belong to has no name. For overcoming the trouble,
-		@CTAGS_NAME_EXECUTABLE@ generates an anonymous extra tag for the struct
-		and fills the scope fields with the name of the extra tag.
-
-		.. code-block:: tags
-
-			__anon9f26d2460108	input.c	/^struct {$/;"	s
-			p	input.c	/^} p = { .x = 0.0, .y = 0.0 };$/;"	v	typeref:struct:__anon9f26d2460108
-			x	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
-			y	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
-
-		The above tag output has ``__anon9f26d2460108`` as an anonymous extra tag.
-		The typeref field of '``p``' also receives the benefit of it.
-
-	``F``/``fileScope``
-		Indicates whether tags scoped only for a single file (i.e. tags which
-		cannot be seen outside of the file in which they are defined, such as
-		language objects with ``static`` modifier of C language) should be included
-		in the output. See also the ``-h`` option. This option is enabled by
-		default. This is the replacement for ``--file-scope`` option of
-		Exuberant Ctags.
-
-		.. TODO: "This option" is ambiguous. fileScope Extra Tag or -h option?
-
-	``f``/``inputFile``
-		Include an entry for the base file name of every source file
-		(e.g. ``example.c``), which addresses the first line of the file.
-		This flag is the replacement for ``--file-tags`` hidden option of
-		Exuberant Ctags.
-
-		If the ``end:`` field is enabled, the end line number of the file can be
-		attached to the tag. (However, @CTAGS_NAME_EXECUTABLE@ omits the ``end:`` field
-		if no newline is in the file like an empty file.)
-
-		By default, @CTAGS_NAME_EXECUTABLE@ doesn't create the ``f/inputFile`` extra
-		tag for the source file when @CTAGS_NAME_EXECUTABLE@ doesn't find a parser
-		for it. Enabling ``Unknown`` parser with ``--languages=+Unknown`` forces
-		@CTAGS_NAME_EXECUTABLE@ to create the extra tags for any source files.
-
-		The etags mode enables the ``Unknown`` parser implicitly.
-
-	``p``/``pseudo``
-		Include pseudo-tags. Enabled by default unless the tag file is
-		written to standard output. See ctags-client-tools(7) about
-		the detail of pseudo-tags.
-
-	``q``/``qualified``
-		Include an extra class-qualified or namespace-qualified tag entry
-		for each tag which is a member of a class or a namespace.
-
-		This may allow easier location of a specific tags when
-		multiple occurrences of a tag name occur in the tag file.
-		Note, however, that this could potentially more than double
-		the size of the tag file.
-
-		The actual form of the qualified tag depends upon the language
-		from which the tag was derived (using a form that is most
-		natural for how qualified calls are specified in the
-		language). For C++ and Perl, it is in the form
-		``class::member``; for Eiffel and Java, it is in the form
-		``class.member``.
-
-		Note: Using backslash characters as separators forming
-		qualified name in PHP. However, in tags output of
-		Universal Ctags, a backslash character in a name is escaped
-		with a backslash character. See tags(5) about the escaping.
-
-	``r``/``reference``
-		Include reference tags. See "`TAG ENTRIES`_" about reference tags.
-
-	Inquire the output of ``--list-extras`` option for the other minor
-	extras.
-
 ``--extras-<LANG>=[+|-]flags|*``
 	Specifies whether to include extra tag entries for certain kinds of
 	information for language *<LANG>*. Universal Ctags
@@ -729,73 +638,6 @@ Tags File Contents Options
 	controlling them.
 
 	.. TODO: Confirm the description above is correct.
-
-	.. TODO: move the following list to "Fields"
-
-	The meaning of major fields is as follows (one-letter flag/long-name flag):
-
-	``a``/``access``
-		Access (or export) of class members
-
-	``e``/``end``
-		End lines of various items
-
-	``f``/``file``
-		File-restricted scoping. Enabled by default.
-
-	``i``/``inherits``
-		Inheritance information.
-
-	``k``
-		Kind of tag as one-letter. Enabled by default.
-		Exceptionally this has no long-name.
-		See also ``z``/``kind`` flag.
-
-	``K``
-		Kind of tag as long-name.
-		Exceptionally this has no long-name.
-		See also ``z``/``kind`` flag.
-
-	``l``/``language``
-		Language of source file containing tag
-
-	``m``/``implementation``
-		Implementation information
-
-	``n``/``line``
-		Line number of tag definition
-
-	``p``/``scopeKind``
-		Kind of scope as long-name
-
-	``r``/``roles``
-		Roles assigned to the tag.
-		For a definition tag, this field takes ``def`` as a value.
-
-	``s``
-		Scope of tag definition. Enabled by default.
-		Exceptionally this has no long-name.
-		See also ``Z`` flag.
-
-		.. TODO? implement "scope" of Z/scope flag.
-
-	``S``/``signature``
-		Signature of routine (e.g. prototype or parameter list)
-
-	``t``/``typeref``
-		Type and name of a variable, typedef, or return type of
-		callable like function as ``typeref:`` field.
-		Enabled by default.
-
-	``z``/``kind``
-		Include the ``kind:`` key in kind field.  See also ``k`` and ``K`` flags.
-
-	``Z``
-		Include the ``scope:`` key in scope field.
-		Exceptionally this has no long-name.  See also ``s`` flag.
-
-	Check the output of the ``--list-fields`` option for the other minor
-	fields.
 
 ``--fields-<LANG>=[+|-]flags|*``
 	Specifies which language-specific fields are to be included in
@@ -1720,124 +1562,6 @@ Examples:
 
 ``NONE`` means that @CTAGS_NAME_EXECUTABLE@ does not select any parser for the file.
 
-.. _tag_entries:
-
-TAG ENTRIES
------------
-
-A tag is an index for a language object. The concept of a tag and related
-items in Exuberant Ctags are refined and extended in Universal Ctags.
-
-A tag is categorized into *definition tags* or *reference tags*.
-In general, Exuberant Ctags only tags *definitions* of
-language objects: places where newly named language objects *are introduced*.
-Universal Ctags, on the other hand, can also tag *references* of language
-objects: places where named language objects *are used*. However, support
-for generating reference tags is new and limited to specific areas of
-specific languages in the current version.
-
-
-Fields
-~~~~~~
-
-A tag can record various information, called *fields*. The
-essential fields are: *name* of language objects, *input*,
-*pattern*, and *line*. ``input:`` is the name of source file where
-``name:`` is defined or referenced. ``pattern:`` can be used to search
-the *name* in ``input:``. *line* is the line number where
-``name:`` is defined or referenced in ``input:``.
-
-@CTAGS_NAME_EXECUTABLE@ offers extension fields. See also the
-descriptions of ``--list-fields`` option and ``--fields`` option.
-
-
-Kinds
-~~~~~~
-
-``kind:`` is a field which represents the *kind* of language object
-specified by a tag. Kinds used and defined are very different between
-parsers. For example, C language defines ``macro``, ``function``,
-``variable``, ``typedef``, etc. See also the descriptions of
-``--list-kinds-full`` option and ``--kinds-<LANG>`` option.
-
-
-Extras
-~~~~~~
-
-Generally, @CTAGS_NAME_EXECUTABLE@ tags only language objects appearing
-in source files, as is. In other words, a value for a ``name:`` field
-should be found on the source file associated with the ``name:``. An
-``extra`` type tag (*extra*) is for tagging a language object with a processed
-name, or for tagging something not associated with a language object. A typical
-extra tag is ``qualified``, which tags a language object with a
-class-qualified or scope-qualified name.
-
-The following example demonstrates the ``qualified`` extra tag.
-
-.. code-block:: Java
-
-	package Bar;
-	import Baz;
-
-	class Foo {
-		// ...
-	}
-
-For the above source file, @CTAGS_NAME_EXECUTABLE@ tags ``Bar`` and ``Foo`` by
-default.  If the ``qualified`` extra is enabled from the command line
-(``--extras=+q``), then ``Bar.Foo`` is also tagged even though the string
-``Bar.Foo`` is not in the source code.
-
-See also the descriptions of ``--list-extras`` option and ``--extras``
-option in "`OPTIONS`_".
-
-
-Roles
-~~~~~~
-
-*Role* is a newly introduced concept in Universal Ctags. Role is a
-concept associated with reference tags, and is not implemented widely yet.
-
-As described previously in "`Kinds`_", the ``kind`` field represents the type
-of language object specified with a tag, such as a function vs. a variable.
-Specific kinds are defined for reference tags, such as the C++ kind ``header`` for
-header file, or Java kind ``package`` for package statements. For such reference
-kinds, a ``roles`` field can be added to distinguish the role of the reference
-kind. In other words, the ``kind`` field identifies the *what* of the language
-object, whereas the ``roles`` field identifies the *how* of a referenced language
-object. Roles are only used with specific kinds.
-
-For example, for the source file used for demonstrating in the "`Extras`_"
-subsection, ``Baz`` is tagged as a reference tag with kind ``package`` and with
-role ``imported``. Another example is for a C++ ``header`` kind tag, generated by
-``#include`` statements: the ``roles:system`` or ``roles:local`` fields will be
-added depending on whether the include file name begins with '``<``' or not.
-
-See also the descriptions of ``--list-roles`` and ``--roles-<LANG>.<KIND>=``
-options.
-
-
-Language-specific fields and extras
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Exuberant Ctags has the concept of *fields* and *extras*. They are common
-between parsers of different languages. Universal Ctags extends this concept
-by providing language-specific fields and extras.
-
-.. options should be explained and revised here
-   ``--list-languages`` (done)
-   ``--list-kinds``     (done)
-   ``--list-kinds-full``(done)
-   ``--list-fields``    (done)
-   ``--list-extras``    (done)
-   ``--list-roles``     (done)
-   ``--kinds-<LANG>=``  (done)
-   ``--fields=``        (done)
-   ``--fields-<LANG>``  (done)
-   ``--extras=``        (done)
-   ``--extras-<LANG>=`` (done)
-
-
 TAG FILE FORMAT
 ---------------
 
@@ -1874,44 +1598,40 @@ specified on the command line was relative to the current directory, then
 it will be recorded in that same manner in the tag file. See, however,
 the ``--tag-relative`` option for how this behavior can be modified.
 
+.. _tag_entries:
+
+TAG ENTRIES
+-----------
+
+A tag is an index for a language object. The concept of a tag and related
+items in Exuberant Ctags are refined and extended in Universal Ctags.
+
+A tag is categorized into *definition tags* or *reference tags*.
+In general, Exuberant Ctags only tags *definitions* of
+language objects: places where newly named language objects *are introduced*.
+Universal Ctags, on the other hand, can also tag *references* of language
+objects: places where named language objects *are used*. However, support
+for generating reference tags is new and limited to specific areas of
+specific languages in the current version.
+
+Fields
+~~~~~~
+
+A tag can record various information, called *fields*. The
+essential fields are: *name* of language objects, *input*,
+*pattern*, and *line*. ``input:`` is the name of source file where
+``name:`` is defined or referenced. ``pattern:`` can be used to search
+the *name* in ``input:``. *line* is the line number where
+``name:`` is defined or referenced in ``input:``.
+
+@CTAGS_NAME_EXECUTABLE@ offers extension fields. See also the
+descriptions of ``--list-fields`` option and ``--fields`` option.
+
 Extension fields are tab-separated key-value pairs appended to the end of
 the EX command as a comment, as described above. These key value pairs
 appear in the general form ``key:value``. Their presence in the lines of the
 tag file are controlled by the ``--fields`` option. The possible keys and
 the meaning of their values are as follows:
-
-.. Q: this list is very out-of-date. Should we just say "use --list-fields"?
-
-access
-	Indicates the visibility of this class member, where value is specific
-	to the language.
-
-file
-	Indicates that the tag has file-limited visibility. This key has no
-	corresponding value.
-
-kind
-	Indicates the type, or kind, of tag. Its value is either one of the
-	corresponding one-letter flags described under the various
-	``--kinds-<LANG>`` options above, or a long-name flag. It is permitted
-	(and is, in fact, the default) for the key portion of this field to be
-	omitted. The optional behaviors are controlled with the ``--fields`` option.
-
-implementation
-	When present, this indicates a limited implementation (abstract vs.
-	concrete) of a routine or class, where value is specific to the
-	language (``virtual`` or ``pure virtual`` for C++; ``abstract`` for Java).
-
-inherits
-	When present, value. is a comma-separated list of classes from which
-	this class is derived (i.e. inherits from).
-
-signature
-	When present, value is a language-dependent representation of the
-	signature of a routine. A routine signature in its complete form
-	specifies the return type of a routine and its formal argument list.
-	This extension field is presently supported only for C-based
-	languages and does not include the return type.
 
 In addition, information on the scope of the tag definition may be
 available, with the key portion equal to some language-dependent construct
@@ -1920,6 +1640,268 @@ This scope entry indicates the scope in which the tag was found.
 For example, a tag generated for a C structure member would have a scope
 looking like ``struct:myStruct``.
 
+The meaning of major fields is as follows (one-letter flag/long-name flag):
+
+``access``/``a``
+	Access (or export) of class members
+
+	Indicates the visibility of this class member, where value is specific
+	to the language.
+
+``end``/``e``
+	End lines of various items
+
+``file``/``f``
+	File-restricted scoping. Enabled by default.
+
+	Indicates that the tag has file-limited visibility. This key has no
+	corresponding value.
+
+``implementation``/``m``
+	Implementation information
+
+	When present, this indicates a limited implementation (abstract vs.
+	concrete) of a routine or class, where value is specific to the
+	language (``virtual`` or ``pure virtual`` for C++; ``abstract`` for Java).
+
+``inherits``/``i``
+	Inheritance information.
+
+	When present, value. is a comma-separated list of classes from which
+	this class is derived (i.e. inherits from).
+
+``k``
+	Kind of tag as one-letter. Enabled by default.
+	Exceptionally this has no long-name.
+	See also ``kind``/``z`` flag.
+
+``K``
+	Kind of tag as long-name.
+	Exceptionally this has no long-name.
+	See also ``kind``/``z`` flag.
+
+``kind``/``z``
+	Include the ``kind:`` key in kind field.  See also ``k`` and ``K`` flags.
+
+``language``/``l``
+	Language of source file containing tag
+
+``line``/``n``
+	Line number of tag definition
+
+``roles``/``r``
+	Roles assigned to the tag.
+	For a definition tag, this field takes ``def`` as a value.
+
+``s``
+	Scope of tag definition. Enabled by default.
+	Exceptionally this has no long-name.
+	See also ``Z`` flag.
+
+	.. TODO? implement "scope" of Z/scope flag.
+
+``Z``
+	Include the ``scope:`` key in scope field.
+	Exceptionally this has no long-name.  See also ``s`` flag.
+
+``scopeKind``/``p``
+	Kind of scope as long-name
+
+``signature``/``S``
+	Signature of routine (e.g. prototype or parameter list)
+
+	When present, value is a language-dependent representation of the
+	signature of a routine. A routine signature in its complete form
+	specifies the return type of a routine and its formal argument list.
+	This extension field is presently supported only for C-based
+	languages and does not include the return type.
+
+``typeref``/``t``
+	Type and name of a variable, typedef, or return type of
+	callable like function as ``typeref:`` field.
+	Enabled by default.
+
+Check the output of the ``--list-fields`` option for the other minor
+fields.
+
+Kinds
+~~~~~~
+
+``kind:`` is a field which represents the *kind* of language object
+specified by a tag. Kinds used and defined are very different between
+parsers. For example, C language defines ``macro``, ``function``,
+``variable``, ``typedef``, etc. See also the descriptions of
+``--list-kinds-full`` option and ``--kinds-<LANG>`` option.
+
+Indicates the type, or kind, of tag. Its value is either one of the
+corresponding one-letter flags described under the various
+``--kinds-<LANG>`` options above, or a long-name flag. It is permitted
+(and is, in fact, the default) for the key portion of this field to be
+omitted. The optional behaviors are controlled with the ``--fields`` option.
+
+Roles
+~~~~~~
+
+*Role* is a newly introduced concept in Universal Ctags. Role is a
+concept associated with reference tags, and is not implemented widely yet.
+
+As described previously in "`Kinds`_", the ``kind`` field represents the type
+of language object specified with a tag, such as a function vs. a variable.
+Specific kinds are defined for reference tags, such as the C++ kind ``header`` for
+header file, or Java kind ``package`` for package statements. For such reference
+kinds, a ``roles`` field can be added to distinguish the role of the reference
+kind. In other words, the ``kind`` field identifies the *what* of the language
+object, whereas the ``roles`` field identifies the *how* of a referenced language
+object. Roles are only used with specific kinds.
+
+For example, for the source file used for demonstrating in the "`Extras`_"
+subsection, ``Baz`` is tagged as a reference tag with kind ``package`` and with
+role ``imported``. Another example is for a C++ ``header`` kind tag, generated by
+``#include`` statements: the ``roles:system`` or ``roles:local`` fields will be
+added depending on whether the include file name begins with '``<``' or not.
+
+See also the descriptions of ``--list-roles`` and ``--roles-<LANG>.<KIND>=``
+options.
+
+
+Extras
+~~~~~~
+
+Generally, @CTAGS_NAME_EXECUTABLE@ tags only language objects appearing
+in source files, as is. In other words, a value for a ``name:`` field
+should be found on the source file associated with the ``name:``. An
+``extra`` type tag (*extra*) is for tagging a language object with a processed
+name, or for tagging something not associated with a language object. A typical
+extra tag is ``qualified``, which tags a language object with a
+class-qualified or scope-qualified name.
+
+Inquire the output of ``--list-extras`` option for the other minor
+extras.
+
+See also the descriptions of ``--list-extras`` option and ``--extras``
+option in "`OPTIONS`_".
+
+The meaning of major extras is as follows (one-letter flag/long-name flag):
+
+none/``anonymous``
+	Include an entry for the language object that has no name like lambda
+	function. This extra has no one-letter flag and is enabled by
+	default. The extra tag is useful as a placeholder to fill scope fields
+	for language objects defined in a language object with no name.
+
+	.. code-block:: C
+
+		struct {
+			double x, y;
+		} p = { .x = 0.0, .y = 0.0 };
+
+	'``x``' and '``y``' are the members of a structure. When filling the scope
+	fields for them, @CTAGS_NAME_EXECUTABLE@ has trouble because the struct
+	where '``x``' and '``y``' belong to has no name. For overcoming the trouble,
+	@CTAGS_NAME_EXECUTABLE@ generates an anonymous extra tag for the struct
+	and fills the scope fields with the name of the extra tag.
+
+	.. code-block:: tags
+
+		__anon9f26d2460108	input.c	/^struct {$/;"	s
+		p	input.c	/^} p = { .x = 0.0, .y = 0.0 };$/;"	v	typeref:struct:__anon9f26d2460108
+		x	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
+		y	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
+
+	The above tag output has ``__anon9f26d2460108`` as an anonymous extra tag.
+	The typeref field of '``p``' also receives the benefit of it.
+
+``fileScope``/``F``
+	Indicates whether tags scoped only for a single file (i.e. tags which
+	cannot be seen outside of the file in which they are defined, such as
+	language objects with ``static`` modifier of C language) should be included
+	in the output. See also the ``-h`` option. This option is enabled by
+	default. This is the replacement for ``--file-scope`` option of
+	Exuberant Ctags.
+
+	.. TODO: "This option" is ambiguous. fileScope Extra Tag or -h option?
+
+``inputFile``/``f``
+	Include an entry for the base file name of every source file
+	(e.g. ``example.c``), which addresses the first line of the file.
+	This flag is the replacement for ``--file-tags`` hidden option of
+	Exuberant Ctags.
+
+	If the ``end:`` field is enabled, the end line number of the file can be
+	attached to the tag. (However, @CTAGS_NAME_EXECUTABLE@ omits the ``end:`` field
+	if no newline is in the file like an empty file.)
+
+	By default, @CTAGS_NAME_EXECUTABLE@ doesn't create the ``f/inputFile`` extra
+	tag for the source file when @CTAGS_NAME_EXECUTABLE@ doesn't find a parser
+	for it. Enabling ``Unknown`` parser with ``--languages=+Unknown`` forces
+	@CTAGS_NAME_EXECUTABLE@ to create the extra tags for any source files.
+
+	The etags mode enables the ``Unknown`` parser implicitly.
+
+``pseudo``/``p``
+	Include pseudo-tags. Enabled by default unless the tag file is
+	written to standard output. See ctags-client-tools(7) about
+	the detail of pseudo-tags.
+
+``qualified``/``q``
+	Include an extra class-qualified or namespace-qualified tag entry
+	for each tag which is a member of a class or a namespace.
+
+	This may allow easier location of a specific tags when
+	multiple occurrences of a tag name occur in the tag file.
+	Note, however, that this could potentially more than double
+	the size of the tag file.
+
+	The actual form of the qualified tag depends upon the language
+	from which the tag was derived (using a form that is most
+	natural for how qualified calls are specified in the
+	language). For C++ and Perl, it is in the form
+	``class::member``; for Eiffel and Java, it is in the form
+	``class.member``.
+
+	Note: Using backslash characters as separators forming
+	qualified name in PHP. However, in tags output of
+	Universal Ctags, a backslash character in a name is escaped
+	with a backslash character. See tags(5) about the escaping.
+
+	The following example demonstrates the ``qualified`` extra tag.
+
+	.. code-block:: Java
+
+		package Bar;
+		import Baz;
+
+		class Foo {
+			// ...
+		}
+
+	For the above source file, @CTAGS_NAME_EXECUTABLE@ tags ``Bar`` and ``Foo`` by
+	default.  If the ``qualified`` extra is enabled from the command line
+	(``--extras=+q``), then ``Bar.Foo`` is also tagged even though the string
+	``Bar.Foo`` is not in the source code.
+
+``reference``/``r``
+	Include reference tags. See "`TAG ENTRIES`_" about reference tags.
+
+Language-specific fields and extras
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Exuberant Ctags has the concept of *fields* and *extras*. They are common
+between parsers of different languages. Universal Ctags extends this concept
+by providing language-specific fields and extras.
+
+.. options should be explained and revised here
+   ``--list-languages`` (done)
+   ``--list-kinds``     (done)
+   ``--list-kinds-full``(done)
+   ``--list-fields``    (done)
+   ``--list-extras``    (done)
+   ``--list-roles``     (done)
+   ``--kinds-<LANG>=``  (done)
+   ``--fields=``        (done)
+   ``--fields-<LANG>``  (done)
+   ``--extras=``        (done)
+   ``--extras-<LANG>=`` (done)
 
 HOW TO USE WITH VI
 ------------------

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -19,12 +19,12 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-The **@CTAGS_NAME_EXECUTABLE@** and **@ETAGS_NAME_EXECUTABLE@** programs
+The *@CTAGS_NAME_EXECUTABLE@* and *@ETAGS_NAME_EXECUTABLE@* programs
 (hereinafter collectively referred to as @CTAGS_NAME_EXECUTABLE@,
 except where distinguished) generate an index (or "tag") file for a
-variety of **language objects** found in **source file(s)**. This tag file allows
+variety of *language objects* found in *source file(s)*. This tag file allows
 these items to be quickly and easily located by a text editor or other
-utilities (**client tools**). A **tag** signifies a language object for which an index entry is
+utilities (*client tools*). A *tag* signifies a language object for which an index entry is
 available (or, alternatively, the index entry created for that object).
 
 Alternatively, @CTAGS_NAME_EXECUTABLE@ can generate a cross reference
@@ -37,14 +37,14 @@ jump to the file and line which defines the name. See the manual of your
 favorite editor about utilizing @CTAGS_NAME_EXECUTABLE@ command and
 the tag index files in the editor.
 
-@CTAGS_NAME_EXECUTABLE@ is capable of generating different **kinds** of tags
-for each of many different **languages**. For a complete list of supported
+@CTAGS_NAME_EXECUTABLE@ is capable of generating different *kinds* of tags
+for each of many different *languages*. For a complete list of supported
 languages, the names by which they are recognized, and the kinds of tags
 which are generated for each, see the ``--list-languages`` and ``--list-kinds-full``
 options.
 
-This man page describes **Universal Ctags**, an implementation of ctags
-derived from **Exuberant Ctags**. The major incompatible changes between
+This man page describes *Universal Ctags*, an implementation of ctags
+derived from *Exuberant Ctags*. The major incompatible changes between
 Universal Ctags and Exuberant Ctags are enumerated in
 ctags-incompatibilities(7).
 
@@ -63,7 +63,7 @@ COMMAND LINE INTERFACE
 
 Despite the wealth of available options, defaults are set so that
 @CTAGS_NAME_EXECUTABLE@ is most commonly executed without any options (e.g.
-"@CTAGS_NAME_EXECUTABLE@ \*", or "@CTAGS_NAME_EXECUTABLE@ -R"), which will
+"``@CTAGS_NAME_EXECUTABLE@ *``", or "``@CTAGS_NAME_EXECUTABLE@ -R``"), which will
 create a tag file in the current directory for all recognized source
 files. The options described below are provided merely to allow custom
 tailoring to meet special needs.
@@ -72,13 +72,13 @@ Note that spaces separating the single-letter options from their parameters
 are optional.
 
 Note also that the boolean parameters to the long form options (those
-beginning with "--" and that take a "[=yes|no]" parameter) may be omitted,
-in which case "=yes" is implied. (e.g. ``--sort`` is equivalent to ``--sort=yes``).
-Note further that "=1", "=on", and "=true" are considered synonyms for "=yes",
-and that "=0", "=off", and "=false" are considered synonyms for "=no".
+beginning with "``--``" and that take a "``[=yes|no]``" parameter) may be omitted,
+in which case "``=yes``" is implied. (e.g. "``--sort``" is equivalent to "``--sort=yes``").
+Note further that "``=1``", "``=on``", and "``=true``" are considered synonyms for "``=yes``",
+and that "``=0``", "``=off``", and "``=false``" are considered synonyms for "``=no``".
 
 Some options are either ignored or useful only when used while running in
-etags mode (see -e option). Such options will be noted.
+etags mode (see ``-e`` option). Such options will be noted.
 
 Most options may appear anywhere on the command line, affecting only those
 files which follow the option. A few options, however, must appear
@@ -124,7 +124,7 @@ adjust the output of the most of ``--list-...`` options.
 The default setting (``--with-list-header=yes`` and ``--machinable=no``)
 is for using interactively from a terminal. The header that explains
 the meaning of columns is simply added to the output, and each column is
-aligned in all lines. The header line starts with a hash ('#') character.
+aligned in all lines. The header line starts with a hash ('``#``') character.
 
 For scripting in a client tool, ``--with-list-header=no`` and
 ``--machinable=yes`` may be useful. The header is not added to the
@@ -156,20 +156,20 @@ Input/Output File Options
 	be specified as many times as desired. For each file name considered
 	by @CTAGS_NAME_EXECUTABLE@, each pattern specified using this option
 	will be compared against both the complete path (e.g.
-	some/path/base.ext) and the base name (e.g. base.ext) of the file, thus
+	``some/path/base.ext``) and the base name (e.g. ``base.ext``) of the file, thus
 	allowing patterns which match a given file name irrespective of its
 	path, or match only a specific path. If appropriate support is available
 	from the runtime library of your C compiler, then pattern may
 	contain the usual shell wildcards (not regular expressions) common on
 	Unix (be sure to quote the option parameter to protect the wildcards from
 	being expanded by the shell before being passed to @CTAGS_NAME_EXECUTABLE@;
-	also be aware that wildcards can match the slash character, '/').
+	also be aware that wildcards can match the slash character, '``/``').
 	You can determine if shell wildcards are available on your platform by
 	examining the output of the ``--list-features`` option, which will include
-	"wildcards" in the compiled feature list; otherwise, pattern is matched
+	``wildcards`` in the compiled feature list; otherwise, pattern is matched
 	against file names using a simple textual comparison.
 
-	If pattern begins with the character '@', then the rest of the string
+	If pattern begins with the character '``@``', then the rest of the string
 	is interpreted as a file name from which to read exclusion patterns,
 	one per line. If pattern is empty, the list of excluded patterns is
 	cleared.
@@ -187,10 +187,10 @@ Input/Output File Options
 	affects the files and directories that are excluded by the pattern
 	specified with ``--exclude=`` option.
 
-	For an example, you want @CTAGS_NAME_EXAMPLE@ to ignore all files
-	under "foo" directory except "foo/main.c", use the following command
-	line: "--exclude=foo/* --exclude-exception=foo/main.c". Don't forget
-	shell quoting for '*'.
+	For an example, you want @CTAGS_NAME_EXECUTABLE@ to ignore all files
+	under ``foo`` directory except ``foo/main.c``, use the following command
+	line: ``--exclude=foo/* --exclude-exception=foo/main.c``. Don't forget
+	shell quoting for '``*``'.
 
 ``--filter[=yes|no]``
 	Makes @CTAGS_NAME_EXECUTABLE@ behave as a filter, reading source
@@ -215,10 +215,10 @@ Input/Output File Options
 ``--recurse[=yes|no]``
 	Recurse into directories encountered in the list of supplied files.
 	If the list of supplied files is empty and no file list is specified with
-	the -L option, then the current directory (i.e. ".") is assumed.
-	Symbolic links are followed. If you don't like these behaviors, either
-	explicitly specify the files or pipe the output of find(1) into
-	@CTAGS_NAME_EXECUTABLE@ -L- instead. Note: This option is not supported on
+	the ``-L`` option, then the current directory (i.e. '``.``') is assumed.
+	Symbolic links are followed by default. If you don't like these behaviors, either
+	explicitly specify the files or pipe the output of ``find(1)`` into
+	``@CTAGS_NAME_EXECUTABLE@ -L -`` instead. Note: This option is not supported on
 	all platforms at present. It is available if the output of the ``--help``
 	option includes this option. See, also, the ``--exclude`` and
 	``--maxdepth`` to limit recursion.
@@ -228,7 +228,7 @@ Input/Output File Options
 
 ``-L file``
 	Read from file a list of file names for which tags should be generated.
-	If file is specified as "-", then file names are read from standard
+	If file is specified as '``-``', then file names are read from standard
 	input. File names read using this option are processed following file
 	names appearing on the command line. Options are also accepted in this
 	input. If this option is specified more than once, only the last will
@@ -241,25 +241,25 @@ Input/Output File Options
 ``--append[=yes|no]``
 	Indicates whether tags generated from the specified files should be
 	appended to those already present in the tag file or should replace them.
-	This option is "no" by default. This option must appear before the
+	This option is ``no`` by default. This option must appear before the
 	first file name.
 
 ``-a``
 	Equivalent to ``--append``.
 
 ``-f tagfile``
-	Use the name specified by tagfile for the tag file (default is "tags",
-	or "TAGS" when running in etags mode). If tagfile is specified as "-",
+	Use the name specified by tagfile for the tag file (default is "``tags``",
+	or "``TAGS``" when running in etags mode). If tagfile is specified as '``-``',
 	then the tags are written to standard output instead. @CTAGS_NAME_EXECUTABLE@
 	will stubbornly refuse to take orders if tagfile exists and
 	its first line contains something other than a valid tags line. This
-	will save your neck if you mistakenly type "@CTAGS_NAME_EXECUTABLE@ -f
-	\*.c", which would otherwise overwrite your first C file with the tags
+	will save your neck if you mistakenly type ``@CTAGS_NAME_EXECUTABLE@ -f
+	*.c``, which would otherwise overwrite your first C file with the tags
 	generated by the rest! It will also refuse to accept a multi-character
-	file name which begins with a '-' (dash) character, since this most
+	file name which begins with a '``-``' (dash) character, since this most
 	likely means that you left out the tag file name and this option tried to
 	grab the next option as the file name. If you really want to name your
-	output tag file "-ugly", specify it as "./-ugly". This option must
+	output tag file ``-ugly``, specify it as ``-f ./-ugly``. This option must
 	appear before the first file name. If this option is specified more
 	than once, only the last will apply.
 
@@ -287,15 +287,15 @@ Output Format Options
 	values for level are 1 or 2. Level 1 specifies the original tag file
 	format and level 2 specifies a new extended format containing extension
 	fields (but in a manner which retains backward-compatibility with
-	original vi(1) implementations). The default level is 2. This option
+	original ``vi(1)`` implementations). The default level is 2. This option
 	must appear before the first file name. [Ignored in etags mode]
 
 ``--output-format=u-ctags|e-ctags|etags|xref|json``
-	Specify the output format. The default is "u-ctags".
-	See tags(5) for "u-ctags" and "e-ctags".
-	See ``-e`` for "etags", and ``-x`` for "xref".
-	"json" is experimental format, and available only if
-	the ctags executable is built with libjansson.
+	Specify the output format. The default is ``u-ctags``.
+	See tags(5) for ``u-ctags`` and ``e-ctags``.
+	See ``-e`` for ``etags``, and ``-x`` for ``xref``.
+	``json`` is experimental format, and available only if
+	the ctags executable is built with ``libjansson``.
 	This option must appear before the first file name.
 
 .. TODO: convert output-json.rst to ctags-json-output.1.rst (ctags-json-output(1)).
@@ -318,19 +318,19 @@ Output Format Options
 	file which defines the tag. No tag file is written and all options
 	affecting tag file output will be ignored. Example applications for this
 	feature are generating a listing of all functions located in a source
-	file (e.g. "@CTAGS_NAME_EXECUTABLE@ -x --kinds-c=f file"), or generating
+	file (e.g. ``@CTAGS_NAME_EXECUTABLE@ -x --kinds-c=f file``), or generating
 	a list of all externally visible global variables located in a source
-	file (e.g. "@CTAGS_NAME_EXECUTABLE@ -x --kinds-c=v --extras=-F file").
+	file (e.g. ``@CTAGS_NAME_EXECUTABLE@ -x --kinds-c=v --extras=-F file``).
 	This option must appear before the first file name.
 
 ``--sort[=yes|no|foldcase]``
 	Indicates whether the tag file should be sorted on the tag name
-	(default is yes). Note that the original vi(1) required sorted tags.
+	(default is yes). Note that the original ``vi(1)`` required sorted tags.
 	The foldcase value specifies case insensitive (or case-folded) sorting.
 	Fast binary searches of tag files sorted with case-folding will require
 	special support from tools using tag files, such as that found in the
 	@CTAGS_NAME_EXECUTABLE@ readtags library, or Vim version 6.2 or higher
-	(using "set ignorecase"). This option must appear before the first file
+	(using ``set ignorecase``). This option must appear before the first file
 	name. [Ignored in etags mode]
 
 ``-u``
@@ -347,7 +347,7 @@ Output Format Options
 	encoding to the encoding specified by ``--output-encoding=encoding``.
 
 ``--input-encoding-<LANG>=encoding``
-	Specifies a specific input encoding for ``LANG``. It overrides the global
+	Specifies a specific input encoding for *<LANG>*. It overrides the global
 	default value given with ``--input-encoding``.
 
 ``--output-encoding=encoding``
@@ -357,7 +357,7 @@ Output Format Options
 
 	In addition ``encoding`` is specified at the top the tags file as the
 	value for the ``TAG_FILE_ENCODING`` pseudo-tag. The default value of
-	``encoding`` is UTF-8.
+	``encoding`` is ``UTF-8``.
 
 .. _option_lang_mapping:
 
@@ -369,7 +369,7 @@ Language Selection and Mapping Options
 	determined (see "`Determining file language`_", above). This option forces the specified
 	*language* (case-insensitive; either built-in or user-defined) to be used
 	for every supplied file instead of automatically selecting the language
-	based upon its extension. In addition, the special value "auto" indicates
+	based upon its extension. In addition, the special value ``auto`` indicates
 	that the language should be automatically selected (which effectively
 	disables this option).
 
@@ -377,11 +377,11 @@ Language Selection and Mapping Options
 	Specifies the languages for which tag generation is enabled, with *list*
 	containing a comma-separated list of language names (case-insensitive;
 	either built-in or user-defined). If the first language of *list* is not
-	preceded by either a '+' or '-', the current list (the current settings
+	preceded by either a '``+``' or '``-``', the current list (the current settings
 	of enabled/disabled languages managed in @CTAGS_NAME_EXECUTABLE@ internally)
-	will be cleared before adding or removing the languages in *list*. Until a '-' is
+	will be cleared before adding or removing the languages in *list*. Until a '``-``' is
 	encountered, each language in the *list* will be added to the current list.
-	As either the '+' or '-' is encountered in the *list*, the languages
+	As either the '``+``' or '``-``' is encountered in the *list*, the languages
 	following it are added or removed from the current list, respectively.
 	Thus, it becomes simple to replace the current list with a new one, or
 	to add or remove languages from the current list.
@@ -392,7 +392,7 @@ Language Selection and Mapping Options
 	languages, including user-defined languages, are enabled unless explicitly
 	disabled using this option. Language names included in list may be any
 	built-in language or one previously defined with ``--langdef``. The default
-	is "all", which is also accepted as a valid argument. See the
+	is ``all``, which is also accepted as a valid argument. See the
 	``--list-languages`` option for a list of the all (built-in and user-defined)
 	language names.
 
@@ -400,16 +400,16 @@ Language Selection and Mapping Options
 	specified with different arguments multiple times in a command line.
 
 ``--alias-<LANG>=[+|-]aliasPattern``
-	Adds ('+') or removes ('-') an alias pattern to a language specified
+	Adds ('``+``') or removes ('``-``') an alias pattern to a language specified
 	with *<LANG>*. @CTAGS_NAME_EXECUTABLE@ refers to the alias pattern in
 	"`Determining file language`_" stage.
 
-	The parameter aliasPattern is not a list. Use this option multiple
+	The parameter ``aliasPattern`` is not a list. Use this option multiple
 	times in a command line to add or remove multiple alias
 	patterns.
 
-	To restore the default language aliases, specify "default" as the
-	parameter aliasPattern. Using "all" for *<LANG>* has meaning in
+	To restore the default language aliases, specify ``default`` as the
+	parameter aliasPattern. Using ``all`` for *<LANG>* has meaning in
 	following two cases:
 
 	``--alias-all=``
@@ -428,11 +428,11 @@ Language Selection and Mapping Options
 ``--langmap=map[,map[...]]``
 	Controls how file names are mapped to languages (see the ``--list-maps``
 	option). Each comma-separated *map* consists of the language name (either
-	a built-in or user-defined language), a colon, and a list of **file
-	extensions** and/or **file name patterns**. A file extension is specified by
-	preceding the extension with a period (e.g. ".c"). A file name pattern
+	a built-in or user-defined language), a colon, and a list of *file
+	extensions* and/or *file name patterns*. A file extension is specified by
+	preceding the extension with a period (e.g. ``.c``). A file name pattern
 	is specified by enclosing the pattern in parentheses (e.g.
-	"([Mm]akefile)").
+	``([Mm]akefile)``).
 
 	If appropriate support is available from the runtime
 	library of your C compiler, then the file name pattern may contain the usual
@@ -440,7 +440,7 @@ Language Selection and Mapping Options
 	protect the wildcards from being expanded by the shell before being
 	passed to @CTAGS_NAME_EXECUTABLE@). You can determine if shell wildcards
 	are available on your platform by examining the output of the
-	``--list-features`` option, which will include "wildcards" in the compiled
+	``--list-features`` option, which will include ``wildcards`` in the compiled
 	feature list; otherwise, the file name patterns are matched against
 	file names using a simple textual comparison.
 
@@ -448,24 +448,24 @@ Language Selection and Mapping Options
 	it will first be unmapped from any other languages. (``--map-<LANG>``
 	option provides more fine-grained control.)
 
-	If the first character in a map is a plus sign ('+'), then the extensions and
+	If the first character in a map is a plus sign ('``+``'), then the extensions and
 	file name patterns in that map will be appended to the current map
 	for that language; otherwise, the map will replace the current map.
-	For example, to specify that only files with extensions of .c and .x are
-	to be treated as C language files, use "--langmap=c:.c.x"; to also add
-	files with extensions of .j as Java language files, specify
-	"--langmap=c:.c.x,java:+.j". To map makefiles (e.g. files named either
-	"Makefile", "makefile", or having the extension ".mak") to a language
-	called "make", specify "--langmap=make:([Mm]akefile).mak". To map files
+	For example, to specify that only files with extensions of ``.c`` and ``.x`` are
+	to be treated as C language files, use ``--langmap=c:.c.x``; to also add
+	files with extensions of ``.j`` as Java language files, specify
+	``--langmap=c:.c.x,java:+.j``. To map makefiles (e.g. files named either
+	``Makefile``, ``makefile``, or having the extension ``.mak``) to a language
+	called ``make``, specify ``--langmap=make:([Mm]akefile).mak``. To map files
 	having no extension, specify a period not followed by a non-period
-	character (e.g. ".", "..x", ".x.").
+	character (e.g. '``.``', ``..x``, ``.x.``).
 
 	To clear the mapping for a
 	particular language (thus inhibiting automatic generation of tags for
-	that language), specify an empty extension list (e.g. "--langmap=fortran:").
+	that language), specify an empty extension list (e.g. ``--langmap=fortran:``).
 	To restore the default language mappings for a particular language,
-	supply the keyword "default" for the mapping. To specify restore the
-	default language mappings for all languages, specify "--langmap=default".
+	supply the keyword ``default`` for the mapping. To specify restore the
+	default language mappings for all languages, specify ``--langmap=default``.
 
 	Note that file name patterns are tested before file extensions when inferring
 	the language of a file. This order of Universal Ctags is different from
@@ -481,12 +481,12 @@ Language Selection and Mapping Options
 	``--langmap`` option handle only *1:1 map*, only one language
 	mapping to one file name pattern or file extension.  A typical N:1
 	map is seen in C++ and ObjectiveC language; both languages have
-	a map to ".h" as a file extension.
+	a map to ``.h`` as a file extension.
 
-	A file extension is specified by preceding the extension with a period (e.g. ".c").
+	A file extension is specified by preceding the extension with a period (e.g. ``.c``).
 	A file name pattern is specified by enclosing the pattern in parentheses (e.g.
-	"([Mm]akefile)"). A prefixed plus ('+') sign is for adding, and
-	minus ('-') is for removing. No prefix means replacing the map of *<LANG>*.
+	``([Mm]akefile)``). A prefixed plus ('``+``') sign is for adding, and
+	minus ('``-``') is for removing. No prefix means replacing the map of *<LANG>*.
 
 	Unlike ``--langmap``, *extension* (or *pattern*) is not a list.
 	``--map-<LANG>`` takes one *extension* (or *pattern*). However,
@@ -498,20 +498,20 @@ Language Selection and Mapping Options
 Tags File Contents Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``--excmd=type``
-	Determines the type of EX command used to locate tags in the source
+	Determines the type of ``EX`` command used to locate tags in the source
 	file. [Ignored in etags mode]
 
-	The valid values for type (either the entire word or the first letter
+	The valid values for *type* (either the entire word or the first letter
 	is accepted) are:
 
-	number
+	``number``
 		Use only line numbers in the tag file for locating tags. This has
 		four advantages:
 
 		1.	Significantly reduces the size of the resulting tag file.
 		2.	Eliminates failures to find tags because the line defining the
 			tag has changed, causing the pattern match to fail (note that
-			some editors, such as vim, are able to recover in many such
+			some editors, such as ``vim``, are able to recover in many such
 			instances).
 		3.	Eliminates finding identical matching, but incorrect, source
 			lines (see "`BUGS`_").
@@ -528,13 +528,13 @@ Tags File Contents Options
 		to which it is applied is not subject to change. Selecting this
 		option type causes the following options to be ignored: ``-BF``.
 
-	pattern
+	``pattern``
 		Use only search patterns for all tags, rather than the line numbers
 		usually used for macro definitions. This has the advantage of
 		not referencing obsolete line numbers when lines have been added or
 		removed since the tag file was generated.
 
-	mixed
+	``mixed``
 		In this mode, patterns are generally used with a few exceptions.
 		For C, line numbers are used for macro definition tags. This was
 		the default format generated by the original ctags and is, therefore,
@@ -543,7 +543,7 @@ Tags File Contents Options
 		are generally identical, making pattern searches useless
 		for finding all matches.
 
-	combine
+	``combine``
 		Concatenate the line number and pattern with a semicolon in between.
 
 ``-n``
@@ -558,10 +558,10 @@ Tags File Contents Options
 
 	The parameter flags is a set of one-letter flags (and/or long-name flags), each
 	representing one kind of extra tag entry to include in the tag file.
-	If flags is preceded by either the '+' or '-' character, the effect of
+	If flags is preceded by either the '``+``' or '``-``' character, the effect of
 	each flag is added to, or removed from, those currently enabled;
 	otherwise the flags replace any current settings. All entries are
-	included  if '*' is given.
+	included  if '``*``' is given.
 
 	This ``--extras=`` option is for controlling extras common in all
 	languages (or language-independent extras).  Universal Ctags also
@@ -571,7 +571,7 @@ Tags File Contents Options
 
 	The meaning of major extras is as follows (one-letter flag/long-name flag):
 
-	/anonymous
+	none/``anonymous``
 		Include an entry for the language object that has no name like lambda
 		function. This extra has no one-letter flag and is enabled by
 		default. The extra tag is useful as a placeholder to fill scope fields
@@ -583,9 +583,9 @@ Tags File Contents Options
 				double x, y;
 			} p = { .x = 0.0, .y = 0.0 };
 
-		"x" and "y" are the members of a structure. When filling the scope
+		'``x``' and '``y``' are the members of a structure. When filling the scope
 		fields for them, @CTAGS_NAME_EXECUTABLE@ has trouble because the struct
-		where "x" and "y" belong to has no name. For overcoming the trouble,
+		where '``x``' and '``y``' belong to has no name. For overcoming the trouble,
 		@CTAGS_NAME_EXECUTABLE@ generates an anonymous extra tag for the struct
 		and fills the scope fields with the name of the extra tag.
 
@@ -596,20 +596,20 @@ Tags File Contents Options
 			x	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
 			y	input.c	/^	double x, y;$/;"	m	struct:__anon9f26d2460108
 
-		The above tag output has "__anon9f26d2460108" as an anonymous extra tag.
-		The typeref field of "p" also receives the benefit of it.
+		The above tag output has ``__anon9f26d2460108`` as an anonymous extra tag.
+		The typeref field of '``p``' also receives the benefit of it.
 
-	F/fileScope
+	``F``/``fileScope``
 		Indicates whether tags scoped only for a single file (i.e. tags which
 		cannot be seen outside of the file in which they are defined, such as
-		language objects with "static" modifier of C language) should be included
+		language objects with ``static`` modifier of C language) should be included
 		in the output. See, also, the ``-h`` option. This option is enabled by
 		default. This is the replacement for ``--file-scope`` option of
 		Exuberant Ctags.
 
-	f/inputFile
+	``f``/``inputFile``
 		Include an entry for the base file name of every source file
-		(e.g. "example.c"), which addresses the first line of the file.
+		(e.g. ``example.c``), which addresses the first line of the file.
 		This flag is the replacement for ``--file-tags`` hidden option of
 		Exuberant Ctags.
 
@@ -617,19 +617,19 @@ Tags File Contents Options
 		attached to the tag. (However, @CTAGS_NAME_EXAMPLE@ omits the ``end:`` field
 		if no newline is in the file like an empty file.)
 
-		By default, @CTAGS_NAME_EXAMPLE@ doesn't create the "f/inputFile" extra
+		By default, @CTAGS_NAME_EXAMPLE@ doesn't create the ``f/inputFile`` extra
 		tag for the source file when @CTAGS_NAME_EXAMPLE@ doesn't find a parser
-		for it. Enabling "Unknown" parser with "--languages=+Unknown" forces
+		for it. Enabling ``Unknown`` parser with ``--languages=+Unknown`` forces
 		@CTAGS_NAME_EXAMPLE@ to create the extra tags for any source files.
 
-		The etags mode enables the "Unknown" parser implicitly.
+		The etags mode enables the ``Unknown`` parser implicitly.
 
-	p/pseudo
+	``p``/``pseudo``
 		Include pseudo-tags. Enabled by default unless the tag file is
 		written to standard output. See ctags-client-tools(7) about
 		the detail of pseudo-tags.
 
-	q/qualified
+	``q``/``qualified``
 		Include an extra class-qualified or namespace-qualified tag entry
 		for each tag which is a member of a class or a namespace.
 
@@ -642,15 +642,15 @@ Tags File Contents Options
 		from which the tag was derived (using a form that is most
 		natural for how qualified calls are specified in the
 		language). For C++ and Perl, it is in the form
-		"class::member"; for Eiffel and Java, it is in the form
-		"class.member".
+		``class::member``; for Eiffel and Java, it is in the form
+		``class.member``.
 
 		Note: Using backslash characters as separators forming
 		qualified name in PHP. However, in tags output of
 		Universal Ctags, a backslash character in a name is escaped
 		with a backslash character. See tags(5) about the escaping.
 
-	r/reference
+	``r``/``reference``
 		Include reference tags. See "`TAG ENTRIES`_" about reference tags.
 
 	Inquire the output of ``--list-extras`` option for the other minor
@@ -658,18 +658,18 @@ Tags File Contents Options
 
 ``--extras-<LANG>=[+|-]flags|*``
 	Specifies whether to include extra tag entries for certain kinds of
-	information for language <LANG>. Universal Ctags
+	information for language *<LANG>*. Universal Ctags
 	introduces language-specific extras. See "`Language-specific fields and
 	extras`_" about the concept. This option is for controlling them.
 
-	Specifies "all" as <LANG> to apply the parameter flags to all
-	languages; all extras are enabled with specifying '*' as the
+	Specifies ``all`` as *<LANG>* to apply the parameter flags to all
+	languages; all extras are enabled with specifying '``*``' as the
 	parameter flags. If specifying nothing as the parameter flags
 	(``--extras-all=``), all extras are disabled. These two combinations
 	are useful for testing.
 
 	Check the output of the ``--list-extras=<LANG>`` option for the
-	extras of specific language <LANG>.
+	extras of specific language *<LANG>*.
 
 ``--extra=[+|-]flags|*``
 	Equivalent to ``--extras=[+|-]flags|*``, which was introduced to
@@ -683,13 +683,13 @@ Tags File Contents Options
 	the tag entries (see "`TAG FILE FORMAT`_" second, and "`Fields`_"
 	subsection , for more information).
 
-	The parameter flags is a set of one-letter flags (and/or long-name flags),
+	The parameter ``flags`` is a set of one-letter flags (and/or long-name flags),
 	each representing one type of extension field to include.
-	Each letter or group of letters may be preceded by either '+' to add it
-	to the default set, or '-' to exclude it. In the absence of any
-	preceding '+' or '-' sign, only those fields explicitly listed in flags
+	Each letter or group of letters may be preceded by either '``+``' to add it
+	to the default set, or '``-``' to exclude it. In the absence of any
+	preceding '``+``' or '``-``' sign, only those fields explicitly listed in flags
 	will be included in the output (i.e. overriding the default set). All
-	fields are included if '*' is given. This option is ignored if the
+	fields are included if '``*``' is given. This option is ignored if the
 	option ``--format=1`` (legacy tag file format) has been specified.
 
 	This ``--fields=`` option is for controlling fields common in all
@@ -701,64 +701,64 @@ Tags File Contents Options
 
 	The meaning of major fields is as follows (one-letter flag/long-name flag):
 
-	a/access
+	``a``/``access``
 		Access (or export) of class members
 
-	e/end
+	``e``/``end``
 		End lines of various items
 
-	f/file
+	``f``/``file``
 		File-restricted scoping. Enabled by default.
 
-	i/inherits
+	``i``/``inherits``
 		Inheritance information.
 
-	k
+	``k``
 		Kind of tag as one-letter. Enabled by default.
 		Exceptionally this has no field name.
-		See also z/kind flag.
+		See also ``z``/``kind`` flag.
 
-	K
+	``K``
 		Kind of tag as long-name.
 		Exceptionally this has no field name.
-		See also z/kind flag.
+		See also ``z``/``kind`` flag.
 
-	l/language
+	``l``/``language``
 		Language of source file containing tag
 
-	m/implementation
+	``m``/``implementation``
 		Implementation information
 
-	n/line
+	``n``/``line``
 		Line number of tag definition
 
-	p/scopeKind
+	``p``/``scopeKind``
 		Kind of scope as long-name
 
-	r/roles
+	``r``/``roles``
 		Roles assigned to the tag.
-		For a definition tag, this field takes "def" as a value.
+		For a definition tag, this field takes ``def`` as a value.
 
-	s
+	``s``
 		Scope of tag definition. Enabled by default.
 		Exceptionally this has no name.
-		See also Z flag.
+		See also ``Z`` flag.
 
 		.. TODO? implement "scope" of Z/scope flag.
 
-	S/signature
+	``S``/``signature``
 		Signature of routine (e.g. prototype or parameter list)
 
-	t/typeref
+	``t``/``typeref``
 		Type and name of a variable, typedef or return type of
-		callable like function as "typeref:" field.
+		callable like function as ``typeref:`` field.
 		Enabled by default.
 
-	z/kind
-		Include the "kind:" key in kind field
+	``z``/``kind``
+		Include the ``kind:`` key in kind field
 
-	Z
-		Include the "scope:" key in scope field.
+	``Z``
+		Include the ``scope:`` key in scope field.
 		Exceptionally this has no name.
 
 	Check the output of the ``--list-fields`` option for the other minor
@@ -770,41 +770,41 @@ Tags File Contents Options
 	supports language-specific fields. (See "`Language-specific fields and
 	extras`_" about the concept). This option is for controlling them.
 
-	Specify "all" as <LANG> to apply the parameter flags to all
-	fields; all fields are enabled with specifying '*' as the
-	parameter flags. If specifying nothing as the parameter flags
+	Specify ``all`` as *<LANG>* to apply the parameter ``flags`` to all
+	languages; all fields are enabled with specifying '``*``' as the
+	parameter flags. If specifying nothing as the parameter ``flags``
 	(``--fields-all=``), all fields are disabled. These two combinations
 	are useful for testing.
 
 ``--kinds-<LANG>=[+|-]kinds|*``
 	Specifies a list of language-specific kinds of tags (or kinds) to
-	include in the output file for a particular language, where <LANG> is
+	include in the output file for a particular language, where *<LANG>* is
 	case-insensitive and is one of the built-in language names (see the
-	``--list-languages`` option for a complete list). The parameter kinds is a group
+	``--list-languages`` option for a complete list). The parameter ``kinds`` is a group
 	of one-letter flags (and/or long-name flags) designating kinds of tags (particular to the language)
 	to either include or exclude from the output. The specific sets of
 	flags recognized for each language, their meanings and defaults may be
 	list using the ``--list-kinds-full`` option. Each letter or group of letters
-	may be preceded by either '+' to add it to, or '-' to remove it from,
-	the default set. In the absence of any preceding '+' or '-' sign, only
+	may be preceded by either '``+``' to add it to, or '``-``' to remove it from,
+	the default set. In the absence of any preceding '``+``' or '``-``' sign, only
 	those kinds explicitly listed in kinds will be included in the output
 	(i.e. overriding the default for the specified language).
 
-	Specify '*' as the parameter to include all kinds implemented
-	in <LANG> in the output. Furthermore if "all" is given as <LANG>,
-	specification of the parameter kinds affects all languages defined
-	in @CTAGS_NAME_EXECUTABLE@. Giving "all" makes sense only when '*' or
-	'F' is given as the parameter kinds.
+	Specify '``*``' as the parameter to include all kinds implemented
+	in *<LANG>* in the output. Furthermore if ``all`` is given as *<LANG>*,
+	specification of the parameter ``kinds`` affects all languages defined
+	in @CTAGS_NAME_EXECUTABLE@. Giving ``all`` makes sense only when '``*``' or
+	'``F``' is given as the parameter ``kinds``.
 
 	As an example for the C language, in order to add prototypes and
 	external variable declarations to the default set of tag kinds,
-	but exclude macros, use "--kinds-c=+px-d"; to include only tags for
-	functions, use "--kinds-c=f".
+	but exclude macros, use ``--kinds-c=+px-d``; to include only tags for
+	functions, use ``--kinds-c=f``.
 
 	Some kinds of C and C++ languages are synchronized; enabling
 	(or disabling) a kind in one language enables the kind having
 	the same one-letter and long-name in the other language. See also the
-	description of MASTER column of ``--list-kinds-full``.
+	description of ``MASTER`` column of ``--list-kinds-full``.
 
 ``--<LANG>-kinds=[+|-]kinds|*``
 	This option is obsolete. Use ``--kinds-<LANG>=...`` instead.
@@ -814,7 +814,7 @@ Tags File Contents Options
 	``--list-params``.
 
 ``--pattern-length-limit=N``
-	Cutoff patterns of tag entries after N characters. Disable by setting to 0
+	Cutoff patterns of tag entries after '``N``' characters. Disable by setting to 0
 	(default is 96). Specifying 0 as *N* results no truncation.
 
 	An input source file with long lines and multiple tag matches per
@@ -836,11 +836,11 @@ Tags File Contents Options
 	up to an extra 3 bytes above the limit.
 
 ``--pseudo-tags=[+|-]ptag``, ``--pseudo-tags=*``
-	Enable/disable emitting pseudo-tag named ptag.
-	If \* is given, enable emitting all pseudo-tags.
+	Enable/disable emitting pseudo-tag named ``ptag``.
+	If '``*``' is given, enable emitting all pseudo-tags.
 
 ``--put-field-prefix``
-	Put "UCTAGS" as prefix for the name of fields newly introduced in
+	Put ``UCTAGS`` as prefix for the name of fields newly introduced in
 	Universal Ctags.
 
 	Some fields are newly introduced in Universal Ctags and more will
@@ -859,56 +859,56 @@ Tags File Contents Options
 		$ @CTAGS_NAME_EXECUTABLE@ --put-field-prefix --fields='{line}{end}' -o - /tmp/hello.c
 		main	/tmp/hello.c	/^main(int argc, char **argv)$/;"	f	line:3	UCTAGSend:6
 
-	In the above example, the prefix is put to "end" field which is
+	In the above example, the prefix is put to ``end`` field which is
 	newly introduced in Universal Ctags.
 
 ``--roles-<LANG>.<KIND>=[+|-]roles``, ``--roles-<LANG>.<KIND>=*|``
-    Specifies a list of kind-specific roles of tags to include in the
+	Specifies a list of kind-specific roles of tags to include in the
 	output file for a particular language.
-	<KIND> specifies the kind where the role is defined.
-	<LANG> specifies the language where the kind is defined.
-	Each role in roles must be surrounded by braces (e.g. "{system}"
+	*<KIND>* specifies the kind where the ``roles`` are defined.
+	*<LANG>* specifies the language where the kind is defined.
+	Each role in ``roles`` must be surrounded by braces (e.g. ``{system}``
 	for a role named "system").
 
-	Like ``--kinds-<LANG>`` option, '+' is for adding the role to the
-	list, and '-' is for removing from the list. '*' is for including
+	Like ``--kinds-<LANG>`` option, '``+``' is for adding the role to the
+	list, and '``-``' is for removing from the list. '``*``' is for including
 	all roles of the kind to the list. 	The option with no argument
 	makes the list empty.
 
 	Both a one-letter flag or a long name flag surrounded by braces are
-	acceptable for specifying a kind (e.g. "--roles-C.h=+{system}{local}"
-	or "--roles-C.{header}=+{system}{local}").  '*' can be used for <KIND>
+	acceptable for specifying a kind (e.g. ``--roles-C.h=+{system}{local}``
+	or ``--roles-C.{header}=+{system}{local}``).  '``*``' can be used for *<KIND>*
 	only for adding/removing all roles of all kinds in a language to/from
-	the list (e.g.  "--roles-C.*=*" or "--roles-C.*=").
+	the list (e.g.  ``--roles-C.*=*`` or ``--roles-C.*=``).
 
-	"all" can be used for <LANG> only for adding/removing all roles of
+	``all`` can be used for *<LANG>* only for adding/removing all roles of
 	all kinds in all languages to/from the list
-	(e.g.  "--roles-all.*=*" or "--roles-all.*=").
+	(e.g.  ``--roles-all.*=*`` or ``--roles-all.*=``).
 
 ``--tag-relative[=yes|no|always|never]``
-	The yes value indicates that the file paths recorded in the tag file should be
+	The ``yes`` value indicates that the file paths recorded in the tag file should be
 	relative to the directory containing the tag file, rather than relative
 	to the current directory, unless the files supplied on the command line
 	are specified with absolute paths. This option must appear before the
-	first file name. The default is yes when running in etags mode (see
-	the ``-e`` option), no otherwise.
-	The always value indicates the recorded file paths should be relative
+	first file name. The default is ``yes`` when running in etags mode (see
+	the ``-e`` option), ``no`` otherwise.
+	The ``always`` value indicates the recorded file paths should be relative
 	even if source file names are passed in with absolute paths.
-	The never value indicates the recorded file paths should be absolute
+	The ``never`` value indicates the recorded file paths should be absolute
 	even if source file names are passed in with relative paths.
 
 ``--use-slash-as-filename-separator[=yes|no]``
 	Uses slash character as filename separators instead of backslash
 	character when printing ``input:`` field.
 	This option is available on MSWindows only.
-	The default is yes for the default "u-ctags" output format, and
-	no for the other formats.
+	The default is ``yes`` for the default "u-ctags" output format, and
+	``no`` for the other formats.
 
 ``-B``
-	Use backward searching patterns (e.g. ?pattern?). [Ignored in etags mode]
+	Use backward searching patterns (e.g. ``?pattern?``). [Ignored in etags mode]
 
 ``-F``
-	Use forward searching patterns (e.g. /pattern/) (default). [Ignored
+	Use forward searching patterns (e.g. ``/pattern/``) (default). [Ignored
 	in etags mode]
 
 Option File Options
@@ -916,33 +916,33 @@ Option File Options
 ``--options=pathname``
 	Read additional options from file or directory.
 
-	@CTAGS_NAME_EXECUTABLE@ searches *pathname* in optlib path list
+	@CTAGS_NAME_EXECUTABLE@ searches ``pathname`` in the optlib path list
 	first. If @CTAGS_NAME_EXECUTABLE@ cannot find a file or directory
 	in the list, @CTAGS_NAME_EXECUTABLE@ reads a file or directory
-	at the specified *pathname*.
+	at the specified ``pathname``.
 
 	If a file is specified, it should contain one option per line. If
-	a directory is specified, files suffixed with ".ctags" under it
+	a directory is specified, files suffixed with ``.ctags`` under it
 	are read in alphabetical order.
 
-	As a special case, if "--options=NONE" is specified as the first
+	As a special case, if ``--options=NONE`` is specified as the first
 	option on the command line, preloading is disabled; the option
 	will disable the automatic reading of any configuration options
 	from either a file or the environment (see "`FILES`_").
 
 ``--options-maybe=pathname``
 	Same as ``--options`` but doesn't cause an error if file
-	(or directory) specified with *pathname* doesn't exist.
+	(or directory) specified with ``pathname`` doesn't exist.
 
 ``--optlib-dir=[+]directory``
-	Add an optlib *directory* to or reset **optlib** path list.
+	Add an optlib ``directory`` to or reset optlib path list.
 	By default, the optlib path list is empty.
 
 optlib Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``--kinddef-<LANG>=letter,name,description``
-	See ctags-optlib(7).
-	Be not confused this with ``--kinds-<LANG>``.
+	Define a kind for *<LANG>*.
+	Don't be confused this with ``--kinds-<LANG>``.
 
 ``--langdef=name``
 	See ctags-optlib(7).
@@ -958,17 +958,17 @@ optlib Options
 Language Specific Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``--if0[=yes|no]``
-	Indicates a preference as to whether code within an "#if 0" branch of a
+	Indicates a preference as to whether code within an ``#if 0`` branch of a
 	preprocessor conditional should be examined for non-macro tags (macro
 	tags are always included). Because the intent of this construct is to
-	disable code, the default value of this option is no. Note that this
+	disable code, the default value of this option is ``no``. Note that this
 	indicates a preference only and does not guarantee skipping code within
-	an "#if 0" branch, since the fall-back algorithm used to generate
+	an ``#if 0`` branch, since the fall-back algorithm used to generate
 	tags when preprocessor conditionals are too complex follows all branches
 	of a conditional. This option is disabled by default.
 
 ``--line-directives[=yes|no]``
-	Specifies whether "#line" directives should be recognized. These are
+	Specifies whether ``#line`` directives should be recognized. These are
 	present in the output of preprocessors and contain the line number, and
 	possibly the file name, of the original source file(s) from which the
 	preprocessor output file was generated. When enabled, this option will
@@ -978,7 +978,7 @@ Language Specific Options
 	file names placed into the tag file will have the same leading path
 	components as the preprocessor output file, since it is assumed that
 	the original source files are located relative to the preprocessor
-	output file (unless, of course, the #line directive specifies an
+	output file (unless, of course, the ``#line`` directive specifies an
 	absolute path). This option is off by default. Note: This option is generally
 	only useful when used together with the ``--excmd=number`` (``-n``) option.
 	Also, you may have to use either the ``--langmap`` or ``--language-force`` option
@@ -997,7 +997,7 @@ Language Specific Options
 	Specifies a list of file extensions, separated by periods, which are
 	to be interpreted as include (or header) files. To indicate files having
 	no extension, use a period not followed by a non-period character
-	(e.g. ".", "..x", ".x."). This option only affects how the scoping of
+	(e.g. '``.``', ``..x``, ``.x.``). This option only affects how the scoping of
 	particular kinds of tags are interpreted (i.e. whether or not they are
 	considered as globally visible or visible only within the file in which
 	they are defined); it does not map the extension to any particular
@@ -1007,9 +1007,9 @@ Language Specific Options
 	will be considered to have file-limited scope. If the first character
 	in the list is a plus sign, then the extensions in the list will be
 	appended to the current list; otherwise, the list will replace the
-	current list. See, also, the "F/fileScope" flag of ``--extras`` option.
+	current list. See, also, the ``F/fileScope`` flag of ``--extras`` option.
 	The default list is
-	".h.H.hh.hpp.hxx.h++.inc.def". To restore the default list, specify ``-h``
+	``.h.H.hh.hpp.hxx.h++.inc.def``. To restore the default list, specify ``-h``
 	default. Note that if an extension supplied to this option is not
 	already mapped to a particular language (see "`Determining file language`_", above),
 	you will also need to use either the ``--langmap`` or ``--language-force`` option.
@@ -1020,22 +1020,22 @@ Language Specific Options
 	to handle special cases arising through the use of preprocessor macros.
 	When the identifiers listed are simple identifiers, these identifiers
 	will be ignored during parsing of the source files. If an identifier is
-	suffixed with a '+' character, @CTAGS_NAME_EXECUTABLE@ will also
+	suffixed with a '``+``' character, @CTAGS_NAME_EXECUTABLE@ will also
 	ignore any parenthesis-enclosed argument list which may immediately
 	follow the identifier in the source files. If two identifiers are
-	separated with the '=' character, the first identifiers is replaced by
+	separated with the '``=``' character, the first identifiers is replaced by
 	the second identifiers for parsing purposes. The list of identifiers may
 	be supplied directly on the command line or read in from a separate file.
-	If the first character of identifier-list is '@', '.' or a pathname
-	separator (``'/'`` or ``'\'``), or the first two characters specify a drive
-	letter (e.g. "C:"), the parameter identifier-list will be interpreted as
+	If the first character of identifier-list is '``@``', '``.``' or a pathname
+	separator ('``/``' or '``\``'), or the first two characters specify a drive
+	letter (e.g. ``C:``), the parameter identifier-list will be interpreted as
 	a filename from which to read a list of identifiers, one per input line.
 	Otherwise, identifier-list is a list of identifiers (or identifier
 	pairs) to be specially handled, each delimited by either a comma or
 	by white space (in which case the list should be quoted to keep the
 	entire list as one command line argument). Multiple ``-I`` options may be
 	supplied. To clear the list of ignore identifiers, supply a single
-	dash ("-") for identifier-list.
+	dash ('``-``') for identifier-list.
 
 	This feature is useful when preprocessor macros are used in such a way
 	that they cause syntactic confusion due to their presence. Indeed,
@@ -1047,9 +1047,9 @@ Language Specific Options
 
 		int foo ARGDECL4(void *, ptr, long int, nbytes)
 
-	In the above example, the macro "ARGDECL4" would be mistakenly
+	In the above example, the macro ``ARGDECL4`` would be mistakenly
 	interpreted to be the name of the function instead of the correct name
-	of "foo". Specifying "-I ARGDECL4" results in the correct behavior.
+	of ``foo``. Specifying ``-I ARGDECL4`` results in the correct behavior.
 
 	.. code-block:: C
 
@@ -1062,7 +1062,7 @@ Language Specific Options
 	much like a K&R style function parameter declaration). In fact, this
 	seeming function definition could possibly even cause the rest of the
 	file to be skipped over while trying to complete the definition.
-	Specifying "-I MODULE_VERSION+" would avoid such a problem.
+	Specifying ``-I MODULE_VERSION+`` would avoid such a problem.
 
 	.. code-block:: C
 
@@ -1070,21 +1070,25 @@ Language Specific Options
 			// your content here
 		};
 
-	The example above uses "CLASS" as a preprocessor macro which expands to
-	something different for each platform. For instance CLASS may be
-	defined as "class __declspec(dllexport)" on Win32 platforms and simply
-	"class" on UNIX. Normally, the absence of the C++ keyword "class"
+	The example above uses ``CLASS`` as a preprocessor macro which expands to
+	something different for each platform. For instance ``CLASS`` may be
+	defined as ``class __declspec(dllexport)`` on Win32 platforms and simply
+	``class`` on UNIX. Normally, the absence of the C++ keyword ``class``
 	would cause the source file to be incorrectly parsed. Correct behavior
-	can be restored by specifying "-I CLASS=class".
+	can be restored by specifying ``-I CLASS=class``.
 
-.. _option_listing:
+``--param-<LANG>:name=argument``
+	Set *<LANG>* specific parameter. Available parameters can be listed with
+	``--list-params``.
+
+	.. TODO: add description of "parameter".
 
 Listing Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``--list-aliases[=language|all]``
-	Lists the aliases for either the specified *language* or **all**
+	Lists the aliases for either the specified ``language`` or ``all``
 	languages, and then exits.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 	The aliases are used when heuristically testing a language parser for a
 	source file.
 
@@ -1093,8 +1097,8 @@ Listing Options
 
 ``--list-extras[=language|all]``
 	Lists the extras recognized for either the specified *language* or
-	**all** languages. See "`Extras`_" subsection to know what are extras.
-	**all** is used as default value if the option argument is omitted.
+	*all* languages. See "`Extras`_" subsection to know what are extras.
+	``all`` is used as default value if the option argument is omitted.
 
 	An extra can be enabled or disabled with ``--extras=`` for common
 	extras in all languages, or ``--extras-<LANG>=`` for the specified
@@ -1104,17 +1108,17 @@ Listing Options
 	The meaning of columns are as follows:
 
 	LETTER
-		One-letter flag. '-' means the extra does not have one-letter flag.
+		One-letter flag. '``-``' means the extra does not have one-letter flag.
 
 	NAME
 		Long-name flag. The long-name is used in ``extras:`` field.
 
 	ENABLED
-		Whether the extra is enabled or not. It takes "yes" or "no".
+		Whether the extra is enabled or not. It takes ``yes`` or ``no``.
 
 	LANGUAGE
 		The name of language if the extra is owned by a parser.
-		"NONE" means the extra is common in parsers.
+		``NONE`` means the extra is common in parsers.
 
 	DESCRIPTION
 		Human readable description for the extra.
@@ -1124,8 +1128,8 @@ Listing Options
 
 ``--list-fields[=language|all]``
 	Lists the fields recognized for either the specified *language* or
-	**all** languages. See "`Fields`_" subsection to know what are fields.
-	**all** is used as default value if the option argument is omitted.
+	*all* languages. See "`Fields`_" subsection to know what are fields.
+	``all`` is used as default value if the option argument is omitted.
 
 	.. TODO? xref output
 
@@ -1137,37 +1141,37 @@ Listing Options
 	The meaning of columns are as follows:
 
 	LETTER
-		One-letter flag. '-' means the field does not have one-letter flag.
+		One-letter flag. '``-``' means the field does not have one-letter flag.
 
 	NAME
 		Long-name of field.
 
 	ENABLED
-		Whether the field is enabled or not. It takes "yes" or "no".
+		Whether the field is enabled or not. It takes ``yes`` or ``no``.
 
 	LANGUAGE
 		The name of language if the field is owned by a parser.
-		"NONE" means the extra is common in parsers.
+		``NONE`` means the extra is common in parsers.
 
 	JSTYPE
-		Json type used in printing the value of field when "--output-format=json"
+		Json type used in printing the value of field when ``--output-format=json``
 		is specified.
 
 		Following characters are used for representing types.
 
-		s
+		``s``
 			string
-		i
+		``i``
 			integer
-		b
+		``b``
 			boolean (true or false)
 
 		The representation of this field and the output format used in
-		"--output-format=json" are still experimental.
+		``--output-format=json`` are still experimental.
 
 	FIXED
 	   Whether this field can be disabled or not. Some fields are printed always
-	   in tags output. They have "yes" as the value for this column.
+	   in tags output. They have ``yes`` as the value for this column.
 
 	DESCRIPTION
 		Human readable description for the field.
@@ -1179,7 +1183,7 @@ Listing Options
 	This option prints only LETTER, DESCRIPTION, and ENABLED fields
 	of ``--list-kinds-full`` output. However, the presentation of
 	ENABLED column is different from that of ``--list-kinds-full``
-	option; "[off]" follows after description if the kind is disabled,
+	option; ``[off]`` follows after description if the kind is disabled,
 	and nothing follows	if enabled. The most of all kinds are enabled
 	by default.
 
@@ -1193,9 +1197,9 @@ Listing Options
 
 ``--list-kinds-full[=language|all]``
 	Lists the tag kinds recognized for either the specified *language*
-	or **all** languages, and then exits. See "`Kinds`_" subsection to
+	or *all* languages, and then exits. See "`Kinds`_" subsection to
 	learn what kinds are.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 
 	Each kind of tag recorded in the tag file is represented by a
 	one-letter flag, or a long-name flag. They are also used to filter the tags
@@ -1212,7 +1216,7 @@ Listing Options
 
 	NAME
 		The long-name flag of the kind. This can be used as the alternative
-		to the one-letter flag described above. If enabling 'K' field with
+		to the one-letter flag described above. If enabling ``K`` field with
 		``--fields=+K``, @CTAGS_NAME_EXECUTABLE@ uses long-names instead of
 		one-letters in tags output. To enable/disable a kind with
 		``--kinds-<LANG>`` option, long-name surrounded by braces instead
@@ -1220,11 +1224,11 @@ Listing Options
 		unique in a language.
 
 	ENABLED
-		Whether the kind is enabled or not. It takes "yes" or "no".
+		Whether the kind is enabled or not. It takes ``yes`` or ``no``.
 
 	REFONLY
 		Whether the kind is specialized for reference tagging or not.
-		If the column is "yes", the kind is for reference tagging, and
+		If the column is ``yes``, the kind is for reference tagging, and
 		it is never used for definition tagging. See also "`TAG ENTRIES`_".
 
 	NROLES
@@ -1242,7 +1246,7 @@ Listing Options
 		C++. Enabling/disabling kindX in C language enables/disables a
 		kind in C++ language having the same long-name flag with kindX. To
 		emulate this behavior in Universal Ctags, a concept named
-		"master parser" is introduced. Enabling/disabling some kinds
+		*master parser* is introduced. Enabling/disabling some kinds
 		are synchronized under the control of a master language.
 
 		.. code-block:: console
@@ -1256,8 +1260,8 @@ Listing Options
 			#LANGUAGE  LETTER NAME   ENABLED REFONLY NROLES MASTER DESCRIPTION
 			C++        l      local  no      no      0      C      local variables
 
-		You see "ENABLED" field of "local" kind of C++ language is changed
-		Though "local" kind of C language is enabled/disabled. If you swap the languages, you
+		You see ``ENABLED`` field of ``local`` kind of C++ language is changed
+		Though ``local`` kind of C language is enabled/disabled. If you swap the languages, you
 		see the same result.
 
 	DESCRIPTION
@@ -1269,7 +1273,7 @@ Listing Options
 	used in many other options like ``--language-force``,
 	``--languages``, ``--kinds-<LANG>``, ``--regex-<LANG>``, and so on.
 
-	Each language listed is disabled if followed by "[disabled]".
+	Each language listed is disabled if followed by ``[disabled]``.
 	To use the parser for such a language, specify the language as an
 	argument of ``--languages=+`` option.
 
@@ -1278,22 +1282,22 @@ Listing Options
 
 ``--list-map-extensions[=language|all]``
 	Lists the file extensions which associate a file
-	name with a language for either the specified *language* or **all**
+	name with a language for either the specified *language* or *all*
 	languages, and then exits.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 
 ``--list-map-patterns[=language|all]``
 	Lists the file name patterns which associate a file
-	name with a language for either the specified *language* or **all**
+	name with a language for either the specified *language* or *all*
 	languages, and then exits.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 
 ``--list-maps[=language|all]``
 	Lists file name patterns and the file extensions which associate a file
-	name with a language for either the specified *language* or **all**
+	name with a language for either the specified *language* or *all*
 	languages, and then exits. See the ``--langmap`` option, and
 	"`Determining file language`_", above.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 
 	To list the file extensions or file name patterns individually, use
 	``--list-map-extensions`` or ``--list-map-patterns`` option.
@@ -1307,9 +1311,9 @@ Listing Options
 	definition.
 
 ``--list-params[=language|all]``
-	Lists the parameters for either the specified *language* or **all**
+	Lists the parameters for either the specified *language* or *all*
 	languages, and then exits.
-	**all** is used as default value if the option argument is omitted.
+	``all`` is used as default value if the option argument is omitted.
 
 ``--list-pseudo-tags``
 	Output list of pseudo-tags.
@@ -1318,10 +1322,10 @@ Listing Options
 	See ctags-optlib(7).
 
 ``--list-roles[=language|all[.kinds]]``
-	List the roles for either the specified *language* or **all** languages.
-	**all** is used as default value if the option argument is omitted.
-	If the parameter kinds is given after the parameter
-	*language* or **all** with concatenating with '.', list only roles
+	List the roles for either the specified *language* or *all* languages.
+	``all`` is used as default value if the option argument is omitted.
+	If the parameter ``kinds`` is given after the parameter
+	``language`` or ``all`` with concatenating with '``.``', list only roles
 	defined in the kinds. Both one-letter flags and long name flags surrounded
 	by braces are acceptable as the parameter kinds.
 
@@ -1337,7 +1341,7 @@ Listing Options
 		The long-name flag of the role.
 
 	ENABLED
-		Whether the kind is enabled or not. It takes "yes" or "no".
+		Whether the kind is enabled or not. It takes ``yes`` or ``no``.
 		(Currently all roles are enabled. No option for disabling
 		a specified role is not implemented yet.)
 
@@ -1346,8 +1350,8 @@ Listing Options
 
 ``--list-subparsers[=baselang|all]``
 	Lists the subparsers for a base language for either the specified
-	*baselang* or **all** languages, and then exits.
-	**all** is used as default value if the option argument is omitted.
+	*baselang* or *all* languages, and then exits.
+	``all`` is used as default value if the option argument is omitted.
 
 ``--machinable[=yes|no]``
 	Use tab character as separators for ``--list-`` option output.  It
@@ -1381,14 +1385,14 @@ Miscellaneous Options
 	Just prints the language parsers for specified source files, and then exits.
 
 ``--quiet[=yes|no]``
-	Write fewer messages (default is no).
+	Write fewer messages (default is ``no``).
 
 ``--totals[=yes|no|extra]``
 	Prints statistics about the source files read and the tag file written
 	during the current invocation of @CTAGS_NAME_EXECUTABLE@. This option
 	is off by default. This option must appear before the first file name.
 
-	The extra value prints parser specific statistics for parsers
+	The ``extra`` value prints parser specific statistics for parsers
 	gathering such information.
 
 ``--verbose[=yes|no]``
@@ -1399,7 +1403,7 @@ Miscellaneous Options
 	from the configuration files (see "`FILES`_", below) and the CTAGS
 	environment variable. However, if this option is the first argument on
 	the command line, it will take effect before any options are read from
-	these sources. The default is no.
+	these sources. The default is ``no``.
 
 ``-V``
 	Equivalent to ``--verbose``.
@@ -1416,8 +1420,8 @@ Obsoleted Options
 	ctags of SVR4 Unix.
 
 ``--file-scope[=yes|no]``
-	This options is removed. Use "--extras=[+|-]F" or
-	"--extras=[+|-]{fileScope}" instead.
+	This options is removed. Use ``--extras=[+|-]F`` or
+	``--extras=[+|-]{fileScope}`` instead.
 
 OPERATIONAL DETAILS
 -------------------
@@ -1440,7 +1444,7 @@ In general, @CTAGS_NAME_EXECUTABLE@ tries to be smart about conditional
 preprocessor directives. If a preprocessor conditional is encountered
 within a statement which defines a tag, @CTAGS_NAME_EXECUTABLE@ follows
 only the first branch of that conditional (except in the special case of
-"#if 0", in which case it follows only the last branch). The reason for
+``#if 0``, in which case it follows only the last branch). The reason for
 this is that failing to pursue only one branch can result in ambiguous
 syntax, as in the following example:
 
@@ -1463,7 +1467,7 @@ generally due to complicated and inconsistent pairing within the
 conditionals, @CTAGS_NAME_EXECUTABLE@ will retry the file using a
 different heuristic which does not selectively follow conditional
 preprocessor branches, but instead falls back to relying upon a closing
-brace ("}") in column 1 as indicating the end of a block once any brace
+brace ('``}``') in column 1 as indicating the end of a block once any brace
 imbalance results from following a #if conditional branch.
 
 @CTAGS_NAME_EXECUTABLE@ will also try to specially handle arguments lists
@@ -1472,7 +1476,7 @@ conditional construct::
 
 	extern void foo __ARGS((int one, char two));
 
-Any name immediately preceding the "((" will be automatically ignored and
+Any name immediately preceding the '``((``' will be automatically ignored and
 the previous name will be used.
 
 C++ operator definitions are specially handled. In order for consistency
@@ -1492,7 +1496,7 @@ File name mapping
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Unless the ``--language-force`` option is specified, the language of each source
-file is automatically selected based upon a **mapping** of file names to
+file is automatically selected based upon a *mapping* of file names to
 languages. The mappings in effect for each language may be displayed using
 the ``--list-maps`` option and may be changed using the ``--langmap`` or
 ``--map-<LANG>`` options.
@@ -1503,12 +1507,12 @@ to heuristically guess the language for the file by inspecting its content. See
 
 All files that have no file name mapping and no guessed parser are
 ignored. This permits running @CTAGS_NAME_EXECUTABLE@ on all files in
-either a single directory (e.g.  "@CTAGS_NAME_EXECUTABLE@ \*"), or on
+either a single directory (e.g.  ``@CTAGS_NAME_EXECUTABLE@ *``), or on
 all files in an entire source directory tree
-(e.g. "@CTAGS_NAME_EXECUTABLE@ -R"), since only those files whose
+(e.g. ``@CTAGS_NAME_EXECUTABLE@ -R``), since only those files whose
 names are mapped to languages will be scanned.
 
-The same extensions are mapped to multiple parsers. For example, ".h"
+The same extensions are mapped to multiple parsers. For example, ``.h``
 are mapped to C++, C and ObjectiveC. These mappings can cause
 issues. @CTAGS_NAME_EXECUTABLE@ tries to select the proper parser
 for the source file by applying heuristics to its content, however
@@ -1533,23 +1537,23 @@ If @CTAGS_NAME_EXECUTABLE@ cannot select a parser from the mapping of file names
 various heuristic tests are conducted to determine the language:
 
 template file name testing
-	If the file name has an ".in" extension, @CTAGS_NAME_EXECUTABLE@ applies
+	If the file name has an ``.in`` extension, @CTAGS_NAME_EXECUTABLE@ applies
 	the mapping to the file name without the extension. For example,
-	"config.h" is tested for a file named "config.h.in".
+	``config.h`` is tested for a file named ``config.h.in``.
 
 "interpreter" testing
-	The first line of the file is checked to see if the file is a "#!"
+	The first line of the file is checked to see if the file is a ``#!``
 	script for a recognized language. @CTAGS_NAME_EXECUTABLE@ looks for
 	a parser having the same name.
 
 	If @CTAGS_NAME_EXECUTABLE@ finds no such parser,
 	@CTAGS_NAME_EXECUTABLE@ looks for the name in alias lists. For
-	example, consider if the first line is "#!/bin/sh".  Though
+	example, consider if the first line is ``#!/bin/sh``.  Though
 	@CTAGS_NAME_EXECUTABLE@ has a "shell" parser, it doesn't have a "sh"
-	parser. However, "sh" is listed as an alias for "shell", therefore
+	parser. However, ``sh`` is listed as an alias for ``shell``, therefore
 	@CTAGS_NAME_EXECUTABLE@ selects the "shell" parser for the file.
 
-	An exception is "env". If "env" is specified, @CTAGS_NAME_EXECUTABLE@
+	An exception is ``env``. If ``env`` is specified, @CTAGS_NAME_EXECUTABLE@
 	reads more lines to find real interpreter specification.
 
 	To display the list of aliases, use ``--list-aliases`` option.
@@ -1557,7 +1561,7 @@ template file name testing
 	``--alias-<LANG>=[+|-]aliasPattern`` option.
 
 "zsh autoload tag" testing
-	If the first line starts with "#compdef" or "#autoload",
+	If the first line starts with ``#compdef`` or ``#autoload``,
 	@CTAGS_NAME_EXECUTABLE@ regards the line as "zsh".
 
 "emacs mode at the first line" testing
@@ -1566,7 +1570,7 @@ template file name testing
 	and utilize the marker for the mode selection. This heuristic test does
 	the same as what Emacs does.
 
-	@CTAGS_NAME_EXECUTABLE@ treats *MODE* as a name of interpreter and applies the same
+	@CTAGS_NAME_EXECUTABLE@ treats ``MODE`` as a name of interpreter and applies the same
 	rule of "interpreter" testing if the first line has one of
 	the following patterns::
 
@@ -1582,7 +1586,7 @@ template file name testing
 	Emacs editor recognizes another marker at the end of file as a
 	mode specifier. This heuristic test does the same as what Emacs does.
 
-	@CTAGS_NAME_EXECUTABLE@ treats *MODE* as a name of an interpreter and applies the same
+	@CTAGS_NAME_EXECUTABLE@ treats ``MODE`` as a name of an interpreter and applies the same
 	rule of "interpreter" heuristic testing, if the lines at the tail of the file
 	have the following pattern::
 
@@ -1596,7 +1600,7 @@ template file name testing
 
 "vim modeline" testing
 	Like the modeline of the Emacs editor, Vim editor has the same concept.
-	@CTAGS_NAME_EXECUTABLE@ treats *TYPE* as a name of interpreter and applies the same
+	@CTAGS_NAME_EXECUTABLE@ treats ``TYPE`` as a name of interpreter and applies the same
 	rule of "interpreter" heuristic testing if the last 5 lines of the file
 	have one of the following patterns::
 
@@ -1609,7 +1613,7 @@ template file name testing
 		ft=TYPE
 
 "PHP marker" testing
-	If the first line is started with "<?php",
+	If the first line is started with ``<?php``,
 	@CTAGS_NAME_EXECUTABLE@ regards the line as "php".
 
 Looking into the file contents is a more expensive operation than file
@@ -1641,7 +1645,7 @@ TAG ENTRIES
 A tag is an index for a language object. The concept of a tag and related
 items in Exuberant Ctags are refined and extended in Universal Ctags.
 
-A tag is categorized into **definition tags** or **reference tags**.
+A tag is categorized into *definition tags* or *reference tags*.
 In general, Exuberant Ctags only tags *definitions* of
 language objects: places where newly named language objects are introduced.
 Universal Ctags, on the other hand, can also tag *references* of language
@@ -1653,11 +1657,11 @@ specific languages in the current version.
 Fields
 ~~~~~~
 
-A tag can record various information, called **fields**. The
-essential fields are: **name** of language objects, **input**,
-**pattern**, and **line**. ``input:`` is the name of source file where
+A tag can record various information, called *fields*. The
+essential fields are: *name* of language objects, *input*,
+*pattern*, and *line*. ``input:`` is the name of source file where
 ``name:`` is defined or referenced. ``pattern:`` can be used to search
-the **name** in ``input:``. **line** is the line number where
+the *name* in ``input:``. *line* is the line number where
 ``name:`` is defined or referenced in ``input:``.
 
 @CTAGS_NAME_EXECUTABLE@ offers extension fields. See also the
@@ -1669,8 +1673,8 @@ Kinds
 
 ``kind:`` is a field which represents the *kind* of language object
 specified by a tag. Kinds used and defined are very different between
-parsers. For example, C language defines "macro", "function",
-"variable", "typedef", etc. See also the descriptions of
+parsers. For example, C language defines ``macro``, ``function``,
+``variable``, ``typedef``, etc. See also the descriptions of
 ``--list-kinds-full`` option and ``--kinds-<LANG>`` option.
 
 
@@ -1680,12 +1684,12 @@ Extras
 Generally, @CTAGS_NAME_EXECUTABLE@ tags only language objects appearing
 in source files, as is. In other words, a value for a ``name:`` field
 should be found on the source file associated with the ``name:``. An
-"extra" type tag (*extra*) is for tagging a language object with a processed
+``extra`` type tag (*extra*) is for tagging a language object with a processed
 name, or for tagging something not associated with a language object. A typical
-extra tag is "qualified", which tags a language object with a
+extra tag is ``qualified``, which tags a language object with a
 class-qualified or scope-qualified name.
 
-The following example demonstrates the "qualified" extra tag.
+The following example demonstrates the ``qualified`` extra tag.
 
 .. code-block:: Java
 
@@ -1696,10 +1700,10 @@ The following example demonstrates the "qualified" extra tag.
 		// ...
 	}
 
-For the above source file, @CTAGS_NAME_EXECUTABLE@ tags "Bar" and "Foo" by
-default.  If the "qualified" extra is enabled from the command line
-(``--extras=+q``), then "Bar.Foo" is also tagged even though the string
-"Bar.Foo" is not in the source code.
+For the above source file, @CTAGS_NAME_EXECUTABLE@ tags ``Bar`` and ``Foo`` by
+default.  If the ``qualified`` extra is enabled from the command line
+(``--extras=+q``), then ``Bar.Foo`` is also tagged even though the string
+``Bar.Foo`` is not in the source code.
 
 See also the descriptions of ``--list-extras`` option and ``--extras``
 option in "`OPTIONS`_".
@@ -1711,20 +1715,20 @@ Roles
 *Role* is a newly introduced concept in Universal Ctags. Role is a
 concept associated with reference tags, and is not implemented widely yet.
 
-As described previously in "Kinds", the "kind" field represents the type
+As described previously in "`Kinds`_", the ``kind`` field represents the type
 of language object specified with a tag, such as a function vs. a variable.
-Specific kinds are defined for reference tags, such as the C++ kind "header" for
-header file, or Java kind "package" for package statements. For such reference
-kinds, a "roles" field can be added to distinguish the role of the reference
-kind. In other words, the "kind" field identifies the "what" of the language
-object, whereas the "roles" field identifies the "how" of a referenced language
+Specific kinds are defined for reference tags, such as the C++ kind ``header`` for
+header file, or Java kind ``package`` for package statements. For such reference
+kinds, a ``roles`` field can be added to distinguish the role of the reference
+kind. In other words, the ``kind`` field identifies the *what* of the language
+object, whereas the ``roles`` field identifies the *how* of a referenced language
 object. Roles are only used with specific kinds.
 
 For example, for the source file used for demonstrating in the "`Extras`_"
-subsection, "Baz" is tagged as a reference tag with kind "package" and with
-role "imported". Another example is for a C++ "header" kind tag, generated by
-"#include" statements: the ``roles:system`` or ``roles:local`` fields will be
-added depending on whether the include file name begins with "<" or not.
+subsection, ``Baz`` is tagged as a reference tag with kind ``package`` and with
+role ``imported``. Another example is for a C++ ``header`` kind tag, generated by
+``#include`` statements: the ``roles:system`` or ``roles:local`` fields will be
+added depending on whether the include file name begins with '``<``' or not.
 
 See also the descriptions of ``--list-roles`` and ``--roles-<LANG>.<KIND>=``
 options.
@@ -1733,7 +1737,7 @@ options.
 Language-specific fields and extras
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Exuberant Ctags has the concept of "fields" and "extras". They are common
+Exuberant Ctags has the concept of *fields* and *extras*. They are common
 between parsers of different languages. Universal Ctags extends this concept
 by providing language-specific fields and extras.
 
@@ -1787,7 +1791,7 @@ the ``--tag-relative`` option for how this behavior can be modified.
 
 Extension fields are tab-separated key-value pairs appended to the end of
 the EX command as a comment, as described above. These key value pairs
-appear in the general form "key:value". Their presence in the lines of the
+appear in the general form ``key:value``. Their presence in the lines of the
 tag file are controlled by the ``--fields`` option. The possible keys and
 the meaning of their values are as follows:
 
@@ -1811,7 +1815,7 @@ kind
 implementation
 	When present, this indicates a limited implementation (abstract vs.
 	concrete) of a routine or class, where value is specific to the
-	language ("virtual" or "pure virtual" for C++; "abstract" for Java).
+	language (``virtual`` or ``pure virtual`` for C++; ``abstract`` for Java).
 
 inherits
 	When present, value. is a comma-separated list of classes from which
@@ -1829,48 +1833,48 @@ available, with the key portion equal to some language-dependent construct
 name and its value the name declared for that construct in the program.
 This scope entry indicates the scope in which the tag was found.
 For example, a tag generated for a C structure member would have a scope
-looking like "struct:myStruct".
+looking like ``struct:myStruct``.
 
 
 HOW TO USE WITH VI
 ------------------
 
-Vi will, by default, expect a tag file by the name "tags" in the current
+Vi will, by default, expect a tag file by the name ``tags`` in the current
 directory. Once the tag file is built, the following commands exercise
 the tag indexing feature:
 
-vi -t tag
-	Start vi and position the cursor at the file and line where "tag"
+``vi -t tag``
+	Start vi and position the cursor at the file and line where ``tag``
 	is defined.
 
-:ta tag
+``:ta tag``
 	Find a tag.
 
-Ctrl-]
+``Ctrl-]``
 	Find the tag under the cursor.
 
-Ctrl-T
+``Ctrl-T``
 	Return to previous location before jump to tag (not widely implemented).
 
 
 HOW TO USE WITH GNU EMACS
 -------------------------
 
-Emacs will, by default, expect a tag file by the name "TAGS" in the
+Emacs will, by default, expect a tag file by the name ``TAGS`` in the
 current directory. Once the tag file is built, the following commands
 exercise the tag indexing feature:
 
-M-x visit-tags-table <RET> FILE <RET>
-	Select the tag file, "FILE", to use.
+``M-x visit-tags-table <RET> FILE <RET>``
+	Select the tag file, ``FILE``, to use.
 
-M-. [TAG] <RET>
+``M-. [TAG] <RET>``
 	Find the first definition of TAG. The default tag is the identifier
 	under the cursor.
 
-M-*
-	Pop back to where you previously invoked "M-.".
+``M-*``
+	Pop back to where you previously invoked ``M-.``.
 
-C-u M-.
+``C-u M-.``
 	Find the next definition for the last tag.
 
 For more commands, see the Tags topic in the Emacs info document.
@@ -1882,8 +1886,8 @@ HOW TO USE WITH NEDIT
 NEdit version 5.1 and later can handle the new extended tag file format
 (see ``--format``). To make NEdit use the tag file, select "File->Load Tags
 File". To jump to the definition for a tag, highlight the word, then press
-Ctrl-D. NEdit 5.1 can read multiple tag files from different
-directories. Setting the X resource nedit.tagFile to the name of a tag
+``Ctrl-D``. NEdit 5.1 can read multiple tag files from different
+directories. Setting the X resource ``nedit.tagFile`` to the name of a tag
 file instructs NEdit to automatically load that tag file at startup time.
 
 
@@ -1926,9 +1930,9 @@ This can be avoided by use of the ``--excmd=n`` option.
 BUGS
 ----
 
-@CTAGS_NAME_EXECUTABLE@ has more options than ls(1).
+@CTAGS_NAME_EXECUTABLE@ has more options than ``ls(1)``.
 
-When parsing a C++ member function definition (e.g. "className::function"),
+When parsing a C++ member function definition (e.g. ``className::function``),
 @CTAGS_NAME_EXECUTABLE@ cannot determine whether the scope specifier
 is a class name or a namespace specifier and always lists it as a class name
 in the scope portion of the extension fields. Also, if a C++ function
@@ -1936,14 +1940,14 @@ is defined outside of the class declaration (the usual case), the access
 specification (i.e. public, protected, or private) and implementation
 information (e.g. virtual, pure virtual) contained in the function
 declaration are not known when the tag is generated for the function
-definition. It will, however be available for prototypes (e.g. "--kinds-c++=+p").
+definition. It will, however be available for prototypes (e.g. ``--kinds-c++=+p``).
 
 No qualified tags are generated for language objects inherited into a class.
 
 ENVIRONMENT VARIABLES
 ---------------------
 
-CTAGS
+``CTAGS``
 	If this environment variable exists, it will be expected to contain a
 	set of default options which are read when @CTAGS_NAME_EXECUTABLE@
 	starts, after the configuration files listed in FILES, below, are read,
@@ -1954,13 +1958,13 @@ CTAGS
 	an option parameter containing an embedded space. If this is a problem,
 	use a configuration file instead.
 
-ETAGS
-	Similar to the CTAGS variable above, this variable, if found, will be
+``ETAGS``
+	Similar to the ``CTAGS`` variable above, this variable, if found, will be
 	read when @ETAGS_NAME_EXECUTABLE@ starts. If this variable is not
-	found, @ETAGS_NAME_EXECUTABLE@ will try to use CTAGS instead.
+	found, @ETAGS_NAME_EXECUTABLE@ will try to use ``CTAGS`` instead.
 
-TMPDIR
-	On Unix-like hosts where mkstemp() is available, the value of this
+``TMPDIR``
+	On Unix-like hosts where ``mkstemp()`` is available, the value of this
 	variable specifies the directory in which to place temporary files.
 	This can be useful if the size of a temporary file becomes too large
 	to fit on the partition holding the default temporary directory
@@ -1968,35 +1972,36 @@ TMPDIR
 	files only if either (1) an emacs-style tag file is being
 	generated, (2) the tag file is being sent to standard output, or
 	(3) the program was compiled to use an internal sort algorithm to sort
-	the tag files instead of the sort utility of the operating system.
-	If the sort utility of the operating system is being used, it will
+	the tag files instead of the ``sort`` utility of the operating system.
+	If the ``sort`` utility of the operating system is being used, it will
 	generally observe this variable also. Note that if @CTAGS_NAME_EXECUTABLE@
-	is setuid, the value of TMPDIR will be ignored.
+	is setuid, the value of ``TMPDIR`` will be ignored.
 
 
 FILES
 -----
 
-$XDG_CONFIG_HOME/ctags/\*.ctags, or $HOME/.config/ctags/\*.ctags if $XDG_CONFIG_HOME is not defined
+``$XDG_CONFIG_HOME/ctags/*.ctags``, or ``$HOME/.config/ctags/*.ctags`` if
+``$XDG_CONFIG_HOME`` is not defined
 (on other than MSWindows)
 
-$HOME/.ctags.d/\*.ctags
+``$HOME/.ctags.d/*.ctags``
 
-$HOMEDRIVE$HOMEPATH/ctags.d/\*.ctags (on MSWindows only)
+``$HOMEDRIVE$HOMEPATH/ctags.d/*.ctags`` (on MSWindows only)
 
-.ctags.d/\*.ctags
+``.ctags.d/*.ctags``
 
-ctags.d/\*.ctags
+``ctags.d/*.ctags``
 
 	If any of these configuration files exist, each will be expected to
 	contain a set of default options which are read in the order listed
-	when @CTAGS_NAME_EXECUTABLE@ starts, but before the CTAGS environment
+	when @CTAGS_NAME_EXECUTABLE@ starts, but before the ``CTAGS`` environment
 	variable is read or any command line options are read. This makes it
 	possible to set up personal or project-level defaults. It
 	is possible to compile @CTAGS_NAME_EXECUTABLE@ to read an additional
 	configuration file before any of those shown above, which will be
 	indicated if the output produced by the ``--version`` option lists the
-	"custom-conf" feature. Options appearing in the CTAGS environment
+	``custom-conf`` feature. Options appearing in the ``CTAGS`` environment
 	variable or on the command line will override options specified in these
 	files. Only options will be read from these files. Note that the option
 	files are read in line-oriented mode in which spaces are significant
@@ -2004,14 +2009,14 @@ ctags.d/\*.ctags
 	of a line are ignored. Each line of the file is read as
 	one command line parameter (as if it were quoted with single quotes).
 	Therefore, use new lines to indicate separate command-line arguments.
-	A line starting with '#' is treated as a comment.
+	A line starting with '``#``' is treated as a comment.
 
-	\*.ctags files in a directory are loaded in alphabetical order.
+	``*.ctags`` files in a directory are loaded in alphabetical order.
 
-tags
+``tags``
 	The default tag file created by @CTAGS_NAME_EXECUTABLE@.
 
-TAGS
+``TAGS``
 	The default tag file created by @ETAGS_NAME_EXECUTABLE@.
 
 
@@ -2069,9 +2074,9 @@ service to humanity."
 CREDITS
 -------
 This version of @CTAGS_NAME_EXECUTABLE@ (Universal Ctags) derived from
-the repository, known as **fishman-ctags**, started by Reza Jelveh.
+the repository, known as fishman-ctags, started by Reza Jelveh.
 
-Some parsers are taken from **tagmanager** of **Geany** (https://www.geany.org/)
+Some parsers are taken from ``tagmanager`` of the Geany (https://www.geany.org/)
 project.
 
 


### PR DESCRIPTION
- ctags(1) updates
  - markups fixes
    - 5c473165 docs: ctags(1): more consistent markups
    - 0da01779 docs: ctags(1): not use Sphinx extensions
    - 04e8a42c docs: ctags(1): additional markup fixes
  - contents reordering
    - e0fd0467 docs: ctags(1): reorder tag entries related descriptions
  - contents fixes (**please review carefully**)
    - 92a648ca docs: ctags(1): misc fixes
    - 2f6f62bd docs: ctags(1): update TAGS FILE FORMAT and TAG ENTRIES
    - dba2d592 docs: ctags(1): update OPTIONS
- docs fixes
  - db6aec7a docs: update and deal with TODO list
