### PR TITLE
C++: avoid getting confused by unbalanced less-than/greater-than signs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@
 *.od
 *.pdf
 *.pyc
-*.ssexwsp
-*.ssexwsp.user
+*.c3workspace
+*.c3workspace.user
 *.tar.gz
 *.TMP
 *.tmp

--- a/Units/parser-cxx.r/operators.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/operators.cpp.d/expected.tags
@@ -17,6 +17,7 @@ operator delete	input.cpp	/^	void operator delete(void *);$/;"	p	class:X	typeref
 operator new[]	input.cpp	/^	void * operator new[](size_t);$/;"	p	class:X	typeref:typename:void *	file:
 operator delete[]	input.cpp	/^	void operator delete[](void *);$/;"	p	class:X	typeref:typename:void	file:
 operator Type	input.cpp	/^	operator Type() const;$/;"	p	class:X	file:
+operator <=>	input.cpp	/^	auto operator<=>(const X&a) const -> decltype(1 <=> 2)$/;"	f	class:X	typeref:typename:decltype (1<=>2)	file:
 operator *=	input.cpp	/^X & X::operator *= (int x)$/;"	f	class:X	typeref:typename:X &
 operator *=	input.cpp	/^X & X::operator *= (const X & x)$/;"	f	class:X	typeref:typename:X &
 operator &&	input.cpp	/^X X::operator && (const X &a)$/;"	f	class:X	typeref:typename:X

--- a/Units/parser-cxx.r/operators.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/operators.cpp.d/input.cpp
@@ -75,6 +75,12 @@ public:
 	void operator delete[](void *);
 
 	operator Type() const;
+
+	// requires -std=c++20 to compile
+	auto operator<=>(const X&a) const -> decltype(1 <=> 2)
+	{
+		return std::strong_ordering::less;
+	}
 };
 
 X & X::operator *= (int x)

--- a/Units/parser-cxx.r/templates-enable-if.d/args.ctags
+++ b/Units/parser-cxx.r/templates-enable-if.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--kinds-C++=*
+--fields-c++=+{template}

--- a/Units/parser-cxx.r/templates-enable-if.d/expected.tags
+++ b/Units/parser-cxx.r/templates-enable-if.d/expected.tags
@@ -1,0 +1,8 @@
+A	input.cpp	/^class A$/;"	c	file:
+f1	input.cpp	/^		typename std::enable_if<2 << 3,int>::type f1(X x)$/;"	f	class:A	typeref:typename:std::enable_if<2<<3,int>::type	file:	template:<typename X>
+X	input.cpp	/^	template<typename X> $/;"	Z	function:A::f1	typeref:meta:typename
+x	input.cpp	/^		typename std::enable_if<2 << 3,int>::type f1(X x)$/;"	z	function:A::f1	typeref:typename:X	file:
+f2	input.cpp	/^		typename std::enable_if<!false,int>::type f2(X x)$/;"	f	class:A	typeref:typename:std::enable_if<!false,int>::type	file:	template:<typename X>
+X	input.cpp	/^	template<typename X> $/;"	Z	function:A::f2	typeref:meta:typename
+x	input.cpp	/^		typename std::enable_if<!false,int>::type f2(X x)$/;"	z	function:A::f2	typeref:typename:X	file:
+B	input.cpp	/^class B$/;"	c	file:

--- a/Units/parser-cxx.r/templates-enable-if.d/input.cpp
+++ b/Units/parser-cxx.r/templates-enable-if.d/input.cpp
@@ -1,0 +1,21 @@
+#include <type_traits>
+
+class A
+{
+public:
+	template<typename X> 
+		typename std::enable_if<2 << 3,int>::type f1(X x)
+		{
+			return (int)x;
+		};
+	
+	template<typename X> 
+		typename std::enable_if<!false,int>::type f2(X x)
+		{
+			return (int)x;
+		};
+};
+
+class B
+{
+};

--- a/parsers/cxx/cxx_parser_block.c
+++ b/parsers/cxx/cxx_parser_block.c
@@ -265,7 +265,6 @@ static bool cxxParserParseBlockInternal(bool bExpectClosingBracket)
 		cppBeginStatement();
 	}
 
-	int iNestedAngleBracketLevel = 0;
 	for(;;)
 	{
 		if(!cxxParserParseNextToken())
@@ -396,27 +395,45 @@ process_token:
 						}
 					break;
 					case CXXKeywordCLASS:
-						if(iNestedAngleBracketLevel == 0 &&
-						   !cxxParserParseClassStructOrUnion(CXXKeywordCLASS,CXXTagCPPKindCLASS,CXXScopeTypeClass))
+						if(
+							// do not trigger on X<class Y>
+							(!g_cxx.pToken->pPrev) ||
+							(!cxxTokenTypeIsOneOf(g_cxx.pToken->pPrev,CXXTokenTypeSmallerThanSign | CXXTokenTypeComma))
+						)
 						{
-							CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
-							return false;
+							if(!cxxParserParseClassStructOrUnion(CXXKeywordCLASS,CXXTagCPPKindCLASS,CXXScopeTypeClass))
+							{
+								CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
+								return false;
+							}
 						}
 					break;
 					case CXXKeywordSTRUCT:
-						if(iNestedAngleBracketLevel == 0 &&
-						   !cxxParserParseClassStructOrUnion(CXXKeywordSTRUCT,CXXTagKindSTRUCT,CXXScopeTypeStruct))
+						if(
+							// do not trigger on X<struct Y>
+							(!g_cxx.pToken->pPrev) ||
+							(!cxxTokenTypeIsOneOf(g_cxx.pToken->pPrev,CXXTokenTypeSmallerThanSign | CXXTokenTypeComma))
+						)
 						{
-							CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
-							return false;
+							if(!cxxParserParseClassStructOrUnion(CXXKeywordSTRUCT,CXXTagKindSTRUCT,CXXScopeTypeStruct))
+							{
+								CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
+								return false;
+							}
 						}
 					break;
 					case CXXKeywordUNION:
-						if(iNestedAngleBracketLevel == 0 &&
-						   !cxxParserParseClassStructOrUnion(CXXKeywordUNION,CXXTagKindUNION,CXXScopeTypeUnion))
+						if(
+							// do not trigger on X<union Y>
+							(!g_cxx.pToken->pPrev) ||
+							(!cxxTokenTypeIsOneOf(g_cxx.pToken->pPrev,CXXTokenTypeSmallerThanSign | CXXTokenTypeComma))
+						)
 						{
-							CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
-							return false;
+							if(!cxxParserParseClassStructOrUnion(CXXKeywordUNION,CXXTagKindUNION,CXXScopeTypeUnion))
+							{
+								CXX_DEBUG_LEAVE_TEXT("Failed to parse class/struct/union");
+								return false;
+							}
 						}
 					break;
 					case CXXKeywordPUBLIC:
@@ -751,12 +768,6 @@ process_token:
 				else if (cxxScopeGetType() == CXXScopeTypeClass)
 					cxxSubparserUnknownIdentifierInClassNotify(g_cxx.pToken);
 			break;
-			case CXXTokenTypeSmallerThanSign:
-				iNestedAngleBracketLevel++;
-				break;
-			case CXXTokenTypeGreaterThanSign:
-				iNestedAngleBracketLevel--;
-				break;
 			default:
 				// something else we didn't handle
 			break;


### PR DESCRIPTION
Fix #2867 in a different way, so the parser doesn't get confused by unbalanced less-than/greater-than signs and the file reported in #3053 is parsed properly.

Fixes #3053 