### PR TITLE
Python: PEP 604 -- allow writing union types as X | Y

### DIFF
--- a/Units/parser-python.r/pep604-bar-operator-for-union.d/args.ctags
+++ b/Units/parser-python.r/pep604-bar-operator-for-union.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-Python=+z

--- a/Units/parser-python.r/pep604-bar-operator-for-union.d/expected.tags
+++ b/Units/parser-python.r/pep604-bar-operator-for-union.d/expected.tags
@@ -1,0 +1,4 @@
+v	input.py	/^v: float | str = 'a'$/;"	v	typeref:typename:float|str
+f	input.py	/^def f(list: List[int|str], param: int | None) -> float|str:$/;"	f	typeref:typename:float|str
+list	input.py	/^def f(list: List[int|str], param: int | None) -> float|str:$/;"	z	function:f	typeref:typename:List[int|str]	file:
+param	input.py	/^def f(list: List[int|str], param: int | None) -> float|str:$/;"	z	function:f	typeref:typename:int|None	file:

--- a/Units/parser-python.r/pep604-bar-operator-for-union.d/input.py
+++ b/Units/parser-python.r/pep604-bar-operator-for-union.d/input.py
@@ -1,0 +1,6 @@
+from typing import List, Union
+v: float | str = 'a'
+
+# Taken from https://www.python.org/dev/peps/pep-0604/
+def f(list: List[int|str], param: int | None) -> float|str:
+    pass

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -1228,12 +1228,17 @@ static bool skipVariableTypeAnnotation (tokenInfo *const token, vString *const r
 	if (readNext)
 		readToken (token);
 	/* skip subscripts and calls */
-	while (token->type == '[' || token->type == '(' || token->type == '.')
+	while (token->type == '[' || token->type == '(' || token->type == '.' || token->type == '|')
 	{
 		switch (token->type)
 		{
 			case '[': readNext = skipOverPair (token, '[', ']', repr, true); break;
 			case '(': readNext = skipOverPair (token, '(', ')', repr, true); break;
+			case '|':
+				reprCat (repr, token);
+				skipVariableTypeAnnotation (token, repr);
+				readNext = false;
+				break;
 			case '.':
 				reprCat (repr, token);
 				readToken (token);


### PR DESCRIPTION
Supprot the syntax newly introduced in python3.10.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>