### PR TITLE
docs: as a highlighter, specify CtagsOtplibLexer instance instead of class

### DIFF
--- a/docs/_ext/lexers.py
+++ b/docs/_ext/lexers.py
@@ -1,5 +1,5 @@
 from ctags_optlib_highlighter import CtagsOtplibLexer
 
 def setup(app):
-    app.add_lexer('ctags', CtagsOtplibLexer)
+    app.add_lexer('ctags', CtagsOtplibLexer())
 


### PR DESCRIPTION

Signed-off-by: Masatake YAMATO <yamato@redhat.com>