### PR TITLE
GitHub Actions(netbsd): add autoconf dependency in .github/workflows/testing-netbsd.yml

### DIFF
--- a/.github/workflows/testing-netbsd.yml
+++ b/.github/workflows/testing-netbsd.yml
@@ -18,7 +18,7 @@ jobs:
         mem: 2048
         box: generic/netbsd9
         run: |
-          run sudo pkgin -y install mozilla-rootcerts automake pkg-config
+          run sudo pkgin -y install mozilla-rootcerts automake autoconf pkg-config
 
           run sudo mozilla-rootcerts install
 


### PR DESCRIPTION
It seems that the `NetBSD pkgin repository dependency tree` changed, `autoconf` is not installed along with `automake` now. 