### PR TITLE
Units(SQL): add a missing test input

### DIFF
--- a/Units/parser-sql.r/sql-plsql-ccflags.d/input.sql
+++ b/Units/parser-sql.r/sql-plsql-ccflags.d/input.sql
@@ -1,0 +1,1 @@
+ALTER SESSION SET PLSQL_CCFlags = 'UW_Flag:1, Some_Flag:2, PLSQL_CCFlags:42';


### PR DESCRIPTION
The input file should be included in
56b419e90d4dd933cf7c417184551f1087d16df4.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>