### PR TITLE
BibTeX: accept ':' as a part of a name 

### DIFF
--- a/Units/parser-bibtex.r/bib-simple.d/expected.tags
+++ b/Units/parser-bibtex.r/bib-simple.d/expected.tags
@@ -9,6 +9,7 @@ doe+rocket	input.bib	/^@Book{doe+rocket,$/;"	b
 doe_mastersth	input.bib	/^@mastersthesis{doe_mastersth,$/;"	M
 doe_mastersth_data	input.bib	/^@misc{doe_mastersth_data,$/;"	n
 doe_phd	input.bib	/^@phdthesis{doe_phd,$/;"	p
+hicks:2001	input.bib	/^@Book{hicks:2001,$/;"	b
 john_doe	input.bib	/^@string{john_doe = "Prof. Dr. John Doe"}$/;"	s
 man_loc_splits	input.bib	/^@manual{man_loc_splits,$/;"	m
 tiny_collect	input.bib	/^@booklet{tiny_collect,$/;"	B

--- a/Units/parser-bibtex.r/bib-simple.d/input.bib
+++ b/Units/parser-bibtex.r/bib-simple.d/input.bib
@@ -97,3 +97,15 @@
   title  = "Thoughts on the future of splits",
   note   = "Heavily thought about"
 }
+
+@Comment Taken from https://ja.wikipedia.org/wiki/BibTeX
+@Book{hicks:2001,
+ author = "von Hicks, III, Michael",
+ title = "Design of a Carbon Fiber Composite Grid Structure for the GLAST
+ Spacecraft Using a Novel Manufacturing Technique",
+ publisher = "Stanford Press",
+ year = 2001,
+ address = "Palo Alto",
+ edition = "1st,",
+ isbn = "0-69-697269-4"
+ }

--- a/parsers/bibtex.c
+++ b/parsers/bibtex.c
@@ -33,7 +33,7 @@
 #define isType(token,t)		(bool) ((token)->type == (t))
 #define isKeyword(token,k)	(bool) ((token)->keyword == (k))
 #define isIdentChar(c) \
-	(isalpha (c) || isdigit (c) || (c) == '_' || (c) == '-' || (c) == '+')
+	(isalpha (c) || isdigit (c) || (c) == '_' || (c) == '-' || (c) == '+' || (c) == ':')
 
 /*
  *	 DATA DECLARATIONS

--- a/parsers/bibtex.c
+++ b/parsers/bibtex.c
@@ -140,7 +140,7 @@ static const keywordTable BibKeywordTable [] = {
 	{ "techreport",	  KEYWORD_techreport		},
 	{ "unpublished",	KEYWORD_unpublished		}
 };
-  
+
 /*
  *	 FUNCTION DEFINITIONS
  */
@@ -323,7 +323,6 @@ static bool parseTag (tokenInfo *const token, bibKind kind)
 			goto out;
 		}
 	}
-  
 
  out:
 	deleteToken (name);


### PR DESCRIPTION
 BibTeX: accept ':' as a part of a name

Close #2934
The change was proposed by @berndf in #2934.

Quoted from the issue:

    Since my BibTeX keys are of the form author:year (one of the more
    common choices I'd say), the new bibtex parser breaks ctags for me, as
    isIdentChar() does not allow a colon.

@masatake added a test case.