### PR TITLE
build-sys,main,mingw: Enable MANUAL_GLOBBING

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,10 @@ AH_TEMPLATE([NON_CONST_PUTENV_PROTOTYPE],
 	doesn't declare its argument as "const char *".])
 AH_TEMPLATE([MSDOS_STYLE_PATH],
 	[Define to 1 if your system uses MS-DOS style path.])
+AH_TEMPLATE([MANUAL_GLOBBING],
+	[Define to 1 if your system doesn't expand wildcards.])
+AH_TEMPLATE([HAVE__FINDFIRST],
+	[Define to 1 if your system have _findfirst().])
 AH_TEMPLATE([ENABLE_GCOV],
 	[Define to 1 if gcov is instrumented.])
 
@@ -488,6 +492,8 @@ case "$host" in
 	# See https://github.com/universal-ctags/ctags/pull/3069
 	gl_cv_have_weak=no
 	AC_DEFINE(MSDOS_STYLE_PATH)
+	AC_DEFINE(MANUAL_GLOBBING)
+	AC_DEFINE(HAVE__FINDFIRST)
 	;;
 esac
 AM_CONDITIONAL([HOST_MINGW], [test "x${host_mingw}" = "xyes"])

--- a/main/main.c
+++ b/main/main.c
@@ -121,8 +121,9 @@ static bool recurseUsingOpendir (const char *const dirName)
 	}
 	return resize;
 }
+#endif
 
-#elif defined (HAVE__FINDFIRST)
+#ifdef HAVE__FINDFIRST
 
 static bool createTagsForWildcardEntry (
 		const char *const pattern, const size_t dirLength,
@@ -145,9 +146,8 @@ static bool createTagsForWildcardUsingFindfirst (const char *const pattern)
 {
 	bool resize = false;
 	const size_t dirLength = baseFilename (pattern) - pattern;
-#if defined (HAVE__FINDFIRST)
 	struct _finddata_t fileInfo;
-	findfirst_t hFile = _findfirst (pattern, &fileInfo);
+	intptr_t hFile = _findfirst (pattern, &fileInfo);
 	if (hFile != -1L)
 	{
 		do
@@ -157,7 +157,6 @@ static bool createTagsForWildcardUsingFindfirst (const char *const pattern)
 		} while (_findnext (hFile, &fileInfo) == 0);
 		_findclose (hFile);
 	}
-#endif
 	return resize;
 }
 


### PR DESCRIPTION
On Windows, the shell doesn't expand wildcards.
Ctags should expand them by ourselves.

See also: https://github.com/universal-ctags/ctags/issues/3014#issuecomment-863628889