### PR TITLE
GitHub Actions (MacOS): don't install autoconf explicitly 

### DIFF
--- a/.github/workflows/testing-mac.yml
+++ b/.github/workflows/testing-mac.yml
@@ -28,7 +28,7 @@ jobs:
     - name: install tools and libraries
       run: |
         brew upgrade python@3.9 || brew link --overwrite python@3.9
-        brew install autoconf automake pkg-config bash libxml2 jansson libyaml gdb docutils
+        brew install automake pkg-config bash libxml2 jansson libyaml gdb docutils
     - name: autogen.sh
       run: ./autogen.sh
     - name: report the version of cc


### PR DESCRIPTION
Quoted from the build log at the platform:

    ==> Downloading https://homebrew.bintray.com/bottles/autoconf-2.71.catalina.bottle.tar.gz
    To upgrade to 2.71, run:
    ==> Downloading from https://d29vzk4ow07wi7.cloudfront.net/258a94bef23057c52818adf64d682af20bc6e09b46eac135047e2b87fc8206c7?response-content-disposition=attachment%3Bfilename%3D%22autoconf-2.71.catalina.bottle.tar.gz%22&Policy=eyJTdGF0ZW1lbnQiOiBbeyJSZXNvdXJjZSI6Imh0dHAqOi8vZDI5dnprNG93MDd3aTcuY2xvdWRmcm9udC5uZXQvMjU4YTk0YmVmMjMwNTdjNTI4MThhZGY2NGQ2ODJhZjIwYmM2ZTA5YjQ2ZWFjMTM1MDQ3ZTJiODdmYzgyMDZjNz9yZXNwb25zZS1jb250ZW50LWRpc3Bvc2l0aW9uPWF0dGFjaG1lbnQlM0JmaWxlbmFtZSUzRCUyMmF1dG9jb25mLTIuNzEuY2F0YWxpbmEuYm90dGxlLnRhci5neiUyMiIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTYxNzIxOTEzM30sIklwQWRkcmVzcyI6eyJBV1M6U291cmNlSXAiOiIwLjAuMC4wLzAifX19XX0_&Signature=mJNsp69nMLV50OikXNToqmzb6yI8MepHPf4~ekLd-SWAsLGu6DaHglPoCdNu1TqS4u8~XdbWFNF4NTP0d7GIchZswYb0bBnTWfT8a~N6jCFXPRRHh~GhNhiWhq855NaqyE1~H4jgT6QsXvmVdt9oykpsiJQVQ1OojhWUSohhFU~ssMl-XSJxLVwenxajBBcGZCcP1xTmNLoLcNOmkCtT1c6SROwmdIir5c21eh7L7B-nOBnFCZhYF1m~Plf5hfQ5zczcohlHpd3MTxh7NblHM2zYV3KeQdDJYu05thx22HtDBOG~-zueDKTuif8xpAcPGISYKAN7zv9XchJq2nXzpQ__&Key-Pair-Id=APKAIFKFWOMXM2UMTSFA
      brew upgrade autoconf

autoconf-2.69 is installed when doing "brew install autoconf" as written in testing-mac.yml.
On the other hand, automake requires autoconf-2.71 in solving dependencies.

To avoid the conflict, this change removes autoconf from the
installation list.
