### PR TITLE
Tex: add missing `break` statement

### DIFF
--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -932,6 +932,7 @@ static void parseTexFile (tokenInfo *const token)
 				case KEYWORD_bibliography:
 					eof = parseTagFull (token, TEXTAG_XINPUT, TEX_XINPUT_BIBLIOGRAPHY,
 										false, &tokenUnprocessed);
+					break;
 				case KEYWORD_newcommand:
 					eof = parseNewcommand (token, &tokenUnprocessed);
 					break;


### PR DESCRIPTION
Found by: [scan-build](https://clang-analyzer.llvm.org/scan-build)