### PR TITLE
Add statx to seccomp rules

### DIFF
--- a/main/seccomp.c
+++ b/main/seccomp.c
@@ -46,6 +46,10 @@ int installSyscallFilter (void)
 #ifdef __SNR_newfstatat
 	seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (newfstatat), 0);
 #endif
+#ifdef __SNR_statx
+	// armhf fallback
+	seccomp_rule_add (ctx, SCMP_ACT_ALLOW, SCMP_SYS (statx), 0);
+#endif
 
 	// seems unnecessary, but this comes from
 	// main/parse.c:2764 : tagFilePosition (&tagfpos);


### PR DESCRIPTION
Add statx to seccomp rules as a fallback for newfstatat. This is
specially important for the case where the newfstatat system call is not
available on a platform using glibc >= 2.33

This patch was created as an effort to fix FTBFS builds on Ubuntu after the glibc 2.33 migration. See https://bugs.launchpad.net/ubuntu/+source/universal-ctags/+bug/1934829 for further reference.