### PR TITLE
mini-geany: Call initRegexOptscript() in ctagsInit()

### DIFF
--- a/main/mini-geany.c
+++ b/main/mini-geany.c
@@ -94,6 +94,7 @@ static void ctagsInit(void)
 
 	initializeParsing ();
 	initOptions ();
+	initRegexOptscript ();
 
 	/* make sure all parsers are initialized */
 	initializeParser (LANG_AUTO);


### PR DESCRIPTION
This is now needed in Geany too since the introduction of optscript
so update mini-geany accordingly.