### PR TITLE
Use `&X[3]` instead of `X + 3` to fix clang warnings

### DIFF
--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -120,7 +120,7 @@ static int  lisp_hint2kind (const vString *const hint)
 	int n;
 
 	/* 4 means strlen("(def"). */
-#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
+#define EQN(X) strncmp(vStringValue (hint) + 4, &X[3], n) == 0
 	switch (vStringLength (hint) - 4)
 	{
 	case 2:
@@ -155,7 +155,7 @@ static int  elisp_hint2kind (const vString *const hint)
 	int n;
 
 	/* 4 means strlen("(def"). */
-#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
+#define EQN(X) strncmp(vStringValue (hint) + 4, &X[3], n) == 0
 	switch (vStringLength (hint) - 4)
 	{
 	case 2:


### PR DESCRIPTION
Hello!

On latest master `clang version 10.0.0-4ubuntu1` produces following warnings:
```
parsers/lisp.c:128:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("DEFUN"))
                    ^~~~~~~~~~~~
parsers/lisp.c:123:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:128:7: note: use array indexing to silence this warning
parsers/lisp.c:123:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:133:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("DEFVAR"))
                    ^~~~~~~~~~~~~
parsers/lisp.c:123:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:133:7: note: use array indexing to silence this warning
parsers/lisp.c:123:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:138:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("DEFMACRO"))
                    ^~~~~~~~~~~~~~~
parsers/lisp.c:123:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:138:7: note: use array indexing to silence this warning
parsers/lisp.c:123:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:143:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("DEFCONSTANT"))
                    ^~~~~~~~~~~~~~~~~~
parsers/lisp.c:123:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:143:7: note: use array indexing to silence this warning
parsers/lisp.c:123:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:163:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("defun"))
                    ^~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:163:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:168:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("defvar"))
                    ^~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:168:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:170:12: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                else if (EQN("defun*"))
                         ^~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:170:12: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:175:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("defface"))
                    ^~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:175:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:179:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("defconst"))
                    ^~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:179:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:181:12: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                else if (EQN("defmacro"))
                         ^~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:181:12: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:183:12: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                else if (EQN("defalias"))
                         ^~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:183:12: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:185:12: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                else if (EQN("defsubst"))
                         ^~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:185:12: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:187:12: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                else if (EQN("defgroup"))
                         ^~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:187:12: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:189:12: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                else if (EQN("deftheme"))
                         ^~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:189:12: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:194:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("defcustom"))
                    ^~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:194:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:196:12: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                else if (EQN("defsubst*"))
                         ^~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:196:12: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:198:12: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                else if (EQN("defmacro*"))
                         ^~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:198:12: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:203:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("define-key"))
                    ^~~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:203:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:208:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("defvar-local"))
                    ^~~~~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:208:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:210:12: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                else if (EQN("define-error"))
                         ^~~~~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:210:12: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:215:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("defvaralias"))
                    ^~~~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:215:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:220:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("define-inline"))
                    ^~~~~~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:220:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:225:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("define-minor-mode"))
                    ^~~~~~~~~~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:225:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:230:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("define-derived-mode"))
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:230:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:235:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("define-global-minor-mode"))
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:235:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:240:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("define-globalized-minor-mode"))
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:240:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
parsers/lisp.c:245:7: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
                if (EQN("define-obsolete-function-alias"))
                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                ~~^~~
parsers/lisp.c:245:7: note: use array indexing to silence this warning
parsers/lisp.c:158:51: note: expanded from macro 'EQN'
#define EQN(X) strncmp(vStringValue (hint) + 4, X + 3, n) == 0
                                                  ^
```

This PR fixes these warnings.

Thanks!