### PR TITLE
Moose: support parameter-list notation of wrappers extended by Function::Parameters module

### DIFF
--- a/Units/simple-function-parameters.d/expected.tags
+++ b/Units/simple-function-parameters.d/expected.tags
@@ -4,3 +4,7 @@ create_point	input.pl	/^fun create_point(:$x, :$y, :$color) {$/;"	fun	language:F
 Derived	input.pl	/^package Derived {$/;"	package	language:Perl
 Derived	input.pl	/^package Derived {$/;"	class	language:Moose
 go_big	input.pl	/^    has 'go_big' => ($/;"	attribute	language:Moose	class:Derived
+size	input.pl	/^    around size($x, $y) {$/;"	wrapper	language:Moose	class:Derived	wrapping:around
+Derived0	input-0.pl	/^package Derived0 {$/;"	package	language:Perl
+Derived0	input-0.pl	/^package Derived0 {$/;"	class	language:Moose
+go_big0	input-0.pl	/^    has 'go_big0' => ($/;"	attribute	language:Moose	class:Derived0

--- a/Units/simple-function-parameters.d/input-0.pl
+++ b/Units/simple-function-parameters.d/input-0.pl
@@ -1,0 +1,18 @@
+package Derived0 {
+    use Function::Parameters qw(
+	:std
+	);
+    use Moo;
+
+    extends 'Base';
+
+    has 'go_big0' => (
+	is => 'ro',
+    );
+
+    # "around" method with implicit $orig and $self
+    around size0_dont_capture_me() {
+	return $self->$orig() * 2 if $self->go_big;
+	return $self->$orig();
+    }
+}

--- a/Units/simple-function-parameters.d/input.pl
+++ b/Units/simple-function-parameters.d/input.pl
@@ -23,7 +23,10 @@ create_point(
 );
  
 package Derived {
-    use Function::Parameters qw(:std :modifiers);
+    use Function::Parameters qw(
+	:std
+	:modifiers
+	);
     use Moo;
  
     extends 'Base';
@@ -33,7 +36,7 @@ package Derived {
     );
  
     # "around" method with implicit $orig and $self
-    around size() {
+    around size($x, $y) {
         return $self->$orig() * 2 if $self->go_big;
         return $self->$orig();
     }

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -54,7 +54,7 @@ static kindDefinition PerlKinds [] = {
 *   FUNCTION DEFINITIONS
 */
 
-static void notifyEntringPod ()
+static void notifyEnteringPod ()
 {
 	subparser *sub;
 
@@ -366,7 +366,7 @@ static void findPerlTags (void)
 			if (skipPodDoc)
 			{
 				podStart = getSourceLineNumber ();
-				notifyEntringPod ();
+				notifyEnteringPod ();
 			}
 			continue;
 		}

--- a/parsers/perl.h
+++ b/parsers/perl.h
@@ -34,6 +34,9 @@ enum PerlKindType {
 
 struct sPerlSubparser {
 	subparser subparser;
+	void (* findingQuotedWordNotify) (perlSubparser *,
+									  int moduleIndex,
+									  const char *qwd);
 	void (* enteringPodNotify) (perlSubparser *);
 	void (* leavingPodNotify)    (perlSubparser *);
 };


### PR DESCRIPTION
Function::Parameters module with 'qw/:modifiers/' allows specifying a
parameter list when defining a wrapper like:
    
        before foo($x, $y, $z) {
            ...
        }
    
With this change, Moose parser can detect the use of
Function::Parameters module with 'qw/:modifiers/' and extract wrappers with the extended notation.