### PR TITLE
circleci(fedora33_distcheck): don't make core when running ./configure

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -176,6 +176,7 @@ jobs:
        - run:
            name: Test
            command: |
+             ulimit -c 0
              make distcheck
 
    centos_make:


### PR DESCRIPTION
None in the build process removes the core file created during running
./configure. It can make "make distcheck" fail.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>