### PR TITLE
　dsl: Fix a typo in es.h

### DIFF
--- a/dsl/es.h
+++ b/dsl/es.h
@@ -114,7 +114,7 @@ int          es_boolean_get (const EsObject*   object);
  * String
  */
 EsObject*    es_string_new  (const char*        value);
-EsObject*    es_string_newL (const char*        value, size_t lenght);
+EsObject*    es_string_newL (const char*        value, size_t length);
 int          es_string_p    (const EsObject*   object);
 const char*  es_string_get  (const EsObject*   object);
 


### PR DESCRIPTION
Fix a spelling typo "lenght" in es.h.

Signed-off-by: Masanari Iida <standby24x7@gmail.com>