### PR TITLE
C++: recognize operator= even if the statement starts from struct, class or union

### DIFF
--- a/Units/parser-cxx.r/struct-keyword-not-for-defining-struct.d/args.ctags
+++ b/Units/parser-cxx.r/struct-keyword-not-for-defining-struct.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-C++=+plz

--- a/Units/parser-cxx.r/struct-keyword-not-for-defining-struct.d/expected.tags
+++ b/Units/parser-cxx.r/struct-keyword-not-for-defining-struct.d/expected.tags
@@ -1,0 +1,6 @@
+Currency	input.cc	/^typedef struct Currency$/;"	s	file:
+Dollar	input.cc	/^    int Dollar;$/;"	m	struct:Currency	typeref:typename:int	file:
+Cents	input.cc	/^    int Cents;$/;"	m	struct:Currency	typeref:typename:int	file:
+operator =	input.cc	/^    struct Currency &operator=(Currency& value)$/;"	f	struct:Currency	typeref:struct:Currency &	file:
+value	input.cc	/^    struct Currency &operator=(Currency& value)$/;"	z	function:Currency::operator =	typeref:typename:Currency &	file:
+test	input.cc	/^void test()$/;"	f	typeref:typename:void

--- a/Units/parser-cxx.r/struct-keyword-not-for-defining-struct.d/input.cc
+++ b/Units/parser-cxx.r/struct-keyword-not-for-defining-struct.d/input.cc
@@ -1,0 +1,17 @@
+// Taken from #2840 submitted by @chongchal
+typedef struct Currency
+{
+    int Dollar;
+    int Cents;
+
+    struct Currency &operator=(Currency& value)
+    {
+        Dollar = value.Dollar;
+        Cents = value.Cents;
+        return *this;
+    }
+};
+
+void test()
+{
+}

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -966,7 +966,8 @@ static bool cxxParserParseClassStructOrUnionInternal(
 
 	unsigned int uTerminatorTypes = CXXTokenTypeEOF | CXXTokenTypeSingleColon |
 			CXXTokenTypeSemicolon | CXXTokenTypeOpeningBracket |
-			CXXTokenTypeSmallerThanSign | CXXTokenTypeParenthesisChain;
+			CXXTokenTypeSmallerThanSign | (cxxParserCurrentLanguageIsCPP()? CXXTokenTypeKeyword: 0) |
+			CXXTokenTypeParenthesisChain;
 
 	if(uTagKind != CXXTagCPPKindCLASS)
 		uTerminatorTypes |= CXXTokenTypeAssignment;
@@ -982,6 +983,15 @@ static bool cxxParserParseClassStructOrUnionInternal(
 			cxxKeywordEnableFinal(false);
 			CXX_DEBUG_LEAVE_TEXT("Could not parse class/struct/union name");
 			return false;
+		}
+
+		if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeKeyword))
+		{
+			/* The statement declears or defines an operator,
+			 * not a class, struct not union. */
+			if(g_cxx.pToken->eKeyword == CXXKeywordOPERATOR)
+				return true;
+			continue;
 		}
 
 		if(


### PR DESCRIPTION
Close #2840.

The original code assumed a statement startnig from struct as a
definition of a struct. This caused that the parser failed in
recognizing an operator= definition (or prototype) returning a struct typed data.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>