### PR TITLE
 Kconfig: tag CONFIG_FOO_MODULE as configPrefixed extra tag for FOO 

### DIFF
--- a/Units/simple-kconfig.d/expected.tags
+++ b/Units/simple-kconfig.d/expected.tags
@@ -14,61 +14,89 @@ lib/Kconfig.debug	input.kconfig	/^source "lib\/Kconfig.debug"$/;"	k	roles:source
 Documentation/Kconfig	input.kconfig	/^source "Documentation\/Kconfig"$/;"	k	roles:source
 JFFS2_FS	input-1.kconfig	/^config JFFS2_FS$/;"	c	roles:def
 CONFIG_JFFS2_FS	input-1.kconfig	/^config JFFS2_FS$/;"	c	roles:def
+CONFIG_JFFS2_FS_MODULE	input-1.kconfig	/^config JFFS2_FS$/;"	c	roles:def
 JFFS2_FS_DEBUG	input-1.kconfig	/^config JFFS2_FS_DEBUG$/;"	c	roles:def
 CONFIG_JFFS2_FS_DEBUG	input-1.kconfig	/^config JFFS2_FS_DEBUG$/;"	c	roles:def
+CONFIG_JFFS2_FS_DEBUG_MODULE	input-1.kconfig	/^config JFFS2_FS_DEBUG$/;"	c	roles:def
 JFFS2_FS_WRITEBUFFER	input-1.kconfig	/^config JFFS2_FS_WRITEBUFFER$/;"	c	roles:def
 CONFIG_JFFS2_FS_WRITEBUFFER	input-1.kconfig	/^config JFFS2_FS_WRITEBUFFER$/;"	c	roles:def
+CONFIG_JFFS2_FS_WRITEBUFFER_MODULE	input-1.kconfig	/^config JFFS2_FS_WRITEBUFFER$/;"	c	roles:def
 JFFS2_FS_WBUF_VERIFY	input-1.kconfig	/^config JFFS2_FS_WBUF_VERIFY$/;"	c	roles:def
 CONFIG_JFFS2_FS_WBUF_VERIFY	input-1.kconfig	/^config JFFS2_FS_WBUF_VERIFY$/;"	c	roles:def
+CONFIG_JFFS2_FS_WBUF_VERIFY_MODULE	input-1.kconfig	/^config JFFS2_FS_WBUF_VERIFY$/;"	c	roles:def
 JFFS2_SUMMARY	input-1.kconfig	/^config JFFS2_SUMMARY$/;"	c	roles:def
 CONFIG_JFFS2_SUMMARY	input-1.kconfig	/^config JFFS2_SUMMARY$/;"	c	roles:def
+CONFIG_JFFS2_SUMMARY_MODULE	input-1.kconfig	/^config JFFS2_SUMMARY$/;"	c	roles:def
 JFFS2_FS_XATTR	input-1.kconfig	/^config JFFS2_FS_XATTR$/;"	c	roles:def
 CONFIG_JFFS2_FS_XATTR	input-1.kconfig	/^config JFFS2_FS_XATTR$/;"	c	roles:def
+CONFIG_JFFS2_FS_XATTR_MODULE	input-1.kconfig	/^config JFFS2_FS_XATTR$/;"	c	roles:def
 JFFS2_FS_POSIX_ACL	input-1.kconfig	/^config JFFS2_FS_POSIX_ACL$/;"	c	roles:def
 CONFIG_JFFS2_FS_POSIX_ACL	input-1.kconfig	/^config JFFS2_FS_POSIX_ACL$/;"	c	roles:def
+CONFIG_JFFS2_FS_POSIX_ACL_MODULE	input-1.kconfig	/^config JFFS2_FS_POSIX_ACL$/;"	c	roles:def
 JFFS2_FS_SECURITY	input-1.kconfig	/^config JFFS2_FS_SECURITY$/;"	c	roles:def
 CONFIG_JFFS2_FS_SECURITY	input-1.kconfig	/^config JFFS2_FS_SECURITY$/;"	c	roles:def
+CONFIG_JFFS2_FS_SECURITY_MODULE	input-1.kconfig	/^config JFFS2_FS_SECURITY$/;"	c	roles:def
 JFFS2_COMPRESSION_OPTIONS	input-1.kconfig	/^config JFFS2_COMPRESSION_OPTIONS$/;"	c	roles:def
 CONFIG_JFFS2_COMPRESSION_OPTIONS	input-1.kconfig	/^config JFFS2_COMPRESSION_OPTIONS$/;"	c	roles:def
+CONFIG_JFFS2_COMPRESSION_OPTIONS_MODULE	input-1.kconfig	/^config JFFS2_COMPRESSION_OPTIONS$/;"	c	roles:def
 JFFS2_ZLIB	input-1.kconfig	/^config JFFS2_ZLIB$/;"	c	roles:def
 CONFIG_JFFS2_ZLIB	input-1.kconfig	/^config JFFS2_ZLIB$/;"	c	roles:def
+CONFIG_JFFS2_ZLIB_MODULE	input-1.kconfig	/^config JFFS2_ZLIB$/;"	c	roles:def
 JFFS2_LZO	input-1.kconfig	/^config JFFS2_LZO$/;"	c	roles:def
 CONFIG_JFFS2_LZO	input-1.kconfig	/^config JFFS2_LZO$/;"	c	roles:def
+CONFIG_JFFS2_LZO_MODULE	input-1.kconfig	/^config JFFS2_LZO$/;"	c	roles:def
 JFFS2_RTIME	input-1.kconfig	/^config JFFS2_RTIME$/;"	c	roles:def
 CONFIG_JFFS2_RTIME	input-1.kconfig	/^config JFFS2_RTIME$/;"	c	roles:def
+CONFIG_JFFS2_RTIME_MODULE	input-1.kconfig	/^config JFFS2_RTIME$/;"	c	roles:def
 JFFS2_RUBIN	input-1.kconfig	/^config JFFS2_RUBIN$/;"	c	roles:def
 CONFIG_JFFS2_RUBIN	input-1.kconfig	/^config JFFS2_RUBIN$/;"	c	roles:def
+CONFIG_JFFS2_RUBIN_MODULE	input-1.kconfig	/^config JFFS2_RUBIN$/;"	c	roles:def
 choice29ffa23a0104	input-1.kconfig	/^choice$/;"	C	roles:def
 JFFS2_CMODE_NONE	input-1.kconfig	/^config JFFS2_CMODE_NONE$/;"	c	choice:choice29ffa23a0104	roles:def
 CONFIG_JFFS2_CMODE_NONE	input-1.kconfig	/^config JFFS2_CMODE_NONE$/;"	c	choice:choice29ffa23a0104	roles:def
+CONFIG_JFFS2_CMODE_NONE_MODULE	input-1.kconfig	/^config JFFS2_CMODE_NONE$/;"	c	choice:choice29ffa23a0104	roles:def
 JFFS2_CMODE_PRIORITY	input-1.kconfig	/^config JFFS2_CMODE_PRIORITY$/;"	c	choice:choice29ffa23a0104	roles:def
 CONFIG_JFFS2_CMODE_PRIORITY	input-1.kconfig	/^config JFFS2_CMODE_PRIORITY$/;"	c	choice:choice29ffa23a0104	roles:def
+CONFIG_JFFS2_CMODE_PRIORITY_MODULE	input-1.kconfig	/^config JFFS2_CMODE_PRIORITY$/;"	c	choice:choice29ffa23a0104	roles:def
 JFFS2_CMODE_SIZE	input-1.kconfig	/^config JFFS2_CMODE_SIZE$/;"	c	choice:choice29ffa23a0104	roles:def
 CONFIG_JFFS2_CMODE_SIZE	input-1.kconfig	/^config JFFS2_CMODE_SIZE$/;"	c	choice:choice29ffa23a0104	roles:def
+CONFIG_JFFS2_CMODE_SIZE_MODULE	input-1.kconfig	/^config JFFS2_CMODE_SIZE$/;"	c	choice:choice29ffa23a0104	roles:def
 JFFS2_CMODE_FAVOURLZO	input-1.kconfig	/^config JFFS2_CMODE_FAVOURLZO$/;"	c	choice:choice29ffa23a0104	roles:def
 CONFIG_JFFS2_CMODE_FAVOURLZO	input-1.kconfig	/^config JFFS2_CMODE_FAVOURLZO$/;"	c	choice:choice29ffa23a0104	roles:def
+CONFIG_JFFS2_CMODE_FAVOURLZO_MODULE	input-1.kconfig	/^config JFFS2_CMODE_FAVOURLZO$/;"	c	choice:choice29ffa23a0104	roles:def
 HAVE_ARCH_KGDB	input-2.kconfig	/^config HAVE_ARCH_KGDB$/;"	c	roles:def
 CONFIG_HAVE_ARCH_KGDB	input-2.kconfig	/^config HAVE_ARCH_KGDB$/;"	c	roles:def
+CONFIG_HAVE_ARCH_KGDB_MODULE	input-2.kconfig	/^config HAVE_ARCH_KGDB$/;"	c	roles:def
 KGDB	input-2.kconfig	/^menuconfig KGDB$/;"	c	roles:def
 CONFIG_KGDB	input-2.kconfig	/^menuconfig KGDB$/;"	c	roles:def
+CONFIG_KGDB_MODULE	input-2.kconfig	/^menuconfig KGDB$/;"	c	roles:def
 KGDB_SERIAL_CONSOLE	input-2.kconfig	/^config KGDB_SERIAL_CONSOLE$/;"	c	roles:def
 CONFIG_KGDB_SERIAL_CONSOLE	input-2.kconfig	/^config KGDB_SERIAL_CONSOLE$/;"	c	roles:def
+CONFIG_KGDB_SERIAL_CONSOLE_MODULE	input-2.kconfig	/^config KGDB_SERIAL_CONSOLE$/;"	c	roles:def
 KGDB_TESTS	input-2.kconfig	/^config KGDB_TESTS$/;"	c	roles:def
 CONFIG_KGDB_TESTS	input-2.kconfig	/^config KGDB_TESTS$/;"	c	roles:def
+CONFIG_KGDB_TESTS_MODULE	input-2.kconfig	/^config KGDB_TESTS$/;"	c	roles:def
 KGDB_TESTS_ON_BOOT	input-2.kconfig	/^config KGDB_TESTS_ON_BOOT$/;"	c	roles:def
 CONFIG_KGDB_TESTS_ON_BOOT	input-2.kconfig	/^config KGDB_TESTS_ON_BOOT$/;"	c	roles:def
+CONFIG_KGDB_TESTS_ON_BOOT_MODULE	input-2.kconfig	/^config KGDB_TESTS_ON_BOOT$/;"	c	roles:def
 KGDB_TESTS_BOOT_STRING	input-2.kconfig	/^config KGDB_TESTS_BOOT_STRING$/;"	c	roles:def
 CONFIG_KGDB_TESTS_BOOT_STRING	input-2.kconfig	/^config KGDB_TESTS_BOOT_STRING$/;"	c	roles:def
+CONFIG_KGDB_TESTS_BOOT_STRING_MODULE	input-2.kconfig	/^config KGDB_TESTS_BOOT_STRING$/;"	c	roles:def
 KGDB_LOW_LEVEL_TRAP	input-2.kconfig	/^config KGDB_LOW_LEVEL_TRAP$/;"	c	roles:def
 CONFIG_KGDB_LOW_LEVEL_TRAP	input-2.kconfig	/^config KGDB_LOW_LEVEL_TRAP$/;"	c	roles:def
+CONFIG_KGDB_LOW_LEVEL_TRAP_MODULE	input-2.kconfig	/^config KGDB_LOW_LEVEL_TRAP$/;"	c	roles:def
 KGDB_KDB	input-2.kconfig	/^config KGDB_KDB$/;"	c	roles:def
 CONFIG_KGDB_KDB	input-2.kconfig	/^config KGDB_KDB$/;"	c	roles:def
+CONFIG_KGDB_KDB_MODULE	input-2.kconfig	/^config KGDB_KDB$/;"	c	roles:def
 KDB_DEFAULT_ENABLE	input-2.kconfig	/^config KDB_DEFAULT_ENABLE$/;"	c	roles:def
 CONFIG_KDB_DEFAULT_ENABLE	input-2.kconfig	/^config KDB_DEFAULT_ENABLE$/;"	c	roles:def
+CONFIG_KDB_DEFAULT_ENABLE_MODULE	input-2.kconfig	/^config KDB_DEFAULT_ENABLE$/;"	c	roles:def
 KDB_KEYBOARD	input-2.kconfig	/^config KDB_KEYBOARD$/;"	c	roles:def
 CONFIG_KDB_KEYBOARD	input-2.kconfig	/^config KDB_KEYBOARD$/;"	c	roles:def
+CONFIG_KDB_KEYBOARD_MODULE	input-2.kconfig	/^config KDB_KEYBOARD$/;"	c	roles:def
 KDB_CONTINUE_CATASTROPHIC	input-2.kconfig	/^config KDB_CONTINUE_CATASTROPHIC$/;"	c	roles:def
 CONFIG_KDB_CONTINUE_CATASTROPHIC	input-2.kconfig	/^config KDB_CONTINUE_CATASTROPHIC$/;"	c	roles:def
+CONFIG_KDB_CONTINUE_CATASTROPHIC_MODULE	input-2.kconfig	/^config KDB_CONTINUE_CATASTROPHIC$/;"	c	roles:def
 Networking options	input-3.kconfig	/^menu "Networking options"$/;"	m	roles:def
 net/packet/Kconfig	input-3.kconfig	/^source "net\/packet\/Kconfig"$/;"	k	menu:Networking options	roles:source
 net/unix/Kconfig	input-3.kconfig	/^source "net\/unix\/Kconfig"$/;"	k	menu:Networking options	roles:source
@@ -79,22 +107,29 @@ net/smc/Kconfig	input-3.kconfig	/^source "net\/smc\/Kconfig"$/;"	k	menu:Networki
 net/xdp/Kconfig	input-3.kconfig	/^source "net\/xdp\/Kconfig"$/;"	k	menu:Networking options	roles:source
 INET	input-3.kconfig	/^config INET$/;"	c	menu:Networking options	roles:def
 CONFIG_INET	input-3.kconfig	/^config INET$/;"	c	menu:Networking options	roles:def
+CONFIG_INET_MODULE	input-3.kconfig	/^config INET$/;"	c	menu:Networking options	roles:def
 net/ipv4/Kconfig	input-3.kconfig	/^source "net\/ipv4\/Kconfig"$/;"	k	menu:Networking options	roles:source
 net/ipv6/Kconfig	input-3.kconfig	/^source "net\/ipv6\/Kconfig"$/;"	k	menu:Networking options	roles:source
 net/netlabel/Kconfig	input-3.kconfig	/^source "net\/netlabel\/Kconfig"$/;"	k	menu:Networking options	roles:source
 net/mptcp/Kconfig	input-3.kconfig	/^source "net\/mptcp\/Kconfig"$/;"	k	menu:Networking options	roles:source
 NETWORK_SECMARK	input-3.kconfig	/^config NETWORK_SECMARK$/;"	c	menu:Networking options	roles:def
 CONFIG_NETWORK_SECMARK	input-3.kconfig	/^config NETWORK_SECMARK$/;"	c	menu:Networking options	roles:def
+CONFIG_NETWORK_SECMARK_MODULE	input-3.kconfig	/^config NETWORK_SECMARK$/;"	c	menu:Networking options	roles:def
 NET_PTP_CLASSIFY	input-3.kconfig	/^config NET_PTP_CLASSIFY$/;"	c	menu:Networking options	roles:def
 CONFIG_NET_PTP_CLASSIFY	input-3.kconfig	/^config NET_PTP_CLASSIFY$/;"	c	menu:Networking options	roles:def
+CONFIG_NET_PTP_CLASSIFY_MODULE	input-3.kconfig	/^config NET_PTP_CLASSIFY$/;"	c	menu:Networking options	roles:def
 NETWORK_PHY_TIMESTAMPING	input-3.kconfig	/^config NETWORK_PHY_TIMESTAMPING$/;"	c	menu:Networking options	roles:def
 CONFIG_NETWORK_PHY_TIMESTAMPING	input-3.kconfig	/^config NETWORK_PHY_TIMESTAMPING$/;"	c	menu:Networking options	roles:def
+CONFIG_NETWORK_PHY_TIMESTAMPING_MODULE	input-3.kconfig	/^config NETWORK_PHY_TIMESTAMPING$/;"	c	menu:Networking options	roles:def
 NETFILTER	input-3.kconfig	/^menuconfig NETFILTER$/;"	c	menu:Networking options	roles:def
 CONFIG_NETFILTER	input-3.kconfig	/^menuconfig NETFILTER$/;"	c	menu:Networking options	roles:def
+CONFIG_NETFILTER_MODULE	input-3.kconfig	/^menuconfig NETFILTER$/;"	c	menu:Networking options	roles:def
 NETFILTER_ADVANCED	input-3.kconfig	/^config NETFILTER_ADVANCED$/;"	c	menu:Networking options	roles:def
 CONFIG_NETFILTER_ADVANCED	input-3.kconfig	/^config NETFILTER_ADVANCED$/;"	c	menu:Networking options	roles:def
+CONFIG_NETFILTER_ADVANCED_MODULE	input-3.kconfig	/^config NETFILTER_ADVANCED$/;"	c	menu:Networking options	roles:def
 BRIDGE_NETFILTER	input-3.kconfig	/^config BRIDGE_NETFILTER$/;"	c	menu:Networking options	roles:def
 CONFIG_BRIDGE_NETFILTER	input-3.kconfig	/^config BRIDGE_NETFILTER$/;"	c	menu:Networking options	roles:def
+CONFIG_BRIDGE_NETFILTER_MODULE	input-3.kconfig	/^config BRIDGE_NETFILTER$/;"	c	menu:Networking options	roles:def
 net/netfilter/Kconfig	input-3.kconfig	/^source "net\/netfilter\/Kconfig"$/;"	k	menu:Networking options	roles:source
 net/ipv4/netfilter/Kconfig	input-3.kconfig	/^source "net\/ipv4\/netfilter\/Kconfig"$/;"	k	menu:Networking options	roles:source
 net/ipv6/netfilter/Kconfig	input-3.kconfig	/^source "net\/ipv6\/netfilter\/Kconfig"$/;"	k	menu:Networking options	roles:source
@@ -136,31 +171,44 @@ net/qrtr/Kconfig	input-3.kconfig	/^source "net\/qrtr\/Kconfig"$/;"	k	menu:Networ
 net/ncsi/Kconfig	input-3.kconfig	/^source "net\/ncsi\/Kconfig"$/;"	k	menu:Networking options	roles:source
 RPS	input-3.kconfig	/^config RPS$/;"	c	menu:Networking options	roles:def
 CONFIG_RPS	input-3.kconfig	/^config RPS$/;"	c	menu:Networking options	roles:def
+CONFIG_RPS_MODULE	input-3.kconfig	/^config RPS$/;"	c	menu:Networking options	roles:def
 RFS_ACCEL	input-3.kconfig	/^config RFS_ACCEL$/;"	c	menu:Networking options	roles:def
 CONFIG_RFS_ACCEL	input-3.kconfig	/^config RFS_ACCEL$/;"	c	menu:Networking options	roles:def
+CONFIG_RFS_ACCEL_MODULE	input-3.kconfig	/^config RFS_ACCEL$/;"	c	menu:Networking options	roles:def
 XPS	input-3.kconfig	/^config XPS$/;"	c	menu:Networking options	roles:def
 CONFIG_XPS	input-3.kconfig	/^config XPS$/;"	c	menu:Networking options	roles:def
+CONFIG_XPS_MODULE	input-3.kconfig	/^config XPS$/;"	c	menu:Networking options	roles:def
 HWBM	input-3.kconfig	/^config HWBM$/;"	c	menu:Networking options	roles:def
 CONFIG_HWBM	input-3.kconfig	/^config HWBM$/;"	c	menu:Networking options	roles:def
+CONFIG_HWBM_MODULE	input-3.kconfig	/^config HWBM$/;"	c	menu:Networking options	roles:def
 CGROUP_NET_PRIO	input-3.kconfig	/^config CGROUP_NET_PRIO$/;"	c	menu:Networking options	roles:def
 CONFIG_CGROUP_NET_PRIO	input-3.kconfig	/^config CGROUP_NET_PRIO$/;"	c	menu:Networking options	roles:def
+CONFIG_CGROUP_NET_PRIO_MODULE	input-3.kconfig	/^config CGROUP_NET_PRIO$/;"	c	menu:Networking options	roles:def
 CGROUP_NET_CLASSID	input-3.kconfig	/^config CGROUP_NET_CLASSID$/;"	c	menu:Networking options	roles:def
 CONFIG_CGROUP_NET_CLASSID	input-3.kconfig	/^config CGROUP_NET_CLASSID$/;"	c	menu:Networking options	roles:def
+CONFIG_CGROUP_NET_CLASSID_MODULE	input-3.kconfig	/^config CGROUP_NET_CLASSID$/;"	c	menu:Networking options	roles:def
 NET_RX_BUSY_POLL	input-3.kconfig	/^config NET_RX_BUSY_POLL$/;"	c	menu:Networking options	roles:def
 CONFIG_NET_RX_BUSY_POLL	input-3.kconfig	/^config NET_RX_BUSY_POLL$/;"	c	menu:Networking options	roles:def
+CONFIG_NET_RX_BUSY_POLL_MODULE	input-3.kconfig	/^config NET_RX_BUSY_POLL$/;"	c	menu:Networking options	roles:def
 BQL	input-3.kconfig	/^config BQL$/;"	c	menu:Networking options	roles:def
 CONFIG_BQL	input-3.kconfig	/^config BQL$/;"	c	menu:Networking options	roles:def
+CONFIG_BQL_MODULE	input-3.kconfig	/^config BQL$/;"	c	menu:Networking options	roles:def
 BPF_JIT	input-3.kconfig	/^config BPF_JIT$/;"	c	menu:Networking options	roles:def
 CONFIG_BPF_JIT	input-3.kconfig	/^config BPF_JIT$/;"	c	menu:Networking options	roles:def
+CONFIG_BPF_JIT_MODULE	input-3.kconfig	/^config BPF_JIT$/;"	c	menu:Networking options	roles:def
 BPF_STREAM_PARSER	input-3.kconfig	/^config BPF_STREAM_PARSER$/;"	c	menu:Networking options	roles:def
 CONFIG_BPF_STREAM_PARSER	input-3.kconfig	/^config BPF_STREAM_PARSER$/;"	c	menu:Networking options	roles:def
+CONFIG_BPF_STREAM_PARSER_MODULE	input-3.kconfig	/^config BPF_STREAM_PARSER$/;"	c	menu:Networking options	roles:def
 NET_FLOW_LIMIT	input-3.kconfig	/^config NET_FLOW_LIMIT$/;"	c	menu:Networking options	roles:def
 CONFIG_NET_FLOW_LIMIT	input-3.kconfig	/^config NET_FLOW_LIMIT$/;"	c	menu:Networking options	roles:def
+CONFIG_NET_FLOW_LIMIT_MODULE	input-3.kconfig	/^config NET_FLOW_LIMIT$/;"	c	menu:Networking options	roles:def
 Network testing	input-3.kconfig	/^menu "Network testing"$/;"	m	menu:Networking options	roles:def
 NET_PKTGEN	input-3.kconfig	/^config NET_PKTGEN$/;"	c	menu:Networking options""Network testing	roles:def
 CONFIG_NET_PKTGEN	input-3.kconfig	/^config NET_PKTGEN$/;"	c	menu:Networking options""Network testing	roles:def
+CONFIG_NET_PKTGEN_MODULE	input-3.kconfig	/^config NET_PKTGEN$/;"	c	menu:Networking options""Network testing	roles:def
 NET_DROP_MONITOR	input-3.kconfig	/^config NET_DROP_MONITOR$/;"	c	menu:Networking options""Network testing	roles:def
 CONFIG_NET_DROP_MONITOR	input-3.kconfig	/^config NET_DROP_MONITOR$/;"	c	menu:Networking options""Network testing	roles:def
+CONFIG_NET_DROP_MONITOR_MODULE	input-3.kconfig	/^config NET_DROP_MONITOR$/;"	c	menu:Networking options""Network testing	roles:def
 Kconfig.host	input-4.kconfig	/^source Kconfig.host$/;"	k	roles:source
 backends/Kconfig	input-4.kconfig	/^source backends\/Kconfig$/;"	k	roles:source
 accel/Kconfig	input-4.kconfig	/^source accel\/Kconfig$/;"	k	roles:source

--- a/optlib/kconfig.c
+++ b/optlib/kconfig.c
@@ -70,6 +70,8 @@ extern parserDefinition* KconfigParser (void)
 		{"^[ \t]*(menu)?config[ \t]+([A-Za-z0-9_]+)[ \t]*$", "\\2",
 		"c", "{scope=ref}", NULL, false},
 		{"^[ \t]*(menu)?config[ \t]+([A-Za-z0-9_]+)[ \t]*$", "CONFIG_\\2",
+		"c", "{scope=ref}{_extra=configPrefixed}", NULL, false},
+		{"^[ \t]*(menu)?config[ \t]+([A-Za-z0-9_]+)[ \t]*$", "CONFIG_\\2_MODULE",
 		"c", "{scope=ref}{_extra=configPrefixed}{exclusive}", NULL, false},
 		{"^[ \t]*menu[ \t]+\"([^\"]+)\"[ \t]*", "\\1",
 		"m", "{scope=push}{exclusive}", NULL, false},

--- a/optlib/kconfig.ctags
+++ b/optlib/kconfig.ctags
@@ -51,7 +51,8 @@
 --regex-Kconfig=/^[ \t]*#.*$//{placeholder}
 
 --regex-Kconfig=/^[ \t]*(menu)?config[ \t]+([A-Za-z0-9_]+)[ \t]*$/\2/c/{scope=ref}
---regex-Kconfig=/^[ \t]*(menu)?config[ \t]+([A-Za-z0-9_]+)[ \t]*$/CONFIG_\2/c/{scope=ref}{_extra=configPrefixed}{exclusive}
+--regex-Kconfig=/^[ \t]*(menu)?config[ \t]+([A-Za-z0-9_]+)[ \t]*$/CONFIG_\2/c/{scope=ref}{_extra=configPrefixed}
+--regex-Kconfig=/^[ \t]*(menu)?config[ \t]+([A-Za-z0-9_]+)[ \t]*$/CONFIG_\2_MODULE/c/{scope=ref}{_extra=configPrefixed}{exclusive}
 
 --regex-Kconfig=/^[ \t]*menu[ \t]+"([^"]+)"[ \t]*/\1/m/{scope=push}{exclusive}
 --regex-Kconfig=/^[ \t]*endmenu[ \t]*//{scope=pop}{placeholder}{exclusive}

--- a/optlib/kconfig.ctags
+++ b/optlib/kconfig.ctags
@@ -9,7 +9,7 @@
 #  Reference
 #     https://www.kernel.org/doc/html/latest/kbuild/kconfig-language.html
 #
-#  
+#
 #  This parser was originally written in C as proplosed in #2553 by Maxime.
 #  Masatake converted it to an optlib file.
 #
@@ -43,7 +43,7 @@
 # Date:   Thu Jun 22 12:21:20 2006 +0900
 #
 #    kbuild: adding symbols in Kconfig and defconfig to TAGS
-#    
+#
 --_extradef-Kconfig=configPrefixed,prepend CONFIG_ to config names
 --extras-Kconfig=+{configPrefixed}
 


### PR DESCRIPTION
Quoted from a comment in kconfig.h of Linux:

```C
    /*
     * IS_ENABLED(CONFIG_FOO) evaluates to 1 if CONFIG_FOO is set to 'y' or 'm',
     * 0 otherwise.  Note that CONFIG_FOO=y results in "#define CONFIG_FOO 1" in
     * autoconf.h, while CONFIG_FOO=m results in "#define CONFIG_FOO_MODULE 1".
     */
```
ctags already tagged CONFIG_FOO as a configPrefix extra tag for FOO.
This change exnted the extra tag.  With this change, ctags tags
CONFIG_FOO_MODULE as a configPrefix extra tag in addition to
CONFIG_FOO.