### PR TITLE
GitHub Actions: run only ctags related tests in Citre

### DIFF
--- a/.github/workflows/run-citre-tests.yml
+++ b/.github/workflows/run-citre-tests.yml
@@ -38,13 +38,13 @@ jobs:
         run: make
       - name: report features
         run: ./ctags --list-features
-      - name: install Emacs and GLOBAL
-        run: sudo apt-get -y -o APT::Immediate-Configure=false install emacs global
+      - name: install Emacs
+        run: sudo apt-get -y -o APT::Immediate-Configure=false install emacs
       - name: checkout Citre repo
         uses: actions/checkout@v2
         with:
           repository: 'universal-ctags/citre'
           path: 'citre'
-      - name: run Citre unit tests
+      - name: run Citre unit tests for ctags backend
         working-directory: 'citre'
-        run: make test
+        run: make test-ctags


### PR DESCRIPTION
Citre now has separated make targets for testing tag data structure, ctags backend and global backend. We can run only ctags related tests, and we don't need to install global.