### PR TITLE
CPreProcessor: extract macro names used in #if/#ifdef/#elif conditions as reference tags

### DIFF
--- a/Tmain/kind-long.d/stdout-expected.txt
+++ b/Tmain/kind-long.d/stdout-expected.txt
@@ -1,3 +1,3 @@
 L       label      yes     no      0      C      goto labels
 D       macroparam no      no      0      C      parameters inside macro definitions
-d       macro      no      no      1      C      macro definitions
+d       macro      no      no      2      C      macro definitions

--- a/Tmain/list-kinds-full.d/stdout-expected.txt
+++ b/Tmain/list-kinds-full.d/stdout-expected.txt
@@ -1,7 +1,7 @@
 #LETTER	NAME	ENABLED	REFONLY	NROLES	MASTER	DESCRIPTION
 D	macroparam	no	no	0	C	parameters inside macro definitions
 L	label	no	no	0	C	goto labels
-d	macro	yes	no	1	C	macro definitions
+d	macro	yes	no	2	C	macro definitions
 e	enumerator	yes	no	0	C	enumerators (values inside an enumeration)
 f	function	yes	no	0	C	function definitions
 g	enum	yes	no	0	C	enumeration names
@@ -23,7 +23,7 @@ N	name	no	no	0	NONE	names imported via using scope::symbol
 U	using	no	yes	0	NONE	using namespace statements
 Z	tparam	no	no	0	NONE	template parameters
 c	class	yes	no	0	NONE	classes
-d	macro	yes	no	1	C	macro definitions
+d	macro	yes	no	2	C	macro definitions
 e	enumerator	yes	no	0	C	enumerators (values inside an enumeration)
 f	function	yes	no	0	C	function definitions
 g	enum	yes	no	0	C	enumeration names

--- a/Tmain/list-roles-with-kind-names.d/stdout-expected.txt
+++ b/Tmain/list-roles-with-kind-names.d/stdout-expected.txt
@@ -43,25 +43,32 @@ Automake       d/directory ltlibrary on      directory for LTLIBRARIES primary
 Automake       d/directory man       on      directory for MANS primary
 Automake       d/directory program   on      directory for PROGRAMS primary
 Automake       d/directory script    on      directory for SCRIPTS primary
+C              d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 C              d/macro     undef     on      undefined
 C              h/header    local     on      local header
 C              h/header    system    on      system header
+C++            d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 C++            d/macro     undef     on      undefined
 C++            h/header    local     on      local header
 C++            h/header    system    on      system header
+CPreProcessor  d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 CPreProcessor  d/macro     undef     on      undefined
 CPreProcessor  h/header    local     on      local header
 CPreProcessor  h/header    system    on      system header
+CUDA           d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 CUDA           d/macro     undef     on      undefined
 CUDA           h/header    local     on      local header
 CUDA           h/header    system    on      system header
 M4             d/macro     undef     on      undefined
+OldC           d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 OldC           d/macro     undef     on      undefined
 OldC           h/header    local     on      local header
 OldC           h/header    system    on      system header
+OldC++         d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 OldC++         d/macro     undef     on      undefined
 OldC++         h/header    local     on      local header
 OldC++         h/header    system    on      system header
+Vera           d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 Vera           d/macro     undef     on      undefined
 Vera           h/header    local     on      local header
 Vera           h/header    system    on      system header

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -16,15 +16,19 @@ Automake       d/directory       ltlibrary          on      directory for LTLIBR
 Automake       d/directory       man                on      directory for MANS primary
 Automake       d/directory       program            on      directory for PROGRAMS primary
 Automake       d/directory       script             on      directory for SCRIPTS primary
+C              d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 C              d/macro           undef              on      undefined
 C              h/header          local              on      local header
 C              h/header          system             on      system header
+C++            d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 C++            d/macro           undef              on      undefined
 C++            h/header          local              on      local header
 C++            h/header          system             on      system header
+CPreProcessor  d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 CPreProcessor  d/macro           undef              on      undefined
 CPreProcessor  h/header          local              on      local header
 CPreProcessor  h/header          system             on      system header
+CUDA           d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 CUDA           d/macro           undef              on      undefined
 CUDA           h/header          local              on      local header
 CUDA           h/header          system             on      system header
@@ -89,6 +93,7 @@ Tex            i/xinput          included           on      external input file 
 Tex            i/xinput          input              on      external input file specified with \input
 Thrift         T/thriftFile      included           on      included file
 VHDL           e/entity          desigend           on      designed by an architecture
+Vera           d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 Vera           d/macro           undef              on      undefined
 Vera           h/header          local              on      local header
 Vera           h/header          system             on      system header
@@ -110,15 +115,19 @@ Automake       d/directory       ltlibrary          on      directory for LTLIBR
 Automake       d/directory       man                on      directory for MANS primary
 Automake       d/directory       program            on      directory for PROGRAMS primary
 Automake       d/directory       script             on      directory for SCRIPTS primary
+C              d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 C              d/macro           undef              on      undefined
 C              h/header          local              on      local header
 C              h/header          system             on      system header
+C++            d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 C++            d/macro           undef              on      undefined
 C++            h/header          local              on      local header
 C++            h/header          system             on      system header
+CPreProcessor  d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 CPreProcessor  d/macro           undef              on      undefined
 CPreProcessor  h/header          local              on      local header
 CPreProcessor  h/header          system             on      system header
+CUDA           d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 CUDA           d/macro           undef              on      undefined
 CUDA           h/header          local              on      local header
 CUDA           h/header          system             on      system header
@@ -183,6 +192,7 @@ Tex            i/xinput          included           on      external input file 
 Tex            i/xinput          input              on      external input file specified with \input
 Thrift         T/thriftFile      included           on      included file
 VHDL           e/entity          desigend           on      designed by an architecture
+Vera           d/macro           condition          off     used in part of #if/#ifdef/#elif conditions
 Vera           d/macro           undef              on      undefined
 Vera           h/header          local              on      local header
 Vera           h/header          system             on      system header
@@ -190,10 +200,11 @@ Vera           h/header          system             on      system header
 #
 # C.*
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # all.d
@@ -205,11 +216,16 @@ Automake       d/directory ltlibrary on      directory for LTLIBRARIES primary
 Automake       d/directory man       on      directory for MANS primary
 Automake       d/directory program   on      directory for PROGRAMS primary
 Automake       d/directory script    on      directory for SCRIPTS primary
+C              d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 C              d/macro     undef     on      undefined
+C++            d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 C++            d/macro     undef     on      undefined
+CPreProcessor  d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 CPreProcessor  d/macro     undef     on      undefined
+CUDA           d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 CUDA           d/macro     undef     on      undefined
 M4             d/macro     undef     on      undefined
+Vera           d/macro     condition off     used in part of #if/#ifdef/#elif conditions
 Vera           d/macro     undef     on      undefined
 
 #
@@ -221,44 +237,49 @@ s/script   loaded on      loaded
 #
 # C.* with disabling all roles of all languages
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  off     undefined
-h/header   local  off     local header
-h/header   system off     system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     off     undefined
+h/header   local     off     local header
+h/header   system    off     system header
 
 #
 # C.* with disabling all roles of all kinds of all languages
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  off     undefined
-h/header   local  off     local header
-h/header   system off     system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     off     undefined
+h/header   local     off     local header
+h/header   system    off     system header
 
 #
 # C.* with enabling all roles of all kinds in all languages
 # after disabling system role of header kind of C language
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition on      used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # C.* with enabling all roles in all languages
 # after disabling system role of header kind of C language
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition on      used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # C.* with disabling all roles in C language
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  off     undefined
-h/header   local  off     local header
-h/header   system off     system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     off     undefined
+h/header   local     off     local header
+h/header   system    off     system header
 
 #
 # Sh.* with disabling all roles in C language
@@ -270,10 +291,11 @@ s/script   loaded    on      loaded
 #
 # C.* with disabling all roles of all kinds in C language
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  off     undefined
-h/header   local  off     local header
-h/header   system off     system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     off     undefined
+h/header   local     off     local header
+h/header   system    off     system header
 
 #
 # Sh.* with disabling all roles of all kinds in C language
@@ -286,10 +308,11 @@ s/script   loaded    on      loaded
 # C.* with enabling all roles in C language
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition on      used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # Sh.* with enabling all roles in C language
@@ -303,10 +326,11 @@ s/script   loaded    off     loaded
 # C.* with enabling all roles of all kinds in C language
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition on      used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # Sh.* with enabling all roles of all kinds in C language
@@ -319,10 +343,11 @@ s/script   loaded    off     loaded
 #
 # C.* with disabling all roles of {header} kind in C language
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  off     local header
-h/header   system off     system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     off     local header
+h/header   system    off     system header
 
 #
 # Sh.* with disabling all roles of {header} kind in C language
@@ -334,10 +359,11 @@ s/script   loaded    on      loaded
 #
 # C.* with disabling all roles of h kind in C language
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  off     local header
-h/header   system off     system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     off     local header
+h/header   system    off     system header
 
 #
 # Sh.* with disabling all roles of h kind in C language
@@ -350,10 +376,11 @@ s/script   loaded    on      loaded
 # C.* with enabling all roles of {header} kind in C language
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  off     undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     off     undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # Sh.* with enabling all roles of {header} kind in C language
@@ -367,10 +394,11 @@ s/script   loaded    off     loaded
 # C.* with enabling all roles of h kind in C language
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  off     undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     off     undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # Sh.* with enabling all roles of h kind in C language
@@ -383,97 +411,109 @@ s/script   loaded    off     loaded
 #
 # C.* with disabling system role of h kind
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  on      local header
-h/header   system off     system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     on      local header
+h/header   system    off     system header
 
 #
 # C.* with disabling system role of {header} kind
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  on      local header
-h/header   system off     system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     on      local header
+h/header   system    off     system header
 
 #
 # C.* with enabling system role of h kind after disabling the role
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # C.* with enabling system role of {header} kind after disabling the role
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # C.* with disabling system and local roles of h kind
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  off     local header
-h/header   system off     system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     off     local header
+h/header   system    off     system header
 
 #
 # C.* with disabling system and local roles of {header} kind
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  off     local header
-h/header   system off     system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     off     local header
+h/header   system    off     system header
 
 #
 # C.* with enabling system and local roles of h kind
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  off     undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     off     undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # C.* with enabling system and local roles of {header} kind
 # after disabling all roles in all languages
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  off     undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     off     undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # C.* with disabling local role of h kind and undef role of d kind
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  off     undefined
-h/header   local  off     local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     off     undefined
+h/header   local     off     local header
+h/header   system    on      system header
 
 #
 # C.* with enabling all roles of header kinds after disabling all roles of the kind
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  on      undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     on      undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # C.* with enabling all roles of header kinds after disabling all roles of the kinds of C language
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  off     undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     off     undefined
+h/header   local     on      local header
+h/header   system    on      system header
 
 #
 # C.* with enabling all roles of header kinds after disabling all roles of the kinds of C language (short notation)
 #
-#KIND(L/N) NAME   ENABLED DESCRIPTION
-d/macro    undef  off     undefined
-h/header   local  on      local header
-h/header   system on      system header
+#KIND(L/N) NAME      ENABLED DESCRIPTION
+d/macro    condition off     used in part of #if/#ifdef/#elif conditions
+d/macro    undef     off     undefined
+h/header   local     on      local header
+h/header   system    on      system header

--- a/Tmain/nested-subparsers.d/stdout-expected.txt
+++ b/Tmain/nested-subparsers.d/stdout-expected.txt
@@ -36,7 +36,7 @@ n  name
 #LETTER NAME       ENABLED REFONLY NROLES MASTER DESCRIPTION
 D       macroparam no      no      0      C      parameters inside macro definitions
 L       label      no      no      0      C      goto labels
-d       macro      yes     no      1      C      macro definitions
+d       macro      yes     no      2      C      macro definitions
 e       enumerator yes     no      0      C      enumerators (values inside an enumeration)
 f       function   yes     no      0      C      function definitions
 g       enum       yes     no      0      C      enumeration names

--- a/Units/parser-cpreprocessor.r/macro-condition-role.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/macro-condition-role.d/args.ctags
@@ -1,0 +1,4 @@
+--sort=no
+--roles-C++.{macro}=+{condition}
+--extras=+r
+--fields=+rn

--- a/Units/parser-cpreprocessor.r/macro-condition-role.d/expected.tags
+++ b/Units/parser-cpreprocessor.r/macro-condition-role.d/expected.tags
@@ -1,0 +1,7 @@
+X0	input.h	/^#ifdef X0$/;"	d	line:1	roles:condition
+HAVE_FEAT	input.h	/^#if defined HAVE_FEAT && (Y_2k1 && _0Z \\$/;"	d	line:2	roles:condition
+Y_2k1	input.h	/^#if defined HAVE_FEAT && (Y_2k1 && _0Z \\$/;"	d	line:2	roles:condition
+_0Z	input.h	/^#if defined HAVE_FEAT && (Y_2k1 && _0Z \\$/;"	d	line:2	roles:condition
+_A_0_	input.h	/^						  || \/* C *\/ _A_0_)$/;"	d	line:3	roles:condition
+X1	input.h	/^#ifndef X1$/;"	d	line:5	roles:condition
+Y1	input.h	/^#elif Y1$/;"	d	line:7	roles:condition

--- a/Units/parser-cpreprocessor.r/macro-condition-role.d/input.h
+++ b/Units/parser-cpreprocessor.r/macro-condition-role.d/input.h
@@ -1,0 +1,14 @@
+#ifdef X0
+#if defined HAVE_FEAT && (Y_2k1 && _0Z \
+						  || /* C */ _A_0_)
+extern
+#ifndef X1
+int
+#elif Y1
+long
+#else
+short
+#endif
+x;
+#endif
+#endif

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -312,7 +312,7 @@ static void findAsmTags (void)
 	const unsigned char *line;
 
 	cppInit (false, false, false, false,
-			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX, KIND_GHOST_INDEX, 0, 0,
+			 KIND_GHOST_INDEX, 0, 0, KIND_GHOST_INDEX, KIND_GHOST_INDEX, 0, 0,
 			 FIELD_UNKNOWN);
 
 	 int lastMacroCorkIndex = CORK_NIL;

--- a/parsers/c.c
+++ b/parsers/c.c
@@ -309,10 +309,12 @@ static int AnonymousID = 0;
 /* Used to index into the CKinds table. */
 typedef enum {
 	CR_MACRO_UNDEF,
+	CR_MACRO_CONDITION,
 } cMacroRole;
 
 static roleDefinition CMacroRoles [] = {
 	RoleTemplateUndef,
+	RoleTemplateCondition,
 };
 
 typedef enum {
@@ -439,10 +441,12 @@ static kindDefinition JavaKinds [] = {
 /* Used to index into the VeraKinds table. */
 typedef enum {
 	VR_MACRO_UNDEF,
+	VR_MACRO_CONDITION,
 } veraMacroRole;
 
 static roleDefinition VeraMacroRoles [] = {
 	RoleTemplateUndef,
+	RoleTemplateCondition,
 };
 
 
@@ -3469,7 +3473,8 @@ static rescanReason findCTags (const unsigned int passCount)
 	int kind_for_define = KIND_GHOST_INDEX;
 	int kind_for_header = KIND_GHOST_INDEX;
 	int kind_for_param  = KIND_GHOST_INDEX;
-	int role_for_macro_undef   = ROLE_DEFINITION_INDEX;
+	int role_for_macro_undef = ROLE_DEFINITION_INDEX;
+	int role_for_macro_condition = ROLE_DEFINITION_INDEX;
 	int role_for_header_system   = ROLE_DEFINITION_INDEX;
 	int role_for_header_local   = ROLE_DEFINITION_INDEX;
 
@@ -3483,6 +3488,7 @@ static rescanReason findCTags (const unsigned int passCount)
 		kind_for_header = CK_HEADER;
 		kind_for_param = CK_MACRO_PARAM,
 		role_for_macro_undef = CR_MACRO_UNDEF;
+		role_for_macro_condition = CR_MACRO_CONDITION;
 		role_for_header_system = CR_HEADER_SYSTEM;
 		role_for_header_local = CR_HEADER_LOCAL;
 	}
@@ -3492,13 +3498,14 @@ static rescanReason findCTags (const unsigned int passCount)
 		kind_for_header = VK_HEADER;
 		kind_for_param  = VK_MACRO_PARAM,
 		role_for_macro_undef = VR_MACRO_UNDEF;
+		role_for_macro_condition = VR_MACRO_CONDITION;
 		role_for_header_system = VR_HEADER_SYSTEM;
 		role_for_header_local = VR_HEADER_LOCAL;
 	}
 
 	cppInit ((bool) (passCount > 1), isInputLanguage (Lang_csharp), isInputLanguage(Lang_cpp),
 		 isInputLanguage(Lang_vera),
-		 kind_for_define, role_for_macro_undef, kind_for_param,
+		 kind_for_define, role_for_macro_undef, role_for_macro_condition, kind_for_param,
 		 kind_for_header, role_for_header_system, role_for_header_local,
 		 FIELD_UNKNOWN);
 

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -64,6 +64,7 @@
 
 
 #define RoleTemplateUndef { true, "undef", "undefined" }
+#define RoleTemplateCondition { false, "condition", "used in part of #if/#ifdef/#elif conditions" }
 
 #define RoleTemplateSystem { true, "system", "system header" }
 #define RoleTemplateLocal  { true, "local", "local header" }
@@ -83,6 +84,7 @@ extern void cppInit (const bool state,
 		     const bool hasSingleQuoteLiteralNumbers,
 		     int defineMacroKindIndex,
 		     int macroUndefRoleIndex,
+		     int macroConditionRoleIndex,
 		     int headerKindIndex,
 		     int headerSystemRoleIndex, int headerLocalRoleIndex,
 		     int macroParamKindIndex,

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1860,6 +1860,7 @@ static rescanReason cxxParserMain(const unsigned int passCount)
 	int kind_for_header = CXXTagKindINCLUDE;
 	int kind_for_macro_param = CXXTagKindMACROPARAM;
 	int role_for_macro_undef = CR_MACRO_UNDEF;
+	int role_for_macro_condition = CR_MACRO_CONDITION;
 	int role_for_header_system = CR_HEADER_SYSTEM;
 	int role_for_header_local = CR_HEADER_LOCAL;
 
@@ -1872,6 +1873,7 @@ static rescanReason cxxParserMain(const unsigned int passCount)
 			false,
 			kind_for_define,
 			role_for_macro_undef,
+			role_for_macro_condition,
 			kind_for_macro_param,
 			kind_for_header,
 			role_for_header_system,

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -22,6 +22,7 @@
 #define CXX_COMMON_MACRO_ROLES(__langPrefix) \
 	static roleDefinition __langPrefix##MacroRoles [] = { \
 		RoleTemplateUndef, \
+		RoleTemplateCondition, \
 	}
 
 CXX_COMMON_MACRO_ROLES(C);

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -188,6 +188,7 @@ void cxxTag(unsigned int uKind,CXXToken * pToken);
 
 typedef enum {
 	CR_MACRO_UNDEF,
+	CR_MACRO_CONDITION,
 } cMacroRole;
 
 typedef enum {

--- a/parsers/dts.c
+++ b/parsers/dts.c
@@ -39,7 +39,8 @@ static tagRegexTable dtsTagRegexTable [] = {
 static void runCppGetc (void)
 {
 	cppInit (false, false, false, false,
-			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX,
+			 KIND_GHOST_INDEX, 0, 0,
+			 KIND_GHOST_INDEX,
 			 KIND_GHOST_INDEX, 0, 0,
 			 FIELD_UNKNOWN);
 

--- a/parsers/ldscript.c
+++ b/parsers/ldscript.c
@@ -697,7 +697,8 @@ static void findLdScriptTags (void)
 	tokenInfo *const tmp = newLdScriptToken ();
 
 	cppInit (false, false, false, false,
-			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX,
+			 KIND_GHOST_INDEX, 0, 0,
+			 KIND_GHOST_INDEX,
 			 KIND_GHOST_INDEX, 0, 0,
 			 FIELD_UNKNOWN);
 

--- a/parsers/protobuf.c
+++ b/parsers/protobuf.c
@@ -655,7 +655,8 @@ static void findProtobufTags0 (bool oneshot, int originalScopeCorkIndex)
 static void findProtobufTags (void)
 {
 	cppInit (false, false, false, false,
-			 KIND_GHOST_INDEX, 0, KIND_GHOST_INDEX,
+			 KIND_GHOST_INDEX, 0, 0,
+			 KIND_GHOST_INDEX,
 			 KIND_GHOST_INDEX, 0, 0,
 			 FIELD_UNKNOWN);
 	token.value = vStringNew ();


### PR DESCRIPTION
    An example session:
    
      $ cat /tmp/foo.c
      #ifdef FOO
      #elif defined(BAR)
      #endif
    
      $ ./ctags --sort=no --roles-C.'{macro}'='+{condition}' --extras=+r --fields=+r -o -  /tmp/foo.c
      FOO   /tmp/foo.c      /^#ifdef FOO$/;"        d       roles:condition
      BAR   /tmp/foo.c      /^#elif defined(BAR)$/;"        d       roles:condition
