### PR TITLE
buildsys;man/Makefile: fix `sed --version` report error when run on macOS

### DIFF
--- a/man/Makefile
+++ b/man/Makefile
@@ -90,7 +90,7 @@ cites := ${subst .,(,${addsuffix ),${man_pages}}}
 # ctags(1) tags(5) ...
 # => -e 's/\<ctags(1)/:ref:`& <&>`/g' -e 's/\<ctags(5)/:ref:`& <&>`/g' ...
 #
-is_gnu_sed := $(shell sed --version | grep -q GNU && echo 1)
+is_gnu_sed := $(shell sed --version 2>/dev/null | grep -q GNU && echo 1)
 ifeq ($(is_gnu_sed),1)
 reppat := $(foreach m,$(cites),-e 's/\<$(m)/:ref:`& <&>`/g')
 else


### PR DESCRIPTION
`BSD sed` no `--version` argument.