### PR TITLE
Tmain: using `shift_jis` instead of `cp932` coding.

### DIFF
--- a/Tmain/input-encoding-option.d/run.sh
+++ b/Tmain/input-encoding-option.d/run.sh
@@ -11,7 +11,7 @@ BUILDDIR=$2
 if ${CTAGS} --quiet --options=NONE --list-features | grep -q iconv; then
   if ${CTAGS} --quiet --options=NONE \
 	      --pseudo-tags=-TAG_PROC_CWD \
-	      --input-encoding=utf-8 --input-encoding-java=cp932 --input-encoding-javascript=euc-jp \
+	      --input-encoding=utf-8 --input-encoding-java=shift_jis --input-encoding-javascript=euc-jp \
 	      -o ${BUILDDIR}/tags \
 	      input.js input.java ; then
       remove_commit_id ${BUILDDIR}/tags

--- a/Tmain/output-encoding-option.d/run.sh
+++ b/Tmain/output-encoding-option.d/run.sh
@@ -10,7 +10,7 @@ BUILDDIR=$2
 if ${CTAGS} --quiet --options=NONE --list-features | grep -q iconv; then
   if ${CTAGS}  --quiet --options=NONE \
 	       --pseudo-tags=-TAG_PROC_CWD \
-	       --output-encoding=cp932 --input-encoding=utf-8 --input-encoding-javascript=euc-jp \
+	       --output-encoding=shift_jis --input-encoding=utf-8 --input-encoding-javascript=euc-jp \
 	       -o ${BUILDDIR}/tags \
 	       input.js input.java ; then
       remove_commit_id ${BUILDDIR}/tags

--- a/Tmain/output-encoding-option.d/tags-expected.txt
+++ b/Tmain/output-encoding-option.d/tags-expected.txt
@@ -1,4 +1,4 @@
-!_TAG_FILE_ENCODING	cp932	//
+!_TAG_FILE_ENCODING	shift_jis	//
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
 !_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/


### PR DESCRIPTION
`musl-libc iconv API` dosn't support `cp932` coding but supports
`shift_jis` coding. `shift_jis` coding is also supportted by `GNU
libiconv`

although `shift_jis` coding is different from `cp932` coding, but in our
case, it can be replaced by each other.

References:
http://una.soragoto.net/topics/13.html
https://wiki.musl-libc.org/functional-differences-from-glibc.html
https://github.com/bminor/musl/blob/master/src/locale/iconv.c
https://www.gnu.org/software/libiconv