### PR TITLE
Cxx: extract parameters in a prototype

### DIFF
--- a/Tmain/list-kinds-full.d/stdout-expected.txt
+++ b/Tmain/list-kinds-full.d/stdout-expected.txt
@@ -14,7 +14,7 @@ t	typedef	yes	no	0	C	typedefs
 u	union	yes	no	0	C	union names
 v	variable	yes	no	0	C	variable definitions
 x	externvar	no	no	0	C	external and forward variable declarations
-z	parameter	no	no	0	C	function parameters inside function definitions
+z	parameter	no	no	0	C	function parameters inside function or prototype definitions
 #LETTER	NAME	ENABLED	REFONLY	NROLES	MASTER	DESCRIPTION
 A	alias	no	no	0	NONE	namespace aliases
 D	macroparam	no	no	0	C	parameters inside macro definitions
@@ -37,4 +37,4 @@ t	typedef	yes	no	0	C	typedefs
 u	union	yes	no	0	C	union names
 v	variable	yes	no	0	C	variable definitions
 x	externvar	no	no	0	C	external and forward variable declarations
-z	parameter	no	no	0	C	function parameters inside function definitions
+z	parameter	no	no	0	C	function parameters inside function or prototype definitions

--- a/Tmain/nested-subparsers.d/stdout-expected.txt
+++ b/Tmain/nested-subparsers.d/stdout-expected.txt
@@ -14,7 +14,7 @@ t  typedefs
 u  union names
 v  variable definitions
 x  external and forward variable declarations [off]
-z  function parameters inside function definitions [off]
+z  function parameters inside function or prototype definitions [off]
 L  goto labels [off]
 D  parameters inside macro definitions [off]
 #
@@ -49,7 +49,7 @@ t       typedef    yes     no      0      C      typedefs
 u       union      yes     no      0      C      union names
 v       variable   yes     no      0      C      variable definitions
 x       externvar  no      no      0      C      external and forward variable declarations
-z       parameter  no      no      0      C      function parameters inside function definitions
+z       parameter  no      no      0      C      function parameters inside function or prototype definitions
 #
 # list kinds-full Event
 #

--- a/Units/parser-cxx.r/attribute.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/attribute.cpp.d/expected.tags
@@ -18,6 +18,7 @@ e1e1	input.cpp	/^	e1e1 __attribute__((deprecated)),$/;"	e	enum:e1	file:
 e1e2	input.cpp	/^	e1e2$/;"	e	enum:e1	file:
 p1	input.cpp	/^__attribute__((noreturn)) void p1(void),$/;"	p	typeref:typename:void	file:	signature:(void)
 p2	input.cpp	/^	__attribute__((format(printf, 1, 2))) p2 (const char *, ...),$/;"	p	typeref:typename:void	file:	signature:(const char *,...)
+__anon6f96ad27010d	input.cpp	/^	__attribute__((format(printf, 1, 2))) p2 (const char *, ...),$/;"	z	prototype:p2	typeref:typename:const char *	file:
 p3	input.cpp	/^	p3 (void);$/;"	p	typeref:typename:void	file:	signature:(void)
 p4	input.cpp	/^void (__attribute__((noreturn)) ****p4) (void) __attribute__((deprecated));$/;"	v	typeref:typename:void (****)(void)	properties:deprecated
 p5	input.cpp	/^void p5() __attribute__ ((weak, alias ("p4")));$/;"	p	typeref:typename:void	file:	signature:()

--- a/Units/parser-cxx.r/complex-macros.d/args.ctags
+++ b/Units/parser-cxx.r/complex-macros.d/args.ctags
@@ -11,6 +11,6 @@
 -D STRINGIFY(token)=#token
 -D IMPLEMENT_FUNCTIONS(_prefix)=void _prefix ## a(){ }; void _prefix ## b(){ };
 -D DECLARE_VARS(_prefix)=int _prefix ## a; int _prefix ## b;
--D DECLARE_FUNCTION_4(Ret,Class,Method,...)=Ret Class##__##Method(Class *this, ##__VA_ARGS__)
+-D DECLARE_FUNCTION_4(Ret,Class,Method,...)=Ret Class##__##Method(Class *that, ##__VA_ARGS__)
 -D DECLARE_FUNCTION_4_BEGIN(...)={
 -D DECLARE_FUNCTION_4_END(...)=}

--- a/Units/parser-cxx.r/complex-macros.d/expected.tags
+++ b/Units/parser-cxx.r/complex-macros.d/expected.tags
@@ -11,6 +11,8 @@ _ret	input.cpp	/^#define DECLARE_FUNCTION_3(_ret,_name,...) _ret _name(__VA_ARGS
 _name	input.cpp	/^#define DECLARE_FUNCTION_3(_ret,_name,...) _ret _name(__VA_ARGS__);$/;"	D	macro:DECLARE_FUNCTION_3
 DECLARE_FUNCTION_3	input.cpp	/^#define DECLARE_FUNCTION_3(/;"	d	file:	signature:(_ret,_name,...)
 p3	input.cpp	/^DECLARE_FUNCTION_3(int,p3,int a,int b);$/;"	p	typeref:typename:int	file:	signature:(int a,int b)
+a	input.cpp	/^DECLARE_FUNCTION_3(int,p3,int a,int b);$/;"	z	prototype:p3	typeref:typename:int	file:
+b	input.cpp	/^DECLARE_FUNCTION_3(int,p3,int a,int b);$/;"	z	prototype:p3	typeref:typename:int	file:
 DEPRECATED	input.cpp	/^#define DEPRECATED(/;"	d	file:	signature:(...)
 p4	input.cpp	/^DEPRECATED(int p4());$/;"	p	typeref:typename:int	file:	signature:()	properties:deprecated
 _prefix1	input.cpp	/^#define DECLARE_TWO_VERSIONS_OF_FUNCTIONS(_prefix1,_prefix2) \\$/;"	D	macro:DECLARE_TWO_VERSIONS_OF_FUNCTIONS
@@ -37,5 +39,7 @@ f1b	input.cpp	/^IMPLEMENT_FUNCTIONS(f1);$/;"	f	typeref:typename:void	signature:(
 _prefix	input.cpp	/^#define DECLARE_VARS(_prefix) int _prefix ## a; int _prefix ## b;$/;"	D	macro:DECLARE_VARS
 DECLARE_VARS	input.cpp	/^#define DECLARE_VARS(/;"	d	file:	signature:(_prefix)
 main	input.cpp	/^int main(int,char **)$/;"	f	typeref:typename:int	signature:(int,char **)
+__anonb64b5bec010d	input.cpp	/^int main(int,char **)$/;"	z	function:main	typeref:typename:int	file:
+__anonb64b5bec020d	input.cpp	/^int main(int,char **)$/;"	z	function:main	typeref:typename:char **	file:
 la	input.cpp	/^	DECLARE_VARS(l);$/;"	l	function:main	typeref:typename:int	file:
 lb	input.cpp	/^	DECLARE_VARS(l);$/;"	l	function:main	typeref:typename:int	file:

--- a/Units/parser-cxx.r/complex-macros.d/expected.tags
+++ b/Units/parser-cxx.r/complex-macros.d/expected.tags
@@ -21,13 +21,14 @@ p6a	input.cpp	/^DECLARE_TWO_VERSIONS_OF_FUNCTIONS(p5,p6)$/;"	p	typeref:typename:
 token	input.cpp	/^#define STRINGIFY(token) #token$/;"	D	macro:STRINGIFY
 STRINGIFY	input.cpp	/^#define STRINGIFY(/;"	d	file:	signature:(token)
 test	input.cpp	/^const char * test = "" STRINGIFY(; int notVisible;);$/;"	v	typeref:typename:const char *
-Ret	input.cpp	/^#define DECLARE_FUNCTION_4(Ret,Class,Method,...) Ret Class##__##Method(Class *this, ##__VA_ARGS_/;"	D	macro:DECLARE_FUNCTION_4
-Class	input.cpp	/^#define DECLARE_FUNCTION_4(Ret,Class,Method,...) Ret Class##__##Method(Class *this, ##__VA_ARGS_/;"	D	macro:DECLARE_FUNCTION_4
-Method	input.cpp	/^#define DECLARE_FUNCTION_4(Ret,Class,Method,...) Ret Class##__##Method(Class *this, ##__VA_ARGS_/;"	D	macro:DECLARE_FUNCTION_4
+Ret	input.cpp	/^#define DECLARE_FUNCTION_4(Ret,Class,Method,...) Ret Class##__##Method(Class *that, ##__VA_ARGS_/;"	D	macro:DECLARE_FUNCTION_4
+Class	input.cpp	/^#define DECLARE_FUNCTION_4(Ret,Class,Method,...) Ret Class##__##Method(Class *that, ##__VA_ARGS_/;"	D	macro:DECLARE_FUNCTION_4
+Method	input.cpp	/^#define DECLARE_FUNCTION_4(Ret,Class,Method,...) Ret Class##__##Method(Class *that, ##__VA_ARGS_/;"	D	macro:DECLARE_FUNCTION_4
 DECLARE_FUNCTION_4	input.cpp	/^#define DECLARE_FUNCTION_4(/;"	d	file:	signature:(Ret,Class,Method,...)
 DECLARE_FUNCTION_4_BEGIN	input.cpp	/^#define DECLARE_FUNCTION_4_BEGIN(/;"	d	file:	signature:(...)
 DECLARE_FUNCTION_4_END	input.cpp	/^#define DECLARE_FUNCTION_4_END(/;"	d	file:	signature:(...)
-foo__bar	input.cpp	/^DECLARE_FUNCTION_4(int,foo,bar,int x)$/;"	f	typeref:typename:int	signature:(foo * this,int x)
+foo__bar	input.cpp	/^DECLARE_FUNCTION_4(int,foo,bar,int x)$/;"	f	typeref:typename:int	signature:(foo * that,int x)
+that	input.cpp	/^DECLARE_FUNCTION_4(int,foo,bar,int x)$/;"	z	function:foo__bar	typeref:typename:foo *	file:
 x	input.cpp	/^DECLARE_FUNCTION_4(int,foo,bar,int x)$/;"	z	function:foo__bar	typeref:typename:int	file:
 _prefix	input.cpp	/^#define IMPLEMENT_FUNCTIONS(_prefix) \\$/;"	D	macro:IMPLEMENT_FUNCTIONS
 IMPLEMENT_FUNCTIONS	input.cpp	/^#define IMPLEMENT_FUNCTIONS(/;"	d	file:	signature:(_prefix)

--- a/Units/parser-cxx.r/complex-macros.d/input.cpp
+++ b/Units/parser-cxx.r/complex-macros.d/input.cpp
@@ -41,7 +41,7 @@ DECLARE_TWO_VERSIONS_OF_FUNCTIONS(p5,p6)
 const char * test = "" STRINGIFY(; int notVisible;);
 
 // Unbalanced brackets (this comes from a nasty example in a github issue)
-#define DECLARE_FUNCTION_4(Ret,Class,Method,...) Ret Class##__##Method(Class *this, ##__VA_ARGS__)
+#define DECLARE_FUNCTION_4(Ret,Class,Method,...) Ret Class##__##Method(Class *that, ##__VA_ARGS__)
 #define DECLARE_FUNCTION_4_BEGIN(...) { /*not really this, but this is what ctags should see*/
 #define DECLARE_FUNCTION_4_END(...) } /*not really this, but this is what ctags should see*/
 

--- a/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-lambdas.d/expected.tags
@@ -17,24 +17,26 @@ l4	input.cpp	/^		auto l4 = [a,b](int c){ return a+b+c; };$/;"	local	function:tes
 l3	input.cpp	/^	auto l3 = [=](int a,int b) -> int {$/;"	local	function:test	typeref:typename:auto	file:	end:21
 __anon4e7b1b580502	input.cpp	/^	auto l5 = [](X<int,int> x,X<long,long>) -> X<double,double> { return X<double,double>(); };$/;"	function	function:test	typeref:typename:X<double,double>	file:	signature:(X<int,int> x,X<long,long>) 	end:23	captures:[]
 x	input.cpp	/^	auto l5 = [](X<int,int> x,X<long,long>) -> X<double,double> { return X<double,double>(); };$/;"	parameter	function:test::__anon4e7b1b580502	typeref:typename:X<int,int>	file:
+__anon4e7b1b58060d	input.cpp	/^	auto l5 = [](X<int,int> x,X<long,long>) -> X<double,double> { return X<double,double>(); };$/;"	parameter	function:test::__anon4e7b1b580502	typeref:typename:X<long,long>	file:
 l5	input.cpp	/^	auto l5 = [](X<int,int> x,X<long,long>) -> X<double,double> { return X<double,double>(); };$/;"	local	function:test	typeref:typename:auto	file:
-__anon4e7b1b580602	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	signature:(int a,int b) 	end:28	captures:[l1,l2,l3]
-a	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580602	typeref:typename:int	file:
-b	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580602	typeref:typename:int	file:
+__anon4e7b1b580702	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	function	function:test	typeref:typename:int	file:	signature:(int a,int b) 	end:28	captures:[l1,l2,l3]
+a	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580702	typeref:typename:int	file:
+b	input.cpp	/^			[l1,l2,l3](int a,int b) -> int {$/;"	parameter	function:test::__anon4e7b1b580702	typeref:typename:int	file:
 v1	input.cpp	/^	int v1 = call($/;"	local	function:test	typeref:typename:int	file:	end:29
-__anon4e7b1b580702	input.cpp	/^auto lg1 = [] { return 0; };$/;"	function	file:	end:32	captures:[] 
+__anon4e7b1b580802	input.cpp	/^auto lg1 = [] { return 0; };$/;"	function	file:	end:32	captures:[] 
 lg1	input.cpp	/^auto lg1 = [] { return 0; };$/;"	variable	typeref:typename:auto	end:32
-__anon4e7b1b580802	input.cpp	/^auto lg2 = [](int a,int b) { return a > b ? a : b; };$/;"	function	file:	signature:(int a,int b) 	end:34	captures:[]
-a	input.cpp	/^auto lg2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:__anon4e7b1b580802	typeref:typename:int	file:
-b	input.cpp	/^auto lg2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:__anon4e7b1b580802	typeref:typename:int	file:
+__anon4e7b1b580902	input.cpp	/^auto lg2 = [](int a,int b) { return a > b ? a : b; };$/;"	function	file:	signature:(int a,int b) 	end:34	captures:[]
+a	input.cpp	/^auto lg2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:__anon4e7b1b580902	typeref:typename:int	file:
+b	input.cpp	/^auto lg2 = [](int a,int b) { return a > b ? a : b; };$/;"	parameter	function:__anon4e7b1b580902	typeref:typename:int	file:
 lg2	input.cpp	/^auto lg2 = [](int a,int b) { return a > b ? a : b; };$/;"	variable	typeref:typename:auto	end:34
-__anon4e7b1b580902	input.cpp	/^auto lg3 = [=](int a,int b) -> int {$/;"	function	typeref:typename:int	file:	signature:(int a,int b) 	end:39	captures:[=]
-a	input.cpp	/^auto lg3 = [=](int a,int b) -> int {$/;"	parameter	function:__anon4e7b1b580902	typeref:typename:int	file:
-b	input.cpp	/^auto lg3 = [=](int a,int b) -> int {$/;"	parameter	function:__anon4e7b1b580902	typeref:typename:int	file:
-__anon4e7b1b580a02	input.cpp	/^	auto lg4 = [a,b](int c){ return a+b+c; };$/;"	function	function:__anon4e7b1b580902	file:	signature:(int c)	end:37	captures:[a,b]
-c	input.cpp	/^	auto lg4 = [a,b](int c){ return a+b+c; };$/;"	parameter	function:__anon4e7b1b580902::__anon4e7b1b580a02	typeref:typename:int	file:
-lg4	input.cpp	/^	auto lg4 = [a,b](int c){ return a+b+c; };$/;"	local	function:__anon4e7b1b580902	typeref:typename:auto	file:	end:37
+__anon4e7b1b580a02	input.cpp	/^auto lg3 = [=](int a,int b) -> int {$/;"	function	typeref:typename:int	file:	signature:(int a,int b) 	end:39	captures:[=]
+a	input.cpp	/^auto lg3 = [=](int a,int b) -> int {$/;"	parameter	function:__anon4e7b1b580a02	typeref:typename:int	file:
+b	input.cpp	/^auto lg3 = [=](int a,int b) -> int {$/;"	parameter	function:__anon4e7b1b580a02	typeref:typename:int	file:
+__anon4e7b1b580b02	input.cpp	/^	auto lg4 = [a,b](int c){ return a+b+c; };$/;"	function	function:__anon4e7b1b580a02	file:	signature:(int c)	end:37	captures:[a,b]
+c	input.cpp	/^	auto lg4 = [a,b](int c){ return a+b+c; };$/;"	parameter	function:__anon4e7b1b580a02::__anon4e7b1b580b02	typeref:typename:int	file:
+lg4	input.cpp	/^	auto lg4 = [a,b](int c){ return a+b+c; };$/;"	local	function:__anon4e7b1b580a02	typeref:typename:auto	file:	end:37
 lg3	input.cpp	/^auto lg3 = [=](int a,int b) -> int {$/;"	variable	typeref:typename:auto	end:39
-__anon4e7b1b580b02	input.cpp	/^auto lg5 = [](X<int,int> x,X<long,long>) -> X<double,double> { return X<double,double>(); };$/;"	function	typeref:typename:X<double,double>	file:	signature:(X<int,int> x,X<long,long>) 	end:41	captures:[]
-x	input.cpp	/^auto lg5 = [](X<int,int> x,X<long,long>) -> X<double,double> { return X<double,double>(); };$/;"	parameter	function:__anon4e7b1b580b02	typeref:typename:X<int,int>	file:
+__anon4e7b1b580c02	input.cpp	/^auto lg5 = [](X<int,int> x,X<long,long>) -> X<double,double> { return X<double,double>(); };$/;"	function	typeref:typename:X<double,double>	file:	signature:(X<int,int> x,X<long,long>) 	end:41	captures:[]
+x	input.cpp	/^auto lg5 = [](X<int,int> x,X<long,long>) -> X<double,double> { return X<double,double>(); };$/;"	parameter	function:__anon4e7b1b580c02	typeref:typename:X<int,int>	file:
+__anon4e7b1b580d0d	input.cpp	/^auto lg5 = [](X<int,int> x,X<long,long>) -> X<double,double> { return X<double,double>(); };$/;"	parameter	function:__anon4e7b1b580c02	typeref:typename:X<long,long>	file:
 lg5	input.cpp	/^auto lg5 = [](X<int,int> x,X<long,long>) -> X<double,double> { return X<double,double>(); };$/;"	variable	typeref:typename:auto

--- a/Units/parser-cxx.r/cxx11enum.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11enum.cpp.d/expected.tags
@@ -47,5 +47,6 @@ CEC1_member1	input.cpp	/^	enum class CEC1 : unsigned long int { CEC1_member1 };$
 CES1	input.cpp	/^	enum struct CES1 : int { CES1_member1 };$/;"	g	class:Class	typeref:typename:int	file:	end:30	properties:scopedenum
 CES1_member1	input.cpp	/^	enum struct CES1 : int { CES1_member1 };$/;"	e	enum:Class::CES1	file:
 Function1	input.cpp	/^	virtual enum CEC1 Function1(enum CE1 parameter);$/;"	p	class:Class	typeref:enum:CEC1	file:	end:31	properties:virtual
+parameter	input.cpp	/^	virtual enum CEC1 Function1(enum CE1 parameter);$/;"	z	prototype:Class::Function1	typeref:enum:CE1	file:
 E1_var1	input.cpp	/^enum E1 E1_var1;$/;"	v	typeref:enum:E1	end:41
 EC1_var1	input.cpp	/^enum EC1 EC1_var1[10][10];$/;"	v	typeref:enum:EC1[10][10]	end:42

--- a/Units/parser-cxx.r/functions.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/functions.cpp.d/expected.tags
@@ -11,6 +11,7 @@ f05	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	f	typere
 f05a01	input.cpp	/^static inline std::string f05(const int *** f05a01)$/;"	z	function:f05	typeref:typename:const int ***	file:
 f06	input.cpp	/^		auto f06(n01::c01 && f06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && f06a01)	end:15
 f06	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	f	class:n01::n02	typeref:typename:n01::n02::type01 *	signature:(n01::c01 && f06a01)	end:59
+f06a01	input.cpp	/^		auto f06(n01::c01 && f06a01) -> type01 *;$/;"	z	prototype:n01::n02::f06	typeref:typename:n01::c01 &&	file:
 f06a01	input.cpp	/^auto n01::n02::f06(n01::c01 && f06a01) -> n01::n02::type01 *$/;"	z	function:n01::n02::f06	typeref:typename:n01::c01 &&	file:
 f07	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	f	typeref:typename:unsigned int	signature:(int (* f07a01)(int * x1,int x2),...)	end:64
 f07a01	input.cpp	/^unsigned int f07(int (*f07a01)(int * x1,int x2),...)$/;"	z	function:f07	typeref:typename:int (*)(int * x1,int x2)	file:
@@ -25,14 +26,24 @@ f10a03	input.cpp	/^int f10(int f10a01,int f10a02[],int f10a03[2][3],int (f10a04)
 f10a04	input.cpp	/^int f10(int f10a01,int f10a02[],int f10a03[2][3],int (f10a04)[],int (f10a05)[][5])$/;"	z	function:f10	typeref:typename:int ()[]	file:
 f10a05	input.cpp	/^int f10(int f10a01,int f10a02[],int f10a03[2][3],int (f10a04)[],int (f10a05)[][5])$/;"	z	function:f10	typeref:typename:int ()[][5]	file:
 p01	input.cpp	/^int p01(int p01a01,int p01a02);$/;"	p	typeref:typename:int	file:	signature:(int p01a01,int p01a02)	end:21
+p01a01	input.cpp	/^int p01(int p01a01,int p01a02);$/;"	z	prototype:p01	typeref:typename:int	file:
+p01a02	input.cpp	/^int p01(int p01a01,int p01a02);$/;"	z	prototype:p01	typeref:typename:int	file:
 p02	input.cpp	/^unsigned short int * p02(unsigned int & p02a01,...);$/;"	p	typeref:typename:unsigned short int *	file:	signature:(unsigned int & p02a01,...)	end:22
+p02a01	input.cpp	/^unsigned short int * p02(unsigned int & p02a01,...);$/;"	z	prototype:p02	typeref:typename:unsigned int &	file:
 p03	input.cpp	/^auto p03(const int & p03a01,void * p03a02) -> const int &;$/;"	p	typeref:typename:const int &	file:	signature:(const int & p03a01,void * p03a02)	end:23
+p03a01	input.cpp	/^auto p03(const int & p03a01,void * p03a02) -> const int &;$/;"	z	prototype:p03	typeref:typename:const int &	file:
+p03a02	input.cpp	/^auto p03(const int & p03a01,void * p03a02) -> const int &;$/;"	z	prototype:p03	typeref:typename:void *	file:
 p04	input.cpp	/^auto p04() -> int (*)(int);$/;"	p	typeref:typename:int (*)(int)	file:	signature:()	end:24
 p05	input.cpp	/^static std::string p05(const int *** p05a01);$/;"	p	typeref:typename:std::string	file:	signature:(const int *** p05a01)	end:25
+p05a01	input.cpp	/^static std::string p05(const int *** p05a01);$/;"	z	prototype:p05	typeref:typename:const int ***	file:
 p06	input.cpp	/^		auto p06(n01::c01 && p06a01) -> type01 *;$/;"	p	namespace:n01::n02	typeref:typename:type01 *	file:	signature:(n01::c01 && p06a01)	end:16
 p06	input.cpp	/^auto n01::n02::p06(n01::c01 && p06a01) -> n01::n02::type01 *;$/;"	p	class:n01::n02	typeref:typename:n01::n02::type01 *	file:	signature:(n01::c01 && p06a01)	end:26
+p06a01	input.cpp	/^		auto p06(n01::c01 && p06a01) -> type01 *;$/;"	z	prototype:n01::n02::p06	typeref:typename:n01::c01 &&	file:
+p06a01	input.cpp	/^auto n01::n02::p06(n01::c01 && p06a01) -> n01::n02::type01 *;$/;"	z	prototype:n01::n02::p06	typeref:typename:n01::c01 &&	file:
 p07	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	p	typeref:typename:unsigned int	file:	signature:(int (* p07a01)(int * x1,int x2),...)	end:27
+p07a01	input.cpp	/^unsigned int p07(int (*p07a01)(int * x1,int x2),...);$/;"	z	prototype:p07	typeref:typename:int (*)(int * x1,int x2)	file:
 p08	input.cpp	/^void (*p08(void (*)(int *p08a01)))(int *);$/;"	p	typeref:typename:void (*)(int *)	file:	signature:(void (*)(int * p08a01))	end:28
+p08a01	input.cpp	/^void (*p08(void (*)(int *p08a01)))(int *);$/;"	z	prototype:p08	typeref:typename:void (*)(int *)	file:
 t01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t01a01)	end:85
 t01a01	input.cpp	/^template <typename T> std::unique_ptr<T> t01(T && t01a01)$/;"	z	function:t01	typeref:typename:T &&	file:
 t02	input.cpp	/^template <typename T> auto t02(T && t02a01) -> std::unique_ptr<T>$/;"	f	typeref:typename:std::unique_ptr<T>	signature:(T && t02a01)	end:94

--- a/Units/parser-cxx.r/template-prototype.d/args.ctags
+++ b/Units/parser-cxx.r/template-prototype.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--kinds-C++=+pZ
+--fields=+K

--- a/Units/parser-cxx.r/template-prototype.d/expected.tags
+++ b/Units/parser-cxx.r/template-prototype.d/expected.tags
@@ -1,0 +1,4 @@
+f	input.cc	/^template <class T> int f (T t);$/;"	prototype	typeref:typename:int	file:
+T	input.cc	/^template <class T> int f (T t);$/;"	tparam	prototype:f	typeref:meta:class
+g	input.cc	/^template <class S> int g (S s) {$/;"	function	typeref:typename:int
+S	input.cc	/^template <class S> int g (S s) {$/;"	tparam	function:g	typeref:meta:class

--- a/Units/parser-cxx.r/template-prototype.d/input.cc
+++ b/Units/parser-cxx.r/template-prototype.d/input.cc
@@ -1,0 +1,4 @@
+template <class T> int f (T t);
+template <class S> int g (S s) {
+  return 0;
+}

--- a/Units/parser-cxx.r/template-specializations.d/expected.tags
+++ b/Units/parser-cxx.r/template-specializations.d/expected.tags
@@ -3,15 +3,15 @@ T	input.cpp	/^template<typename T>$/;"	Z	struct:A	typeref:meta:typename
 f	input.cpp	/^    void f(T); \/\/ member, declared in the primary template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T)
 h	input.cpp	/^    void h(T) {} \/\/ member, defined in the primary template$/;"	f	struct:A	typeref:typename:void	file:	signature:(T)
 g1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T,X1)	template:<class X1>
-X1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	Z	function:A::g1	typeref:meta:class
+X1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	Z	prototype:A::g1	typeref:meta:class
 g2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T,X2)	template:<class X2>
-X2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	Z	function:A::g2	typeref:meta:class
+X2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	Z	prototype:A::g2	typeref:meta:class
 f	input.cpp	/^template<> void A<int>::f(int);$/;"	p	class:A	typeref:typename:void	file:	signature:(int)	template:<>	properties:scopespecialization,specialization
 h	input.cpp	/^template<> void A<int>::h(int) {}$/;"	f	class:A	typeref:typename:void	signature:(int)	template:<>	properties:scopespecialization,specialization
 g1	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	f	class:A	typeref:typename:void	signature:(T,X1)	template:<class X1>	properties:scopespecialization,specialization
 X1	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	Z	function:A::g1	typeref:meta:class
 g1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	p	class:A	typeref:typename:void	file:	signature:(int,X1)	template:<class X1>	properties:scopespecialization,specialization
-X1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	Z	function:A::g1	typeref:meta:class
+X1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	Z	prototype:A::g1	typeref:meta:class
 g2	input.cpp	/^template<> void A<int>::g2<char>(int, char); \/\/ for X2 = char$/;"	p	class:A	typeref:typename:void	file:	signature:(int,char)	template:<>	specialization:<char>	properties:scopespecialization,specialization
 g1	input.cpp	/^template<> void A<int>::g1(int, char);$/;"	p	class:A	typeref:typename:void	file:	signature:(int,char)	template:<>	properties:scopespecialization,specialization
 m	input.cpp	/^template<typename X> void m(X)$/;"	f	typeref:typename:void	signature:(X)	template:<typename X>

--- a/Units/parser-cxx.r/template-specializations.d/expected.tags
+++ b/Units/parser-cxx.r/template-specializations.d/expected.tags
@@ -1,27 +1,47 @@
 A	input.cpp	/^struct A {$/;"	s	file:	template:<typename T>
 T	input.cpp	/^template<typename T>$/;"	Z	struct:A	typeref:meta:typename
 f	input.cpp	/^    void f(T); \/\/ member, declared in the primary template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T)
+__anonc12ce61d010d	input.cpp	/^    void f(T); \/\/ member, declared in the primary template$/;"	z	prototype:A::f	typeref:typename:T	file:
 h	input.cpp	/^    void h(T) {} \/\/ member, defined in the primary template$/;"	f	struct:A	typeref:typename:void	file:	signature:(T)
+__anonc12ce61d020d	input.cpp	/^    void h(T) {} \/\/ member, defined in the primary template$/;"	z	function:A::h	typeref:typename:T	file:
 g1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T,X1)	template:<class X1>
 X1	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	Z	prototype:A::g1	typeref:meta:class
+__anonc12ce61d030d	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	z	prototype:A::g1	typeref:typename:T	file:
+__anonc12ce61d040d	input.cpp	/^    template<class X1> void g1(T, X1); \/\/ member template$/;"	z	prototype:A::g1	typeref:typename:X1	file:
 g2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	p	struct:A	typeref:typename:void	file:	signature:(T,X2)	template:<class X2>
 X2	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	Z	prototype:A::g2	typeref:meta:class
+__anonc12ce61d050d	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	z	prototype:A::g2	typeref:typename:T	file:
+__anonc12ce61d060d	input.cpp	/^    template<class X2> void g2(T, X2); \/\/ member template$/;"	z	prototype:A::g2	typeref:typename:X2	file:
 f	input.cpp	/^template<> void A<int>::f(int);$/;"	p	class:A	typeref:typename:void	file:	signature:(int)	template:<>	properties:scopespecialization,specialization
+__anonc12ce61d070d	input.cpp	/^template<> void A<int>::f(int);$/;"	z	prototype:A::f	typeref:typename:int	file:
 h	input.cpp	/^template<> void A<int>::h(int) {}$/;"	f	class:A	typeref:typename:void	signature:(int)	template:<>	properties:scopespecialization,specialization
+__anonc12ce61d080d	input.cpp	/^template<> void A<int>::h(int) {}$/;"	z	function:A::h	typeref:typename:int	file:
 g1	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	f	class:A	typeref:typename:void	signature:(T,X1)	template:<class X1>	properties:scopespecialization,specialization
 X1	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	Z	function:A::g1	typeref:meta:class
+__anonc12ce61d090d	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	z	function:A::g1	typeref:typename:T	file:
+__anonc12ce61d0a0d	input.cpp	/^template<class X1> void A<T>::g1(T, X1) { }$/;"	z	function:A::g1	typeref:typename:X1	file:
 g1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	p	class:A	typeref:typename:void	file:	signature:(int,X1)	template:<class X1>	properties:scopespecialization,specialization
 X1	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	Z	prototype:A::g1	typeref:meta:class
+__anonc12ce61d0b0d	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	z	prototype:A::g1	typeref:typename:int	file:
+__anonc12ce61d0c0d	input.cpp	/^template<class X1> void A<int>::g1(int, X1);$/;"	z	prototype:A::g1	typeref:typename:X1	file:
 g2	input.cpp	/^template<> void A<int>::g2<char>(int, char); \/\/ for X2 = char$/;"	p	class:A	typeref:typename:void	file:	signature:(int,char)	template:<>	specialization:<char>	properties:scopespecialization,specialization
+__anonc12ce61d0d0d	input.cpp	/^template<> void A<int>::g2<char>(int, char); \/\/ for X2 = char$/;"	z	prototype:A::g2	typeref:typename:int	file:
+__anonc12ce61d0e0d	input.cpp	/^template<> void A<int>::g2<char>(int, char); \/\/ for X2 = char$/;"	z	prototype:A::g2	typeref:typename:char	file:
 g1	input.cpp	/^template<> void A<int>::g1(int, char);$/;"	p	class:A	typeref:typename:void	file:	signature:(int,char)	template:<>	properties:scopespecialization,specialization
+__anonc12ce61d0f0d	input.cpp	/^template<> void A<int>::g1(int, char);$/;"	z	prototype:A::g1	typeref:typename:int	file:
+__anonc12ce61d100d	input.cpp	/^template<> void A<int>::g1(int, char);$/;"	z	prototype:A::g1	typeref:typename:char	file:
 m	input.cpp	/^template<typename X> void m(X)$/;"	f	typeref:typename:void	signature:(X)	template:<typename X>
 X	input.cpp	/^template<typename X> void m(X)$/;"	Z	function:m	typeref:meta:typename
+__anonc12ce61d110d	input.cpp	/^template<typename X> void m(X)$/;"	z	function:m	typeref:typename:X	file:
 m	input.cpp	/^template<> void m<int>(int)$/;"	f	typeref:typename:void	signature:(int)	template:<>	specialization:<int>	properties:specialization
+__anonc12ce61d120d	input.cpp	/^template<> void m<int>(int)$/;"	z	function:m	typeref:typename:int	file:
 m	input.cpp	/^template<> void m<A<int>>(A<int> a)$/;"	f	typeref:typename:void	signature:(A<int> a)	template:<>	specialization:<A<int>>	properties:specialization
 a	input.cpp	/^template<> void m<A<int>>(A<int> a)$/;"	z	function:m	typeref:typename:A<int>	file:
 B	input.cpp	/^struct B { };$/;"	s	file:
 m	input.cpp	/^template<> void m<B>(B)$/;"	f	typeref:typename:void	signature:(B)	template:<>	specialization:<B>	properties:specialization
+__anonc12ce61d130d	input.cpp	/^template<> void m<B>(B)$/;"	z	function:m	typeref:typename:B	file:
 m	input.cpp	/^template<> void m(char)$/;"	f	typeref:typename:void	signature:(char)	template:<>	properties:specialization
+__anonc12ce61d140d	input.cpp	/^template<> void m(char)$/;"	z	function:m	typeref:typename:char	file:
 C	input.cpp	/^class C {};$/;"	c	file:	template:<class T1,class T2,int I>
 T1	input.cpp	/^template<class T1, class T2, int I>$/;"	Z	class:C	typeref:meta:class
 T2	input.cpp	/^template<class T1, class T2, int I>$/;"	Z	class:C	typeref:meta:class

--- a/parsers/cxx/cxx_debug.c
+++ b/parsers/cxx/cxx_debug.c
@@ -170,6 +170,7 @@ const char* cxxDebugScopeDecode(enum CXXScopeType scope)
 		[CXXScopeTypeUnion] = "union",
 		[CXXScopeTypeStruct] = "struct",
 		[CXXScopeTypeVariable] = "variable",
+		[CXXScopeTypePrototype]  = "prototype",
 	};
 	if (CXXScopeTypeLAST > scope)
 		return table[scope];

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1478,9 +1478,11 @@ void cxxParserAnalyzeOtherStatement(void)
 	}
 
 	// prefer function.
+	CXXTypedVariableSet oParamInfo;
+	const bool bPrototypeParams = cxxTagKindEnabled(CXXTagKindPROTOTYPE) && cxxTagKindEnabled(CXXTagKindPARAMETER);
 check_function_signature:
 
-	if(cxxParserLookForFunctionSignature(g_cxx.pTokenChain,&oInfo,NULL))
+	if(cxxParserLookForFunctionSignature(g_cxx.pTokenChain,&oInfo,bPrototypeParams?&oParamInfo:NULL))
 	{
 		CXX_DEBUG_PRINT("Found function prototype");
 
@@ -1500,6 +1502,10 @@ check_function_signature:
 				CXXToken * t = cxxTokenChainLast(g_cxx.pTokenChain);
 				cxxParserSetEndLineForTagInCorkQueue (piCorkQueueIndex, t->iLineNumber);
 			}
+
+			if(bPrototypeParams)
+				cxxParserEmitFunctionParameterTags(&oParamInfo);
+
 			while(iScopesPushed > 0)
 			{
 				cxxScopePop();

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -1817,6 +1817,7 @@ int cxxParserExtractFunctionSignatureBeforeOpeningBracket(
 void cxxParserEmitFunctionParameterTags(CXXTypedVariableSet * pInfo)
 {
 	// emit parameters
+	CXX_DEBUG_ENTER();
 
 	unsigned int i = 0;
 	while(i < pInfo->uCount)
@@ -1827,7 +1828,7 @@ void cxxParserEmitFunctionParameterTags(CXXTypedVariableSet * pInfo)
 			);
 
 		if(!tag)
-			return;
+			break;
 
 		CXXToken * pTypeName;
 
@@ -1877,6 +1878,7 @@ void cxxParserEmitFunctionParameterTags(CXXTypedVariableSet * pInfo)
 
 		i++;
 	}
+	CXX_DEBUG_LEAVE();
 }
 
 

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -21,6 +21,7 @@
 #include "debug.h"
 #include "keyword.h"
 #include "read.h"
+#include "trashbox.h"
 
 #include <string.h>
 
@@ -1789,8 +1790,9 @@ int cxxParserExtractFunctionSignatureBeforeOpeningBracket(
 	cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 
 	CXXTypedVariableSet oParamInfo;
+	bool bParams = cxxTagKindEnabled(CXXTagKindPARAMETER);
 
-	if(!cxxParserLookForFunctionSignature(g_cxx.pTokenChain,pInfo,&oParamInfo))
+	if(!cxxParserLookForFunctionSignature(g_cxx.pTokenChain,pInfo,bParams?&oParamInfo:NULL))
 	{
 		CXX_DEBUG_LEAVE_TEXT("No parenthesis found: no function");
 		return 0;
@@ -1806,7 +1808,7 @@ int cxxParserExtractFunctionSignatureBeforeOpeningBracket(
 			piCorkQueueIndex
 		);
 
-	if(cxxTagKindEnabled(CXXTagKindPARAMETER))
+	if(bParams)
 		cxxParserEmitFunctionParameterTags(&oParamInfo);
 
 	CXX_DEBUG_LEAVE();
@@ -1868,6 +1870,10 @@ void cxxParserEmitFunctionParameterTags(CXXTypedVariableSet * pInfo)
 		}
 
 		tag->isFileScope = true;
+
+		if (pInfo->uAnonymous & (0x1u << i))
+			markTagExtraBit(tag, XTAG_ANONYMOUS);
+
 		cxxTagCommit();
 
 		if(pTypeName)
@@ -2148,10 +2154,22 @@ try_again:
 					}
 				}
 
-				if(pIdentifier)
+				if(pIdentifier || isXtagEnabled(XTAG_ANONYMOUS))
 				{
 					pParamInfo->aTypeStarts[pParamInfo->uCount] = pStart;
 					pParamInfo->aTypeEnds[pParamInfo->uCount] = t->pPrev;
+					pParamInfo->uAnonymous &= ~(0x1u << pParamInfo->uCount);
+					if(!pIdentifier)
+					{
+						/* This block handles parameter having no name lie
+						 *
+						 *   void f(int *);
+						 */
+						pIdentifier = cxxTokenCreateAnonymousIdentifier(CXXTagKindPARAMETER);
+						pIdentifier->iLineNumber = t->pPrev->iLineNumber;
+						pIdentifier->oFilePosition = t->pPrev->oFilePosition;
+						pParamInfo->uAnonymous |= (0x1u << pParamInfo->uCount);
+					}
 					pParamInfo->aIdentifiers[pParamInfo->uCount] = pIdentifier;
 					pParamInfo->uCount++;
 
@@ -2176,6 +2194,35 @@ try_again:
 			} else {
 				pParamInfo = NULL; // reset so condition will be faster to check
 			}
+		} else if (pParamInfo
+				   && (pParamInfo->uCount < CXX_TYPED_VARIABLE_SET_ITEM_COUNT)
+				   && (!cxxTokenIsKeyword(pStart, CXXKeywordVOID))
+				   && (!cxxTokenTypeIs(pStart,CXXTokenTypeMultipleDots))
+				   && isXtagEnabled(XTAG_ANONYMOUS)) {
+			/* This block handles parameter having no name like
+			 *
+			 *    int f (int);
+			 *
+			 * In C language, you will find such a thing in a prototype.
+			 * In C++ language, you will find it even in a function definition.
+			 *
+			 */
+			CXXToken * pFakeStart = cxxTokenCopy(pStart);
+			CXXToken * pFakeId = cxxTokenCreateAnonymousIdentifier(CXXTagKindPARAMETER);
+			pFakeId->iLineNumber = pStart->iLineNumber;
+			pFakeId->oFilePosition = pStart->oFilePosition;
+
+			pFakeStart->pNext = pFakeId;
+			pFakeId->pPrev = pFakeStart;
+
+			pParamInfo->aTypeStarts[pParamInfo->uCount] = pFakeStart;
+			pParamInfo->aTypeEnds[pParamInfo->uCount] = pFakeId;
+			pParamInfo->aIdentifiers[pParamInfo->uCount] = pFakeId;
+			pParamInfo->uAnonymous |= (0x1u << pParamInfo->uCount);
+			pParamInfo->uCount++;
+
+			PARSER_TRASH_BOX (pFakeStart, cxxTokenDestroy);
+			/* pFakeId may be destroyed via pParamInfo->aIdentifiers[i]. */
 		}
 
 		if(cxxTokenTypeIs(t,CXXTokenTypeClosingParenthesis))

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -1732,7 +1732,9 @@ int cxxParserEmitFunctionTags(
 
 	if(bPushScopes)
 	{
-		cxxScopePush(pIdentifier,CXXScopeTypeFunction,CXXScopeAccessUnknown);
+		cxxScopePush(pIdentifier,
+					 (uTagKind == CXXTagKindPROTOTYPE)? CXXScopeTypePrototype: CXXScopeTypeFunction,
+					 CXXScopeAccessUnknown);
 		iScopesPushed++;
 	} else {
 		cxxTokenDestroy(pIdentifier);

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -160,6 +160,8 @@ int cxxParserExtractFunctionSignatureBeforeOpeningBracket(
 		int * piCorkQueueIndex
 	);
 
+/* This must be smaller than (sizeof(unsigned int) * 8).
+ * See CXXTypedVariableSet::uAnonymous. */
 #define CXX_TYPED_VARIABLE_SET_ITEM_COUNT 24
 
 typedef struct _CXXTypedVariableSet
@@ -175,6 +177,8 @@ typedef struct _CXXTypedVariableSet
 	CXXToken * aTypeEnds[CXX_TYPED_VARIABLE_SET_ITEM_COUNT];
 	// The identifier tokens
 	CXXToken * aIdentifiers[CXX_TYPED_VARIABLE_SET_ITEM_COUNT];
+
+	unsigned int uAnonymous;
 } CXXTypedVariableSet;
 
 bool cxxParserTokenChainLooksLikeFunctionParameterList(

--- a/parsers/cxx/cxx_scope.c
+++ b/parsers/cxx/cxx_scope.c
@@ -75,6 +75,7 @@ unsigned int cxxScopeGetVariableKind(void)
 		case CXXScopeTypeFunction:
 			return CXXTagKindLOCAL;
 		break;
+		//case CXXScopeTypePrototype:
 		//case CXXScopeTypeNamespace:
 		//case CXXScopeTypeEnum:
 		default:
@@ -101,6 +102,8 @@ unsigned int cxxScopeGetKind(void)
 			return CXXTagKindENUM;
 		case CXXScopeTypeFunction:
 			return CXXTagKindFUNCTION;
+		case CXXScopeTypePrototype:
+			return CXXTagKindPROTOTYPE;
 		case CXXScopeTypeStruct:
 			return CXXTagKindSTRUCT;
 		case CXXScopeTypeUnion:

--- a/parsers/cxx/cxx_scope.h
+++ b/parsers/cxx/cxx_scope.h
@@ -30,6 +30,7 @@ enum CXXScopeType
 	CXXScopeTypeUnion,
 	CXXScopeTypeStruct,
 	CXXScopeTypeVariable, // template variables, mainly
+	CXXScopeTypePrototype,
 	CXXScopeTypeLAST
 };
 

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -57,7 +57,7 @@ CXX_COMMON_HEADER_ROLES(CUDA);
 	{ true,  'u', "union",      "union names", .syncWith = _syncWith },			\
 	{ true,  'v', "variable",   "variable definitions", .syncWith = _syncWith },		\
 	{ false, 'x', "externvar",  "external and forward variable declarations", .syncWith = _syncWith }, \
-	{ false, 'z', "parameter",  "function parameters inside function definitions", .syncWith = _syncWith }, \
+	{ false, 'z', "parameter",  "function parameters inside function or prototype definitions", .syncWith = _syncWith }, \
 	{ false, 'L', "label",      "goto labels", .syncWith = _syncWith }, \
 	{ false, 'D', "macroparam", "parameters inside macro definitions", .syncWith = _syncWith }
 
@@ -645,7 +645,7 @@ int cxxTagCommit(void)
 
 	enum CXXScopeType eScopeType = cxxScopeGetType();
 
-	if(eScopeType == CXXScopeTypeFunction)
+	if(eScopeType == CXXScopeTypeFunction || eScopeType == CXXScopeTypePrototype)
 	{
 		// old ctags didn't do this, and --extra=+q is mainly
 		// for backward compatibility so...

--- a/parsers/cxx/cxx_token.c
+++ b/parsers/cxx/cxx_token.c
@@ -110,6 +110,19 @@ void cxxTokenForceDestroy(CXXToken * t)
 	eFree(t);
 }
 
+CXXToken * cxxTokenCopy(CXXToken * pToken)
+{
+	CXXToken * pRetToken = cxxTokenCreate();
+	pRetToken->iLineNumber = pToken->iLineNumber;
+	pRetToken->oFilePosition = pToken->oFilePosition;
+	pRetToken->eType = pToken->eType;
+	pRetToken->eKeyword = pToken->eKeyword;
+	pToken->bFollowedBySpace = pToken->bFollowedBySpace;
+	vStringCat(pRetToken->pszWord,pToken->pszWord);
+
+	return pRetToken;
+}
+
 CXXToken * cxxTokenCreateKeyword(int iLineNumber,MIOPos oFilePosition,CXXKeyword eKeyword)
 {
 	CXXToken * pToken = cxxTokenCreate();

--- a/parsers/cxx/cxx_token.h
+++ b/parsers/cxx/cxx_token.h
@@ -91,6 +91,9 @@ typedef struct _CXXToken
 CXXToken * cxxTokenCreate(void);
 void cxxTokenDestroy(CXXToken * t);
 
+// A shortcut for quickly creating a fake token.
+CXXToken * cxxTokenCopy(CXXToken *pToken);
+
 // A shortcut for quickly creating keyword tokens.
 CXXToken * cxxTokenCreateKeyword(int iLineNumber,MIOPos oFilePosition,CXXKeyword eKeyword);
 


### PR DESCRIPTION
Close #3045.

Parameters in functions were tagged.
This change extends it.
With this change, parameters in prototypes are tagged.

It is usual that a parameter in a prototype has no name. In such a case, this change generates an anonymous name.

