### PR TITLE
[INCOMPATIBLE]main: don't read CTAGS and/or ETAGS environment variables 46d54fd 

### DIFF
--- a/docs/man/ctags-incompatibilities.7.rst
+++ b/docs/man/ctags-incompatibilities.7.rst
@@ -28,6 +28,12 @@ Universal Ctags doesn't load ``~/.ctags`` at starting up time.
 File paths for preload files are changed.
 See "FILES" section of :ref:`ctags(1) <ctags(1)>`.
 
+Environment variables for arranging command lines
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Universal Ctags doesn't read ``CTAGS`` and/or ``ETAGS`` environment
+variables.
+
 Incompatibilities in command line interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -2141,6 +2141,12 @@ ENVIRONMENT VARIABLES
 FILES
 -----
 
+``tags``
+	The default tag file created by ctags.
+
+``TAGS``
+	The default tag file created by etags.
+
 ``$XDG_CONFIG_HOME/ctags/*.ctags``, or ``$HOME/.config/ctags/*.ctags`` if
 ``$XDG_CONFIG_HOME`` is not defined
 (on other than MS Windows)
@@ -2152,12 +2158,6 @@ FILES
 ``.ctags.d/*.ctags``
 
 ``ctags.d/*.ctags``
-
-``tags``
-	The default tag file created by ctags.
-
-``TAGS``
-	The default tag file created by etags.
 
 	If any of these configuration files exist, each will be expected to
 	contain a set of default options which are read in the order listed

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -820,7 +820,7 @@ Option File Options
 	As a special case, if ``--options=NONE`` is specified as the first
 	option on the command line, preloading is disabled; the option
 	will disable the automatic reading of any configuration options
-	from either a file or the environment variable (see "`FILES`_").
+	from a file (see "`FILES`_").
 
 ``--options-maybe=<pathname>``
 	Same as ``--options`` but doesn't cause an error if file
@@ -1320,8 +1320,8 @@ Miscellaneous Options
 	and a brief message describing what action is being taken for each file
 	considered by ctags. Normally, ctags
 	does not read command line arguments until after options are read
-	from the configuration files (see "`FILES`_", below) and the CTAGS
-	environment variable. However, if this option is the first argument on
+	from the configuration files (see "`FILES`_", below).
+	However, if this option is the first argument on
 	the command line, it will take effect before any options are read from
 	these sources. The default is ``no``.
 
@@ -2119,26 +2119,6 @@ No qualified tags are generated for language objects inherited into a class.
 
 ENVIRONMENT VARIABLES
 ---------------------
-
-``CTAGS``
-	If this environment variable exists, it will be expected to contain a
-	set of default options which are read when ctags
-	starts, after the configuration files listed in "`FILES`_", below, are read,
-	but before any command line options are read. Options appearing on
-	the command line will override options specified in this variable.
-
-	Only options will be read from this variable.
-
-	Note that all white space
-	in this variable is considered a separator, making it impossible to pass
-	an option parameter containing an embedded space. If this is a problem,
-	use a configuration file instead.
-
-``ETAGS``
-	Similar to the ``CTAGS`` variable above, this variable, if found, will be
-	read when etags starts. If this variable is not
-	found, etags will try to use ``CTAGS`` instead.
-
 ``TMPDIR``
 	On Unix-like hosts where ``mkstemp(3)`` is available, the value of this
 	variable specifies the directory in which to place temporary files.
@@ -2181,9 +2161,8 @@ FILES
 
 	If any of these configuration files exist, each will be expected to
 	contain a set of default options which are read in the order listed
-	when ctags starts, but before the ``CTAGS`` environment
-	variable is read or any command line options are read. This makes it
-	possible to set up personal or project-level defaults.
+	when ctags starts, but before any command line options
+	are read. This makes it possible to set up personal or project-level defaults.
 
 	It
 	is possible to compile ctags to read an additional
@@ -2191,9 +2170,9 @@ FILES
 	indicated if the output produced by the ``--version`` option lists the
 	``custom-conf`` feature.
 
-	Options appearing in the ``CTAGS`` environment
-	variable or on the command line will override options specified in these
-	files. Only options will be read from these files.
+	Options appearing on the command line will override options
+	specified in these files. Only options will be read from these
+	files.
 
 	Note that the option
 	files are read in line-oriented mode in which spaces are significant

--- a/main/options.c
+++ b/main/options.c
@@ -80,7 +80,6 @@
 			verbose ("Entering configuration stage: loading %s\n", StageDescription[Stage]); \
 		}																\
 	} while (0)
-#define ACCEPT(STAGE) (1UL << OptionLoadingStage##STAGE)
 
 /*
 *   Data declarations

--- a/main/options.c
+++ b/main/options.c
@@ -193,13 +193,9 @@ struct localOptionValues {
 typedef enum eOptionLoadingStage {
 	OptionLoadingStageNone,
 	OptionLoadingStageCustom,
-	OptionLoadingStageDosCnf,
-	OptionLoadingStageEtc,
-	OptionLoadingStageLocalEtc,
 	OptionLoadingStageXdg,
 	OptionLoadingStageHomeRecursive,
 	OptionLoadingStageCurrentRecursive,
-	OptionLoadingStagePreload,
 	OptionLoadingStageEnvVar,
 	OptionLoadingStageCmdline,
 } OptionLoadingStage;
@@ -598,13 +594,9 @@ static struct Feature {
 static const char *const StageDescription [] = {
 	[OptionLoadingStageNone]   = "not initialized",
 	[OptionLoadingStageCustom] = "custom file",
-	[OptionLoadingStageDosCnf] = "DOS .cnf file",
-	[OptionLoadingStageEtc] = "file under /etc (e.g. ctags.conf)",
-	[OptionLoadingStageLocalEtc] = "file under /usr/local/etc (e.g. ctags.conf)",
 	[OptionLoadingStageXdg] = "file(s) under $XDG_CONFIG_HOME and $HOME/.config",
 	[OptionLoadingStageHomeRecursive] = "file(s) under $HOME",
 	[OptionLoadingStageCurrentRecursive] = "file(s) under the current directory",
-	[OptionLoadingStagePreload] = "optlib preload files",
 	[OptionLoadingStageEnvVar] = "environment variable",
 	[OptionLoadingStageCmdline] = "command line",
 };

--- a/main/options.c
+++ b/main/options.c
@@ -597,7 +597,6 @@ static const char *const StageDescription [] = {
 	[OptionLoadingStageXdg] = "file(s) under $XDG_CONFIG_HOME and $HOME/.config",
 	[OptionLoadingStageHomeRecursive] = "file(s) under $HOME",
 	[OptionLoadingStageCurrentRecursive] = "file(s) under the current directory",
-	[OptionLoadingStageEnvVar] = "environment variable",
 	[OptionLoadingStageCmdline] = "command line",
 };
 
@@ -3762,40 +3761,10 @@ static void parseConfigurationFileOptions (void)
 	preload (preload_path_list);
 }
 
-static void parseEnvironmentOptions (void)
-{
-	const char *envOptions = NULL;
-	const char* var = NULL;
-
-	ENTER(EnvVar);
-	if (Option.etags)
-	{
-		var = ETAGS_ENVIRONMENT;
-		envOptions = getenv (var);
-	}
-	if (envOptions == NULL)
-	{
-		var = CTAGS_ENVIRONMENT;
-		envOptions = getenv (var);
-	}
-	if (envOptions != NULL  &&  envOptions [0] != '\0')
-	{
-		cookedArgs* const args = cArgNewFromString (envOptions);
-		verbose ("Reading options from $CTAGS\n");
-		parseOptions (args);
-		cArgDelete (args);
-		if (NonOptionEncountered)
-			error (WARNING, "Ignoring non-option in %s variable", var);
-	}
-}
-
 extern void readOptionConfiguration (void)
 {
 	if (! SkipConfiguration)
-	{
 		parseConfigurationFileOptions ();
-		parseEnvironmentOptions ();
-	}
 }
 
 /*

--- a/main/options.c
+++ b/main/options.c
@@ -190,6 +190,20 @@ struct localOptionValues {
 	.withListHeader = true,
 };
 
+typedef enum eOptionLoadingStage {
+	OptionLoadingStageNone,
+	OptionLoadingStageCustom,
+	OptionLoadingStageDosCnf,
+	OptionLoadingStageEtc,
+	OptionLoadingStageLocalEtc,
+	OptionLoadingStageXdg,
+	OptionLoadingStageHomeRecursive,
+	OptionLoadingStageCurrentRecursive,
+	OptionLoadingStagePreload,
+	OptionLoadingStageEnvVar,
+	OptionLoadingStageCmdline,
+} OptionLoadingStage;
+
 static OptionLoadingStage Stage = OptionLoadingStageNone;
 #define STAGE_ANY ~0UL
 

--- a/main/options_p.h
+++ b/main/options_p.h
@@ -70,20 +70,6 @@ typedef enum eTagRelative {
 	TREL_NEVER,
 } tagRelative;
 
-typedef enum eOptionLoadingStage {
-	OptionLoadingStageNone,
-	OptionLoadingStageCustom,
-	OptionLoadingStageDosCnf,
-	OptionLoadingStageEtc,
-	OptionLoadingStageLocalEtc,
-	OptionLoadingStageXdg,
-	OptionLoadingStageHomeRecursive,
-	OptionLoadingStageCurrentRecursive,
-	OptionLoadingStagePreload,
-	OptionLoadingStageEnvVar,
-	OptionLoadingStageCmdline,
-} OptionLoadingStage;
-
 /*  This stores the command line options.
  */
 typedef struct sOptionValues {

--- a/man/ctags-incompatibilities.7.rst.in
+++ b/man/ctags-incompatibilities.7.rst.in
@@ -28,6 +28,12 @@ Universal Ctags doesn't load ``~/.ctags`` at starting up time.
 File paths for preload files are changed.
 See "FILES" section of ctags(1).
 
+Environment variables for arranging command lines
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Universal Ctags doesn't read ``CTAGS`` and/or ``ETAGS`` environment
+variables.
+
 Incompatibilities in command line interface
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -2141,6 +2141,12 @@ ENVIRONMENT VARIABLES
 FILES
 -----
 
+``tags``
+	The default tag file created by @CTAGS_NAME_EXECUTABLE@.
+
+``TAGS``
+	The default tag file created by @ETAGS_NAME_EXECUTABLE@.
+
 ``$XDG_CONFIG_HOME/ctags/*.ctags``, or ``$HOME/.config/ctags/*.ctags`` if
 ``$XDG_CONFIG_HOME`` is not defined
 (on other than MS Windows)
@@ -2152,12 +2158,6 @@ FILES
 ``.ctags.d/*.ctags``
 
 ``ctags.d/*.ctags``
-
-``tags``
-	The default tag file created by @CTAGS_NAME_EXECUTABLE@.
-
-``TAGS``
-	The default tag file created by @ETAGS_NAME_EXECUTABLE@.
 
 	If any of these configuration files exist, each will be expected to
 	contain a set of default options which are read in the order listed

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -820,7 +820,7 @@ Option File Options
 	As a special case, if ``--options=NONE`` is specified as the first
 	option on the command line, preloading is disabled; the option
 	will disable the automatic reading of any configuration options
-	from either a file or the environment variable (see "`FILES`_").
+	from a file (see "`FILES`_").
 
 ``--options-maybe=<pathname>``
 	Same as ``--options`` but doesn't cause an error if file
@@ -1320,8 +1320,8 @@ Miscellaneous Options
 	and a brief message describing what action is being taken for each file
 	considered by @CTAGS_NAME_EXECUTABLE@. Normally, @CTAGS_NAME_EXECUTABLE@
 	does not read command line arguments until after options are read
-	from the configuration files (see "`FILES`_", below) and the CTAGS
-	environment variable. However, if this option is the first argument on
+	from the configuration files (see "`FILES`_", below).
+	However, if this option is the first argument on
 	the command line, it will take effect before any options are read from
 	these sources. The default is ``no``.
 
@@ -2119,26 +2119,6 @@ No qualified tags are generated for language objects inherited into a class.
 
 ENVIRONMENT VARIABLES
 ---------------------
-
-``CTAGS``
-	If this environment variable exists, it will be expected to contain a
-	set of default options which are read when @CTAGS_NAME_EXECUTABLE@
-	starts, after the configuration files listed in "`FILES`_", below, are read,
-	but before any command line options are read. Options appearing on
-	the command line will override options specified in this variable.
-
-	Only options will be read from this variable.
-
-	Note that all white space
-	in this variable is considered a separator, making it impossible to pass
-	an option parameter containing an embedded space. If this is a problem,
-	use a configuration file instead.
-
-``ETAGS``
-	Similar to the ``CTAGS`` variable above, this variable, if found, will be
-	read when @ETAGS_NAME_EXECUTABLE@ starts. If this variable is not
-	found, @ETAGS_NAME_EXECUTABLE@ will try to use ``CTAGS`` instead.
-
 ``TMPDIR``
 	On Unix-like hosts where ``mkstemp(3)`` is available, the value of this
 	variable specifies the directory in which to place temporary files.
@@ -2181,9 +2161,8 @@ FILES
 
 	If any of these configuration files exist, each will be expected to
 	contain a set of default options which are read in the order listed
-	when @CTAGS_NAME_EXECUTABLE@ starts, but before the ``CTAGS`` environment
-	variable is read or any command line options are read. This makes it
-	possible to set up personal or project-level defaults.
+	when @CTAGS_NAME_EXECUTABLE@ starts, but before any command line options
+	are read. This makes it possible to set up personal or project-level defaults.
 
 	It
 	is possible to compile @CTAGS_NAME_EXECUTABLE@ to read an additional
@@ -2191,9 +2170,9 @@ FILES
 	indicated if the output produced by the ``--version`` option lists the
 	``custom-conf`` feature.
 
-	Options appearing in the ``CTAGS`` environment
-	variable or on the command line will override options specified in these
-	files. Only options will be read from these files.
+	Options appearing on the command line will override options
+	specified in these files. Only options will be read from these
+	files.
 
 	Note that the option
 	files are read in line-oriented mode in which spaces are significant


### PR DESCRIPTION
Close #2890.

Using these variables as source of configuration could be trouble.

Consider the following Makefile:
```
  CTAGS=/usr/bin/ctags

  tags: $(SOURCE_FILES)
  	$(CTAGS) $?
```
People can use the Makefile with the following command line:
```
   $ export CTAGS=/home/yamato/bin/u-ctags
   $ make CTAGS=$CTAGS
```
The user may get a strange warning message:
```
   Ignoring non-option in CTAGS variable
```
It is hard for users to understand the meaning of the warning message
if the user doesn't know the variable is used ctags itself as the
source of configuration.

Even u-ctags developers take long time to understand what happened
when #2048 is reported.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>

