### PR TITLE
GitHub Actions: run units target on AlplineLinux

### DIFF
--- a/.github/workflows/testing-alpine.yml
+++ b/.github/workflows/testing-alpine.yml
@@ -1,0 +1,34 @@
+name: run units target on AlpineLinux
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  testing:
+    strategy:
+      fail-fast: false
+      matrix:
+        tag: ['3.10','3.11','3.12','3.13']
+
+    runs-on: ubuntu-20.04
+
+    container: alpine:${{ matrix.tag }}
+
+    steps:
+      - run: apk add libc-dev gcc make automake autoconf pkgconf python3 file diffutils git
+
+      - uses: actions/checkout@v2
+
+      - run: cc --version
+
+      - run: ./autogen.sh
+      - run: ./configure --prefix=/usr
+      - run: make
+      - run: make install
+      - run: file /usr/bin/ctags
+      - run: ctags --version
+      - run: make check V=1 APPVEYOR=1
+      - run: make roundtrip


### PR DESCRIPTION
Alpine Linux is a popular Linux distribution which not built around `glibc` and `bash` but `musl-libc` and `BusyBox`.

References:
https://distrowatch.com/table.php?distribution=alpine
https://alpinelinux.org
https://hub.docker.com/_/alpine

https://www.gnu.org/software/libc
http://musl.libc.org

https://www.gnu.org/software/bash
https://busybox.net