### PR TITLE
TEMP,ci: enable fedora34 as a CI target

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -396,4 +396,4 @@ workflows:
       - fedora30_bmake_roundtrip
       - fedora33_gmake_roundtrip
       - centos7_make_roundtrip
-      # - THIS_WILL_BE_FAILED_fedora34_CANARY
+      - THIS_WILL_BE_FAILED_fedora34_CANARY


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>