### PR TITLE
dls: remove an unused variable that causes an compile error

### DIFF
--- a/dsl/qualifier.c
+++ b/dsl/qualifier.c
@@ -27,8 +27,6 @@ struct sQCode
 /*
  * DATA DEFINITIONS
  */
-static DSLProcBind pbinds [] = {
-};
 
 
 /*
@@ -41,7 +39,7 @@ static int initialize (void)
 	if (initialized)
 		return 1;
 
-	if (!dsl_init (DSL_QUALIFIER, pbinds, sizeof(pbinds)/sizeof(pbinds [0])))
+	if (!dsl_init (DSL_QUALIFIER, NULL, 0))
 	{
 		fprintf(stderr, "MEMORY EXHAUSTED\n");
 		return 0;


### PR DESCRIPTION
Close #3009.

The empty array caseus an compile error when using
Visual Studio 2017 Build Tools or Visual Studio 2019 Build Tool.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>