### PR TITLE
[SELF-INCOMPATIBLE]main,Units,docs: use `.' as the separator in --param instead of `:'

### DIFF
--- a/Units/parser-cpreprocessor.r/if0-false-with-param.c.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/if0-false-with-param.c.d/args.ctags
@@ -1,1 +1,1 @@
---param-CPreProcessor:if0=false
+--param-CPreProcessor.if0=false

--- a/Units/parser-cpreprocessor.r/if0-false-with-param.c.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/if0-false-with-param.c.d/args.ctags
@@ -1,2 +1,1 @@
 --param-CPreProcessor:if0=false
-

--- a/Units/parser-cpreprocessor.r/if0-true-with-param.c.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/if0-true-with-param.c.d/args.ctags
@@ -1,1 +1,1 @@
---param-CPreProcessor:if0=true
+--param-CPreProcessor.if0=true

--- a/Units/parser-cpreprocessor.r/if0-true-with-param.c.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/if0-true-with-param.c.d/args.ctags
@@ -1,2 +1,1 @@
 --param-CPreProcessor:if0=true
-

--- a/Units/parser-cpreprocessor.r/macroexpand.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/macroexpand.d/args.ctags
@@ -1,4 +1,4 @@
---param-CPreProcessor:_expand=1
+--param-CPreProcessor._expand=1
 --fields-C=+{macrodef}
 --fields=+Ss
 --sort=no

--- a/Units/parser-cpreprocessor.r/macros-specified-with-param.c.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/macros-specified-with-param.c.d/args.ctags
@@ -1,5 +1,5 @@
 --kinds-c=+p
 --fields=+S
---param-CPreProcessor:ignore=MACRO2
+--param-CPreProcessor.ignore=MACRO2
 --fields=+r
 --extras=+r

--- a/Units/parser-fypp.r/run-alt-guest.d/args.ctags
+++ b/Units/parser-fypp.r/run-alt-guest.d/args.ctags
@@ -1,6 +1,6 @@
 --fields=+e
 # The next redundant options are for improve the test coverage.
---param-Fypp:guest=Lisp
---param-Fypp:guest=NONE
---param-Fypp:guest=Java
+--param-Fypp.guest=Lisp
+--param-Fypp.guest=NONE
+--param-Fypp.guest=Java
 --extras=+g

--- a/Units/parser-ldscript.r/ld-symtab.d/args.ctags
+++ b/Units/parser-ldscript.r/ld-symtab.d/args.ctags
@@ -1,3 +1,3 @@
---param-CPreProcessor:_expand=1
+--param-CPreProcessor._expand=1
 --fields-CPreProcessor=+{macrodef}
 --fields=+{signature}

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -684,7 +684,7 @@ See "`TAG ENTRIES`_" about fields, kinds, roles, and extras.
 	description of ``MASTER`` column of ``--list-kinds-full``.
 
 ..	COMMENT:
-	``--param-<LANG>:name=argument`` is moved to "Language Specific Options"
+	``--param-<LANG>.name=argument`` is moved to "Language Specific Options"
 
 ``--pattern-length-limit=<N>``
 	Truncate patterns of tag entries after *<N>* characters. Disable by setting to 0
@@ -993,7 +993,7 @@ Language Specific Options
 	would cause the source file to be incorrectly parsed. Correct behavior
 	can be restored by specifying "``-I CLASS=class``".
 
-``--param-<LANG>:<name>=<argument>``
+``--param-<LANG>.<name>=<argument>``
 	Set a *<LANG>* specific parameter, a parameter specific to the *<LANG>*.
 
 	Available parameters can be listed with ``--list-params``.

--- a/docs/output-tags.rst
+++ b/docs/output-tags.rst
@@ -526,12 +526,12 @@ A parser defines a set of parameters. Each parameter has name and
 takes an argument. A user can set a parameter with following notation
 ::
 
-   --param-<LANG>:name=arg
+   --param-<LANG>.name=arg
 
 An example of specifying a parameter
 ::
 
-   --param-CPreProcessor:if0=true
+   --param-CPreProcessor.if0=true
 
 Here `if0` is a name of parameter of CPreProcessor parser and
 `true` is the value of it.

--- a/docs/parser-cxx.rst
+++ b/docs/parser-cxx.rst
@@ -178,7 +178,7 @@ SAME file can be expanded with following options:
 
 .. code-block:: text
 
-   --param-CPreProcessor:_expand=1
+   --param-CPreProcessor._expand=1
    --fields-C=+{macrodef}
    --fields-C++=+{macrodef}
    --fields-CUDA=+{macrodef}
@@ -209,7 +209,7 @@ The output without options:
 The output with options:
 .. code-block::
 
-   $ ctags --param-CPreProcessor:_expand=1 --fields-C=+'{macrodef}' --fields=+'{signature}' -o - input.c
+   $ ctags --param-CPreProcessor._expand=1 --fields-C=+'{macrodef}' --fields=+'{signature}' -o - input.c
    BEGIN	input.c	/^#define BEGIN /;"	d	language:C	file:	macrodef:{
    DEFUN	input.c	/^#define DEFUN(/;"	d	language:C	file:	signature:(NAME)	macrodef:int NAME (int x, int y)
    END	input.c	/^#define END /;"	d	language:C	file:	macrodef:}

--- a/main/options.c
+++ b/main/options.c
@@ -407,7 +407,7 @@ static optionDescription LongOptionDescription [] = {
  {1,0,"  -I [+|-]<list>|@<file>"},
  {1,0,"       A <list> of tokens to be specially handled is read from either the"},
  {1,0,"       command line or the specified <file>."},
- {1,0,"  --param-<LANG>:<name>=<argument>"},
+ {1,0,"  --param-<LANG>.<name>=<argument>"},
  {1,0,"       Set <LANG> specific parameter. Available parameters can be listed with --list-params."},
  {1,0,""},
  {1,0,"Listing Options"},
@@ -796,11 +796,17 @@ extern langType getLanguageComponentInOptionFull (const char *const option,
 	}
 
 	/* Extract <LANG> from
-	 * --param-<LANG>:<PARAM>=..., and
+	 * --param-<LANG>.<PARAM>=..., and
 	 * --_roledef-<LANG>.<KIND>=... */
+
+	/*  `:' is only for keeping self compatibility. */
 	sep = strpbrk (lang, ":.");
 	if (sep)
+	{
+		if (*sep == ':')
+			error (WARNING, "using `:' as a separator is obsolete; use `.' instead: --%s", option);
 		lang_len = sep - lang;
+	}
 	language = getNamedLanguageFull (lang, lang_len, noPretending, false);
 	if (language == LANG_IGNORE)
 	{
@@ -2018,8 +2024,9 @@ extern bool processParamOption (
 		return false;
 
 	sep = option + strlen ("param-") + strlen (getLanguageName (language));
-	if (*sep != ':')
-		error (FATAL, "no separator(:) is given for %s=%s", option, value);
+	/* `:' is only for keeping self compatibility */
+	if (! (*sep == '.' || *sep == ':' ))
+		error (FATAL, "no separator(.) is given for %s=%s", option, value);
 	name = sep + 1;
 
 	if (value == NULL || value [0] == '\0')

--- a/main/parse.c
+++ b/main/parse.c
@@ -2856,10 +2856,10 @@ extern bool processKindsOption (
  * How --param should be change to align --roles-<LANG> notation
  * ---------------------------------------------------------------------
  *
- * --_param-<LANG>.name=argument
+ * --param-<LANG>.name=argument
  *
  * The notation was
- * --_param-<LANG>:name=argument
+ * --param-<LANG>:name=argument
  *
  *
  * How --paramdef should be to align --roles-<LANG> notation

--- a/main/parse.c
+++ b/main/parse.c
@@ -2858,7 +2858,7 @@ extern bool processKindsOption (
  *
  * --_param-<LANG>.name=argument
  *
- *  * The notation was
+ * The notation was
  * --_param-<LANG>:name=argument
  *
  *

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -684,7 +684,7 @@ See "`TAG ENTRIES`_" about fields, kinds, roles, and extras.
 	description of ``MASTER`` column of ``--list-kinds-full``.
 
 ..	COMMENT:
-	``--param-<LANG>:name=argument`` is moved to "Language Specific Options"
+	``--param-<LANG>.name=argument`` is moved to "Language Specific Options"
 
 ``--pattern-length-limit=<N>``
 	Truncate patterns of tag entries after *<N>* characters. Disable by setting to 0
@@ -993,7 +993,7 @@ Language Specific Options
 	would cause the source file to be incorrectly parsed. Correct behavior
 	can be restored by specifying "``-I CLASS=class``".
 
-``--param-<LANG>:<name>=<argument>``
+``--param-<LANG>.<name>=<argument>``
 	Set a *<LANG>* specific parameter, a parameter specific to the *<LANG>*.
 
 	Available parameters can be listed with ``--list-params``.


### PR DESCRIPTION
 `.' was used in the --param option like --param-Fypp:guest=....
This change replaces `.' with `:'.

There are two reasons for the replacement; (A) `:' implies a field, and
(B) `.' is used in --roledef-<LANG>.<KIND> option.

ctags still accept `.' but warns that using `.' is obsolete.
