### PR TITLE
ITcl: don't require 'package require Itcl'

### DIFF
--- a/Units/parser-itcl.r/itcl-3.d/expected.tags
+++ b/Units/parser-itcl.r/itcl-3.d/expected.tags
@@ -1,0 +1,1 @@
+Toaster	input.tcl	/^itcl::class Toaster {$/;"	c

--- a/Units/parser-itcl.r/itcl-3.d/input.tcl
+++ b/Units/parser-itcl.r/itcl-3.d/input.tcl
@@ -1,0 +1,5 @@
+# Toaster should be tagged though Itcl is not required.
+# See #3136. A scrip can be sourced from another script that
+# required ITcl.
+itcl::class Toaster {
+}

--- a/Units/parser-itcl.r/no-itcl-1.d/input.tcl
+++ b/Units/parser-itcl.r/no-itcl-1.d/input.tcl
@@ -1,3 +1,0 @@
-# Toaster should be ignored because Itcl is not required.
-itcl::class Toaster {
-}

--- a/parsers/itcl.c
+++ b/parsers/itcl.c
@@ -18,7 +18,6 @@
 
 struct itclSubparser {
 	tclSubparser tcl;
-	bool foundITclPackageRequired;
 	bool foundITclNamespaceImported;
 };
 
@@ -256,23 +255,12 @@ static int commandNotify (tclSubparser *s, char *command,
 	struct itclSubparser *itcl = (struct itclSubparser *)s;
 	int r = CORK_NIL;
 
-	if (!itcl->foundITclPackageRequired)
-		return r;
-
 	if ((itcl->foundITclNamespaceImported
 		 && (strcmp (command, "class") == 0))
 		|| (strcmp (command, "itcl::class") == 0))
 		r = parseClass (s, parentIndex, pstate);
 
 	return r;
-}
-
-static void packageRequirementNotify (tclSubparser *s, char *package,
-									  void *pstate CTAGS_ATTR_UNUSED)
-{
-	struct itclSubparser *itcl = (struct itclSubparser *)s;
-	if (strcmp (package, "Itcl") == 0)
-		itcl->foundITclPackageRequired = true;
 }
 
 static void namespaceImportNotify (tclSubparser *s, char *namespace,
@@ -289,7 +277,6 @@ static void inputStart (subparser *s)
 {
 	struct itclSubparser *itcl = (struct itclSubparser *)s;
 
-	itcl->foundITclPackageRequired = false;
 	itcl->foundITclNamespaceImported = false;
 }
 
@@ -300,7 +287,6 @@ struct itclSubparser itclSubparser = {
 			.inputStart = inputStart,
 		},
 		.commandNotify = commandNotify,
-		.packageRequirementNotify = packageRequirementNotify,
 		.namespaceImportNotify = namespaceImportNotify,
 	},
 };

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -377,23 +377,6 @@ static const char* getLastComponentInIdentifier(tokenInfo *const token)
 		return NULL;
 }
 
-static void notifyPackageRequirement (tokenInfo *const token)
-{
-	subparser *sub;
-
-	foreachSubparser (sub, false)
-	{
-		tclSubparser *tclsub = (tclSubparser *)sub;
-
-		if (tclsub->packageRequirementNotify)
-		{
-			enterSubparser(sub);
-			tclsub->packageRequirementNotify (tclsub, tokenString (token),
-											  TCL_PSTATE(token));
-			leaveSubparser();
-		}
-	}
-}
 
 static void notifyNamespaceImport (tokenInfo *const token)
 {
@@ -676,12 +659,6 @@ static void parsePackage (tokenInfo *const token)
 		{
 			if (tokenString(token)[0] == '-')
 				goto next;
-
-			if (tokenIsType (token, TCL_IDENTIFIER)
-				&& (vStringLength (token->string) > 0))
-			{
-				notifyPackageRequirement (token);
-			}
 		}
 	}
 	skipToEndOfCmdline(token);

--- a/parsers/tcl.h
+++ b/parsers/tcl.h
@@ -33,8 +33,6 @@ struct sTclSubparser {
 	subparser subparser;
 
 	/* `pstate' is needed to call newTclToken(). */
-	void (* packageRequirementNotify) (tclSubparser *s, char *package,
-									   void *pstate);
 	void (* namespaceImportNotify) (tclSubparser *s, char *namespace,
 									void *pstate);
 	/* Return CORK_NIL if the command line is NOT consumed.


### PR DESCRIPTION
Close #3136.
Close #3139.

The original code requires 'package require Itcl' to run Itcl
subparser from Tcl parser. However, `itcl::` can be used in
a script having no 'package require Itcl' statement.
Suggested by @bigfaceworm.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>