### PR TITLE
ttcn: Skip comments correctly

### DIFF
--- a/Units/parser-ttcn.r/ttcn-types.d/input.ttcn
+++ b/Units/parser-ttcn.r/ttcn-types.d/input.ttcn
@@ -14,7 +14,9 @@ type record Tee
 {
     record of integer nestedIntegersRecord,
     record length (0..5) of integer nestedRangedIntegersRecord,
+    /* a comment */
     set of integer nestedIntegersSet,
+    // a comment
     set length (2..4) of integer nestedRangerdIntegersSet,
     enumerated {e_type1, e_type2} nestedEnum,
     union {Type1 t1, Type2 t2} nestedUnion

--- a/parsers/ttcn.c
+++ b/parsers/ttcn.c
@@ -344,6 +344,7 @@ static int getNonWhiteSpaceChar (void)
 			{
 				/* Line comment */
 				while (((c = getcFromInputFile()) != EOF) && (c != '\n'));
+				continue;
 			}
 			else if (c2=='*')
 			{
@@ -358,6 +359,7 @@ static int getNonWhiteSpaceChar (void)
 						ungetcToInputFile(c2);
 					}
 				}
+				continue;
 			}
 			else
 			{


### PR DESCRIPTION
Right now comments don't get skipped all the way, leading to code like

    type enumerated Enum {
        /* a comment */
        Value
    }

or

    type enumerated Enum {
        // a comment
        Value
    }

resulting in "Value" not being present in the output, due to `getNonWhiteSpaceChar()` returning `'*'` (for `/* */`comments) or `'\n'` (for `//` comments)