### PR TITLE
readtags/dsl: introduce cond special form

### DIFF
--- a/Tmain/readtags-qualifier-op-regexp-quote.d/run.sh
+++ b/Tmain/readtags-qualifier-op-regexp-quote.d/run.sh
@@ -14,22 +14,6 @@ if ! [ -x "${READTAGS}" ]; then
     skip "no readtags"
 fi
 
-#!/bin/sh
-
-# Copyright: 2021 Masatake YAMATO
-# License: GPL-2
-
-READTAGS=$3
-
-. ../utils.sh
-
-#V="valgrind --leak-check=full -v"
-V=
-
-if ! [ -x "${READTAGS}" ]; then
-    skip "no readtags"
-fi
-
 if ! ( "${READTAGS}" -h | grep -q -e -S ); then
     skip "no qualifier function in readtags"
 fi

--- a/Tmain/readtags-qualifier-sf-cond.d/input.c
+++ b/Tmain/readtags-qualifier-sf-cond.d/input.c
@@ -1,0 +1,11 @@
+typedef struct abc {
+	int def;
+	int ghi;
+} jkl;
+
+jkl mno;
+
+jkl pqr(void)
+{
+	return (jkl){.def = 1, .ghi = 2};
+}

--- a/Tmain/readtags-qualifier-sf-cond.d/output.tags
+++ b/Tmain/readtags-qualifier-sf-cond.d/output.tags
@@ -1,0 +1,17 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROC_CWD	/home/jet/var/ctags-github/Tmain/readtags-qualifier-sf-cond.d/	//
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	5.9.0	/b0d456fb4/
+abc	input.c	/^typedef struct abc {$/;"	s	file:
+def	input.c	/^	int def;$/;"	m	struct:abc	typeref:typename:int	file:
+ghi	input.c	/^	int ghi;$/;"	m	struct:abc	typeref:typename:int	file:
+jkl	input.c	/^} jkl;$/;"	t	typeref:struct:abc	file:
+mno	input.c	/^jkl mno;$/;"	v	typeref:typename:jkl
+pqr	input.c	/^jkl pqr(void)$/;"	f	typeref:typename:jkl

--- a/Tmain/readtags-qualifier-sf-cond.d/run.sh
+++ b/Tmain/readtags-qualifier-sf-cond.d/run.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Copyright: 2021 Masatake YAMATO
+# License: GPL-2
+
+READTAGS=$3
+
+. ../utils.sh
+
+#V="valgrind --leak-check=full -v"
+V=
+
+if ! [ -x "${READTAGS}" ]; then
+    skip "no readtags"
+fi
+
+if ! ( "${READTAGS}" -h | grep -q -e -S ); then
+    skip "no qualifier function in readtags"
+fi
+
+${V} ${READTAGS} -e -t output.tags \
+	 -Q '(cond ((eq? $kind "m") (#/.h./ $name)) ((eq? $kind "t")) ((#/.n./ $name) #f) (#t))' \
+	 -l

--- a/Tmain/readtags-qualifier-sf-cond.d/stdout-expected.txt
+++ b/Tmain/readtags-qualifier-sf-cond.d/stdout-expected.txt
@@ -1,0 +1,4 @@
+abc	input.c	/^typedef struct abc {$/;"	kind:s	file:
+ghi	input.c	/^	int ghi;$/;"	kind:m	file:	struct:abc	typeref:typename:int
+jkl	input.c	/^} jkl;$/;"	kind:t	file:	typeref:struct:abc
+pqr	input.c	/^jkl pqr(void)$/;"	kind:f	typeref:typename:jkl

--- a/dsl/dsl.c
+++ b/dsl/dsl.c
@@ -421,7 +421,7 @@ static EsObject *dsl_eval0 (EsObject *object, DSLEnv *env)
 		object = es_object_autounref (es_cons (car, es_cdr (object)));
 		return dsl_eval0 (object, env);
 	}
-	else
+	else if (es_symbol_p(car))
 	{
 		EsObject *cdr = es_cdr (object);
 		int l;
@@ -460,6 +460,8 @@ static EsObject *dsl_eval0 (EsObject *object, DSLEnv *env)
 			pb->cache = r;
 		return r;
 	}
+	else
+		dsl_throw (CALLABLE_REQUIRED, car);
 }
 
 EsObject *dsl_eval (DSLCode *code, DSLEnv *env)

--- a/dsl/dsl.c
+++ b/dsl/dsl.c
@@ -133,7 +133,7 @@ static DSLProcBind pbinds [] = {
 	{ "or",      sform_or,     NULL, DSL_PATTR_SELF_EVAL,
 	  .helpstr = "(or <any> ...) -> <boolean>" },
 	{ "if",      sform_if,       NULL, DSL_PATTR_SELF_EVAL|DSL_PATTR_CHECK_ARITY, 3,
-	  .helpstr = "(if <any:cond> <expr:true> <expr:false>) -> <any:true>|<any:false>" },
+	  .helpstr = "(if <any:cond> <any:true> <any:false>) -> <any:true>|<any:false>" },
 	{ "cond",    sform_cond,     NULL, DSL_PATTR_SELF_EVAL, 0,
 	  .helpstr = "(cond (<any:cond0> ... <any:expr0>) ... (<any:condN> ... <any:exprN>)) -> <any:exprI>|false" } ,
 	{ "not",     builtin_not,    NULL, DSL_PATTR_CHECK_ARITY, 1,

--- a/dsl/dsl.c
+++ b/dsl/dsl.c
@@ -381,7 +381,6 @@ static EsObject *dsl_eval0 (EsObject *object, DSLEnv *env)
 		}
 		else
 			dsl_throw (UNBOUND_VARIABLE, object);
-
 	}
 	else if (es_atom (object))
 		return object;

--- a/dsl/dsl.c
+++ b/dsl/dsl.c
@@ -384,7 +384,9 @@ static EsObject *dsl_eval0 (EsObject *object, DSLEnv *env)
 	}
 	else if (es_atom (object))
 		return object;
-	else if (es_regex_p(car = es_car (object)))
+
+	car = es_car (object);
+	if (es_regex_p(car))
 	{
 		EsObject *cdr = es_cdr (object);
 		int l = length (cdr);

--- a/dsl/dsl.h
+++ b/dsl/dsl.h
@@ -67,6 +67,7 @@ typedef struct sDSLCode DSLCode;
 #define DSL_ERR_BOOLEAN_REQUIRED    (es_error_intern("boolean-required"))
 #define DSL_ERR_INTEGER_REQUIRED    (es_error_intern("integer-required"))
 #define DSL_ERR_NUMBER_REQUIRED     (es_error_intern("number-required"))
+#define DSL_ERR_CALLABLE_REQUIRED   (es_error_intern("callable-required"))
 #define DSL_ERR_WRONG_TYPE_ARGUMENT (es_error_intern("wrong-type-argument"))
 #define DSL_ERR_NO_ALT_ENTRY        (es_error_intern("the-alternative-entry-unavailable"))
 


### PR DESCRIPTION
In filter expression of readtags, you could use `(if ...)`.
`(cond (condtion0 expression0) (condtion1 expression1) ... )` is generic version of `if`.

`cond` will be useful when we introduce "formatter" to readtags.

Minor improvements for readtags are inclluded.