### PR TITLE
Units: change the order of input files for diff

### DIFF
--- a/misc/units
+++ b/misc/units
@@ -1985,8 +1985,8 @@ tmain_compare()
     msg=$(printf '%-60s' "${aspect}")
     generated=${build_subdir}/${aspect}-diff.txt
     if diff -U 0 --strip-trailing-cr \
-	    ${build_subdir}/${aspect}-actual.txt \
 	    ${subdir}/${aspect}-expected.txt \
+	    ${build_subdir}/${aspect}-actual.txt \
 	    > ${generated} 2>&1; then
 	run_result ok "${msg}" '/dev/null'
 	rm ${generated}

--- a/misc/units.py
+++ b/misc/units.py
@@ -1025,7 +1025,7 @@ def tmain_compare(subdir, build_subdir, aspect, file):
         with open(generated, 'wb') as f:
             subprocess.run(['diff', '-U',
                 str(DIFF_U_NUM), '--strip-trailing-cr',
-                actual, expected],
+                expected, actual],
                 stdout=f, stderr=subprocess.STDOUT)
         run_result('error', msg, None, 'diff: ' + generated, file=file)
         return False


### PR DESCRIPTION
This PR fixes the diff output on unit tests.

The current input file order is `diff filtered expected`.  This is not a typical order.
This PR fixes to `diff expected filtered`.
This is also consistent with the other usage of diff in the scripts as follows;

misc/unit.py

```python
  1026              subprocess.run(['diff', '-U',
  1027                  str(DIFF_U_NUM), '--strip-trailing-cr',
  1028                  expected, actual],
  1029                  stdout=f, stderr=subprocess.STDOUT)
```

misc/unit

```sh
   742          diff -U 0 -I '^!_TAG' --strip-trailing-cr "${fexpected}" "${ofiltered}" > "${odiff}"
```

***

Another example of "typical order";

```diff
$ cat from
from
$ cat to
to
$ diff -u from to
--- from        2021-08-09 22:41:49.836670500 +0900
+++ to  2021-08-09 22:41:56.396670500 +0900
@@ -1 +1 @@
-from
+to
$ diff -u --from-file from to
--- from        2021-08-09 22:41:49.836670500 +0900
+++ to  2021-08-09 22:41:56.396670500 +0900
@@ -1 +1 @@
-from
+to
$ diff -u --to-file to from
--- from        2021-08-09 22:41:49.836670500 +0900
+++ to  2021-08-09 22:41:56.396670500 +0900
@@ -1 +1 @@
-from
+to
$ 
```

`expected` and `actual` correspond to `from` and `to`, respectively.

