### PR TITLE
ci-env: use unified CI environment variable

### DIFF
--- a/.github/workflows/testing-alpine.yml
+++ b/.github/workflows/testing-alpine.yml
@@ -30,5 +30,5 @@ jobs:
       - run: make install
       - run: file /usr/bin/ctags
       - run: ctags --version
-      - run: make check V=1 GITHUBACTIONS=1
-      - run: make roundtrip GITHUBACTIONS=1
+      - run: make check V=1
+      - run: make roundtrip

--- a/.github/workflows/testing-cygwin.yml
+++ b/.github/workflows/testing-cygwin.yml
@@ -31,5 +31,5 @@ jobs:
     - run: make install
     - run: file /usr/bin/ctags
     - run: /usr/bin/ctags --version
-    - run: make check V=1 GITHUBACTIONS=1
-    - run: make roundtrip GITHUBACTIONS=1
+    - run: make check V=1
+    - run: make roundtrip

--- a/.github/workflows/testing-freebsd.yml
+++ b/.github/workflows/testing-freebsd.yml
@@ -31,5 +31,5 @@ jobs:
           run make install
           run file ctags
           run ctags --version
-          run make check GITHUBACTIONS=1
-          run make roundtrip GITHUBACTIONS=1
+          run make check
+          run make roundtrip

--- a/.github/workflows/testing-gnulinux.yml
+++ b/.github/workflows/testing-gnulinux.yml
@@ -64,9 +64,9 @@ jobs:
           ./ctags --list-features
         )
     - name: make check
-      run: make -C $BUILDDIR check GITHUBACTIONS=1
+      run: make -C $BUILDDIR check
     - name: make roundtrip
-      run: make -C $BUILDDIR roundtrip GITHUBACTIONS=1
+      run: make -C $BUILDDIR roundtrip
     - name: make dist
       run: make -C $BUILDDIR dist
     - name: make for testing ctags in sandbox
@@ -88,7 +88,7 @@ jobs:
       run: |
         (
           cd $BUILDDIR/universal-ctags*[0-9]
-          make -C ${BUILDDIR} tmain GITHUBACTIONS=1 UNITS=${SANDBOX_CASES}
+          make -C ${BUILDDIR} tmain UNITS=${SANDBOX_CASES}
           make -C ${BUILDDIR}  clean
         )
     - name: send coverage info

--- a/.github/workflows/testing-mac.yml
+++ b/.github/workflows/testing-mac.yml
@@ -51,6 +51,6 @@ jobs:
           ./ctags --list-features
         )
     - name: make check
-      run: make -C $BUILDDIR check GITHUBACTIONS=1
+      run: make -C $BUILDDIR check
     - name: make roundtrip
-      run: make -C $BUILDDIR roundtrip GITHUBACTIONS=1
+      run: make -C $BUILDDIR roundtrip

--- a/.github/workflows/testing-msys2.yml
+++ b/.github/workflows/testing-msys2.yml
@@ -48,9 +48,9 @@ jobs:
     - run: file /usr/bin/ctags
     - run: ctags --version
     
-    - run: make check V=1 GITHUBACTIONS=1
+    - run: make check V=1
      
     # FAILED: "./readtags.exe" -t "/d/a/ctags2/ctags2/Units/parser-asciidoc.r/utf8-asciidoc.d/expected.tags" - "@Ѐ–𐀀"
     # The raw tag name was "@Ѐ–𐀀"
     - if:  matrix.msystem == 'MSYS'
-      run: make roundtrip GITHUBACTIONS=1
+      run: make roundtrip

--- a/.github/workflows/testing-netbsd.yml
+++ b/.github/workflows/testing-netbsd.yml
@@ -32,4 +32,4 @@ jobs:
           run ctags --version
           # bugs to fix
           #run make check
-          run make roundtrip GITHUBACTIONS=1
+          run make roundtrip

--- a/.github/workflows/testing-openbsd.yml
+++ b/.github/workflows/testing-openbsd.yml
@@ -39,4 +39,4 @@ jobs:
           run ctags --version
           # bugs to fix
           #run make check
-          run make roundtrip GITHUBACTIONS=1
+          run make roundtrip

--- a/.github/workflows/testing-with-vlagrind.yml
+++ b/.github/workflows/testing-with-vlagrind.yml
@@ -26,4 +26,4 @@ jobs:
     - name: make
       run: make CFLAGS='-g -O0'
     - name: make units
-      run: make units VG=1 GITHUBACTIONS=1
+      run: make units VG=1

--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ jobs:
        - run:
            name: Test
            command: |
-             make check CIRCLECI=1
+             make check
        - run:
            name: Make HTML documents
            command: |
@@ -63,7 +63,7 @@ jobs:
        - run:
            name: Test
            command: |
-             make roundtrip CIRCLECI=1
+             make roundtrip
 
   #
   # On Fedora 31 bmake package cannot be installed because a package
@@ -101,7 +101,7 @@ jobs:
        - run:
            name: Test
            command: |
-             MAKE=bmake bmake validate-input check codecheck CIRCLECI=1
+             MAKE=bmake bmake validate-input check codecheck
 
    fedora30_bmake_roundtrip:
      working_directory: ~/universal-ctags
@@ -127,7 +127,7 @@ jobs:
        - run:
            name: Test
            command: |
-             MAKE=bmake bmake roundtrip CIRCLECI=1
+             MAKE=bmake bmake roundtrip
 
    fedora33_distcheck:
      working_directory: ~/universal-ctags
@@ -202,7 +202,7 @@ jobs:
        - run:
            name: Test
            command: |
-             make check CIRCLECI=1
+             make check
 
    centos_make_roundtrip:
      working_directory: ~/universal-ctags
@@ -227,7 +227,7 @@ jobs:
        - run:
            name: Test
            command: |
-             make roundtrip CIRCLECI=1
+             make roundtrip
    centos7_make:
      working_directory: ~/universal-ctags
      docker:
@@ -251,7 +251,7 @@ jobs:
        - run:
            name: Test
            command: |
-             make check CIRCLECI=1
+             make check
 
    centos7_make_roundtrip:
      working_directory: ~/universal-ctags
@@ -276,7 +276,7 @@ jobs:
        - run:
            name: Test
            command: |
-             make roundtrip CIRCLECI=1
+             make roundtrip
 
    ubuntu20_mingw:
      working_directory: ~/universal-ctags
@@ -336,8 +336,8 @@ jobs:
        - run:
            name: Test
            command: |
-             # make check roundtrip CIRCLECI=1
-             make units CIRCLECI=1 CATEGORIES=parser-varlink
+             # make check roundtrip
+             make units CATEGORIES=parser-varlink
 
    fedora33_cross_aarch64:
      working_directory: ~/universal-ctags

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -103,7 +103,7 @@ units: $(CTAGS_TEST)
 	if test x$(VG) = x1; then		\
 		VALGRIND=--with-valgrind;	\
 	fi;					\
-	if ! test x$(TRAVIS)$(APPVEYOR)$(CIRCLECI)$(GITHUBACTIONS) = x; then	\
+	if ! test x$(CI) = x; then	\
 		SHOW_DIFF_OUTPUT=--show-diff-output;		\
 	fi;							\
 	builddir=$$(pwd); \
@@ -136,7 +136,6 @@ units: $(CTAGS_TEST)
 		--with-timeout=`expr $(TIMEOUT) '*' 10`\
 		$${SHELL_OPT} \
 		$${SHOW_DIFF_OUTPUT}"; \
-	 TRAVIS=$(TRAVIS) APPVEYOR=$(APPVEYOR) CIRCLECI=$(CIRCLECI) GITHUBACTIONS=$(GITHUBACTIONS)\
 		 $${PROG} $${c} $(srcdir)/Units $${builddir}/Units
 
 clean-units:
@@ -158,7 +157,6 @@ validate-input:
 		VALIDATORS="--validators=$(VALIDATORS)"; \
 	fi; \
 	c="$(srcdir)/misc/units validate-input $${VALIDATORS}"; \
-	TRAVIS=$(TRAVIS) APPVEYOR=$(APPVEYOR) CIRCLECI=$(CIRCLECI) GITHUBACTIONS=$(GITHUBACTIONS)\
 		$(SHELL) $${c} $(srcdir)/Units $(srcdir)/misc/validators
 #
 # Test main part, not parsers
@@ -169,7 +167,7 @@ tmain: $(CTAGS_TEST) $(READTAGS_TEST) $(OPTSCRIPT_TEST)
 	if test x$(VG) = x1; then		\
 		VALGRIND=--with-valgrind;	\
 	fi;					\
-	if ! test x$(TRAVIS)$(APPVEYOR)$(CIRCLECI)$(GITHUBACTIONS) = x; then	\
+	if ! test x$(CI) = x; then	\
 		SHOW_DIFF_OUTPUT=--show-diff-output;		\
 	fi;							\
 	builddir=$$(pwd); \
@@ -198,7 +196,6 @@ tmain: $(CTAGS_TEST) $(READTAGS_TEST) $(OPTSCRIPT_TEST)
 		$${VALGRIND} \
 		$${SHELL_OPT} \
 		$${SHOW_DIFF_OUTPUT}"; \
-	TRAVIS=$(TRAVIS) APPVEYOR=$(APPVEYOR) CIRCLECI=$(CIRCLECI) GITHUBACTIONS=$(GITHUBACTIONS)\
 		$${PROG} $${c} $(srcdir)/Tmain $${builddir}/Tmain
 
 clean-tmain:
@@ -243,7 +240,7 @@ tinst:
 if USE_READCMD
 roundtrip: $(READTAGS_TEST)
 	$(V_RUN) \
-	if ! test x$(TRAVIS)$(APPVEYOR)$(CIRCLECI)$(GITHUBACTIONS) = x; then	\
+	if ! test x$(CI) = x; then	\
 		ROUNDTRIP_FLAGS=--minitrip;			\
 	fi;							\
 	builddir=$$(pwd); \

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -163,7 +163,7 @@ if "%normalbuild%-%ARCH%"=="yes-x64" (
   @echo Tests for msys2 x64 are skipped.
   exit 0
 )
-bash -lc "make check APPVEYOR=1 PYTHON=py"
+bash -lc "make check PYTHON=py"
 
 @echo off
 goto :eof
@@ -256,7 +256,7 @@ c:\cygwin64\bin\file readtags.exe
 :: Check if it works
 .\ctags --version || exit 1
 :: Run tests
-bash -lc "make check APPVEYOR=1 PYTHON=py"
+bash -lc "make check PYTHON=py"
 
 @echo off
 goto :eof


### PR DESCRIPTION
Currently we define our own environment variables for each CI
platform: APPVEYOR, CIRCLECI, TRAIVS and GITHUBACTIONS. We don't have
to define them; we can just refer to CI environment variable.

Originally posted by @k-takata in #3080 (comment):

  Most of the CI environments set the CI environment variable to
  true (or True).

	https://docs.github.com/actions/reference/environment-variables
	https://www.appveyor.com/docs/environment-variables/
	https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables

  If we don't need to distinguish each CI environment and just want
  to know whether we are running the tests on any CI environment, we
  might be able to use the CI variable.

Close #3081