### PR TITLE
Ada: skip string literal in a case

### DIFF
--- a/Units/parser-ada.r/ada-string-liteal.d/expected.tags-e
+++ b/Units/parser-ada.r/ada-string-liteal.d/expected.tags-e
@@ -1,0 +1,15 @@
+
+input.adb,660
+procedure Reproduce isReproduce/p2,18
+  type String_T is new String;String_T/t4,42
+  function "+" (Left : String) return String_T is (String_T(Left));"+"/f5,73
+  function "+" (Left : String_T; Right : String) return String_T is (String_T(String (Left) & Ri"+"/f6,141
+  package Generic_G isGeneric_G/s10,283
+    procedure Go;Go/p11,306
+  package body Generic_G isGeneric_G/b14,342
+    procedure Go isGo/p15,370
+  package Impl isImpl/s21,481
+    procedure Go;Go/p22,499
+  package body Impl isImpl/b25,530
+    package Generic1 is new Generic_G (Description => +"; " +":");Generic1/s26,553
+    procedure Go renames Generic1.Go;Go/p27,620

--- a/Units/parser-ada.r/ada-string-liteal.d/input.adb
+++ b/Units/parser-ada.r/ada-string-liteal.d/input.adb
@@ -1,0 +1,32 @@
+with Ada.Text_IO;
+procedure Reproduce is
+
+  type String_T is new String;
+  function "+" (Left : String) return String_T is (String_T(Left));
+  function "+" (Left : String_T; Right : String) return String_T is (String_T(String (Left) & Right));
+
+  generic
+    Description : String_T;
+  package Generic_G is
+    procedure Go;
+  end Generic_G;
+
+  package body Generic_G is
+    procedure Go is
+    begin
+      Ada.Text_IO.Put_Line (String (Description));
+    end Go;
+  end Generic_G;
+
+  package Impl is
+    procedure Go;
+  end Impl;
+
+  package body Impl is
+    package Generic1 is new Generic_G (Description => +"; " +":");
+    procedure Go renames Generic1.Go;
+  end Impl;
+
+begin
+  Impl.Go;
+end Reproduce;

--- a/parsers/ada.c
+++ b/parsers/ada.c
@@ -334,6 +334,7 @@ static bool adaCmp(const char *match);
 static bool adaKeywordCmp(adaKeyword keyword);
 static void skipUntilWhiteSpace(void);
 static void skipWhiteSpace(void);
+static void skipComments(void);
 static void skipPast(const char *past);
 static void skipPastKeyword(adaKeyword keyword);
 static void skipPastWord(void);
@@ -730,10 +731,7 @@ static void skipUntilWhiteSpace(void)
 {
   /* first check for a comment line, because this would cause the isspace
    * check to be true immediately */
-  while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-  {
-    readNewLine();
-  }
+  skipComments();
 
   while(exception != EXCEPTION_EOF && !isspace(line[pos]))
   {
@@ -761,10 +759,7 @@ static void skipUntilWhiteSpace(void)
     } /* if(pos >= lineLen) */
 
     /* now check for comments here */
-    while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-    {
-      readNewLine();
-    }
+    skipComments();
   } /* while(!isspace(line[pos])) */
 } /* static void skipUntilWhiteSpace(void) */
 
@@ -772,31 +767,30 @@ static void skipWhiteSpace(void)
 {
   /* first check for a comment line, because this would cause the isspace
    * check to fail immediately */
-  while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-  {
-    readNewLine();
-  }
+  skipComments();
 
   while(exception != EXCEPTION_EOF && isspace(line[pos]))
   {
     movePos(1);
 
     /* now check for comments here */
-    while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-    {
-      readNewLine();
-    }
+    skipComments();
   } /* while(isspace(line[pos])) */
 } /* static void skipWhiteSpace(void) */
+
+static void skipComments(void)
+{
+  while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
+  {
+    readNewLine();
+  }
+}
 
 static void skipPast(const char *past)
 {
   /* first check for a comment line, because this would cause the isspace
    * check to fail immediately */
-  while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-  {
-    readNewLine();
-  }
+  skipComments();
 
   /* now look for the keyword */
   while(exception != EXCEPTION_EOF && !adaCmp(past))
@@ -804,10 +798,7 @@ static void skipPast(const char *past)
     movePos(1);
 
     /* now check for comments here */
-    while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-    {
-      readNewLine();
-    }
+    skipComments ();
   }
 } /* static void skipPast(char *past) */
 
@@ -815,10 +806,7 @@ static void skipPastKeyword(adaKeyword keyword)
 {
   /* first check for a comment line, because this would cause the isspace
    * check to fail immediately */
-  while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-  {
-    readNewLine();
-  }
+  skipComments();
 
   /* now look for the keyword */
   while(exception != EXCEPTION_EOF && !adaKeywordCmp(keyword))
@@ -826,10 +814,7 @@ static void skipPastKeyword(adaKeyword keyword)
     movePos(1);
 
     /* now check for comments here */
-    while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-    {
-      readNewLine();
-    }
+    skipComments();
   }
 } /* static void skipPastKeyword(adaKeyword keyword) */
 
@@ -837,10 +822,7 @@ static void skipPastWord(void)
 {
   /* first check for a comment line, because this would cause the isspace
    * check to fail immediately */
-  while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-  {
-    readNewLine();
-  }
+  skipComments();
 
   /* now increment until we hit a non-word character... Specifically,
    * whitespace, '(', ')', ':', and ';' */
@@ -872,10 +854,7 @@ static void skipPastWord(void)
     } /* if(pos >= lineLen) */
 
     /* now check for comments here */
-    while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-    {
-      readNewLine();
-    }
+    skipComments();
   } /* while(!isspace(line[pos])) */
 } /* static void skipPastWord(void) */
 
@@ -883,10 +862,7 @@ static void skipPastLambda(skipCompFn cmpfn, void *data)
 {
   /* first check for a comment line, because this would cause the isspace
    * check to fail immediately */
-  while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-  {
-    readNewLine();
-  }
+  skipComments();
 
   /* now call the predicate */
   while(exception != EXCEPTION_EOF && !cmpfn(data))
@@ -894,10 +870,7 @@ static void skipPastLambda(skipCompFn cmpfn, void *data)
     movePos(1);
 
     /* now check for comments here */
-    while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-    {
-      readNewLine();
-    }
+    skipComments();
   }
 } /* static void skipPast(char *past) */
 
@@ -1314,10 +1287,7 @@ static adaTokenInfo *adaParseVariables(adaTokenInfo *parent, adaKind kind)
 
   /* skip any preliminary whitespace or comments */
   skipWhiteSpace();
-  while(exception != EXCEPTION_EOF && isAdaComment(line, pos, lineLen))
-  {
-    readNewLine();
-  }
+  skipComments();
 
   /* before we start reading input save the current line number and file
    * position, so we can reconstruct the correct line & file position for any


### PR DESCRIPTION
Close #2913.

Ada parser has some functions for skipping input stream.
They don't consider string literals in the stream.

#2913 reports a bug of the inconsideration.

This change fixes the bug in a very limited area.

    ...
	package Generic1 is new Generic_G (Description => +"; " +":");
    ...

adaParseBlock() tries skipping to ';' from "is".  In this case, as the
result, adaParseBlock() expects the input stream points ';' at the end
of line. However, the expectation was not satisfied because there was a
string literal that included ';' between "new" and ';' at the end of
line.

This change extends skipPastLambda() to skip string literal.
adaParseBlock() calls skipPastLambda() indirectly via
skipPastKeywordOrWord(). As the result, the expectation is satisfied.

Extending other functions for skipping may be done when we get more
bug reports.
