### PR TITLE
units: don't pass --fields=-T

### DIFF
--- a/misc/units
+++ b/misc/units
@@ -598,7 +598,7 @@ run_tcase ()
     #
     # Build _CMDLINE
     #
-    _CMDLINE="${CTAGS} --verbose --options=NONE $PRETENSE_OPTS --optlib-dir=+$t/optlib -o -"
+    _CMDLINE="${CTAGS} --verbose --options=NONE --fields=-T $PRETENSE_OPTS --optlib-dir=+$t/optlib -o -"
     [ -f "${fargs}" ] && _CMDLINE="${_CMDLINE} --options=${fargs}"
 
     if [ -f "${fargs}" ] && ! ${_CMDLINE} --_force-quit=0 > /dev/null 2>&1; then


### PR DESCRIPTION
I forgot updating the units shell script
in c314f261c930c6407a904f6e598d646db1c0df35.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>