### PR TITLE
C++: use () to detect a function or prototype even if the statement starts with "class"

### DIFF
--- a/Units/parser-cxx.r/function-return-types.d/expected.tags
+++ b/Units/parser-cxx.r/function-return-types.d/expected.tags
@@ -14,6 +14,7 @@ p12	input.cpp	/^struct Struct p12();$/;"	p	typeref:struct:Struct	file:	end:32
 p13	input.cpp	/^Struct p13();$/;"	p	typeref:typename:Struct	file:	end:33
 p14	input.cpp	/^union Union p14();$/;"	p	typeref:union:Union	file:	end:34
 p15	input.cpp	/^Union p15();$/;"	p	typeref:typename:Union	file:	end:35
+p15p	input.cpp	/^class Class * p15p();$/;"	p	typeref:class:Class *	file:	end:36
 p16	input.cpp	/^Class & p16();$/;"	p	typeref:typename:Class &	file:	end:37
 p17	input.cpp	/^const enum Enum p17();$/;"	p	typeref:typename:const enum Enum	file:	end:38
 p18	input.cpp	/^Enum p18();$/;"	p	typeref:typename:Enum	file:	end:39

--- a/Units/parser-cxx.r/function-return-types.d/input.cpp
+++ b/Units/parser-cxx.r/function-return-types.d/input.cpp
@@ -33,7 +33,7 @@ struct Struct p12();
 Struct p13();
 union Union p14();
 Union p15();
-class Class * p15();
+class Class * p15p();
 Class & p16();
 const enum Enum p17();
 Enum p18();

--- a/Units/parser-cxx.r/keyword-in-return-type.d/args.ctags
+++ b/Units/parser-cxx.r/keyword-in-return-type.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-C++=+p

--- a/Units/parser-cxx.r/keyword-in-return-type.d/expected.tags
+++ b/Units/parser-cxx.r/keyword-in-return-type.d/expected.tags
@@ -1,0 +1,6 @@
+a	input.cc	/^struct Class0 * a();$/;"	p	typeref:struct:Class0 *	file:
+b	input.cc	/^struct Class0 * b() { exit(0); }$/;"	f	typeref:struct:Class0 *
+c	input.cc	/^class Class1 * c();$/;"	p	typeref:class:Class1 *	file:
+d	input.cc	/^class Class1 * d() { exit(0); }$/;"	f	typeref:class:Class1 *
+e	input.cc	/^union Class1 * e();$/;"	p	typeref:union:Class1 *	file:
+f	input.cc	/^union Class1 * f() { exit(0); }$/;"	f	typeref:union:Class1 *

--- a/Units/parser-cxx.r/keyword-in-return-type.d/input.cc
+++ b/Units/parser-cxx.r/keyword-in-return-type.d/input.cc
@@ -1,0 +1,8 @@
+struct Class0 * a();
+struct Class0 * b() { exit(0); }
+
+class Class1 * c();
+class Class1 * d() { exit(0); }
+
+union Class1 * e();
+union Class1 * f() { exit(0); }

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -966,10 +966,10 @@ static bool cxxParserParseClassStructOrUnionInternal(
 
 	unsigned int uTerminatorTypes = CXXTokenTypeEOF | CXXTokenTypeSingleColon |
 			CXXTokenTypeSemicolon | CXXTokenTypeOpeningBracket |
-			CXXTokenTypeSmallerThanSign;
+			CXXTokenTypeSmallerThanSign | CXXTokenTypeParenthesisChain;
 
 	if(uTagKind != CXXTagCPPKindCLASS)
-		uTerminatorTypes |= CXXTokenTypeParenthesisChain | CXXTokenTypeAssignment;
+		uTerminatorTypes |= CXXTokenTypeAssignment;
 
 	bool bRet;
 


### PR DESCRIPTION
Close #3068.

The original code could not extract f in

    class X *f();

Signed-off-by: Masatake YAMATO <yamato@redhat.com>