### PR TITLE
SQL: run guest parsers on strings where procedures are defined with procedural languages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -259,6 +259,7 @@ man_MANS = \
 	man/ctags-lang-verilog.7 \
 	man/ctags-lang-inko.7 \
 	man/ctags-lang-r.7 \
+	man/ctags-lang-sql.7 \
 	\
 	$(NULL)
 rst2man_verbose = $(rst2man_verbose_@AM_V@)

--- a/Units/parser-sql.r/sql_pgSQL_guest.d/args.ctags
+++ b/Units/parser-sql.r/sql_pgSQL_guest.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--extras=+{guest}

--- a/Units/parser-sql.r/sql_pgSQL_guest.d/expected.tags
+++ b/Units/parser-sql.r/sql_pgSQL_guest.d/expected.tags
@@ -1,0 +1,10 @@
+fun1	input.sql	/^CREATE OR REPLACE FUNCTION fun1() RETURNS VARCHAR AS '$/;"	f
+fun2	input.sql	/^CREATE OR REPLACE FUNCTION fun2() RETURNS VARCHAR LANGUAGE plpgsql AS $\$$/;"	f
+test	input.sql	/^CREATE FUNCTION test(keys text[], vals text[]) RETURNS text AS$/;"	f
+test1_var1	input.sql	/^	test1_var1 VARCHAR(64) := $$ABC$$;$/;"	v
+test1_var2	input.sql	/^	test1_var2 VARCHAR(64) := $xyz$XYZ$xyz$;$/;"	v
+test1_var3	input.sql	/^	test1_var3     INTEGER := 1;$/;"	v
+test2_var1	input.sql	/^	test2_var1 VARCHAR(64) := 'ABC2';$/;"	v
+test2_var2	input.sql	/^	test2_var2 VARCHAR(64) := 'XYZ2';$/;"	v
+test2_var3	input.sql	/^	test2_var3        INTEGER := 2;$/;"	v
+o	input.sql	/^	var o = {};$/;"	v

--- a/Units/parser-sql.r/sql_pgSQL_guest.d/input.sql
+++ b/Units/parser-sql.r/sql_pgSQL_guest.d/input.sql
@@ -1,0 +1,33 @@
+-- Derived from a comment of https://github.com/universal-ctags/ctags/issues/3006
+-- submitted by @bagl.
+CREATE OR REPLACE FUNCTION fun1() RETURNS VARCHAR AS '
+DECLARE
+	test1_var1 VARCHAR(64) := $$ABC$$;
+	test1_var2 VARCHAR(64) := $xyz$XYZ$xyz$;
+	test1_var3     INTEGER := 1;
+BEGIN
+	RETURN  TO_CHAR(test_var3, ''000'') || test1_var1 || test1_var2;
+END;
+' LANGUAGE plpgsql;
+
+-- Derived from a comment of https://github.com/universal-ctags/ctags/issues/3006
+-- submitted by @bagl.
+CREATE OR REPLACE FUNCTION fun2() RETURNS VARCHAR LANGUAGE plpgsql AS $$
+DECLARE
+	test2_var1 VARCHAR(64) := 'ABC2';
+	test2_var2 VARCHAR(64) := 'XYZ2';
+	test2_var3        INTEGER := 2;
+BEGIN
+	RETURN  TO_CHAR(test2_var3, '000') || test2_var1 || test2_var2;
+END;
+$$;
+
+-- Derived from https://github.com/plv8/plv8/blob/r3.0alpha/sql/plv8.sql
+CREATE FUNCTION test(keys text[], vals text[]) RETURNS text AS
+$$
+	var o = {};
+	for (var i = 0; i < keys.length; i++)
+		o[keys[i]] = vals[i];
+	return JSON.stringify(o);
+$$
+LANGUAGE plv8 IMMUTABLE STRICT;

--- a/configure.ac
+++ b/configure.ac
@@ -833,6 +833,7 @@ AC_CONFIG_FILES([Makefile
 		 man/ctags-lang-verilog.7.rst
 		 man/ctags-lang-inko.7.rst
 		 man/ctags-lang-r.7.rst
+		 man/ctags-lang-sql.7.rst
 		 man/readtags.1.rst
 		 ])
 

--- a/docs/man-pages.rst
+++ b/docs/man-pages.rst
@@ -18,5 +18,6 @@ Man pages
 	ctags-lang-verilog(7) <man/ctags-lang-verilog.7.rst>
 	ctags-lang-inko(7) <man/ctags-lang-inko.7.rst>
 	ctags-lang-r(7) <man/ctags-lang-r.7.rst>
+	ctags-lang-sql(7) <man/ctags-lang-sql.7.rst>
 	ctags-incompatibilities(7) <man/ctags-incompatibilities.7.rst>
 	readtags(1) <man/readtags.1.rst>

--- a/docs/man/ctags-lang-sql.7.rst
+++ b/docs/man/ctags-lang-sql.7.rst
@@ -1,0 +1,138 @@
+.. _ctags-lang-sql(7):
+
+==============================================================
+ctags-lang-sql
+==============================================================
+
+The man page of the SQL parser for Universal Ctags
+
+:Version: 5.9.0
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**ctags** ... [--extras={guest}] --languages=+SQL ...
+
+
+DESCRIPTION
+-----------
+The SQL parser supports various SQL dialects. PostgreSQL is one of them.
+
+PostgreSQL allows user-defined functions to be written in other
+languages (*procedural languages*) besides SQL and C [PL]_.
+
+The SQL parser makes tags for language objects in the user-defined
+functions written in the procedural languages if the ``guest`` extra
+is enabled.
+
+The SQL parser looks for a token coming after ``LANGUAGE`` keyword in
+the source code to choose a proper guest parser.
+
+.. code-block:: SQL
+
+   ... LANGUAGE plpythonu AS '... user-defined function ' ...
+   ... AS $$ user-defined function $$ LANGUAGE plv8 ...
+
+In the above examples, ``plpythonu`` and ``plv8`` are the names of
+procedural languages. The SQL parser trims `pl` at the start and `u`
+at the end of the name before finding a parser ctags having.  For
+``plpythonu`` and ```plv8``, the SQL parser extracts ``python`` and
+``v8`` as the candidates of guest parsers.
+
+For ``plpythonu``, ctags can run its Python parser.  ctags doesn't
+have a parser named ``v8``. However, JavaScript parser of ctags has
+``v8`` as an alias. So ctags can run the JavaScript parser as the
+guest parser for ``plv8``.
+
+EXAMPLES
+--------
+
+tagging code including a user-defined function in a string literal [GH3006]_:
+
+"input.sql"
+
+.. code-block:: SQL
+
+	CREATE OR REPLACE FUNCTION fun1() RETURNS VARCHAR AS '
+	DECLARE
+		test1_var1 VARCHAR(64) := $$ABC$$;
+		test1_var2 VARCHAR(64) := $xyz$XYZ$xyz$;
+		test1_var3     INTEGER := 1;
+	BEGIN
+		RETURN  TO_CHAR(test_var3, ''000'') || test1_var1 || test1_var2;
+	END;
+	' LANGUAGE plpgsql;
+
+"output.tags"
+with "--options=NONE -o - --sort=no --extras=+{guest} input.sql"
+
+.. code-block:: tags
+
+	fun1	input.sql	/^CREATE OR REPLACE FUNCTION fun1() RETURNS VARCHAR AS '$/;"	f
+	test1_var1	input.sql	/^	test1_var1 VARCHAR(64) := $$ABC$$;$/;"	v
+	test1_var2	input.sql	/^	test1_var2 VARCHAR(64) := $xyz$XYZ$xyz$;$/;"	v
+	test1_var3	input.sql	/^	test1_var3     INTEGER := 1;$/;"	v
+
+tagging code including a user-defined function in a dollar quote [GH3006]_:
+
+"input.sql"
+
+.. code-block:: SQL
+
+	CREATE OR REPLACE FUNCTION fun2() RETURNS VARCHAR LANGUAGE plpgsql AS $$
+	DECLARE
+		test2_var1 VARCHAR(64) := 'ABC2';
+		test2_var2 VARCHAR(64) := 'XYZ2';
+		test2_var3        INTEGER := 2;
+	BEGIN
+		RETURN  TO_CHAR(test2_var3, '000') || test2_var1 || test2_var2;
+	END;
+	$$;
+
+"output.tags"
+with "--options=NONE -o - --sort=no --extras=+{guest} input.sql"
+
+.. code-block:: tags
+
+	fun2	input.sql	/^CREATE OR REPLACE FUNCTION fun2() RETURNS VARCHAR LANGUAGE plpgsql AS $\$$/;"	f
+	test2_var1	input.sql	/^	test2_var1 VARCHAR(64) := 'ABC2';$/;"	v
+	test2_var2	input.sql	/^	test2_var2 VARCHAR(64) := 'XYZ2';$/;"	v
+	test2_var3	input.sql	/^	test2_var3        INTEGER := 2;$/;"	v
+
+tagging code including a user-defined written in JavaScript:
+
+.. code-block:: SQL
+
+	-- Derived from https://github.com/plv8/plv8/blob/r3.0alpha/sql/plv8.sql
+	CREATE FUNCTION test(keys text[], vals text[]) RETURNS text AS
+	$$
+		var o = {};
+		for (var i = 0; i < keys.length; i++)
+			o[keys[i]] = vals[i];
+		return JSON.stringify(o);
+	$$
+	LANGUAGE plv8 IMMUTABLE STRICT;
+
+"output.tags"
+with "--options=NONE -o - --sort=no --extras=+{guest} input.sql"
+
+.. code-block:: tags
+
+	test	input.sql	/^CREATE FUNCTION test(keys text[], vals text[]) RETURNS text AS$/;"	f
+	o	input.sql	/^	var o = {};$/;"	v
+
+KNOWN BUGS
+----------
+Escape sequences (`''`) in a string literal may make a guest parser confused.
+
+SEE ALSO
+--------
+:ref:`ctags(1) <ctags(1)>`, :ref:`ctags-client-tools(7) <ctags-client-tools(7)>`
+
+REFERENCES
+----------
+
+.. [PL] PostgreSQL 9.5.25 Documentation, "Chapter 39. Procedural Languages", https://www.postgresql.org/docs/9.5/xplang.html
+
+.. [GH3006] @bagl's comment submitted to https://github.com/universal-ctags/ctags/issues/3006

--- a/main/options.c
+++ b/main/options.c
@@ -795,7 +795,7 @@ extern langType getLanguageComponentInOptionFull (const char *const option,
 	sep = strpbrk (lang, ":.");
 	if (sep)
 		lang_len = sep - lang;
-	language = getNamedLanguageFull (lang, lang_len, noPretending);
+	language = getNamedLanguageFull (lang, lang_len, noPretending, false);
 	if (language == LANG_IGNORE)
 	{
 		const char *langName = (lang_len == 0)? lang: eStrndup (lang, lang_len);

--- a/main/parse.h
+++ b/main/parse.h
@@ -146,6 +146,7 @@ extern const char *getLanguageName (const langType language);
 extern const char *getLanguageKindName (const langType language, const int kindIndex);
 
 extern langType getNamedLanguage (const char *const name, size_t len);
+extern langType getNamedLanguageOrAlias (const char *const name, size_t len);
 extern langType getLanguageForFilenameAndContents (const char *const fileName);
 extern langType getLanguageForCommand (const char *const command, langType startFrom);
 extern langType getLanguageForFilename (const char *const filename, langType startFrom);

--- a/main/parse_p.h
+++ b/main/parse_p.h
@@ -63,7 +63,7 @@ extern parserDefinitionFunc PEG_PARSER_LIST;
 extern bool doesLanguageAllowNullTag (const langType language);
 extern bool doesLanguageRequestAutomaticFQTag (const langType language);
 
-extern langType getNamedLanguageFull (const char *const name, size_t len, bool noPretending);
+extern langType getNamedLanguageFull (const char *const name, size_t len, bool noPretending, bool include_aliases);
 
 extern kindDefinition* getLanguageKind(const langType language, int kindIndex);
 extern kindDefinition* getLanguageKindForName (const langType language, const char *kindName);

--- a/main/promise.h
+++ b/main/promise.h
@@ -17,6 +17,8 @@
 #include "parse.h"
 #include "numarray.h"
 
+/* parser can be NULL; give a name with promiseUpdateLanguage()
+ * when the name can be determined. */
 int  makePromise   (const char *parser,
 		    unsigned long startLine, long startCharOffset,
 		    unsigned long endLine, long endCharOffset,
@@ -25,5 +27,7 @@ int  makePromise   (const char *parser,
 /* Fill the line with white spaces.
    The callee takes the ownership of lines. */
 void promiseAttachLineFiller (int promise, ulongArray *lines);
+
+void promiseUpdateLanguage  (int promise, langType lang);
 
 #endif	/* CTAGS_MAIN_PROMISE_H */

--- a/main/strlist.c
+++ b/main/strlist.c
@@ -212,6 +212,16 @@ extern vString* stringListExtensionFinds (
 #endif
 }
 
+extern bool stringListCaseMatched (const stringList* const list, const char* const str)
+{
+	return stringListCaseFinds(list, str)? true: false;
+}
+
+extern vString* stringListCaseFinds (const stringList* const list, const char* const str)
+{
+	return stringListFinds (list, str, compareStringInsensitive);
+}
+
 static bool fileNameMatched (
 		const vString* const vpattern, const char* const fileName)
 {

--- a/main/strlist.h
+++ b/main/strlist.h
@@ -49,6 +49,9 @@ extern bool stringListExtensionMatched (const stringList* const list, const char
 extern vString* stringListExtensionFinds (const stringList* const list, const char* const extension);
 extern bool stringListFileMatched (const stringList* const list, const char* const str);
 extern vString* stringListFileFinds (const stringList* const list, const char* const str);
+extern bool stringListCaseMatched (const stringList* const list, const char* const str);
+extern vString* stringListCaseFinds (const stringList* const list, const char* const str);
+
 extern void stringListPrint (const stringList *const current, FILE *fp);
 extern void stringListReverse (const stringList *const current);
 

--- a/main/strlist.h
+++ b/main/strlist.h
@@ -45,6 +45,19 @@ extern bool stringListHasTest (const stringList *const current,
 				  bool (*test)(const char *s, void *userData),
 				  void *userData);
 extern bool stringListDeleteItemExtension (stringList* const current, const char* const extension);
+
+/*
+ * stringListExtension{Matched,Finds}
+ * They compares strcmp or strcasecmp.
+ * The choice of case-sensitive or case-insensitive is platform-dependent.
+ *
+ * stringListFile{Matched,Finds}:
+ * They do glob-matching with fnmatch().
+ * The choice of case-sensitive or case-insensitive is platform-dependent.
+ *
+ * stringListCase{Matched,Finds}:
+ * They always work case-insensitive way.
+ */
 extern bool stringListExtensionMatched (const stringList* const list, const char* const extension);
 extern vString* stringListExtensionFinds (const stringList* const list, const char* const extension);
 extern bool stringListFileMatched (const stringList* const list, const char* const str);

--- a/man/Makefile
+++ b/man/Makefile
@@ -54,6 +54,7 @@ IN_SOURCE_FILES = \
 	ctags-lang-verilog.7.rst.in \
 	ctags-lang-inko.7.rst.in \
 	ctags-lang-r.7.rst.in \
+	ctags-lang-sql.7.rst.in \
 	\
 	readtags.1.rst.in \
 	\

--- a/man/ctags-lang-sql.7.rst.in
+++ b/man/ctags-lang-sql.7.rst.in
@@ -1,0 +1,138 @@
+.. _ctags-lang-sql(7):
+
+==============================================================
+ctags-lang-sql
+==============================================================
+-------------------------------------------------------------------
+The man page of the SQL parser for Universal Ctags
+-------------------------------------------------------------------
+:Version: @VERSION@
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**@CTAGS_NAME_EXECUTABLE@** ... [--extras={guest}] --languages=+SQL ...
+
+
+DESCRIPTION
+-----------
+The SQL parser supports various SQL dialects. PostgreSQL is one of them.
+
+PostgreSQL allows user-defined functions to be written in other
+languages (*procedural languages*) besides SQL and C [PL]_.
+
+The SQL parser makes tags for language objects in the user-defined
+functions written in the procedural languages if the ``guest`` extra
+is enabled.
+
+The SQL parser looks for a token coming after ``LANGUAGE`` keyword in
+the source code to choose a proper guest parser.
+
+.. code-block:: SQL
+
+   ... LANGUAGE plpythonu AS '... user-defined function ' ...
+   ... AS $$ user-defined function $$ LANGUAGE plv8 ...
+
+In the above examples, ``plpythonu`` and ``plv8`` are the names of
+procedural languages. The SQL parser trims `pl` at the start and `u`
+at the end of the name before finding a parser ctags having.  For
+``plpythonu`` and ```plv8``, the SQL parser extracts ``python`` and
+``v8`` as the candidates of guest parsers.
+
+For ``plpythonu``, ctags can run its Python parser.  ctags doesn't
+have a parser named ``v8``. However, JavaScript parser of ctags has
+``v8`` as an alias. So ctags can run the JavaScript parser as the
+guest parser for ``plv8``.
+
+EXAMPLES
+--------
+
+tagging code including a user-defined function in a string literal [GH3006]_:
+
+"input.sql"
+
+.. code-block:: SQL
+
+	CREATE OR REPLACE FUNCTION fun1() RETURNS VARCHAR AS '
+	DECLARE
+		test1_var1 VARCHAR(64) := $$ABC$$;
+		test1_var2 VARCHAR(64) := $xyz$XYZ$xyz$;
+		test1_var3     INTEGER := 1;
+	BEGIN
+		RETURN  TO_CHAR(test_var3, ''000'') || test1_var1 || test1_var2;
+	END;
+	' LANGUAGE plpgsql;
+
+"output.tags"
+with "--options=NONE -o - --sort=no --extras=+{guest} input.sql"
+
+.. code-block:: tags
+
+	fun1	input.sql	/^CREATE OR REPLACE FUNCTION fun1() RETURNS VARCHAR AS '$/;"	f
+	test1_var1	input.sql	/^	test1_var1 VARCHAR(64) := $$ABC$$;$/;"	v
+	test1_var2	input.sql	/^	test1_var2 VARCHAR(64) := $xyz$XYZ$xyz$;$/;"	v
+	test1_var3	input.sql	/^	test1_var3     INTEGER := 1;$/;"	v
+
+tagging code including a user-defined function in a dollar quote [GH3006]_:
+
+"input.sql"
+
+.. code-block:: SQL
+
+	CREATE OR REPLACE FUNCTION fun2() RETURNS VARCHAR LANGUAGE plpgsql AS $$
+	DECLARE
+		test2_var1 VARCHAR(64) := 'ABC2';
+		test2_var2 VARCHAR(64) := 'XYZ2';
+		test2_var3        INTEGER := 2;
+	BEGIN
+		RETURN  TO_CHAR(test2_var3, '000') || test2_var1 || test2_var2;
+	END;
+	$$;
+
+"output.tags"
+with "--options=NONE -o - --sort=no --extras=+{guest} input.sql"
+
+.. code-block:: tags
+
+	fun2	input.sql	/^CREATE OR REPLACE FUNCTION fun2() RETURNS VARCHAR LANGUAGE plpgsql AS $\$$/;"	f
+	test2_var1	input.sql	/^	test2_var1 VARCHAR(64) := 'ABC2';$/;"	v
+	test2_var2	input.sql	/^	test2_var2 VARCHAR(64) := 'XYZ2';$/;"	v
+	test2_var3	input.sql	/^	test2_var3        INTEGER := 2;$/;"	v
+
+tagging code including a user-defined written in JavaScript:
+
+.. code-block:: SQL
+
+	-- Derived from https://github.com/plv8/plv8/blob/r3.0alpha/sql/plv8.sql
+	CREATE FUNCTION test(keys text[], vals text[]) RETURNS text AS
+	$$
+		var o = {};
+		for (var i = 0; i < keys.length; i++)
+			o[keys[i]] = vals[i];
+		return JSON.stringify(o);
+	$$
+	LANGUAGE plv8 IMMUTABLE STRICT;
+
+"output.tags"
+with "--options=NONE -o - --sort=no --extras=+{guest} input.sql"
+
+.. code-block:: tags
+
+	test	input.sql	/^CREATE FUNCTION test(keys text[], vals text[]) RETURNS text AS$/;"	f
+	o	input.sql	/^	var o = {};$/;"	v
+
+KNOWN BUGS
+----------
+Escape sequences (`''`) in a string literal may make a guest parser confused.
+
+SEE ALSO
+--------
+ctags(1), ctags-client-tools(7)
+
+REFERENCES
+----------
+
+.. [PL] PostgreSQL 9.5.25 Documentation, "Chapter 39. Procedural Languages", https://www.postgresql.org/docs/9.5/xplang.html
+
+.. [GH3006] @bagl's comment submitted to https://github.com/universal-ctags/ctags/issues/3006

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -2747,7 +2747,11 @@ extern parserDefinition* JavaScriptParser (void)
 	// which have JS function definitions, so we just use the JS parser
 	static const char *const extensions [] = { "js", "jsx", "mjs", NULL };
 	static const char *const aliases [] = { "js", "node", "nodejs",
-	                                        "seed", "gjs", NULL };
+	                                        "seed", "gjs",
+											/* Used in PostgreSQL
+											 * https://github.com/plv8/plv8 */
+											"v8",
+											NULL };
 	parserDefinition *const def = parserNew ("JavaScript");
 	def->extensions = extensions;
 	def->aliases = aliases;


### PR DESCRIPTION
Close #3017.
    
    PostgreSQL allows users defining functions and procedures with languages other than SQL.
    Languages for defining a procedures or functions are called procedural languages.
    
    From the view point of the syntax of the base language (SQL), the definitions are
    just strings.
    
    This change recognizes the strings and LANGUAGE keywords, and runs
    guest parsers on the strings if syntactical conditions are met.
    
    Signed-off-by: Masatake YAMATO <yamato@redhat.com>
