### PR TITLE
docs: update the description of JSON output  (#2964)

### DIFF
--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -310,7 +310,7 @@ Output Format Options
 	Specify the output format. The default is ``u-ctags``.
 	See :ref:`tags(5) <tags(5)>` for ``u-ctags`` and ``e-ctags``.
 	See ``-e`` for ``etags``, and ``-x`` for ``xref``.
-	``json`` is experimental format, and available only if
+	``json`` format is available only if
 	the ctags executable is built with ``libjansson``.
 
 .. TODO: convert output-json.rst to ctags-json-output.1.rst (ctags-json-output(1)).

--- a/docs/output-json.rst
+++ b/docs/output-json.rst
@@ -4,8 +4,9 @@
 JSON output
 ======================================================================
 
-Experimental JSON output has been added. ``--output-format=json`` can be
-used to enable it.
+`JSON <https://www.json.org/>`_  (strictly speaking `JSON Lines
+<https://jsonlines.org/>`_) output has been added.
+``--output-format=json`` option enables it.
 
 .. code-block:: console
 

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -310,7 +310,7 @@ Output Format Options
 	Specify the output format. The default is ``u-ctags``.
 	See tags(5) for ``u-ctags`` and ``e-ctags``.
 	See ``-e`` for ``etags``, and ``-x`` for ``xref``.
-	``json`` is experimental format, and available only if
+	``json`` format is available only if
 	the ctags executable is built with ``libjansson``.
 
 .. TODO: convert output-json.rst to ctags-json-output.1.rst (ctags-json-output(1)).


### PR DESCRIPTION
- add link to JSON and JSON Lines.
- Now it is not experimental.