### PR TITLE
appveyor,cygwin: install perl package explicitly

### DIFF
--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -237,7 +237,7 @@ goto :eof
 :: ----------------------------------------------------------------------
 :: Using Cygwin, iconv enabled
 @echo on
-c:\cygwin64\setup-x86_64.exe -qnNdO -P dos2unix,libiconv-devel,libjansson-devel,libxml2-devel,libyaml-devel
+c:\cygwin64\setup-x86_64.exe -qnNdO -P dos2unix,libiconv-devel,libjansson-devel,libxml2-devel,libyaml-devel,perl
 PATH c:\cygwin64\bin;%PATH%
 set CHERE_INVOKING=yes
 bash -lc "./autogen.sh"


### PR DESCRIPTION
automake(-1.16) indirectly run from autogen.sh reported:

Can't locate threads.pm in @INC (...  /usr/lib/perl5/5.32/x86_64-cygwin-threads ...) at \
/usr/share/automake-1.16/Automake/ChannelDefs.pm line 23.

threads.pm is listed in https://cygwin.com/packages/x86_64/perl/perl-5.32.1-1.
It is not listed in https://cygwin.com/packages/x86_64/perl_base/perl_base-5.32.1-1.

On the other hand automake requires perl_base, not perl as shown in
https://cygwin.com/packages/summary/automake1.16.html

This change is workaround for the gap.
The gap should be reported to Cygwin project (or automake?).

Signed-off-by: Masatake YAMATO <yamato@redhat.com>