### PR TITLE
man-test: new test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ man/readtags.1.rst
 man/readtags.1.html
 man/tags.5
 man/tags.5.html
+ManTest
 misc/mini-geany.actual
 Tmain/**/Makefile
 Tmain/**/Makefile.am

--- a/docs/man/ctags-lang-julia.7.rst
+++ b/docs/man/ctags-lang-julia.7.rst
@@ -83,7 +83,7 @@ with "--options=NONE -o - --extras=+r --fields=+rzK input.jl"
 
 .. code-block:: tags
 
-	X0	input.jl	/^using X$/;"	kind:module	roles:used
+	X0	input.jl	/^using X0$/;"	kind:module	roles:used
 
 ``--extras=+r`` (or ``--extras=+{reference}``) option is needed for this tag,
 since it's a reference tag. This is because module ``X`` is not defined here.
@@ -101,11 +101,11 @@ with "--options=NONE -o - --extras=+r --fields=+rzKZ input.jl"
 
 .. code-block:: tags
 
-	X1	julia-example.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:namespace
-	X2	julia-example.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:namespace
-	X3	julia-example.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:imported
-	a	julia-example.jl	/^import X1.a, X2.b, X3$/;"	kind:unknown	scope:module:X1	roles:imported
-	b	julia-example.jl	/^import X1.a, X2.b, X3$/;"	kind:unknown	scope:module:X2	roles:imported
+	X1	input.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:namespace
+	X2	input.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:namespace
+	X3	input.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:imported
+	a	input.jl	/^import X1.a, X2.b, X3$/;"	kind:unknown	scope:module:X1	roles:imported
+	b	input.jl	/^import X1.a, X2.b, X3$/;"	kind:unknown	scope:module:X2	roles:imported
 
 Why ``X1`` and ``X2`` have role "namespace", while ``X3`` have role "imported"?
 It's because the symbol ``a`` in module ``X1``, and ``b`` in module ``X2`` are

--- a/docs/man/ctags-lang-python.7.rst
+++ b/docs/man/ctags-lang-python.7.rst
@@ -114,12 +114,14 @@ Summary
 Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 "input.py"
+
 .. code-block:: Python
 
    import X0
 
 "output.tags"
 with "--options=NONE -o - --extras=+r --fields=+rzK input.py"
+
 .. code-block:: tags
 
 	X0	input.py	/^import X0$/;"	kind:module	roles:imported
@@ -131,13 +133,15 @@ imported module is a reference tag; specify ``--extras=+r`` (or
 ``--fields=+r`` is for recording the module is "imported" to the tag file.
 
 "input.py"
+
 .. code-block:: Python
 
 	import X1 as Y1
 
 "output.tags"
-with "--options=NONE -o - --extras=+r --fields=+rzK --fields-Python='+{nameref}' input.py"
-::
+with "--options=NONE -o - --extras=+r --fields=+rzK --fields-Python=+{nameref} input.py"
+
+.. code-block:: tags
 
 	X1	input.py	/^import X1 as Y1$/;"	kind:module	roles:indirectlyImported
 	Y1	input.py	/^import X1 as Y1$/;"	kind:namespace	roles:def	nameref:module:X1
@@ -152,15 +156,17 @@ relationship, ``nameref:`` field is attached to the tag of "Y1".  Instead of
 isn't a module.
 
 "input.py"
+
 .. code-block:: Python
 
 	from X2 import *
 
 "output.tags"
 with "--options=NONE -o - --extras=+r --fields=+rzK input.py"
-::
 
-	X2	input.py	/^from X2 import \*$/;"	kind:module	roles:namespace
+.. code-block:: tags
+
+	X2	input.py	/^from X2 import *$/;"	kind:module	roles:namespace
 
 The module is not defined here; it is defined in another file. So the tag for
 the imported module is a reference tag. Unlike "X0" in "import X0", "X2" may not
@@ -168,13 +174,15 @@ be used because the names defined in "X2" can be used in this source file. To re
 the difference ``namespace`` role is attached to "X2" instead of ``imported``.
 
 "input.py"
+
 .. code-block:: Python
 
 	from X3 import Y3
 
 "output.tags"
 with "--options=NONE -o - --extras=+r --fields=+rzKZ input.py"
-::
+
+.. code-block:: tags
 
 	X3	input.py	/^from X3 import Y3$/;"	kind:module	roles:namespace
 	Y3	input.py	/^from X3 import Y3$/;"	kind:unknown	scope:module:X3	roles:imported
@@ -185,13 +193,15 @@ assigns ``unknown`` kind to "Y3" because ctags cannot know whether "Y3" is a
 class, a variable, or a function from the input file.
 
 "input.py"
+
 .. code-block:: Python
 
 	from X4 import Y4 as Z4
 
 "output.tags"
 with "--options=NONE -o - --extras=+r --fields=+rzKZ input.py"
-::
+
+.. code-block:: tags
 
 	X4	input.py	/^from X4 import Y4 as Z4$/;"	kind:module	roles:namespace
 	Y4	input.py	/^from X4 import Y4 as Z4$/;"	kind:unknown	scope:module:X4	roles:indirectlyImported
@@ -228,6 +238,7 @@ Summary
 Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 "input.py"
+
 .. code-block:: Python
 
 	from typing import Callable
@@ -235,14 +246,15 @@ Examples
 	id_t: Callable[[int], int] = lambda var1: var1
 
 "output.tags"
-with "--options=NONE -o - --sort=no --fields=+KS --fields-Python='+{nameref}' --extras='+{anonymous}' input.py"
-::
+with "--options=NONE -o - --sort=no --fields=+KS --fields-Python=+{nameref} --extras=+{anonymous} input.py"
+
+.. code-block:: tags
 
 	id	input.py	/^id = lambda var0: var0$/;"	function	signature:(var0)
 	id_t	input.py	/^id_t: Callable[[int], int] = lambda var1: var1$/;"\
-   		variable	typeref:typename:Callable[[int], int]	nameref:function:anonFunc84011d2c0101
+		variable	typeref:typename:Callable[[int], int]	nameref:function:anonFunc84011d2c0101
 	anonFunc84011d2c0101	input.py	/^id_t: Callable[[int], int] = lambda var1: var1$/;"\
-   		function	signature:(var1)
+		function	signature:(var1)
 
 If a variable ("id") with no type hint is initialized with a lambda expression,
 ctags assigns ``function`` kind for the tag of "id".

--- a/docs/man/ctags-lang-verilog.7.rst
+++ b/docs/man/ctags-lang-verilog.7.rst
@@ -84,19 +84,19 @@ with "--options=NONE --sort=no -o - --fields-SystemVerilog=+{parameter} input.sv
 
 .. code-block:: tags
 
-	L1      foo.sv  /^parameter L1 = "synonym for the localparam";$/;"      c       parameter:
-	with_parameter_port_list foo.sv  /^module with_parameter_port_list #($/;" m
-	P1      foo.sv  /^    P1, $/;"  c       module:with_parameter_port_list  parameter:
-	L2      foo.sv  /^    localparam L2 = P1+1,$/;" c       module:with_parameter_port_list
-	P2      foo.sv  /^    parameter P2)$/;" c       module:with_parameter_port_list  parameter:
-	L3      foo.sv  /^    parameter  L3 = "synonym for the localparam";$/;" c       module:with_parameter_port_list
-	L4      foo.sv  /^    localparam L4 = "localparam";$/;" c       module:with_parameter_port_list
-	with_empty_parameter_port_list   foo.sv  /^module with_empty_parameter_port_list #()$/;"  m
-	L5      foo.sv  /^    parameter  L5 = "synonym for the localparam";$/;" c       module:with_empty_parameter_port_list
-	L6      foo.sv  /^    localparam L6 = "localparam";$/;" c       module:with_empty_parameter_port_list
-	no_parameter_port_list   foo.sv  /^module no_parameter_port_list$/;"      m
-	P3      foo.sv  /^    parameter  P3 = "parameter";$/;"  c       module:no_parameter_port_list    parameter:
-	L7      foo.sv  /^    localparam L7 = "localparam";$/;" c       module:no_parameter_port_list
+	L1	input.sv	/^parameter L1 = "synonym for the localparam";$/;"	c	parameter:
+	with_parameter_port_list	input.sv	/^module with_parameter_port_list #($/;"	m
+	P1	input.sv	/^	P1,$/;"	c	module:with_parameter_port_list	parameter:
+	L2	input.sv	/^	localparam L2 = P1+1,$/;"	c	module:with_parameter_port_list
+	P2	input.sv	/^	parameter P2)$/;"	c	module:with_parameter_port_list	parameter:
+	L3	input.sv	/^	parameter  L3 = "synonym for the localparam";$/;"	c	module:with_parameter_port_list
+	L4	input.sv	/^	localparam L4 = "localparam";$/;"	c	module:with_parameter_port_list
+	with_empty_parameter_port_list	input.sv	/^module with_empty_parameter_port_list #()$/;"	m
+	L5	input.sv	/^	parameter  L5 = "synonym for the localparam";$/;"	c	module:with_empty_parameter_port_list
+	L6	input.sv	/^	localparam L6 = "localparam";$/;"	c	module:with_empty_parameter_port_list
+	no_parameter_port_list	input.sv	/^module no_parameter_port_list$/;"	m
+	P3	input.sv	/^	parameter  P3 = "parameter";$/;"	c	module:no_parameter_port_list	parameter:
+	L7	input.sv	/^	localparam L7 = "localparam";$/;"	c	module:no_parameter_port_list
 
 Known Issues
 ---------------------------------------------------------------------

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -593,3 +593,119 @@ runs the command in two ways.
     non-zero if the input file contains invalid syntax. This method
     will never run if *is_runnable* method of the command exits with
     non-zero.
+
+
+..	_man_test:
+
+Testing examples in language specific man pages
+---------------------------------------------------------------------
+
+:Maintainer: Masatake YAMATO <yamato@redhat.com>
+
+----
+
+`man-test` is a target for testing the examples in the language
+specific man pages (``man/ctags-lang-<LANG>.7.rst.in``). The command
+line for running the target is:
+
+.. code-block:: console
+
+   $ make man-test
+
+An example for testing must have following form:
+
+.. code-block:: ReStructuredText
+
+  "input.<EXT>"
+
+  .. code-block:: <LANG>
+
+    <INPUT LINES>
+
+  "output.tags"
+  with "<OPTIONS FOR CTAGS>"
+
+  .. code-block:: tags
+
+    <TAGS OUTPUT LINES>
+
+
+The man-test target recognizes the form and does the same as
+the following shell code for each example in the man page:
+
+.. code-block:: console
+
+  $ echo <INPUT LINES> > input.<EXT>
+  $ echo <TAGS OUTPUT LINES> > output.tags
+  $ ctags <OPTIONS FOR CTAGS> > actual.tags
+  $ diff output.tags actual.tags
+
+A backslash character at the end of ``<INPUT LINES>`` or
+``<TAGS OUTPUT LINES>`` represents the continuation of lines;
+a subsequent newline is ignored.
+
+.. code-block:: ReStructuredText
+
+    .. code-block:: tags
+
+       very long\
+            line
+
+is read as:
+
+.. code-block:: ReStructuredText
+
+    .. code-block:: tags
+
+       very long     line
+
+Here is an example of a test case taken from
+``ctags-lang-python.7.rst.in``:
+
+.. code-block:: ReStructuredText
+
+	"input.py"
+
+	.. code-block:: Python
+
+	   import X0
+
+	"output.tags"
+	with "--options=NONE -o - --extras=+r --fields=+rzK input.py"
+
+	.. code-block:: tags
+
+		X0	input.py	/^import X0$/;"	kind:module	roles:imported
+
+``make man-test`` returns 0 if the all test cases in the all language
+specific man pages are passed.
+
+Here is an example output of the man-test target.
+
+.. code-block:: console
+
+	$ make man-test
+	  RUN      man-test
+	# Run test cases in ./man/ctags-lang-julia.7.rst.in
+	```
+	./man/ctags-lang-julia.7.rst.in[0]:75...passed
+	./man/ctags-lang-julia.7.rst.in[1]:93...passed
+	```
+	# Run test cases in ./man/ctags-lang-python.7.rst.in
+	```
+	./man/ctags-lang-python.7.rst.in[0]:116...passed
+	./man/ctags-lang-python.7.rst.in[1]:133...passed
+	./man/ctags-lang-python.7.rst.in[2]:154...passed
+	./man/ctags-lang-python.7.rst.in[3]:170...passed
+	./man/ctags-lang-python.7.rst.in[4]:187...passed
+	./man/ctags-lang-python.7.rst.in[5]:230...passed
+	```
+	# Run test cases in ./man/ctags-lang-verilog.7.rst.in
+	```
+	./man/ctags-lang-verilog.7.rst.in[0]:51...passed
+	```
+	OK
+
+NOTE: keep examples in the man pages simple. If you want to test ctags
+complicated (and or subtle) input, use the units target. The main
+purpose of the examples is for explaining the parser.

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -1,7 +1,7 @@
 # -*- makefile -*-
 .PHONY: check units fuzz noise tmain tinst tlib clean-units clean-tlib clean-tmain clean-gcov run-gcov codecheck cppcheck dicts validate-input
 
-EXTRA_DIST += misc/units misc/units.py
+EXTRA_DIST += misc/units misc/units.py misc/man-test.py
 EXTRA_DIST += misc/tlib misc/mini-geany.expected
 
 check: tmain units tlib

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -278,3 +278,10 @@ CPPCHECK_FLAGS  = --enable=all
 cppcheck:
 	cppcheck $(CPPCHECK_DEFS) $(CPPCHECK_UNDEFS) $(CPPCHECK_FLAGS) \
 		 $$(git  ls-files | grep '^\(parsers\|main\)/.*\.[ch]' )
+#
+# Testing examples in per-language man pages
+#
+man-test: $(CTAGS_TEST)
+	$(V_RUN) \
+	builddir=$$(pwd); \
+	$(PYTHON) $(srcdir)/misc/man-test.py $${builddir}/ManTest $(CTAGS_TEST) $(srcdir)/man/ctags-lang-*.7.rst.in

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -4,7 +4,7 @@
 EXTRA_DIST += misc/units misc/units.py misc/man-test.py
 EXTRA_DIST += misc/tlib misc/mini-geany.expected
 
-check: tmain units tlib
+check: tmain units tlib man-test
 
 clean-local: clean-units clean-tmain
 

--- a/man/ctags-lang-julia.7.rst.in
+++ b/man/ctags-lang-julia.7.rst.in
@@ -83,7 +83,7 @@ with "--options=NONE -o - --extras=+r --fields=+rzK input.jl"
 
 .. code-block:: tags
 
-	X0	input.jl	/^using X$/;"	kind:module	roles:used
+	X0	input.jl	/^using X0$/;"	kind:module	roles:used
 
 ``--extras=+r`` (or ``--extras=+{reference}``) option is needed for this tag,
 since it's a reference tag. This is because module ``X`` is not defined here.
@@ -101,11 +101,11 @@ with "--options=NONE -o - --extras=+r --fields=+rzKZ input.jl"
 
 .. code-block:: tags
 
-	X1	julia-example.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:namespace
-	X2	julia-example.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:namespace
-	X3	julia-example.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:imported
-	a	julia-example.jl	/^import X1.a, X2.b, X3$/;"	kind:unknown	scope:module:X1	roles:imported
-	b	julia-example.jl	/^import X1.a, X2.b, X3$/;"	kind:unknown	scope:module:X2	roles:imported
+	X1	input.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:namespace
+	X2	input.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:namespace
+	X3	input.jl	/^import X1.a, X2.b, X3$/;"	kind:module	roles:imported
+	a	input.jl	/^import X1.a, X2.b, X3$/;"	kind:unknown	scope:module:X1	roles:imported
+	b	input.jl	/^import X1.a, X2.b, X3$/;"	kind:unknown	scope:module:X2	roles:imported
 
 Why ``X1`` and ``X2`` have role "namespace", while ``X3`` have role "imported"?
 It's because the symbol ``a`` in module ``X1``, and ``b`` in module ``X2`` are

--- a/man/ctags-lang-python.7.rst.in
+++ b/man/ctags-lang-python.7.rst.in
@@ -114,12 +114,14 @@ Summary
 Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 "input.py"
+
 .. code-block:: Python
 
    import X0
 
 "output.tags"
 with "--options=NONE -o - --extras=+r --fields=+rzK input.py"
+
 .. code-block:: tags
 
 	X0	input.py	/^import X0$/;"	kind:module	roles:imported
@@ -131,13 +133,15 @@ imported module is a reference tag; specify ``--extras=+r`` (or
 ``--fields=+r`` is for recording the module is "imported" to the tag file.
 
 "input.py"
+
 .. code-block:: Python
 
 	import X1 as Y1
 
 "output.tags"
-with "--options=NONE -o - --extras=+r --fields=+rzK --fields-Python='+{nameref}' input.py"
-::
+with "--options=NONE -o - --extras=+r --fields=+rzK --fields-Python=+{nameref} input.py"
+
+.. code-block:: tags
 
 	X1	input.py	/^import X1 as Y1$/;"	kind:module	roles:indirectlyImported
 	Y1	input.py	/^import X1 as Y1$/;"	kind:namespace	roles:def	nameref:module:X1
@@ -152,15 +156,17 @@ relationship, ``nameref:`` field is attached to the tag of "Y1".  Instead of
 isn't a module.
 
 "input.py"
+
 .. code-block:: Python
 
 	from X2 import *
 
 "output.tags"
 with "--options=NONE -o - --extras=+r --fields=+rzK input.py"
-::
 
-	X2	input.py	/^from X2 import \*$/;"	kind:module	roles:namespace
+.. code-block:: tags
+
+	X2	input.py	/^from X2 import *$/;"	kind:module	roles:namespace
 
 The module is not defined here; it is defined in another file. So the tag for
 the imported module is a reference tag. Unlike "X0" in "import X0", "X2" may not
@@ -168,13 +174,15 @@ be used because the names defined in "X2" can be used in this source file. To re
 the difference ``namespace`` role is attached to "X2" instead of ``imported``.
 
 "input.py"
+
 .. code-block:: Python
 
 	from X3 import Y3
 
 "output.tags"
 with "--options=NONE -o - --extras=+r --fields=+rzKZ input.py"
-::
+
+.. code-block:: tags
 
 	X3	input.py	/^from X3 import Y3$/;"	kind:module	roles:namespace
 	Y3	input.py	/^from X3 import Y3$/;"	kind:unknown	scope:module:X3	roles:imported
@@ -185,13 +193,15 @@ assigns ``unknown`` kind to "Y3" because ctags cannot know whether "Y3" is a
 class, a variable, or a function from the input file.
 
 "input.py"
+
 .. code-block:: Python
 
 	from X4 import Y4 as Z4
 
 "output.tags"
 with "--options=NONE -o - --extras=+r --fields=+rzKZ input.py"
-::
+
+.. code-block:: tags
 
 	X4	input.py	/^from X4 import Y4 as Z4$/;"	kind:module	roles:namespace
 	Y4	input.py	/^from X4 import Y4 as Z4$/;"	kind:unknown	scope:module:X4	roles:indirectlyImported
@@ -228,6 +238,7 @@ Summary
 Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 "input.py"
+
 .. code-block:: Python
 
 	from typing import Callable
@@ -235,14 +246,15 @@ Examples
 	id_t: Callable[[int], int] = lambda var1: var1
 
 "output.tags"
-with "--options=NONE -o - --sort=no --fields=+KS --fields-Python='+{nameref}' --extras='+{anonymous}' input.py"
-::
+with "--options=NONE -o - --sort=no --fields=+KS --fields-Python=+{nameref} --extras=+{anonymous} input.py"
+
+.. code-block:: tags
 
 	id	input.py	/^id = lambda var0: var0$/;"	function	signature:(var0)
 	id_t	input.py	/^id_t: Callable[[int], int] = lambda var1: var1$/;"\
-   		variable	typeref:typename:Callable[[int], int]	nameref:function:anonFunc84011d2c0101
+		variable	typeref:typename:Callable[[int], int]	nameref:function:anonFunc84011d2c0101
 	anonFunc84011d2c0101	input.py	/^id_t: Callable[[int], int] = lambda var1: var1$/;"\
-   		function	signature:(var1)
+		function	signature:(var1)
 
 If a variable ("id") with no type hint is initialized with a lambda expression,
 ctags assigns ``function`` kind for the tag of "id".

--- a/man/ctags-lang-verilog.7.rst.in
+++ b/man/ctags-lang-verilog.7.rst.in
@@ -84,19 +84,19 @@ with "--options=NONE --sort=no -o - --fields-SystemVerilog=+{parameter} input.sv
 
 .. code-block:: tags
 
-	L1      foo.sv  /^parameter L1 = "synonym for the localparam";$/;"      c       parameter:
-	with_parameter_port_list foo.sv  /^module with_parameter_port_list #($/;" m
-	P1      foo.sv  /^    P1, $/;"  c       module:with_parameter_port_list  parameter:
-	L2      foo.sv  /^    localparam L2 = P1+1,$/;" c       module:with_parameter_port_list
-	P2      foo.sv  /^    parameter P2)$/;" c       module:with_parameter_port_list  parameter:
-	L3      foo.sv  /^    parameter  L3 = "synonym for the localparam";$/;" c       module:with_parameter_port_list
-	L4      foo.sv  /^    localparam L4 = "localparam";$/;" c       module:with_parameter_port_list
-	with_empty_parameter_port_list   foo.sv  /^module with_empty_parameter_port_list #()$/;"  m
-	L5      foo.sv  /^    parameter  L5 = "synonym for the localparam";$/;" c       module:with_empty_parameter_port_list
-	L6      foo.sv  /^    localparam L6 = "localparam";$/;" c       module:with_empty_parameter_port_list
-	no_parameter_port_list   foo.sv  /^module no_parameter_port_list$/;"      m
-	P3      foo.sv  /^    parameter  P3 = "parameter";$/;"  c       module:no_parameter_port_list    parameter:
-	L7      foo.sv  /^    localparam L7 = "localparam";$/;" c       module:no_parameter_port_list
+	L1	input.sv	/^parameter L1 = "synonym for the localparam";$/;"	c	parameter:
+	with_parameter_port_list	input.sv	/^module with_parameter_port_list #($/;"	m
+	P1	input.sv	/^	P1,$/;"	c	module:with_parameter_port_list	parameter:
+	L2	input.sv	/^	localparam L2 = P1+1,$/;"	c	module:with_parameter_port_list
+	P2	input.sv	/^	parameter P2)$/;"	c	module:with_parameter_port_list	parameter:
+	L3	input.sv	/^	parameter  L3 = "synonym for the localparam";$/;"	c	module:with_parameter_port_list
+	L4	input.sv	/^	localparam L4 = "localparam";$/;"	c	module:with_parameter_port_list
+	with_empty_parameter_port_list	input.sv	/^module with_empty_parameter_port_list #()$/;"	m
+	L5	input.sv	/^	parameter  L5 = "synonym for the localparam";$/;"	c	module:with_empty_parameter_port_list
+	L6	input.sv	/^	localparam L6 = "localparam";$/;"	c	module:with_empty_parameter_port_list
+	no_parameter_port_list	input.sv	/^module no_parameter_port_list$/;"	m
+	P3	input.sv	/^	parameter  P3 = "parameter";$/;"	c	module:no_parameter_port_list	parameter:
+	L7	input.sv	/^	localparam L7 = "localparam";$/;"	c	module:no_parameter_port_list
 
 Known Issues
 ---------------------------------------------------------------------

--- a/misc/man-test.py
+++ b/misc/man-test.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+
+#
+# man-test.py - test exapmles in a man page
+#
+# Copyright (C) 2021 Masatake YAMATO
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#
+# Python 3.5 or later is required.
+# On Windows, unix-like shell (e.g. bash) and diff command are needed.
+#
+
+import sys
+import re
+import os
+import subprocess
+import copy
+
+def print_usage(n, f):
+    print ('Usage: man-test.py TMPDIR CTAGS ctags-lang-<LANG>.7.rst.in...', file=f)
+    sys.exit(n)
+
+def next_segment(line):
+    if line.endswith ('\\'):
+        return line[0:-1]
+    else:
+        return (line + '\n')
+
+def wash_cmdline(cmdline):
+    return cmdline
+
+def verify_test_case(t):
+    prefix = '%(man_file)s[%(nth)d]:%(start_linum)d: '%t
+    msg = False
+    if not 'code' in t:
+        msg = 'cannot find input lines'
+    elif not 'tags' in t:
+        msg = 'cannot find expected tags output'
+    elif not 'cmdline' in t:
+        msg = 'cannot find ctags command line'
+
+    if msg:
+        msg = prefix + msg
+    return msg
+
+def run_test_case(tmpdir, ctags, t):
+    d = tmpdir + '/' + str(os.getpid())
+    os.makedirs (d,exist_ok=True)
+    i = d + '/' + t['input_file_name']
+    o0 = 'actual.tags'
+    o = d + '/' + o0
+    e0 = 'expected.tags'
+    e = d + '/' + e0
+    D = d + '/' + 'tags.diff'
+    O0 = 'args.ctags'
+    O = d + '/' + O0
+    with open(i, mode='w') as f:
+        f.write(t['code'])
+
+    with open(e, mode='w') as g:
+        g.write(t['tags'])
+
+    inputf=None
+    with open(O, mode='w') as Of:
+        for c in t['cmdline'].split():
+            if c == '--options=NONE':
+                continue
+            elif c.startswith('input.'):
+                inputf = c
+                continue
+            print (c, file=Of)
+
+    with open(o, mode='w') as h:
+        cmdline = [ctags, '--quiet', '--options=NONE',
+                   '--options=' + O0, inputf]
+        subprocess.run(cmdline, cwd=d, stdout=h)
+
+    with open(D, mode='w') as diff:
+        r = subprocess.run(['diff', '-uN', '--strip-trailing-cr', o0, e0],
+                           cwd=d, stdout=diff).returncode
+
+    if r == 0:
+        t['result'] = True
+        t['result_readable'] = 'passed'
+    else:
+        with open(o) as f:
+            t['actual_tags'] = f.read()
+        t['result'] = False
+        t['result_readable'] = 'failed'
+        with open(D) as diff:
+            t['tags_diff'] = diff.read()
+    os.remove(O)
+    os.remove(i)
+    os.remove(e)
+    os.remove(o)
+    os.remove(D)
+    os.rmdir(d)
+    return t
+
+def report_result(r):
+    print ('%(man_file)s[%(nth)d]:%(start_linum)d...%(result_readable)s'%r)
+
+def report_failure(r):
+    print ('## %(man_file)s[%(nth)d]:%(start_linum)d'%r)
+    print ('### input')
+    print ('```')
+    print (r['code'])
+    print ('```')
+    print ('### cmdline')
+    print ('```')
+    print (r['cmdline'])
+    print ('```')
+    print ('### expected tags')
+    print ('```')
+    print (r['tags'])
+    print ('```')
+    print ('### actual tags')
+    print ('```')
+    print (r['actual_tags'])
+    print ('```')
+    print ('### diff of tag files')
+    print ('```')
+    print (r['tags_diff'])
+    print ('```')
+
+class state:
+    start = 0
+    tags  = 1
+    code  = 2
+    code_done = 3
+    input = 4
+    output = 5
+    output_after_options = 6
+
+def extract_test_cases(f):
+    linum=0
+    nth=0
+    s=state.start
+    test_spec = {}
+
+    for line in  f.readlines():
+        linum += 1
+        line = line.rstrip('\r\n')
+
+        if s == state.tags or s == state.code:
+            if prefix:
+                m = re.search('^' + prefix + '(.*)$', line)
+                if m:
+                    sink += next_segment(m.group(1))
+                    continue
+                if line == '':
+                    sink += '\n'
+                    continue
+            else:
+                m = re.search('^([ \t]+)(.+)$', line)
+                if m:
+                    prefix = m.group(1)
+                    sink += next_segment(m.group(2))
+                    continue
+                elif re.search ('^([ \t]*)$', line):
+                    continue
+
+            sink = sink.rstrip('\r\n') + '\n'
+
+            if s == state.code:
+                test_spec['code'] = sink
+                s = state.code_done
+            else:
+                test_spec['tags'] = sink
+                test_spec['nth'] = nth
+                nth += 1
+                test_spec['end_linum'] = linum
+                s = state.start
+                yield test_spec
+
+        m = s == state.start and re.search ('^"(input\.[^"]+)"$', line)
+        if m:
+            test_spec ['start_linum'] = linum
+            test_spec ['input_file_name'] = m.group(1)
+            s = state.input
+            continue
+        m = s == state.input and re.search ('^.. code-block::.*', line)
+        if m:
+            sink = ''
+            prefix = False
+            s = state.code
+            continue
+        m = s == state.code_done and re.search ('^"output.tags"$', line)
+        if m:
+            s = state.output
+            continue
+        m = s == state.output and re.search ('with[ \t]"([^"]+)"', line)
+        if m:
+            test_spec ['cmdline'] = wash_cmdline (m.group(1))
+            s = state.output_after_options
+            continue
+        if s == state.output_after_options \
+           and (line == "::" or re.search ('^.. code-block:: *tags$', line)):
+            sink = ''
+            prefix = False
+            s = state.tags
+            continue
+
+def man_test (tmpdir, ctags, man_file):
+    failures = []
+    result = True
+    print ('# Run test cases in ' + man_file)
+    print ('```')
+    with open(man_file) as f:
+        for t in extract_test_cases (f):
+            t['man_file'] = man_file
+            v = verify_test_case (t)
+            if v:
+                print ("error: " + v, file=sys.stderr)
+                result = False
+                continue
+            r = run_test_case (tmpdir, ctags, t)
+            report_result (r)
+            if not r['result']:
+                result = False
+                failures.append(copy.copy(r))
+    print ('```')
+    if (len(failures) > 0):
+        print ('# Failed test case(s)')
+        for f in failures:
+            report_failure(f)
+    return result
+
+def man_tests (tmpdir, ctags, man_files):
+    result = 0
+    for m in man_files:
+        if not man_test(tmpdir, ctags, m):
+            result += 1
+    print ('OK' if result == 0 else 'FAILED')
+    return result == 0
+
+if (len(sys.argv) < 4) or (sys.argv[1] == '-h' or sys.argv[1] == '--help'):
+    print_usage (2, sys.stderr)
+
+tmpdir = sys.argv[1]
+ctags = os.getcwd() + '/' + sys.argv[2]
+sys.exit(0 if man_tests (tmpdir, ctags, sys.argv[3:]) else 1)


### PR DESCRIPTION
`man-test` is a new test harness for testing examples in per-language man pages (man/ctags-lang-\*.7.rst.in).

If you have python3, you can run it with "make man-test."

TODO:
- ~documentation for writing a test case~
- ~running on CI/CD environment~