### PR TITLE
build-sys: disable xtrace unless CI is set in autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-tools=""
-
 # Report the paths causing trouble frequently
 echo '##################################################################'
 echo '#                     The paths for tools                        #'

--- a/autogen.sh
+++ b/autogen.sh
@@ -11,7 +11,10 @@ for t in autoreconf aclocal pkg-config; do
 done
 echo '##################################################################'
 
-set -xe
+set -e	# errexit (exit on error)
+if [ ! -z "${CI}" ]; then
+	set -x	# xtrace (execution trace)
+fi
 
 type autoreconf > /dev/null 2>&1 || {
 	echo "No autotools (autoconf and automake) found" 1>&2


### PR DESCRIPTION
autogen.sh enabled xtrace (-x) to make remote debugging easier on #1534.
But this makes difficult local autotools debugging.  Valuable errors are hidden by verbose trace messages.

Enable xtrace when environment variable `CI` is set (cf. #3081).

Unused variable `tools` is also removed.