### PR TITLE
Tmain: fix fails on make distcheck (fix for #3093)

### DIFF
--- a/Tmain/lang-sequel.d/run.sh
+++ b/Tmain/lang-sequel.d/run.sh
@@ -7,4 +7,4 @@ CTAGS=$1
 
 . ../utils.sh
 
-${CTAGS} --quiet --options=NONE --options=./args.ctags input.unknown
+${CTAGS} --quiet --options=NONE --options=./args.ctags -o - input.unknown


### PR DESCRIPTION
`make distcheck` fails on Ubuntu 20.04 on Windows 10 WSL2.
These are fixes for them.

I also don't understand why `Tmain/epoch-field.d/run.sh` and  `Tmain/readtags-qualifier-begin.d/run.sh` passed on `make tmain`.

The fix of `Tmain/lang-sequel.d/args.ctags` is only for `make distcheck`.  But I don't understand why it passes on `fedora33_distcheck` CI test.

I found these issues during debugging #3054.