### PR TITLE
Remove redundant code

### DIFF
--- a/dsl/es.c
+++ b/dsl/es.c
@@ -2238,7 +2238,7 @@ get_sequence       (MIO* fp,
 				case 't': c0 = '\t'; break;
 				case 'r': c0 = '\r'; break;
 				case 'f': c0 = '\f'; break;
-				default:  c0 = c0  ; break;
+				default:  break;
 				}
 				seed = token_append(seed, c0);
 				in_escape = 0;

--- a/dsl/optscript.c
+++ b/dsl/optscript.c
@@ -252,7 +252,6 @@ static EsObject*    vm_dstack_pop           (OptVM *vm);
 static void         vm_dstack_clear         (OptVM *vm);
 
 static EsObject*    vm_estack_push          (OptVM *vm, EsObject *p);
-static int          vm_estack_count         (OptVM *vm);
 static EsObject*    vm_estack_pop           (OptVM *vm);
 
 #define declop(OP)										\
@@ -1518,12 +1517,6 @@ vm_estack_push (OptVM *vm, EsObject *p)
 {
 	ptrArrayAdd (vm->estack, es_object_ref (p));
 	return es_false;
-}
-
-static int
-vm_estack_count (OptVM *vm)
-{
-	return ptrArrayCount (vm->estack);
 }
 
 static EsObject*


### PR DESCRIPTION
Hello!

While chasing down following warnings produced by `clang version 10.0.0-4ubuntu1` I thought we can remove the redundant code safely:
```
dsl/es.c:2241:18: warning: explicitly assigning value of variable of type 'char' to itself [-Wself-assign]
                                default:  c0 = c0  ; break;
                                          ~~ ^ ~~
...
dsl/optscript.c:1524:1: warning: unused function 'vm_estack_count' [-Wunused-function]
vm_estack_count (OptVM *vm)
^
```

Thanks!