### PR TITLE
main: give warning when pcre2 is not linked

### DIFF
--- a/main/lregex.c
+++ b/main/lregex.c
@@ -1356,6 +1356,17 @@ static regexPattern *addCompiledCallbackPattern (struct lregexControlBlock *lcb,
 	return ptrn;
 }
 
+#ifndef HAVE_PCRE2
+static void no_pcre2_regex_flag_short (char c, void* data)
+{
+	error (WARNING, "'p' flag is specied but pcre2 regex engine is not linked.");
+}
+static void no_pcre2_regex_flag_long (const char* const s, const char* const unused CTAGS_ATTR_UNUSED, void* data)
+{
+	error (WARNING, "{pcre2} flag is specied but pcre2 regex engine is not linked.");
+}
+#endif
+
 static flagDefinition backendFlagDefs[] = {
 	{ 'b', "basic",  basic_regex_flag_short,  basic_regex_flag_long,
 	  NULL, "interpreted as a Posix basic regular expression."},
@@ -1364,6 +1375,9 @@ static flagDefinition backendFlagDefs[] = {
 #ifdef HAVE_PCRE2
 	{ 'p', "pcre2",  pcre2_regex_flag_short, pcre2_regex_flag_long,
 	  NULL, "use pcre2 regex engine"},
+#else
+	{ 'p', "pcre2",  no_pcre2_regex_flag_short, no_pcre2_regex_flag_long,
+	  NULL, "pcre2 is NOT linked!"},
 #endif
 };
 

--- a/main/options.c
+++ b/main/options.c
@@ -2907,24 +2907,24 @@ static parametricOption ParametricOptions [] = {
 
 static booleanOption BooleanOptions [] = {
 	{ "append",         &Option.append,                 true,  STAGE_ANY },
-	{ "file-scope",     ((bool *)XTAG_FILE_SCOPE),   false, STAGE_ANY, setBooleanToXtagWithWarning },
-	{ "file-tags",      ((bool *)XTAG_FILE_NAMES),   false, STAGE_ANY, setBooleanToXtagWithWarning },
+	{ "file-scope",     ((bool *)XTAG_FILE_SCOPE),      false, STAGE_ANY, setBooleanToXtagWithWarning },
+	{ "file-tags",      ((bool *)XTAG_FILE_NAMES),      false, STAGE_ANY, setBooleanToXtagWithWarning },
 	{ "filter",         &Option.filter,                 true,  STAGE_ANY },
 	{ "guess-language-eagerly", &Option.guessLanguageEagerly, false, STAGE_ANY },
 	{ "line-directives",&Option.lineDirectives,         false, STAGE_ANY },
 	{ "links",          &Option.followLinks,            false, STAGE_ANY },
-	{ "machinable",     &localOption.machinable,             true,  STAGE_ANY },
+	{ "machinable",     &localOption.machinable,        true,  STAGE_ANY },
 	{ "put-field-prefix", &Option.putFieldPrefix,       false, STAGE_ANY },
 	{ "print-language", &Option.printLanguage,          true,  STAGE_ANY },
 	{ "quiet",          &Option.quiet,                  false, STAGE_ANY },
 #ifdef RECURSE_SUPPORTED
 	{ "recurse",        &Option.recurse,                false, STAGE_ANY },
 #endif
-	{ "verbose",        &ctags_verbose,                false, STAGE_ANY },
+	{ "verbose",        &ctags_verbose,                 false, STAGE_ANY },
 #ifdef WIN32
 	{ "use-slash-as-filename-separator", (bool *)&Option.useSlashAsFilenameSeparator, false, STAGE_ANY },
 #endif
-	{ "with-list-header", &localOption.withListHeader,       true,  STAGE_ANY },
+	{ "with-list-header", &localOption.withListHeader,  true,  STAGE_ANY },
 	{ "_fatal-warnings",&Option.fatalWarnings,          false, STAGE_ANY },
 };
 


### PR DESCRIPTION
If a user tries to use p/{pcre2} though one's ctags binary is not linked to pcre2, give a warning.
This change may reduce false-positive bug reports