### PR TITLE
buildsys: expose more configure variables: AR, RANLIB, WINDRES

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -167,7 +167,6 @@ ctags_LDADD += $(ICONV_LIBS)
 dist_ctags_SOURCES = $(CMDLINE_HEADS) $(CMDLINE_SRCS)
 
 if HOST_MINGW
-WINDRES = windres
 RES_OBJ = win32/ctags.res.o
 ctags_LDADD += $(RES_OBJ)
 windres_verbose = $(windres_verbose_@AM_V@)

--- a/configure.ac
+++ b/configure.ac
@@ -262,6 +262,19 @@ AC_ARG_VAR(CFLAGS_FOR_BUILD,[CFLAGS for build system C compiler])
 AC_ARG_VAR(CPPFLAGS_FOR_BUILD,[CPPFLAGS for build system C compiler])
 AC_ARG_VAR(LDFLAGS_FOR_BUILD,[LDFLAGS for build system C compiler])
 
+AC_ARG_VAR(AR,[ar command or path])
+AC_ARG_VAR(RANLIB,[ranlib command or path])
+AC_ARG_VAR(WINDRES,[windres command or path, used with mingw-w64])
+AC_SUBST([WINDRES])
+
+if test "x${AR}" = "x" ; then
+    AR=ar
+fi
+
+if test "x${WINDRES}" = "x" ; then
+    WINDRES=windres
+fi
+
 if test "${with_sparse_cgcc}" = "yes"; then
 	REAL_CC="${CC}"
 	CC="cgcc"


### PR DESCRIPTION
let user can set AR, RANLIB, WINDRES when running configure command.