### PR TITLE
docs: updates ctags-lang-verilog(7)

### DIFF
--- a/docs/man/ctags-lang-verilog.7.rst
+++ b/docs/man/ctags-lang-verilog.7.rst
@@ -4,38 +4,104 @@
 ctags-lang-verilog
 ======================================================================
 
+The man page about SystemVerilog/Verilog parser for Universal Ctags
+
+
 :Version: 5.9.0
 :Manual group: Universal Ctags
 :Manual section: 7
 
 SYNOPSIS
 --------
-|	**ctags** ... [--fields-Verilog=+{parameter}] ...
 |	**ctags** ... [--kinds-systemverilog=+Q] [--fields-SystemVerilog=+{parameter}] ...
-|	**ctags** --list-kinds-full={Verilog|SystemVerilog}
-|	**ctags** --list-fields={Verilog|SystemVerilog}
+|	**ctags** ... [--fields-Verilog=+{parameter}] ...
 
     +---------------+---------------+-------------------+
     | Language      | Language ID   | File Mapping      |
     +===============+===============+===================+
-    | Verilog       | Verilog       | .v                |
-    +---------------+---------------+-------------------+
     | SystemVerilog | SystemVerilog | .sv, .svh, svi    |
+    +---------------+---------------+-------------------+
+    | Verilog       | Verilog       | .v                |
     +---------------+---------------+-------------------+
 
 DESCRIPTION
 -----------
-This man page describes about the Verilog/SystemVerilog parser for Universal Ctags.
+This man page describes about the SystemVerilog/Verilog parser for Universal Ctags.
+SystemVerilog parser supports IEEE Std 1800-2017 keywords.
+Verilog parser supports IEEE Std 1364-2005 keywords.
 
-It assumes the input file is written in the correct grammer.  Otherwise output of
-ctags is undefined.
+Supported Kinds
+~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+	$ ctags --list-kinds-full=SystemVerilog
+	#LETTER NAME       ENABLED REFONLY NROLES MASTER DESCRIPTION
+	A       assert     yes     no      0      NONE   assertions (assert, assume, cover, restrict)
+	C       class      yes     no      0      NONE   classes
+	E       enum       yes     no      0      NONE   enumerators
+	H       checker    yes     no      0      NONE   checkers
+	I       interface  yes     no      0      NONE   interfaces
+	K       package    yes     no      0      NONE   packages
+	L       clocking   yes     no      0      NONE   clocking
+	M       modport    yes     no      0      NONE   modports
+	N       nettype    yes     no      0      NONE   nettype declarations
+	O       constraint yes     no      0      NONE   constraints
+	P       program    yes     no      0      NONE   programs
+	Q       prototype  no      no      0      NONE   prototypes (extern, pure)
+	R       property   yes     no      0      NONE   properties
+	S       struct     yes     no      0      NONE   structs and unions
+	T       typedef    yes     no      0      NONE   type declarations
+	V       covergroup yes     no      0      NONE   covergroups
+	b       block      yes     no      0      NONE   blocks (begin, fork)
+	c       constant   yes     no      0      NONE   constants (define, parameter, specparam, enum values)
+	e       event      yes     no      0      NONE   events
+	f       function   yes     no      0      NONE   functions
+	i       instance   yes     no      0      NONE   instances of module or interface
+	l       ifclass    yes     no      0      NONE   interface class
+	m       module     yes     no      0      NONE   modules
+	n       net        yes     no      0      NONE   net data types
+	p       port       yes     no      0      NONE   ports
+	q       sequence   yes     no      0      NONE   sequences
+	r       register   yes     no      0      NONE   variable data types
+	t       task       yes     no      0      NONE   tasks
+	w       member     yes     no      0      NONE   struct and union members
+
+Note that ``prototype`` (``Q``) is disabled by default.
+
+.. code-block:: console
+
+	$ ctags --list-kinds-full=Verilog
+	#LETTER NAME     ENABLED REFONLY NROLES MASTER DESCRIPTION
+	b       block    yes     no      0      NONE   blocks (begin, fork)
+	c       constant yes     no      0      NONE   constants (define, parameter, specparam)
+	e       event    yes     no      0      NONE   events
+	f       function yes     no      0      NONE   functions
+	i       instance yes     no      0      NONE   instances of module
+	m       module   yes     no      0      NONE   modules
+	n       net      yes     no      0      NONE   net data types
+	p       port     yes     no      0      NONE   ports
+	r       register yes     no      0      NONE   variable data types
+	t       task     yes     no      0      NONE   tasks
+
+Supported Language Specific Fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+	$ ctags --list-fields=Verilog
+	#LETTER NAME      ENABLED LANGUAGE JSTYPE FIXED DESCRIPTION
+	-       parameter no      Verilog  --b    no    parameter whose value can be overridden.
+	$ ctags --list-fields=SystemVerilog
+	#LETTER NAME      ENABLED LANGUAGE      JSTYPE FIXED DESCRIPTION
+	-       parameter no      SystemVerilog --b    no    parameter whose value can be overridden.
 
 ``parameter`` field
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+....................
 
-If the field ``parameter`` is enabled, a tagfield ``parameter:`` is added on a parameter whose
+If the field ``parameter`` is enabled, a field ``parameter:`` is added on a parameter whose
 value can be overridden on an instantiated module, interface, or program.
-This is useful for a editor plugin or extension to enable auto-instatiation of modules with
+This is useful for a editor plugin or extension to enable auto-instantiation of modules with
 parameters which can be overridden.
 
 .. code-block:: console
@@ -43,9 +109,9 @@ parameters which can be overridden.
     $ ctags ... --fields-Verilog=+{parameter} ...
     $ ctags ... --fields-SystemVerilog=+{parameter} ...
 
-On the following source code tagfields ``parameter:`` are added on
-parameter ``P*``, not on ``L*``.  Note that ``L4`` and ``L6`` is declared by
-``parameter`` statement, but tagfields ``parameter:`` are not added,
+On the following source code fields ``parameter:`` are added on
+parameters ``P*``, not on ones ``L*``.  Note that ``L4`` and ``L6`` is declared by
+``parameter`` statement, but fields ``parameter:`` are not added,
 because they cannot be overridden.
 
 "input.sv"
@@ -79,11 +145,9 @@ because they cannot be overridden.
 		// ...
 	endmodule
 
-"output.tags"
-with "--options=NONE --sort=no -o - --fields-SystemVerilog=+{parameter} input.sv"
+.. code-block:: console
 
-.. code-block:: tags
-
+	$ ctags -uo - --fields-SystemVerilog=+{parameter} input.sv
 	L1	input.sv	/^parameter L1 = "synonym for the localparam";$/;"	c	parameter:
 	with_parameter_port_list	input.sv	/^module with_parameter_port_list #($/;"	m
 	P1	input.sv	/^	P1,$/;"	c	module:with_parameter_port_list	parameter:
@@ -98,12 +162,25 @@ with "--options=NONE --sort=no -o - --fields-SystemVerilog=+{parameter} input.sv
 	P3	input.sv	/^	parameter  P3 = "parameter";$/;"	c	module:no_parameter_port_list	parameter:
 	L7	input.sv	/^	localparam L7 = "localparam";$/;"	c	module:no_parameter_port_list
 
-Known Issues
+TIPS
+~~~~
+
+If you want to map files ``*.v`` to SystemVerilog, add
+``--langmap=SystemVerilog:.v`` option.
+
+KNOWN ISSUES
 ---------------------------------------------------------------------
 
-See https://github.com/universal-ctags/ctags/issues/TBD.
-
+See https://github.com/universal-ctags/ctags/issues/2674 for more information.
 
 SEE ALSO
 --------
-:ref:`ctags(1) <ctags(1)>`, :ref:`ctags-client-tools(7) <ctags-client-tools(7)>`
+
+- :ref:`ctags(1) <ctags(1)>`
+- :ref:`ctags-client-tools(7) <ctags-client-tools(7)>`
+- Language Reference Manuals (LRM)
+   - IEEE Standard for SystemVerilog - Unified Hardware Design, Specification, and
+     Verification Language, IEEE Std 1800-2017,
+     https://ieeexplore.ieee.org/document/8299595
+   - IEEE Standard for Verilog Hardware Description Language, IEEE Std 1364-2005,
+     https://ieeexplore.ieee.org/document/1620780

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -2094,6 +2094,10 @@ BUGS
 
 ctags has more options than ``ls(1)``.
 
+ctags assumes the input file is written in the correct
+grammar.  Otherwise output of ctags is undefined. In other words it has garbage
+in, garbage out (GIGO) feature.
+
 .. TODO: move the following paragraph to parser-cxx.rst.
 
 When parsing a C++ member function definition (e.g. ``className::function``),

--- a/man/ctags-lang-verilog.7.rst.in
+++ b/man/ctags-lang-verilog.7.rst.in
@@ -3,6 +3,9 @@
 ======================================================================
 ctags-lang-verilog
 ======================================================================
+--------------------------------------------------------------------
+The man page about SystemVerilog/Verilog parser for Universal Ctags
+--------------------------------------------------------------------
 
 :Version: @VERSION@
 :Manual group: Universal Ctags
@@ -10,32 +13,95 @@ ctags-lang-verilog
 
 SYNOPSIS
 --------
-|	**@CTAGS_NAME_EXECUTABLE@** ... [--fields-Verilog=+{parameter}] ...
 |	**@CTAGS_NAME_EXECUTABLE@** ... [--kinds-systemverilog=+Q] [--fields-SystemVerilog=+{parameter}] ...
-|	**@CTAGS_NAME_EXECUTABLE@** --list-kinds-full={Verilog|SystemVerilog}
-|	**@CTAGS_NAME_EXECUTABLE@** --list-fields={Verilog|SystemVerilog}
+|	**@CTAGS_NAME_EXECUTABLE@** ... [--fields-Verilog=+{parameter}] ...
 
     +---------------+---------------+-------------------+
     | Language      | Language ID   | File Mapping      |
     +===============+===============+===================+
-    | Verilog       | Verilog       | .v                |
-    +---------------+---------------+-------------------+
     | SystemVerilog | SystemVerilog | .sv, .svh, svi    |
+    +---------------+---------------+-------------------+
+    | Verilog       | Verilog       | .v                |
     +---------------+---------------+-------------------+
 
 DESCRIPTION
 -----------
-This man page describes about the Verilog/SystemVerilog parser for Universal Ctags.
+This man page describes about the SystemVerilog/Verilog parser for Universal Ctags.
+SystemVerilog parser supports IEEE Std 1800-2017 keywords.
+Verilog parser supports IEEE Std 1364-2005 keywords.
 
-It assumes the input file is written in the correct grammer.  Otherwise output of
-ctags is undefined.
+Supported Kinds
+~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+	$ ctags --list-kinds-full=SystemVerilog
+	#LETTER NAME       ENABLED REFONLY NROLES MASTER DESCRIPTION
+	A       assert     yes     no      0      NONE   assertions (assert, assume, cover, restrict)
+	C       class      yes     no      0      NONE   classes
+	E       enum       yes     no      0      NONE   enumerators
+	H       checker    yes     no      0      NONE   checkers
+	I       interface  yes     no      0      NONE   interfaces
+	K       package    yes     no      0      NONE   packages
+	L       clocking   yes     no      0      NONE   clocking
+	M       modport    yes     no      0      NONE   modports
+	N       nettype    yes     no      0      NONE   nettype declarations
+	O       constraint yes     no      0      NONE   constraints
+	P       program    yes     no      0      NONE   programs
+	Q       prototype  no      no      0      NONE   prototypes (extern, pure)
+	R       property   yes     no      0      NONE   properties
+	S       struct     yes     no      0      NONE   structs and unions
+	T       typedef    yes     no      0      NONE   type declarations
+	V       covergroup yes     no      0      NONE   covergroups
+	b       block      yes     no      0      NONE   blocks (begin, fork)
+	c       constant   yes     no      0      NONE   constants (define, parameter, specparam, enum values)
+	e       event      yes     no      0      NONE   events
+	f       function   yes     no      0      NONE   functions
+	i       instance   yes     no      0      NONE   instances of module or interface
+	l       ifclass    yes     no      0      NONE   interface class
+	m       module     yes     no      0      NONE   modules
+	n       net        yes     no      0      NONE   net data types
+	p       port       yes     no      0      NONE   ports
+	q       sequence   yes     no      0      NONE   sequences
+	r       register   yes     no      0      NONE   variable data types
+	t       task       yes     no      0      NONE   tasks
+	w       member     yes     no      0      NONE   struct and union members
+
+Note that ``prototype`` (``Q``) is disabled by default.
+
+.. code-block:: console
+
+	$ ctags --list-kinds-full=Verilog
+	#LETTER NAME     ENABLED REFONLY NROLES MASTER DESCRIPTION
+	b       block    yes     no      0      NONE   blocks (begin, fork)
+	c       constant yes     no      0      NONE   constants (define, parameter, specparam)
+	e       event    yes     no      0      NONE   events
+	f       function yes     no      0      NONE   functions
+	i       instance yes     no      0      NONE   instances of module
+	m       module   yes     no      0      NONE   modules
+	n       net      yes     no      0      NONE   net data types
+	p       port     yes     no      0      NONE   ports
+	r       register yes     no      0      NONE   variable data types
+	t       task     yes     no      0      NONE   tasks
+
+Supported Language Specific Fields
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+	$ ctags --list-fields=Verilog
+	#LETTER NAME      ENABLED LANGUAGE JSTYPE FIXED DESCRIPTION
+	-       parameter no      Verilog  --b    no    parameter whose value can be overridden.
+	$ ctags --list-fields=SystemVerilog
+	#LETTER NAME      ENABLED LANGUAGE      JSTYPE FIXED DESCRIPTION
+	-       parameter no      SystemVerilog --b    no    parameter whose value can be overridden.
 
 ``parameter`` field
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+....................
 
-If the field ``parameter`` is enabled, a tagfield ``parameter:`` is added on a parameter whose
+If the field ``parameter`` is enabled, a field ``parameter:`` is added on a parameter whose
 value can be overridden on an instantiated module, interface, or program.
-This is useful for a editor plugin or extension to enable auto-instatiation of modules with
+This is useful for a editor plugin or extension to enable auto-instantiation of modules with
 parameters which can be overridden.
 
 .. code-block:: console
@@ -43,9 +109,9 @@ parameters which can be overridden.
     $ ctags ... --fields-Verilog=+{parameter} ...
     $ ctags ... --fields-SystemVerilog=+{parameter} ...
 
-On the following source code tagfields ``parameter:`` are added on
-parameter ``P*``, not on ``L*``.  Note that ``L4`` and ``L6`` is declared by
-``parameter`` statement, but tagfields ``parameter:`` are not added,
+On the following source code fields ``parameter:`` are added on
+parameters ``P*``, not on ones ``L*``.  Note that ``L4`` and ``L6`` is declared by
+``parameter`` statement, but fields ``parameter:`` are not added,
 because they cannot be overridden.
 
 "input.sv"
@@ -79,11 +145,9 @@ because they cannot be overridden.
 		// ...
 	endmodule
 
-"output.tags"
-with "--options=NONE --sort=no -o - --fields-SystemVerilog=+{parameter} input.sv"
+.. code-block:: console
 
-.. code-block:: tags
-
+	$ ctags -uo - --fields-SystemVerilog=+{parameter} input.sv
 	L1	input.sv	/^parameter L1 = "synonym for the localparam";$/;"	c	parameter:
 	with_parameter_port_list	input.sv	/^module with_parameter_port_list #($/;"	m
 	P1	input.sv	/^	P1,$/;"	c	module:with_parameter_port_list	parameter:
@@ -98,12 +162,25 @@ with "--options=NONE --sort=no -o - --fields-SystemVerilog=+{parameter} input.sv
 	P3	input.sv	/^	parameter  P3 = "parameter";$/;"	c	module:no_parameter_port_list	parameter:
 	L7	input.sv	/^	localparam L7 = "localparam";$/;"	c	module:no_parameter_port_list
 
-Known Issues
+TIPS
+~~~~
+
+If you want to map files ``*.v`` to SystemVerilog, add
+``--langmap=SystemVerilog:.v`` option.
+
+KNOWN ISSUES
 ---------------------------------------------------------------------
 
-See https://github.com/universal-ctags/ctags/issues/TBD.
-
+See https://github.com/universal-ctags/ctags/issues/2674 for more information.
 
 SEE ALSO
 --------
-ctags(1), ctags-client-tools(7)
+
+- ctags(1)
+- ctags-client-tools(7)
+- Language Reference Manuals (LRM)
+   - IEEE Standard for SystemVerilog - Unified Hardware Design, Specification, and
+     Verification Language, IEEE Std 1800-2017,
+     https://ieeexplore.ieee.org/document/8299595
+   - IEEE Standard for Verilog Hardware Description Language, IEEE Std 1364-2005,
+     https://ieeexplore.ieee.org/document/1620780

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -2094,6 +2094,10 @@ BUGS
 
 @CTAGS_NAME_EXECUTABLE@ has more options than ``ls(1)``.
 
+@CTAGS_NAME_EXECUTABLE@ assumes the input file is written in the correct
+grammar.  Otherwise output of ctags is undefined. In other words it has garbage
+in, garbage out (GIGO) feature.
+
 .. TODO: move the following paragraph to parser-cxx.rst.
 
 When parsing a C++ member function definition (e.g. ``className::function``),


### PR DESCRIPTION
- SystemVerilog first.
- add section "Supported Kinds"
- add section "Supported Language Specific Fields"
- add section "TIPS"
- add reference to IEEE Std 1800-2017 (LRM)