### PR TITLE
R: use "function" kind for functions defined in a function

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -224,6 +224,7 @@ man_MANS = \
 	man/ctags-lang-python.7 \
 	man/ctags-lang-verilog.7 \
 	man/ctags-lang-inko.7 \
+	man/ctags-lang-r.7 \
 	\
 	$(NULL)
 rst2man_verbose = $(rst2man_verbose_@AM_V@)

--- a/Units/parser-r.r/r-avoid-duplication.d/expected.tags
+++ b/Units/parser-r.r/r-avoid-duplication.d/expected.tags
@@ -1,4 +1,5 @@
 x	input.r	/^x <- 1$/;"	g	line:1
+x	input.r	/^x <- 2$/;"	g	line:2
 f	input.r	/^f <- function () {$/;"	f	line:4
 x	input.r	/^  x <- 3$/;"	v	line:5	function:f
 f	input.r	/^f <- function () {$/;"	f	line:10
@@ -7,9 +8,9 @@ f	input.r	/^f <- function (x) {$/;"	f	line:14
 x	input.r	/^f <- function (x) {$/;"	z	line:14	function:f
 f	input.r	/^f <- function (x) {$/;"	f	line:18
 x	input.r	/^f <- function (x) {$/;"	z	line:18	function:f
-g	input.r	/^  g <- function () {$/;"	v	line:19	function:f
-x	input.r	/^    x <- 6$/;"	v	line:20	functionVar:f.g
+g	input.r	/^  g <- function () {$/;"	f	line:19	function:f
+x	input.r	/^    x <- 6$/;"	v	line:20	function:f.g
 f	input.r	/^f <- function (x) {$/;"	f	line:24
 x	input.r	/^f <- function (x) {$/;"	z	line:24	function:f
-g	input.r	/^  g <- function () {$/;"	v	line:25	function:f
-x	input.r	/^    x <- 6$/;"	v	line:26	functionVar:f.g
+g	input.r	/^  g <- function () {$/;"	f	line:25	function:f
+x	input.r	/^    x <- 6$/;"	v	line:26	function:f.g

--- a/Units/parser-r.r/r-scope.d/expected.tags
+++ b/Units/parser-r.r/r-scope.d/expected.tags
@@ -30,14 +30,14 @@ f1	input-2.r	/^    {f1 = 1;$/;"	v	line:15	function:f	end:15	assignmentop:=
 g1	input-2.r	/^       g1 <- 2}$/;"	v	line:16	function:f	end:16	assignmentop:<-
 h1	input-2.r	/^    {h1 = 1; j1 <- 2}$/;"	v	line:18	function:f	end:18	assignmentop:=
 j1	input-2.r	/^    {h1 = 1; j1 <- 2}$/;"	v	line:18	function:f	end:18	assignmentop:<-
-g	input-2.r	/^    g = function () {$/;"	v	line:19	function:f	signature:()	end:28	assignmentop:=
-c2	input-2.r	/^	{c2 = 1$/;"	v	line:20	functionVar:f.g	end:20	assignmentop:=
-d2	input-2.r	/^	   d2 <- 2}$/;"	v	line:22	functionVar:f.g	end:22	assignmentop:<-
-f2	input-2.r	/^	{f2 = 1;$/;"	v	line:24	functionVar:f.g	end:24	assignmentop:=
-g2	input-2.r	/^	   g2 <- 2}$/;"	v	line:25	functionVar:f.g	end:25	assignmentop:<-
-h2	input-2.r	/^	{h2 = 1; j2 <- 2}$/;"	v	line:27	functionVar:f.g	end:27	assignmentop:=
-j2	input-2.r	/^	{h2 = 1; j2 <- 2}$/;"	v	line:27	functionVar:f.g	end:27	assignmentop:<-
-h0	input-2.r	/^    }; h0 = function () {$/;"	v	line:28	function:f	signature:()	end:31	assignmentop:=
+g	input-2.r	/^    g = function () {$/;"	f	line:19	function:f	signature:()	end:28	assignmentop:=
+c2	input-2.r	/^	{c2 = 1$/;"	v	line:20	function:f.g	end:20	assignmentop:=
+d2	input-2.r	/^	   d2 <- 2}$/;"	v	line:22	function:f.g	end:22	assignmentop:<-
+f2	input-2.r	/^	{f2 = 1;$/;"	v	line:24	function:f.g	end:24	assignmentop:=
+g2	input-2.r	/^	   g2 <- 2}$/;"	v	line:25	function:f.g	end:25	assignmentop:<-
+h2	input-2.r	/^	{h2 = 1; j2 <- 2}$/;"	v	line:27	function:f.g	end:27	assignmentop:=
+j2	input-2.r	/^	{h2 = 1; j2 <- 2}$/;"	v	line:27	function:f.g	end:27	assignmentop:<-
+h0	input-2.r	/^    }; h0 = function () {$/;"	f	line:28	function:f	signature:()	end:31	assignmentop:=
 k	input-2.r	/^	   k <<- 3$/;"	g	line:29	end:29	assignmentop:<<-
 f	input-3.r	/^f <- function () {$/;"	f	line:1	signature:()	end:8	assignmentop:<-
 d	input-3.r	/^	d <- ($/;"	v	line:2	function:f	end:4	assignmentop:<-

--- a/Units/parser-r.r/r-upper-scope-assignement.d/expected.tags
+++ b/Units/parser-r.r/r-upper-scope-assignement.d/expected.tags
@@ -3,9 +3,9 @@ x	input.r	/^  x <<- 1$/;"	g
 y	input.r	/^y <- 1$/;"	g
 g	input.r	/^g <- function () {$/;"	f
 h	input.r	/^h <- function () {$/;"	f
-h0	input.r	/^  h0 <- function () {$/;"	v	function:h
+h0	input.r	/^  h0 <- function () {$/;"	f	function:h
 i	input.r	/^i <- function () {$/;"	f
 z	input.r	/^  z <- 1$/;"	v	function:i
-i0	input.r	/^  i0 <- function () {$/;"	v	function:i
+i0	input.r	/^  i0 <- function () {$/;"	f	function:i
 v	input.r	/^    v <<- 13$/;"	g
 u	input.r	/^    v ->> u$/;"	g

--- a/Units/simple-s4class.d/expected.tags
+++ b/Units/simple-s4class.d/expected.tags
@@ -1,24 +1,24 @@
 C	input.r	/^setClass("C", representation(x="numeric"))$/;"	c	language:S4Class	extras:subparser
 x	input.r	/^setClass("C", representation(x="numeric"))$/;"	r	language:S4Class	class:C	typeref:typename:numeric	extras:subparser
 run	input.r	/^setGeneric("run", function(object) 1)$/;"	g	language:S4Class	extras:subparser
-anonFuncc203d3890100	input.r	/^setGeneric("run", function(object) 1)$/;"	v	language:R	generic:run	signature:(object)	extras:anonymous
-object	input.r	/^setGeneric("run", function(object) 1)$/;"	z	language:R	functionVar:run.anonFuncc203d3890100
+anonFuncc203d3890100	input.r	/^setGeneric("run", function(object) 1)$/;"	f	language:R	generic:run	signature:(object)	extras:anonymous
+object	input.r	/^setGeneric("run", function(object) 1)$/;"	z	language:R	function:run.anonFuncc203d3890100
 run	input.r	/^setMethod("run", c("C"), definition = function (object) {$/;"	m	language:S4Class	signature:("C")	extras:subparser
-anonFuncc203d3890200	input.r	/^setMethod("run", c("C"), definition = function (object) {$/;"	v	language:R	method:run	signature:(object)	extras:anonymous
-object	input.r	/^setMethod("run", c("C"), definition = function (object) {$/;"	z	language:R	functionVar:run.anonFuncc203d3890200
+anonFuncc203d3890200	input.r	/^setMethod("run", c("C"), definition = function (object) {$/;"	f	language:R	method:run	signature:(object)	extras:anonymous
+object	input.r	/^setMethod("run", c("C"), definition = function (object) {$/;"	z	language:R	function:run.anonFuncc203d3890200
 run2	input.r	/^setGeneric("run2", function(object) 1)$/;"	g	language:S4Class	extras:subparser
-anonFuncc203d3890300	input.r	/^setGeneric("run2", function(object) 1)$/;"	v	language:R	generic:run2	signature:(object)	extras:anonymous
-object	input.r	/^setGeneric("run2", function(object) 1)$/;"	z	language:R	functionVar:run2.anonFuncc203d3890300
+anonFuncc203d3890300	input.r	/^setGeneric("run2", function(object) 1)$/;"	f	language:R	generic:run2	signature:(object)	extras:anonymous
+object	input.r	/^setGeneric("run2", function(object) 1)$/;"	z	language:R	function:run2.anonFuncc203d3890300
 run2	input.r	/^setMethod("run2", c("C"), function (object) {$/;"	m	language:S4Class	signature:("C")	extras:subparser
-anonFuncc203d3890400	input.r	/^setMethod("run2", c("C"), function (object) {$/;"	v	language:R	method:run2	signature:(object)	extras:anonymous
-object	input.r	/^setMethod("run2", c("C"), function (object) {$/;"	z	language:R	functionVar:run2.anonFuncc203d3890400
+anonFuncc203d3890400	input.r	/^setMethod("run2", c("C"), function (object) {$/;"	f	language:R	method:run2	signature:(object)	extras:anonymous
+object	input.r	/^setMethod("run2", c("C"), function (object) {$/;"	z	language:R	function:run2.anonFuncc203d3890400
 D	input.r	/^setClass ("D", contains = "C")$/;"	c	language:S4Class	extras:subparser
 run3	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	g	language:S4Class	extras:subparser
-anonFuncc203d3890500	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	v	language:R	generic:run3	signature:(i, j)	extras:anonymous
-i	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	z	language:R	functionVar:run3.anonFuncc203d3890500
-j	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	z	language:R	functionVar:run3.anonFuncc203d3890500
+anonFuncc203d3890500	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	f	language:R	generic:run3	signature:(i, j)	extras:anonymous
+i	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	z	language:R	function:run3.anonFuncc203d3890500
+j	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	z	language:R	function:run3.anonFuncc203d3890500
 run3	input.r	/^setMethod("run3", signature("numeric", "numeric"),$/;"	m	language:S4Class	signature:("numeric", "numeric")	extras:subparser
-anonFuncc203d3890600	input.r	/^		  function (i, j) { i + j })$/;"	v	language:R	method:run3	signature:(i, j)	extras:anonymous
-i	input.r	/^		  function (i, j) { i + j })$/;"	z	language:R	functionVar:run3.anonFuncc203d3890600
-j	input.r	/^		  function (i, j) { i + j })$/;"	z	language:R	functionVar:run3.anonFuncc203d3890600
+anonFuncc203d3890600	input.r	/^		  function (i, j) { i + j })$/;"	f	language:R	method:run3	signature:(i, j)	extras:anonymous
+i	input.r	/^		  function (i, j) { i + j })$/;"	z	language:R	function:run3.anonFuncc203d3890600
+j	input.r	/^		  function (i, j) { i + j })$/;"	z	language:R	function:run3.anonFuncc203d3890600
 c	input.r	/^c <- new ("C", x = 2)$/;"	g	language:R	assignmentop:<-

--- a/Units/simple-s4class.d/expected.tags
+++ b/Units/simple-s4class.d/expected.tags
@@ -1,24 +1,24 @@
 C	input.r	/^setClass("C", representation(x="numeric"))$/;"	c	language:S4Class	extras:subparser
 x	input.r	/^setClass("C", representation(x="numeric"))$/;"	r	language:S4Class	class:C	typeref:typename:numeric	extras:subparser
 run	input.r	/^setGeneric("run", function(object) 1)$/;"	g	language:S4Class	extras:subparser
-anonFuncc203d3890104	input.r	/^setGeneric("run", function(object) 1)$/;"	v	language:R	generic:run	signature:(object)	extras:anonymous
-object	input.r	/^setGeneric("run", function(object) 1)$/;"	z	language:R	functionVar:run.anonFuncc203d3890104
+anonFuncc203d3890100	input.r	/^setGeneric("run", function(object) 1)$/;"	v	language:R	generic:run	signature:(object)	extras:anonymous
+object	input.r	/^setGeneric("run", function(object) 1)$/;"	z	language:R	functionVar:run.anonFuncc203d3890100
 run	input.r	/^setMethod("run", c("C"), definition = function (object) {$/;"	m	language:S4Class	signature:("C")	extras:subparser
-anonFuncc203d3890204	input.r	/^setMethod("run", c("C"), definition = function (object) {$/;"	v	language:R	method:run	signature:(object)	extras:anonymous
-object	input.r	/^setMethod("run", c("C"), definition = function (object) {$/;"	z	language:R	functionVar:run.anonFuncc203d3890204
+anonFuncc203d3890200	input.r	/^setMethod("run", c("C"), definition = function (object) {$/;"	v	language:R	method:run	signature:(object)	extras:anonymous
+object	input.r	/^setMethod("run", c("C"), definition = function (object) {$/;"	z	language:R	functionVar:run.anonFuncc203d3890200
 run2	input.r	/^setGeneric("run2", function(object) 1)$/;"	g	language:S4Class	extras:subparser
-anonFuncc203d3890304	input.r	/^setGeneric("run2", function(object) 1)$/;"	v	language:R	generic:run2	signature:(object)	extras:anonymous
-object	input.r	/^setGeneric("run2", function(object) 1)$/;"	z	language:R	functionVar:run2.anonFuncc203d3890304
+anonFuncc203d3890300	input.r	/^setGeneric("run2", function(object) 1)$/;"	v	language:R	generic:run2	signature:(object)	extras:anonymous
+object	input.r	/^setGeneric("run2", function(object) 1)$/;"	z	language:R	functionVar:run2.anonFuncc203d3890300
 run2	input.r	/^setMethod("run2", c("C"), function (object) {$/;"	m	language:S4Class	signature:("C")	extras:subparser
-anonFuncc203d3890404	input.r	/^setMethod("run2", c("C"), function (object) {$/;"	v	language:R	method:run2	signature:(object)	extras:anonymous
-object	input.r	/^setMethod("run2", c("C"), function (object) {$/;"	z	language:R	functionVar:run2.anonFuncc203d3890404
+anonFuncc203d3890400	input.r	/^setMethod("run2", c("C"), function (object) {$/;"	v	language:R	method:run2	signature:(object)	extras:anonymous
+object	input.r	/^setMethod("run2", c("C"), function (object) {$/;"	z	language:R	functionVar:run2.anonFuncc203d3890400
 D	input.r	/^setClass ("D", contains = "C")$/;"	c	language:S4Class	extras:subparser
 run3	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	g	language:S4Class	extras:subparser
-anonFuncc203d3890504	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	v	language:R	generic:run3	signature:(i, j)	extras:anonymous
-i	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	z	language:R	functionVar:run3.anonFuncc203d3890504
-j	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	z	language:R	functionVar:run3.anonFuncc203d3890504
+anonFuncc203d3890500	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	v	language:R	generic:run3	signature:(i, j)	extras:anonymous
+i	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	z	language:R	functionVar:run3.anonFuncc203d3890500
+j	input.r	/^setGeneric("run3", function(i, j) 1)$/;"	z	language:R	functionVar:run3.anonFuncc203d3890500
 run3	input.r	/^setMethod("run3", signature("numeric", "numeric"),$/;"	m	language:S4Class	signature:("numeric", "numeric")	extras:subparser
-anonFuncc203d3890604	input.r	/^		  function (i, j) { i + j })$/;"	v	language:R	method:run3	signature:(i, j)	extras:anonymous
-i	input.r	/^		  function (i, j) { i + j })$/;"	z	language:R	functionVar:run3.anonFuncc203d3890604
-j	input.r	/^		  function (i, j) { i + j })$/;"	z	language:R	functionVar:run3.anonFuncc203d3890604
+anonFuncc203d3890600	input.r	/^		  function (i, j) { i + j })$/;"	v	language:R	method:run3	signature:(i, j)	extras:anonymous
+i	input.r	/^		  function (i, j) { i + j })$/;"	z	language:R	functionVar:run3.anonFuncc203d3890600
+j	input.r	/^		  function (i, j) { i + j })$/;"	z	language:R	functionVar:run3.anonFuncc203d3890600
 c	input.r	/^c <- new ("C", x = 2)$/;"	g	language:R	assignmentop:<-

--- a/configure.ac
+++ b/configure.ac
@@ -765,6 +765,7 @@ AC_CONFIG_FILES([Makefile
 		 man/ctags-lang-python.7.rst
 		 man/ctags-lang-verilog.7.rst
 		 man/ctags-lang-inko.7.rst
+		 man/ctags-lang-r.7.rst
 		 man/readtags.1.rst
 		 ])
 

--- a/docs/man/ctags-lang-r.7.rst
+++ b/docs/man/ctags-lang-r.7.rst
@@ -1,0 +1,68 @@
+.. _ctags-lang-r(7):
+
+==============================================================
+ctags-lang-r
+==============================================================
+-------------------------------------------------------------------
+Random notes about tagging R source code with Universal Ctags
+-------------------------------------------------------------------
+:Version: 5.9.0
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**ctags** ... --languages=+R ...
+|	**ctags** ... --language-force=R ...
+|	**ctags** ... --map-Python=+.r ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging R source code
+with Universal Ctags.
+
+Kinds
+-----------
+If a variable gets a value returned from a *well-known constructor*
+and the variable appears for the first time in the current input file,
+the R parser makes a tag for the variable and attaches a kind
+associated with the constructor to the tag regardless of whether
+the variable appears in the top-level context or a function.
+
+Well-known constructor and kind mapping
+
+	=========== ==================
+	Constructor kind
+	=========== ==================
+	function()  function
+	=========== ==================
+
+If a variable doesn't get a value returned from well-known
+constructor, the R parser attaches "globalVar" or "functionVar" kind
+to the tag for the variable depends on the context.
+
+Here is an example demonstrating the usage of the kinds:
+
+"input.r"
+
+.. code-block:: R
+
+	G <- 1
+	f <- function(a) {
+		g <- function (b) a + b
+		L <- 2
+	}
+
+"output.tags"
+with "--options=NONE --sort=no --fields=+KZ -o - input.r"
+
+.. code-block:: tags
+
+	G	input.r	/^G <- 1$/;"	globalVar
+	f	input.r	/^f <- function(a) {$/;"	function
+	g	input.r	/^	g <- function (b) a + b$/;"	function	scope:function:f
+	L	input.r	/^	L <- 2$/;"	functionVar	scope:function:f
+
+SEE ALSO
+--------
+:ref:`ctags(1) <ctags(1)>`

--- a/main/dependency.c
+++ b/main/dependency.c
@@ -292,6 +292,19 @@ extern slaveParser *getFirstSlaveParser (struct slaveControlBlock *scb)
 	return NULL;
 }
 
+extern subparser *getLanguageSubparser (langType sublang,
+										bool including_none_crafted_parser)
+{
+	subparser *s;
+
+	foreachSubparser (s, including_none_crafted_parser)
+	{
+		if (getSubparserLanguage (s) == sublang)
+			return s;
+	}
+	return NULL;
+}
+
 extern struct colprintTable * subparserColprintTableNew (void)
 {
 	return colprintTableNew ("L:NAME", "L:BASEPARSER", "L:DIRECTIONS", NULL);

--- a/main/subparser.h
+++ b/main/subparser.h
@@ -61,6 +61,8 @@ extern void leaveSubparser(void);
 extern subparser* getSubparserRunningBaseparser (void);
 extern void chooseExclusiveSubparser (subparser *s, void *data);
 
+extern subparser *getLanguageSubparser (langType sublang, bool including_none_crafted_parser);
+
 /* Interface for Subparsers   */
 #define RUN_DEFAULT_SUBPARSERS -1
 extern void scheduleRunningBaseparser (int dependencyIndex);

--- a/man/Makefile
+++ b/man/Makefile
@@ -51,6 +51,7 @@ IN_SOURCE_FILES = \
 	ctags-lang-python.7.rst.in \
 	ctags-lang-verilog.7.rst.in \
 	ctags-lang-inko.7.rst.in \
+	ctags-lang-r.7.rst.in \
 	\
 	readtags.1.rst.in \
 	\

--- a/man/ctags-lang-r.7.rst.in
+++ b/man/ctags-lang-r.7.rst.in
@@ -1,0 +1,68 @@
+.. _ctags-lang-r(7):
+
+==============================================================
+ctags-lang-r
+==============================================================
+-------------------------------------------------------------------
+Random notes about tagging R source code with Universal Ctags
+-------------------------------------------------------------------
+:Version: @VERSION@
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**@CTAGS_NAME_EXECUTABLE@** ... --languages=+R ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --language-force=R ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Python=+.r ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging R source code
+with Universal Ctags.
+
+Kinds
+-----------
+If a variable gets a value returned from a *well-known constructor*
+and the variable appears for the first time in the current input file,
+the R parser makes a tag for the variable and attaches a kind
+associated with the constructor to the tag regardless of whether
+the variable appears in the top-level context or a function.
+
+Well-known constructor and kind mapping
+
+	=========== ==================
+	Constructor kind
+	=========== ==================
+	function()  function
+	=========== ==================
+
+If a variable doesn't get a value returned from well-known
+constructor, the R parser attaches "globalVar" or "functionVar" kind
+to the tag for the variable depends on the context.
+
+Here is an example demonstrating the usage of the kinds:
+
+"input.r"
+
+.. code-block:: R
+
+	G <- 1
+	f <- function(a) {
+		g <- function (b) a + b
+		L <- 2
+	}
+
+"output.tags"
+with "--options=NONE --sort=no --fields=+KZ -o - input.r"
+
+.. code-block:: tags
+
+	G	input.r	/^G <- 1$/;"	globalVar
+	f	input.r	/^f <- function(a) {$/;"	function
+	g	input.r	/^	g <- function (b) a + b$/;"	function	scope:function:f
+	L	input.r	/^	L <- 2$/;"	functionVar	scope:function:f
+
+SEE ALSO
+--------
+ctags(1)

--- a/parsers/r-r6class.c
+++ b/parsers/r-r6class.c
@@ -51,6 +51,7 @@ static int r6MakeTagWithTranslation (rSubparser *s,
 									 int kindInR,
 									 const char *const assignmentOperator);
 static bool r6AskTagAcceptancy (rSubparser *s, tagEntryInfo *pe);
+static bool r6HasFunctionAlikeKind (rSubparser *s, tagEntryInfo *e);
 
 static void parseClass (rSubparser *s, tokenInfo *const token, int classIndex);
 
@@ -81,6 +82,7 @@ static struct r6Subparser r6Subparser = {
 		.readRightSideSymbol = r6ReadRightSideSymbol,
 		.makeTagWithTranslation = r6MakeTagWithTranslation,
 		.askTagAcceptancy = r6AskTagAcceptancy,
+		.hasFunctionAlikeKind = r6HasFunctionAlikeKind,
 	},
 	.access = NULL,
 	.activeBinding = false,
@@ -252,6 +254,13 @@ static int r6MakeTagWithTranslation (rSubparser *s,
 static bool r6AskTagAcceptancy (rSubparser *s, tagEntryInfo *pe)
 {
 	return (pe->kindIndex == R6_K_CLASS);
+}
+
+static bool r6HasFunctionAlikeKind (rSubparser *s,
+									tagEntryInfo *e)
+{
+	return e->kindIndex == R6_K_METHOD ||
+		e->kindIndex == R6_K_ACTIVE_BINDING_FUNCTION;
 }
 
 static void findR6Tags(void)

--- a/parsers/r-s4class.c
+++ b/parsers/r-s4class.c
@@ -46,6 +46,7 @@ static int s4ReadRightSideSymbol (rSubparser *s,
 								  int parent,
 								  tokenInfo *const token);
 static bool s4AskTagAcceptancy (rSubparser *s, tagEntryInfo *pe);
+static bool s4HasFunctionAlikeKind (rSubparser *s, tagEntryInfo *e);
 
 
 /*
@@ -74,6 +75,7 @@ static struct s4Subparser s4Subparser = {
 		.readFuncall = s4ReadFuncall,
 		.readRightSideSymbol = s4ReadRightSideSymbol,
 		.askTagAcceptancy = s4AskTagAcceptancy,
+		.hasFunctionAlikeKind = s4HasFunctionAlikeKind,
 	},
 };
 
@@ -309,6 +311,12 @@ static int s4ReadFuncall (rSubparser *s,
 static bool s4AskTagAcceptancy (rSubparser *s, tagEntryInfo *pe)
 {
 	return (pe->kindIndex == S4_K_CLASS);
+}
+
+static bool s4HasFunctionAlikeKind (rSubparser *s, tagEntryInfo *e)
+{
+	return e->kindIndex == S4_K_METHOD ||
+		e->kindIndex == S4_K_GENERIC;
 }
 
 /*

--- a/parsers/r.c
+++ b/parsers/r.c
@@ -1113,22 +1113,18 @@ static  int makeSimpleSubparserTag (int langType,
 									const char *assignmentOperator)
 {
 	int q = CORK_NIL;
-	subparser *sub;
-	foreachSubparser (sub, false)
+	subparser *sub = getLanguageSubparser (langType, false);
+	if (sub)
 	{
-		if (sub->slaveParser->id == langType)
+		rSubparser *rsub = (rSubparser *)sub;
+		if (rsub->makeTagWithTranslation)
 		{
-			rSubparser *rsub = (rSubparser *)sub;
-			if (rsub->makeTagWithTranslation)
-			{
-				enterSubparser (sub);
-				q = rsub->makeTagWithTranslation (rsub,
-												  token, parent,
-												  in_func, kindInR,
-												  assignmentOperator);
-				leaveSubparser ();
-			}
-			break;
+			enterSubparser (sub);
+			q = rsub->makeTagWithTranslation (rsub,
+											  token, parent,
+											  in_func, kindInR,
+											  assignmentOperator);
+			leaveSubparser ();
 		}
 	}
 	return q;
@@ -1137,19 +1133,14 @@ static  int makeSimpleSubparserTag (int langType,
 static  bool askSubparserTagAcceptancy (tagEntryInfo *pe)
 {
 	bool q = false;
-	subparser *sub;
-	foreachSubparser (sub, false)
+	subparser *sub = getLanguageSubparser (pe->langType, false);
 	{
-		if (sub->slaveParser->id == pe->langType)
+		rSubparser *rsub = (rSubparser *)sub;
+		if (rsub->askTagAcceptancy)
 		{
-			rSubparser *rsub = (rSubparser *)sub;
-			if (rsub->askTagAcceptancy)
-			{
-				enterSubparser (sub);
-				q = rsub->askTagAcceptancy (rsub, pe);
-				leaveSubparser ();
-			}
-			break;
+			enterSubparser (sub);
+			q = rsub->askTagAcceptancy (rsub, pe);
+			leaveSubparser ();
 		}
 	}
 	return q;

--- a/parsers/r.c
+++ b/parsers/r.c
@@ -956,8 +956,7 @@ static bool parseStatement (tokenInfo *const token, int parent,
 			/* This statement doesn't start with a symbol.
 			 * This function is not assigned to any symbol. */
 			tokenInfo *const anonfunc = newTokenByCopying (token);
-			anonGenerate (anonfunc->string, "anonFunc",
-						  parent == CORK_NIL? K_GLOBALVAR: K_FUNCVAR);
+			anonGenerate (anonfunc->string, "anonFunc", K_FUNCTION);
 			tokenUnread (token);
 			vStringClear (token->string);
 			parseRightSide (token, anonfunc, parent);

--- a/parsers/r.c
+++ b/parsers/r.c
@@ -104,8 +104,8 @@ static kindDefinition RKinds[KIND_COUNT] = {
 	 .referenceOnly = true, ATTACH_ROLES (RLibraryRoles) },
 	{true, 's', "source", "sources",
 	 .referenceOnly = true, ATTACH_ROLES (RSourceRoles) },
-	{true, 'g', "globalVar", "global variables"},
-	{true, 'v', "functionVar", "function variables"},
+	{true, 'g', "globalVar", "global variables having values other than function()"},
+	{true, 'v', "functionVar", "function variables having values other than function()"},
 	{false,'z', "parameter",  "function parameters inside function definitions" },
 };
 
@@ -204,6 +204,7 @@ static  int notifyReadRightSideSymbol (tokenInfo *const symbol,
 static  int makeSimpleSubparserTag (int langType, tokenInfo *const token, int parent,
 									bool in_func, int kindInR, const char *assignmentOperator);
 static  bool askSubparserTagAcceptancy (tagEntryInfo *pe);
+static  bool askSubparserTagHasFunctionAlikeKind (tagEntryInfo *e);
 static  int notifyReadFuncall (tokenInfo *const func, tokenInfo *const token, int parent);
 
 /*
@@ -223,21 +224,29 @@ static int makeSimpleRTagR (tokenInfo *const token, int parent, int kind,
 			return CORK_NIL;
 
 		parent = CORK_NIL;
-		/* TODO: we must choose K_GLOBALVAR or K_FUNCTION though K_GLOBALVAR
-		 * is used statically here.*/
-		kind = K_GLOBALVAR;
 	}
-	else if (kind != K_FUNCTION)
+
+	/* If the tag (T) to be created is defined in a scope and
+	   the scope already has another tag having the same name
+	   as T, T should not be created. */
+	tagEntryInfo *pe = getEntryInCorkQueue (parent);
+	int cousin = CORK_NIL;
+	if (pe && ((pe->langType == Lang_R && pe->kindIndex == K_FUNCTION)
+			   || (pe->langType != Lang_R && askSubparserTagHasFunctionAlikeKind (pe))))
 	{
-		if (kind == K_FUNCVAR)
-		{
-			if (anyKindsEntryInScope (parent, tokenString (token),
-									  (int[]){K_FUNCVAR, K_PARAM}, 2) != CORK_NIL)
-				return CORK_NIL;
-		}
-		else if (anyKindEntryInScope (parent, tokenString (token), kind) != CORK_NIL)
-			return CORK_NIL;
+		cousin = anyEntryInScope (parent, tokenString (token));
+		if (kind == K_GLOBALVAR)
+			kind = K_FUNCVAR;
 	}
+	else if (pe)
+	{
+		/* The condition for tagging is a bit relaxed here.
+		   Even if the same name tag is created in the scope, a name
+		   is tagged if kinds are different. */
+		cousin = anyKindEntryInScope (parent, tokenString (token), kind);
+	}
+	if (cousin != CORK_NIL)
+		return CORK_NIL;
 
 	int corkIndex = makeSimpleTag (token->string, kind);
 	tagEntryInfo *tag = getEntryInCorkQueue (corkIndex);
@@ -752,8 +761,7 @@ static void parseRightSide (tokenInfo *const token, tokenInfo *const symbol, int
 	if (in_func)
 	{
 		corkIndex = makeSimpleRTag (symbol, parent, true,
-									parent == CORK_NIL? K_FUNCTION: K_FUNCVAR,
-									assignment_operator);
+									K_FUNCTION, assignment_operator);
 		tokenReadNoNewline (token);
 
 		/* Signature */
@@ -778,8 +786,7 @@ static void parseRightSide (tokenInfo *const token, tokenInfo *const symbol, int
 		;
 	else
 		corkIndex = makeSimpleRTag (symbol, parent, false,
-									parent == CORK_NIL? K_GLOBALVAR: K_FUNCVAR,
-									assignment_operator);
+									K_GLOBALVAR, assignment_operator);
 
 	int new_scope = (in_func
 					 ? (corkIndex == CORK_NIL
@@ -873,8 +880,7 @@ static bool preParseLoopCounter(tokenInfo *const token, int parent)
 
 	tokenReadNoNewline (token);
 	if (tokenIsType (token, R_SYMBOL))
-		makeSimpleRTag (token, parent, false,
-						(parent == CORK_NIL) ? K_GLOBALVAR: K_FUNCVAR , NULL);
+		makeSimpleRTag (token, parent, false, K_GLOBALVAR , NULL);
 
 	if (tokenIsEOF (token)
 		|| tokenIsTypeVal (token, ')'))
@@ -1025,8 +1031,7 @@ static bool parseStatement (tokenInfo *const token, int parent,
 				|| tokenIsType (token, R_STRING))
 			{
 				makeSimpleRTag (token, parent, false,
-								parent == CORK_NIL? K_GLOBALVAR: K_FUNCVAR,
-								assignment_operator);
+								K_GLOBALVAR, assignment_operator);
 				tokenRead (token);
 			}
 			eFree (assignment_operator);
@@ -1142,6 +1147,21 @@ static  bool askSubparserTagAcceptancy (tagEntryInfo *pe)
 			q = rsub->askTagAcceptancy (rsub, pe);
 			leaveSubparser ();
 		}
+	}
+	return q;
+}
+
+static  bool askSubparserTagHasFunctionAlikeKind (tagEntryInfo *e)
+{
+	bool q = false;
+	subparser *sub = getLanguageSubparser (e->langType, false);
+	Assert (sub);
+	rSubparser *rsub = (rSubparser *)sub;
+	if (rsub->hasFunctionAlikeKind)
+	{
+		enterSubparser (sub);
+		q = rsub->hasFunctionAlikeKind (rsub, e);
+		leaveSubparser ();
 	}
 	return q;
 }

--- a/parsers/r.h
+++ b/parsers/r.h
@@ -82,6 +82,7 @@ struct sRSubparser {
 									int kindInR,
 									const char *const assignmentOperator);
 	bool (* askTagAcceptancy) (rSubparser *s, tagEntryInfo *pe);
+	bool (* hasFunctionAlikeKind) (rSubparser *s, tagEntryInfo *pe);
 	int (* readFuncall) (rSubparser *s,
 						 tokenInfo *const func,
 						 tokenInfo *const token,


### PR DESCRIPTION
<BUG>
The original code attaches "funcvar" kind to functions defined in a
function.

If a variable in a function gets a value returned from a well-known
constructor, R parser should attach a suitable kind for the
constructor to the variable.

In this case, function() is the well-known constructor.

<HOW IT SHOULD BE>
"function" kind is for a variable that has a value returned from
function(), or a value itself returned from function(). In the latter
case, ctags generates an anonymous name for tagging the value.

"function" kind should be used whether the variable is defined
in the top-level context or in a function.

<NOTE>

Let's call function() a well-known constructor.

If a variable in a function has a value returned from a function call
OTHER THAN the well-known constructor, the tag for the variable should
have "globalVar" or "functionVar" as its kind.  If the variable is
assigned in the top-level context, it should have "globalVar" kind. If
not, it should have "functionVar" kind.

In the future, R parser may support c(), list(), and data.frame() as
well-known constructors. We will introduce "vector",
"list" and "daraFrame" kinds for them

This change is not only a bug fix but also a preparation for #2825.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>