### PR TITLE
Fix for #2885

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,7 @@ EXTRA_DIST   = README.md autogen.sh \
 	       misc/ctags-optlib-mode.el \
 	       misc/mk-interactive-request.sh misc/roundtrip misc/tinst \
 	       misc/packcc/.gitignore misc/packcc/LICENSE.txt \
-	       misc/packcc/README.md misc/packcc/packcc.c \
+	       misc/packcc/README.md \
 	       misc/validators/validator-jq \
 	       misc/validators/validator-KNOWN-INVALIDATION \
 	       misc/validators/validator-NONE \
@@ -29,29 +29,21 @@ EXTRA_DIST   = README.md autogen.sh \
 CLEANFILES =
 MOSTLYCLEANFILES =
 
-clean-local:
-	rm -f packcc$(BUILD_EXEEXT)
-	@if test "$(top_srcdir)" != "$(top_builddir)"; then \
-		rm -rf $(OPTLIB2C_SRCS); \
-	fi
-
 bin_PROGRAMS = ctags
 noinst_LIBRARIES = libctags.a
 
-noinst_PROGRAMS =
+noinst_PROGRAMS = packcc
 noinst_PROGRAMS += mini-geany
 
 if HAVE_STRNLEN_FOR_BUILD
 EXTRA_CPPFLAGS_FOR_BUILD = -DUSE_SYSTEM_STRNLEN
 endif
 
-PACKCC = $(top_builddir)/packcc$(BUILD_EXEEXT)
-
 cc4b_verbose = $(cc4b_verbose_@AM_V@)
 cc4b_verbose_ = $(cc4b_verbose_@AM_DEFAULT_V@)
 cc4b_verbose_0 = @echo CC4BUILD "  $@";
-$(PACKCC): $(top_srcdir)/misc/packcc/packcc.c
-	$(cc4b_verbose)$(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) $(CPPFLAGS_FOR_BUILD) $(EXTRA_CPPFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) -o $@ $(top_srcdir)/misc/packcc/packcc.c
+
+packcc_SOURCES = misc/packcc/packcc.c
 
 if USE_READCMD
 bin_PROGRAMS+= readtags
@@ -144,16 +136,13 @@ SUFFIXES += .ctags
 $(OPTLIB2C_SRCS): $(OPTLIB2C) Makefile
 endif
 
-packcc_verbose = $(packcc_verbose_@AM_V@)
-packcc_verbose_ = $(packcc_verbose_@AM_DEFAULT_V@)
-packcc_verbose_0 = @echo PACKCC "    $@";
 SUFFIXES += .peg
-.peg.c:
-	$(packcc_verbose)$(PACKCC) -i \"general.h\" -o $(top_builddir)/peg/$(*F) "$<"
-.peg.h:
-	$(packcc_verbose)$(PACKCC) -i \"general.h\" -o $(top_builddir)/peg/$(*F) "$<"
-# You cannot use $(PACKCC) as a target name here.
-$(PEG_SRCS) $(PEG_HEADS): $(PACKCC) Makefile
+.peg.c: packcc$(EXEEXT)
+	$(top_builddir)/packcc$(EXEEXT) -i \"general.h\" -o $(top_builddir)/peg/$(*F) "$<"
+.peg.h: packcc$(EXEEXT)
+	$(top_builddir)/packcc$(EXEEXT) -i \"general.h\" -o $(top_builddir)/peg/$(*F) "$<"
+
+$(PEG_SRCS) $(PEG_HEADS): packcc$(EXEEXT)
 dist_libctags_a_SOURCES = $(ALL_LIB_HEADS) $(ALL_LIB_SRCS)
 
 ctags_CPPFLAGS = $(libctags_a_CPPFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -234,33 +234,12 @@ fi
 
 AM_CONDITIONAL(ENABLE_DEBUGGING, [test "x$enable_debugging" = "xyes"])
 
-
 # Checks for programs
 # -------------------
-
 AC_PROG_CC
 AC_PROG_CC_C99
 AC_PROG_RANLIB
 AC_C_BIGENDIAN
-
-# https://www.gnu.org/software/autoconf-archive/ax_prog_cc_for_build.html
-AX_PROG_CC_FOR_BUILD
-
-# We need to compile and run a program on the build machine.
-AC_MSG_CHECKING(for cc for build)
-if test "$cross_compiling" = "yes"; then
-  CC_FOR_BUILD="${CC_FOR_BUILD-cc}"
-else
-  CC_FOR_BUILD="${CC_FOR_BUILD-$CC}"
-  CFLAGS_FOR_BUILD="${CFLAGS_FOR_BUILD-$CFLAGS}"
-  CPPFLAGS_FOR_BUILD="${CPPFLAGS_FOR_BUILD-$CPPFLAGS}"
-  LDFLAGS_FOR_BUILD="${LDFLAGS_FOR_BUILD-$LDFLAGS}"
-fi
-AC_MSG_RESULT($CC_FOR_BUILD)
-AC_ARG_VAR(CC_FOR_BUILD,[build system C compiler])
-AC_ARG_VAR(CFLAGS_FOR_BUILD,[CFLAGS for build system C compiler])
-AC_ARG_VAR(CPPFLAGS_FOR_BUILD,[CPPFLAGS for build system C compiler])
-AC_ARG_VAR(LDFLAGS_FOR_BUILD,[LDFLAGS for build system C compiler])
 
 if test "${with_sparse_cgcc}" = "yes"; then
 	REAL_CC="${CC}"

--- a/configure.ac
+++ b/configure.ac
@@ -237,7 +237,6 @@ AM_CONDITIONAL(ENABLE_DEBUGGING, [test "x$enable_debugging" = "xyes"])
 # Checks for programs
 # -------------------
 AC_PROG_CC
-AC_PROG_CC_C99
 AC_PROG_RANLIB
 AC_C_BIGENDIAN
 


### PR DESCRIPTION
This PR fixes #2885.
It also removes using AC_PROG_CC_C99 as autoupdate from autoconf 2.71 suggests.