### PR TITLE
GitHub Actions: use new freebsd image to avoid ntp related failures

### DIFF
--- a/.github/workflows/testing-freebsd.yml
+++ b/.github/workflows/testing-freebsd.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: run in FreeBSD vm
-      uses: vmactions/freebsd-vm@v0.1.0
+      uses: vmactions/freebsd-vm@v0.1.3
       with:
         usesh: true
         run: |


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>