### PR TITLE
main: truncate output file when rescan is failed

### DIFF
--- a/Tmain/broken-json-output.d/input.f
+++ b/Tmain/broken-json-output.d/input.f
@@ -1,0 +1,5 @@
+* 
+      integer function F(x)
+      end function F
+      program main
+)

--- a/Tmain/broken-json-output.d/run.sh
+++ b/Tmain/broken-json-output.d/run.sh
@@ -1,0 +1,10 @@
+# Copyright: 2021 Masatake YAMATO
+# License: GPL-2
+
+. ../utils.sh
+
+CTAGS=$1
+
+is_feature_available ${CTAGS} json
+
+${CTAGS} --sort=no --output-format=json input.f

--- a/Tmain/broken-json-output.d/stdout-expected.txt
+++ b/Tmain/broken-json-output.d/stdout-expected.txt
@@ -1,0 +1,1 @@
+{"_type": "tag", "name": "main", "path": "input.f", "pattern": "/^      program main$/", "kind": "program"}

--- a/main/entry.c
+++ b/main/entry.c
@@ -2009,15 +2009,28 @@ extern void tagFilePosition (MIOPos *p)
 			   "failed to get file position of the tag file\n");
 }
 
-extern void setTagFilePosition (MIOPos *p)
+extern void setTagFilePosition (MIOPos *p, bool truncation)
 {
 	/* mini-geany doesn't set TagFile.mio. */
 	if 	(TagFile.mio == NULL)
 		return;
 
+
+	long t0 = 0;
+	if (truncation)
+		t0 = mio_tell (TagFile.mio);
+
 	if (mio_setpos (TagFile.mio, p) == -1)
 		error (FATAL|PERROR,
 			   "failed to set file position of the tag file\n");
+
+	if (truncation)
+	{
+		long t1 = mio_tell (TagFile.mio);
+		if (!mio_try_resize (TagFile.mio, (size_t)t1))
+			error (FATAL|PERROR,
+				   "failed to truncate the tag file %ld -> %ld\n", t0, t1);
+	}
 }
 
 extern const char* getTagFileDirectory (void)

--- a/main/entry_p.h
+++ b/main/entry_p.h
@@ -39,7 +39,7 @@ extern unsigned long numTagsTotal(void);
 extern unsigned long maxTagsLine(void);
 extern void invalidatePatternCache(void);
 extern void tagFilePosition (MIOPos *p);
-extern void setTagFilePosition (MIOPos *p);
+extern void setTagFilePosition (MIOPos *p, bool truncation);
 extern const char* getTagFileDirectory (void);
 extern void getTagScopeInformation (tagEntryInfo *const tag,
 				    const char **kind, const char **name);

--- a/main/parse.c
+++ b/main/parse.c
@@ -3864,7 +3864,7 @@ static bool createTagsWithFallback1 (const langType language,
 		{
 			/*  Restore prior state of tag file.
 			*/
-			setTagFilePosition (&tagfpos);
+			setTagFilePosition (&tagfpos, true);
 			setNumTagsAdded (numTags);
 			writerRescanFailed (numTags);
 			tagFileResized = true;

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -237,7 +237,7 @@ goto :eof
 :: ----------------------------------------------------------------------
 :: Using Cygwin, iconv enabled
 @echo on
-c:\cygwin64\setup-x86_64.exe -qnNdO -P dos2unix,libiconv-devel,libjansson-devel,libxml2-devel,libyaml-devel
+c:\cygwin64\setup-x86_64.exe -qnNdO -P dos2unix,libiconv-devel,libjansson-devel,libxml2-devel,libyaml-devel,perl
 PATH c:\cygwin64\bin;%PATH%
 set CHERE_INVOKING=yes
 bash -lc "./autogen.sh"


### PR DESCRIPTION
Close #2948.

When a parser returned RESCAN_FAILED, the original code
just moved the file position.

#2948 indicated reports just moving the file position put
noise to the otuput file; file truncation is needed after
moving the position.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>