### PR TITLE
Fypp: examine the marker for line continuation unless input is empty

### DIFF
--- a/Units/parser-fypp.r/emptyline.d/README
+++ b/Units/parser-fypp.r/emptyline.d/README
@@ -1,0 +1,5 @@
+input.fy caused a valgrind error.
+
+For running this test:
+
+   $ make units LANGUAGES=Fypp VG=1

--- a/Units/parser-fypp.r/emptyline.d/input.fy
+++ b/Units/parser-fypp.r/emptyline.d/input.fy
@@ -1,0 +1,3 @@
+#:for ind in range(repeat)
+
+#:endfor

--- a/parsers/fypp.c
+++ b/parsers/fypp.c
@@ -105,6 +105,8 @@ static vString *fyppGuestParser;
 static bool fypp_does_line_continue(const char *line,
 									const regexMatch *matches)
 {
+	if (matches[0].length == 0)
+		return false;
 	return *(line + matches[0].start + matches[0].length - 1) == '&';
 }
 


### PR DESCRIPTION
The original code examines input line is ended with '&' even when the
input line is empty.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>