### PR TITLE
C++: fix scope kind of tparam in a prototype

### DIFF
--- a/Units/parser-cxx.r/template-prototype.d/args.ctags
+++ b/Units/parser-cxx.r/template-prototype.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--kinds-C++=+pZ
+--fields=+K

--- a/Units/parser-cxx.r/template-prototype.d/expected.tags
+++ b/Units/parser-cxx.r/template-prototype.d/expected.tags
@@ -1,0 +1,4 @@
+f	input.cc	/^template <class T> int f (T t);$/;"	prototype	typeref:typename:int	file:
+T	input.cc	/^template <class T> int f (T t);$/;"	tparam	prototype:f	typeref:meta:class
+g	input.cc	/^template <class S> int g (S s) {$/;"	function	typeref:typename:int
+S	input.cc	/^template <class S> int g (S s) {$/;"	tparam	function:g	typeref:meta:class

--- a/Units/parser-cxx.r/template-prototype.d/input.cc
+++ b/Units/parser-cxx.r/template-prototype.d/input.cc
@@ -1,0 +1,4 @@
+template <class T> int f (T t);
+template <class S> int g (S s) {
+  return 0;
+}

--- a/Units/parser-cxx.r/template-specializations.d/expected.tags
+++ b/Units/parser-cxx.r/template-specializations.d/expected.tags
@@ -3,15 +3,15 @@ T	input.cpp	/^template<typename T>$/;"	Z	struct:A	typeref:meta:typename
 f	input.cpp	/^    void f(T); \/\/ member, declared in the primary template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T)
 h	input.cpp	/^    void h(T) {} \/\/ member, defined in the primary template$/;"	f	struct:A	typeref:typename:void	file:	signature:(T)
 g1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T,X1)	template:<class X1>
-X1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	Z	function:A::g1	typeref:meta:class
+X1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	Z	prototype:A::g1	typeref:meta:class
 g2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T,X2)	template:<class X2>
-X2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	Z	function:A::g2	typeref:meta:class
+X2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	Z	prototype:A::g2	typeref:meta:class
 f	input.cpp	/^template<> void A<int>::f(int);$/;"	p	class:A	typeref:typename:void	file:	signature:(int)	template:<>	properties:scopespecialization,specialization
 h	input.cpp	/^template<> void A<int>::h(int) {}$/;"	f	class:A	typeref:typename:void	signature:(int)	template:<>	properties:scopespecialization,specialization
 g1	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	f	class:A	typeref:typename:void	signature:(T,X1)	template:<class X1>	properties:scopespecialization,specialization
 X1	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	Z	function:A::g1	typeref:meta:class
 g1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	p	class:A	typeref:typename:void	file:	signature:(int,X1)	template:<class X1>	properties:scopespecialization,specialization
-X1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	Z	function:A::g1	typeref:meta:class
+X1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	Z	prototype:A::g1	typeref:meta:class
 g2	input.cpp	/^template<> void A<int>::g2<char>(int, char); \/\/ for X2 = char$/;"	p	class:A	typeref:typename:void	file:	signature:(int,char)	template:<>	specialization:<char>	properties:scopespecialization,specialization
 g1	input.cpp	/^template<> void A<int>::g1(int, char);$/;"	p	class:A	typeref:typename:void	file:	signature:(int,char)	template:<>	properties:scopespecialization,specialization
 m	input.cpp	/^template<typename X> void m(X)$/;"	f	typeref:typename:void	signature:(X)	template:<typename X>

--- a/parsers/cxx/cxx_debug.c
+++ b/parsers/cxx/cxx_debug.c
@@ -170,6 +170,7 @@ const char* cxxDebugScopeDecode(enum CXXScopeType scope)
 		[CXXScopeTypeUnion] = "union",
 		[CXXScopeTypeStruct] = "struct",
 		[CXXScopeTypeVariable] = "variable",
+		[CXXScopeTypePrototype]  = "prototype",
 	};
 	if (CXXScopeTypeLAST > scope)
 		return table[scope];

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -1732,7 +1732,9 @@ int cxxParserEmitFunctionTags(
 
 	if(bPushScopes)
 	{
-		cxxScopePush(pIdentifier,CXXScopeTypeFunction,CXXScopeAccessUnknown);
+		cxxScopePush(pIdentifier,
+					 (uTagKind == CXXTagKindPROTOTYPE)? CXXScopeTypePrototype: CXXScopeTypeFunction,
+					 CXXScopeAccessUnknown);
 		iScopesPushed++;
 	} else {
 		cxxTokenDestroy(pIdentifier);

--- a/parsers/cxx/cxx_scope.c
+++ b/parsers/cxx/cxx_scope.c
@@ -75,6 +75,7 @@ unsigned int cxxScopeGetVariableKind(void)
 		case CXXScopeTypeFunction:
 			return CXXTagKindLOCAL;
 		break;
+		//case CXXScopeTypePrototype:
 		//case CXXScopeTypeNamespace:
 		//case CXXScopeTypeEnum:
 		default:
@@ -101,6 +102,8 @@ unsigned int cxxScopeGetKind(void)
 			return CXXTagKindENUM;
 		case CXXScopeTypeFunction:
 			return CXXTagKindFUNCTION;
+		case CXXScopeTypePrototype:
+			return CXXTagKindPROTOTYPE;
 		case CXXScopeTypeStruct:
 			return CXXTagKindSTRUCT;
 		case CXXScopeTypeUnion:

--- a/parsers/cxx/cxx_scope.h
+++ b/parsers/cxx/cxx_scope.h
@@ -30,6 +30,7 @@ enum CXXScopeType
 	CXXScopeTypeUnion,
 	CXXScopeTypeStruct,
 	CXXScopeTypeVariable, // template variables, mainly
+	CXXScopeTypePrototype,
 	CXXScopeTypeLAST
 };
 


### PR DESCRIPTION
Close #3060.

input.h:

	template <class T> int f (T t);

The scope kind for T was function.
It should be prototype.