### PR TITLE
docs,man: Fix typos

### DIFF
--- a/docs/man/ctags-client-tools.7.rst
+++ b/docs/man/ctags-client-tools.7.rst
@@ -408,8 +408,8 @@ could always start the search from say the beginning of the file.
 
 When both the search pattern and the line number are presented, you could make
 good use of the line number, by going to the line first, then searching for the
-nearest occurence of the pattern. A way to do this is to search both forward
-and backward for the pattern, and when there is a occurence on both sides, go
+nearest occurrence of the pattern. A way to do this is to search both forward
+and backward for the pattern, and when there is a occurrence on both sides, go
 to the nearer one.
 
 What's good about this is when there are multiple identical lines in the source
@@ -460,7 +460,7 @@ Due to this reason, Universal Ctags turns to use the actual line number. A
 client tool could distinguish them by the ``TAG_OUTPUT_EXCMD`` pseudo tag, it's
 "combine" for the old scheme, and "combineV2" for the present scheme. But
 probably there's no need to treat them differently, since "search for the
-nearest occurence from the line" gives good result on both schemes.
+nearest occurrence from the line" gives good result on both schemes.
 
 JSON OUTPUT
 -----------

--- a/docs/man/ctags-lang-iPythonCell.7.rst
+++ b/docs/man/ctags-lang-iPythonCell.7.rst
@@ -22,7 +22,7 @@ iPythonCell is a subparser stacked on top of the Python parser.
 It works when:
 
 * The Python parser is enabled,
-* the ``subparser`` extra is enabeld, and
+* the ``subparser`` extra is enabled, and
 * the iPythonCell parser itself is enabled.
 
 iPythonCell extracts cells explained as in vim-ipython-cell

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -526,7 +526,7 @@ Example 2:
 .. code-block:: console
 
 	$ ctags --options=/tmp/pp.ctags -o - /tmp/input.pp
-	bar	/tmp/input.pp	/^    include bar$/;"	v	class:foo
+	bar	/tmp/input.pp	/^    int bar$/;"	v	class:foo
 	foo	/tmp/input.pp	/^class foo {$/;"	c
 
 

--- a/man/ctags-client-tools.7.rst.in
+++ b/man/ctags-client-tools.7.rst.in
@@ -408,8 +408,8 @@ could always start the search from say the beginning of the file.
 
 When both the search pattern and the line number are presented, you could make
 good use of the line number, by going to the line first, then searching for the
-nearest occurence of the pattern. A way to do this is to search both forward
-and backward for the pattern, and when there is a occurence on both sides, go
+nearest occurrence of the pattern. A way to do this is to search both forward
+and backward for the pattern, and when there is a occurrence on both sides, go
 to the nearer one.
 
 What's good about this is when there are multiple identical lines in the source
@@ -460,7 +460,7 @@ Due to this reason, Universal Ctags turns to use the actual line number. A
 client tool could distinguish them by the ``TAG_OUTPUT_EXCMD`` pseudo tag, it's
 "combine" for the old scheme, and "combineV2" for the present scheme. But
 probably there's no need to treat them differently, since "search for the
-nearest occurence from the line" gives good result on both schemes.
+nearest occurrence from the line" gives good result on both schemes.
 
 JSON OUTPUT
 -----------

--- a/man/ctags-lang-iPythonCell.7.rst.in
+++ b/man/ctags-lang-iPythonCell.7.rst.in
@@ -22,7 +22,7 @@ iPythonCell is a subparser stacked on top of the Python parser.
 It works when:
 
 * The Python parser is enabled,
-* the ``subparser`` extra is enabeld, and
+* the ``subparser`` extra is enabled, and
 * the iPythonCell parser itself is enabled.
 
 iPythonCell extracts cells explained as in vim-ipython-cell


### PR DESCRIPTION
See the line 510:

```
508:	// in /tmp/input.pp
509:	class foo {
510:		int bar;
511:	}
```