### PR TITLE
main: adjust states of enabled/disabled for fixed fields before listing with --list-fields

### DIFF
--- a/Tmain/list-fields-fixed-field-handling.d/run.sh
+++ b/Tmain/list-fields-fixed-field-handling.d/run.sh
@@ -1,0 +1,19 @@
+# Copyright: 2019 Masatake YAMATO
+# License: GPL-2
+
+. ../utils.sh
+
+CTAGS="$1"
+
+is_feature_available "${CTAGS}" json
+
+run()
+{
+	echo '#' "$@"
+	$CTAGS --quiet --options=NONE "$@" | grep -v -e ^-
+}
+
+run --output-format=u-ctags  --fields=n --list-fields
+run --fields=n --output-format=u-ctags  --list-fields
+run --output-format=json  --fields=n --list-fields
+run --fields=n --output-format=json  --list-fields

--- a/Tmain/list-fields-fixed-field-handling.d/stdout-expected.txt
+++ b/Tmain/list-fields-fixed-field-handling.d/stdout-expected.txt
@@ -1,0 +1,104 @@
+# --output-format=u-ctags --fields=n --list-fields
+#LETTER NAME           ENABLED LANGUAGE         JSTYPE FIXED DESCRIPTION
+N       name           yes     NONE             s--    yes   tag name
+F       input          yes     NONE             s--    yes   input file
+P       pattern        yes     NONE             s-b    yes   pattern
+C       compact        no      NONE             s--    no    compact input line (used only in xref output)
+E       extras         no      NONE             s--    no    Extra tag type information
+K       NONE           no      NONE             s--    no    Kind of tag in long-name form
+R       NONE           no      NONE             s--    no    Marker (R or D) representing whether tag is definition or reference
+S       signature      no      NONE             s--    no    Signature of routine (e.g. prototype or parameter list)
+T       epoch          no      NONE             -i-    no    the last modified time of the input file (only for F/file kind tag)
+Z       scope          no      NONE             s--    no    [tags output] prepend "scope:" key to s/scope field output, [xref and json output] the same as s/ field
+a       access         no      NONE             s--    no    Access (or export) of class members
+e       end            no      NONE             -i-    no    end lines of various items
+f       file           no      NONE             --b    no    File-restricted scoping
+i       inherits       no      NONE             s-b    no    Inheritance information
+k       NONE           no      NONE             s--    no    Kind of tag in one-letter form
+l       language       no      NONE             s--    no    Language of input file containing tag
+m       implementation no      NONE             s--    no    Implementation information
+n       line           yes     NONE             -i-    no    Line number of tag definition
+p       scopeKind      no      NONE             s--    no    [tags output] no effect, [xref and json output] kind of scope in long-name form
+r       roles          no      NONE             s--    no    Roles
+s       NONE           no      NONE             s--    no    [tags output] scope (kind:name) of tag definition, [xref and json output] name of scope
+t       typeref        no      NONE             s--    no    Type and name of a variable or typedef
+x       xpath          no      NONE             s--    no    xpath for the tag
+z       kind           no      NONE             s--    no    [tags output] prepend "kind:" to k/ (or K/) field output, [xref and json output] kind in long-name form
+# --fields=n --output-format=u-ctags --list-fields
+#LETTER NAME           ENABLED LANGUAGE         JSTYPE FIXED DESCRIPTION
+N       name           yes     NONE             s--    yes   tag name
+F       input          yes     NONE             s--    yes   input file
+P       pattern        yes     NONE             s-b    yes   pattern
+C       compact        no      NONE             s--    no    compact input line (used only in xref output)
+E       extras         no      NONE             s--    no    Extra tag type information
+K       NONE           no      NONE             s--    no    Kind of tag in long-name form
+R       NONE           no      NONE             s--    no    Marker (R or D) representing whether tag is definition or reference
+S       signature      no      NONE             s--    no    Signature of routine (e.g. prototype or parameter list)
+T       epoch          no      NONE             -i-    no    the last modified time of the input file (only for F/file kind tag)
+Z       scope          no      NONE             s--    no    [tags output] prepend "scope:" key to s/scope field output, [xref and json output] the same as s/ field
+a       access         no      NONE             s--    no    Access (or export) of class members
+e       end            no      NONE             -i-    no    end lines of various items
+f       file           no      NONE             --b    no    File-restricted scoping
+i       inherits       no      NONE             s-b    no    Inheritance information
+k       NONE           no      NONE             s--    no    Kind of tag in one-letter form
+l       language       no      NONE             s--    no    Language of input file containing tag
+m       implementation no      NONE             s--    no    Implementation information
+n       line           yes     NONE             -i-    no    Line number of tag definition
+p       scopeKind      no      NONE             s--    no    [tags output] no effect, [xref and json output] kind of scope in long-name form
+r       roles          no      NONE             s--    no    Roles
+s       NONE           no      NONE             s--    no    [tags output] scope (kind:name) of tag definition, [xref and json output] name of scope
+t       typeref        no      NONE             s--    no    Type and name of a variable or typedef
+x       xpath          no      NONE             s--    no    xpath for the tag
+z       kind           no      NONE             s--    no    [tags output] prepend "kind:" to k/ (or K/) field output, [xref and json output] kind in long-name form
+# --output-format=json --fields=n --list-fields
+#LETTER NAME           ENABLED LANGUAGE         JSTYPE FIXED DESCRIPTION
+C       compact        no      NONE             s--    no    compact input line (used only in xref output)
+E       extras         no      NONE             s--    no    Extra tag type information
+F       input          no      NONE             s--    no    input file
+K       NONE           no      NONE             s--    no    Kind of tag in long-name form
+N       name           no      NONE             s--    no    tag name
+P       pattern        no      NONE             s-b    no    pattern
+R       NONE           no      NONE             s--    no    Marker (R or D) representing whether tag is definition or reference
+S       signature      no      NONE             s--    no    Signature of routine (e.g. prototype or parameter list)
+T       epoch          no      NONE             -i-    no    the last modified time of the input file (only for F/file kind tag)
+Z       scope          no      NONE             s--    no    [tags output] prepend "scope:" key to s/scope field output, [xref and json output] the same as s/ field
+a       access         no      NONE             s--    no    Access (or export) of class members
+e       end            no      NONE             -i-    no    end lines of various items
+f       file           no      NONE             --b    no    File-restricted scoping
+i       inherits       no      NONE             s-b    no    Inheritance information
+k       NONE           no      NONE             s--    no    Kind of tag in one-letter form
+l       language       no      NONE             s--    no    Language of input file containing tag
+m       implementation no      NONE             s--    no    Implementation information
+n       line           yes     NONE             -i-    no    Line number of tag definition
+p       scopeKind      no      NONE             s--    no    [tags output] no effect, [xref and json output] kind of scope in long-name form
+r       roles          no      NONE             s--    no    Roles
+s       NONE           no      NONE             s--    no    [tags output] scope (kind:name) of tag definition, [xref and json output] name of scope
+t       typeref        no      NONE             s--    no    Type and name of a variable or typedef
+x       xpath          no      NONE             s--    no    xpath for the tag
+z       kind           no      NONE             s--    no    [tags output] prepend "kind:" to k/ (or K/) field output, [xref and json output] kind in long-name form
+# --fields=n --output-format=json --list-fields
+#LETTER NAME           ENABLED LANGUAGE         JSTYPE FIXED DESCRIPTION
+C       compact        no      NONE             s--    no    compact input line (used only in xref output)
+E       extras         no      NONE             s--    no    Extra tag type information
+F       input          no      NONE             s--    no    input file
+K       NONE           no      NONE             s--    no    Kind of tag in long-name form
+N       name           no      NONE             s--    no    tag name
+P       pattern        no      NONE             s-b    no    pattern
+R       NONE           no      NONE             s--    no    Marker (R or D) representing whether tag is definition or reference
+S       signature      no      NONE             s--    no    Signature of routine (e.g. prototype or parameter list)
+T       epoch          no      NONE             -i-    no    the last modified time of the input file (only for F/file kind tag)
+Z       scope          no      NONE             s--    no    [tags output] prepend "scope:" key to s/scope field output, [xref and json output] the same as s/ field
+a       access         no      NONE             s--    no    Access (or export) of class members
+e       end            no      NONE             -i-    no    end lines of various items
+f       file           no      NONE             --b    no    File-restricted scoping
+i       inherits       no      NONE             s-b    no    Inheritance information
+k       NONE           no      NONE             s--    no    Kind of tag in one-letter form
+l       language       no      NONE             s--    no    Language of input file containing tag
+m       implementation no      NONE             s--    no    Implementation information
+n       line           yes     NONE             -i-    no    Line number of tag definition
+p       scopeKind      no      NONE             s--    no    [tags output] no effect, [xref and json output] kind of scope in long-name form
+r       roles          no      NONE             s--    no    Roles
+s       NONE           no      NONE             s--    no    [tags output] scope (kind:name) of tag definition, [xref and json output] name of scope
+t       typeref        no      NONE             s--    no    Type and name of a variable or typedef
+x       xpath          no      NONE             s--    no    xpath for the tag
+z       kind           no      NONE             s--    no    [tags output] prepend "kind:" to k/ (or K/) field output, [xref and json output] kind in long-name form

--- a/main/options.c
+++ b/main/options.c
@@ -1542,6 +1542,9 @@ static void processListFeaturesOption(const char *const option CTAGS_ATTR_UNUSED
 static void processListFieldsOption(const char *const option CTAGS_ATTR_UNUSED,
 				    const char *const parameter)
 {
+	/* Before listing, adjust states of enabled/disabled for fixed fields. */
+	writerCheckOptions (Option.fieldsReset);
+
 	struct colprintTable * table = fieldColprintTableNew ();
 
 	if (parameter [0] == '\0' || strcasecmp (parameter, RSV_LANG_ALL) == 0)


### PR DESCRIPTION
This change is a continuation of c0421c5ec596b5f2a3e1a16a61d6ee3368a68842.

The effect of the "FIXED" property of fields cannot be decided till ctags
chooses of an output writer.

c0421c5ec596b5f2a3e1a16a61d6ee3368a68842 considers beginning
of parsing is the timing of the choice.

c0421c5ec596b5f2a3e1a16a61d6ee3368a68842 misses there is one more
case: the choice is made when --list-fields option is processed.

To reflect the choice to the output of --list-fields, this
change calls writerCheckOptions at the beginning of the process.

With this change, the behavior of --list-fields option
consists with the following description of ctags(1):

    ``--list-fields[=language|all]``
            ...
            FIXED
                    Whether this field can be disabled or not in tags output.

                    Some fields are printed always in tags output.
                    They have ``yes`` as the value for this column.

                    Unlike the tag output mode, JSON output mode allows disabling
                    any fields.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>
