### PR TITLE
GitHub Actions: remove the ubuntu-16.04 environment due to it will be removed 3 days later

### DIFF
--- a/.github/workflows/cross-compile-android-ndk.yml
+++ b/.github/workflows/cross-compile-android-ndk.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-10.15]
+        build-machine-os: [ubuntu-18.04, ubuntu-20.04, macos-10.15]
 
     runs-on: ${{ matrix.build-machine-os }}
 

--- a/.github/workflows/cross-compile-mingw-w64.yml
+++ b/.github/workflows/cross-compile-mingw-w64.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-10.15]
+        build-machine-os: [ubuntu-18.04, ubuntu-20.04, macos-10.15]
         target: [i686-w64-mingw32,x86_64-w64-mingw32]
 
     runs-on: ${{ matrix.build-machine-os }}

--- a/.github/workflows/testing-gnulinux.yml
+++ b/.github/workflows/testing-gnulinux.yml
@@ -11,8 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        # os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
-        os: [ubuntu-16.04, ubuntu-20.04]
+        # os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
         compiler: [gcc, clang]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The `ubuntu-16.04` github actions environtment will
 be removed on September 20, 2021. Migrate to `ubuntu18.04` or `ubuntu-latest` instead. For more details see https://github.com/actions/virtual-environments/issues/3287