### PR TITLE
C++: extract operators for user-defined literals

### DIFF
--- a/Units/parser-cxx.r/cxx11-user-defined-literals.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-user-defined-literals.d/expected.tags
@@ -1,0 +1,2 @@
+operator ""_e	input.h	/^float operator ""_e(const char*)$/;"	f	typeref:typename:float
+operator ""_print	input.h	/^void operator"" _print ( const char* str )$/;"	f	typeref:typename:void

--- a/Units/parser-cxx.r/cxx11-user-defined-literals.d/input.h
+++ b/Units/parser-cxx.r/cxx11-user-defined-literals.d/input.h
@@ -1,0 +1,12 @@
+// Quoted from https://en.cppreference.com/w/cpp/language/user_literal:
+
+// used for side-effects
+void operator"" _print ( const char* str )
+{
+    std::cout << str << '\n';
+}
+
+float operator ""_e(const char*)
+{
+	return 0.0;
+}

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -866,6 +866,13 @@ bool cxxParserLookForFunctionSignature(
 						CXX_DEBUG_LEAVE_TEXT("Unexpected token after the operator keyword");
 						return false;
 					}
+				} else if(cxxTokenTypeIs(pToken,CXXTokenTypeStringConstant)) {
+					// check for operator "" _fn ()
+					if (strcmp (vStringValue(pToken->pszWord), "\"\"") != 0)
+					{
+						CXX_DEBUG_LEAVE_TEXT("Non-empty string after operator");
+						return false;
+					}
 				} else if(!cxxTokenTypeIsOneOf(
 						pToken,
 						CXXTokenTypeAnd | CXXTokenTypeAssignment |


### PR DESCRIPTION
Close #2883.

See https://en.cppreference.com/w/cpp/language/user_literal.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>