### PR TITLE
C++: parse member variables using templates with forward declared types

### DIFF
--- a/Units/parser-cxx.r/template-member-forward-declaration.d/args.ctags
+++ b/Units/parser-cxx.r/template-member-forward-declaration.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-C++=m

--- a/Units/parser-cxx.r/template-member-forward-declaration.d/expected.tags
+++ b/Units/parser-cxx.r/template-member-forward-declaration.d/expected.tags
@@ -1,0 +1,4 @@
+p	input.cpp	/^	Class *p;$/;"	m	class:A	typeref:typename:Class *	file:
+a_c_forward	input.cpp	/^	A<class C> a_c_forward;$/;"	m	class:B	typeref:typename:A<class C>	file:
+a_s_forward	input.cpp	/^	A<struct S> a_s_forward;$/;"	m	class:B	typeref:typename:A<struct S>	file:
+a_u_forward	input.cpp	/^	A<union U> a_u_forward;$/;"	m	class:B	typeref:typename:A<union U>	file:

--- a/Units/parser-cxx.r/template-member-forward-declaration.d/input.cpp
+++ b/Units/parser-cxx.r/template-member-forward-declaration.d/input.cpp
@@ -1,0 +1,16 @@
+template <class Class>
+class A
+{
+public:
+	A() { p = new Class(); }
+	Class *p;
+};
+
+class B {
+public:
+	// forward declaration okay because only used as pointer in Template
+	A<class C> a_c_forward;
+	A<struct S> a_s_forward;
+	A<union U> a_u_forward;
+};
+

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -262,6 +262,7 @@ static bool cxxParserParseBlockInternal(bool bExpectClosingBracket)
 		cppBeginStatement();
 	}
 
+	int iNestedAngleBracketLevel = 0;
 	for(;;)
 	{
 		if(!cxxParserParseNextToken())
@@ -392,21 +393,24 @@ process_token:
 						}
 					break;
 					case CXXKeywordCLASS:
-						if(!cxxParserParseClassStructOrUnion(CXXKeywordCLASS,CXXTagCPPKindCLASS,CXXScopeTypeClass))
+						if(iNestedAngleBracketLevel == 0 &&
+						   !cxxParserParseClassStructOrUnion(CXXKeywordCLASS,CXXTagCPPKindCLASS,CXXScopeTypeClass))
 						{
 							CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
 							return false;
 						}
 					break;
 					case CXXKeywordSTRUCT:
-						if(!cxxParserParseClassStructOrUnion(CXXKeywordSTRUCT,CXXTagKindSTRUCT,CXXScopeTypeStruct))
+						if(iNestedAngleBracketLevel == 0 &&
+						   !cxxParserParseClassStructOrUnion(CXXKeywordSTRUCT,CXXTagKindSTRUCT,CXXScopeTypeStruct))
 						{
 							CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
 							return false;
 						}
 					break;
 					case CXXKeywordUNION:
-						if(!cxxParserParseClassStructOrUnion(CXXKeywordUNION,CXXTagKindUNION,CXXScopeTypeUnion))
+						if(iNestedAngleBracketLevel == 0 &&
+						   !cxxParserParseClassStructOrUnion(CXXKeywordUNION,CXXTagKindUNION,CXXScopeTypeUnion))
 						{
 							CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
 							return false;
@@ -744,6 +748,12 @@ process_token:
 				else if (cxxScopeGetType() == CXXScopeTypeClass)
 					cxxSubparserUnknownIdentifierInClassNotify(g_cxx.pToken);
 			break;
+			case CXXTokenTypeSmallerThanSign:
+				iNestedAngleBracketLevel++;
+				break;
+			case CXXTokenTypeGreaterThanSign:
+				iNestedAngleBracketLevel--;
+				break;
 			default:
 				// something else we didn't handle
 			break;


### PR DESCRIPTION
Fixes  #2867.