### PR TITLE
Ada: adjust parsing mode at the end of generic

### DIFF
--- a/Units/parser-ada.r/ada-generic-in-package.d/expected.tags-e
+++ b/Units/parser-ada.r/ada-generic-in-package.d/expected.tags-e
@@ -1,0 +1,8 @@
+
+input.ads,278
+package My_Package isMy_Package/s2,48
+  package Conversions isConversions/s6,108
+    function From_Big_Real (Arg : Integer) return Num;From_Big_Real/f7,133
+    type Num is digits <>;Num5,81
+  type Missing_Tag is recordMissing_Tag/t10,208
+    Num : Integer;Num11,237

--- a/Units/parser-ada.r/ada-generic-in-package.d/input.ads
+++ b/Units/parser-ada.r/ada-generic-in-package.d/input.ads
@@ -1,0 +1,14 @@
+--  Taken from #2925 submitted by @koenmeersman
+package My_Package is
+
+  generic
+    type Num is digits <>;
+  package Conversions is
+    function From_Big_Real (Arg : Integer) return Num;
+  end Conversions;
+
+  type Missing_Tag is record
+    Num : Integer;
+  end record;
+
+end My_Package;

--- a/parsers/ada.c
+++ b/parsers/ada.c
@@ -1754,9 +1754,10 @@ static adaTokenInfo *adaParse(adaParseMode mode, adaTokenInfo *parent)
         if(token != NULL)
         {
           /* if any generic params have been gathered, attach them to
-           * token, and set the mode back to ADA_ROOT */
+           * token, and set the mode back to ADA_ROOT or ADA_DECLARATIONS */
           appendAdaTokenList(token, &genericParamsRoot.children);
-          mode = ADA_ROOT;
+          Assert (parent);
+          mode = (parent->parent)? ADA_DECLARATIONS: ADA_ROOT;
         } /* if(token != NULL) */
 
         break;


### PR DESCRIPTION
Close #2925.

The original code reset the parsing mode to ROOT
at the end of generic package.

This setting causes a bug if the generic package is
not declared at the top level.