### PR TITLE
build-sys: report the path for autoreconf, aclocal and pkg-config at the beginning in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+tools=""
+
+# Report the paths causing trouble frequently
+echo '##################################################################'
+echo '#                     The paths for tools                        #'
+echo '##################################################################'
+for t in autoreconf aclocal pkg-config; do
+	type $t
+done
+echo '##################################################################'
+
 set -xe
 
 type autoreconf > /dev/null 2>&1 || {


### PR DESCRIPTION
See #3042.

What we found were building ctags was failed with the combination
of /usr/bin/pkg-config and /usr/local/bin/aclocal.

Instead of rejecting the combination, this change reports the paths
for the tools. The reported message may help us find the root cause of
the failure.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>