### PR TITLE
docs(web): revert a wrong change for the SQL man page and update it in correct steps

### DIFF
--- a/docs/man/ctags-lang-sql.7.rst
+++ b/docs/man/ctags-lang-sql.7.rst
@@ -36,12 +36,12 @@ the source code to choose a proper guest parser.
 
 In the above examples, ``plpythonu`` and ``plv8`` are the names of
 procedural languages. The SQL parser trims `pl` at the start and `u`
-at the end of the name before finding a parser ctags having.  For
-``plpythonu`` and ```plv8``, the SQL parser extracts ``python`` and
+at the end of the name before finding a ctags parser.  For
+``plpythonu`` and ``plv8``, the SQL parser extracts ``python`` and
 ``v8`` as the candidates of guest parsers.
 
 For ``plpythonu``, ctags can run its Python parser.  ctags doesn't
-have a parser named ``v8``. However, JavaScript parser of ctags has
+have a parser named ``v8``. However, the JavaScript parser in ctags has
 ``v8`` as an alias. So ctags can run the JavaScript parser as the
 guest parser for ``plv8``.
 

--- a/man/ctags-lang-sql.7.rst.in
+++ b/man/ctags-lang-sql.7.rst.in
@@ -36,12 +36,12 @@ the source code to choose a proper guest parser.
 
 In the above examples, ``plpythonu`` and ``plv8`` are the names of
 procedural languages. The SQL parser trims `pl` at the start and `u`
-at the end of the name before finding a parser ctags having.  For
-``plpythonu`` and ```plv8``, the SQL parser extracts ``python`` and
+at the end of the name before finding a ctags parser.  For
+``plpythonu`` and ``plv8``, the SQL parser extracts ``python`` and
 ``v8`` as the candidates of guest parsers.
 
 For ``plpythonu``, ctags can run its Python parser.  ctags doesn't
-have a parser named ``v8``. However, JavaScript parser of ctags has
+have a parser named ``v8``. However, the JavaScript parser in ctags has
 ``v8`` as an alias. So ctags can run the JavaScript parser as the
 guest parser for ``plv8``.
 


### PR DESCRIPTION
This reverts commit 5c46072da18492597296b8da5d8266a1d2eaca60.
This re-introduce commit 1469a65ff404b21e9245c39b0791c54ed0b03d7c correctly.

In 1469a65ff404b21e9245c39b0791c54ed0b03d7c, I changed docs/man/ctags-lang-sql.7.rst
directly. I should not do it. Instead, in this change, I changed man/ctags-lang.sql-7.rst.in.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>