### PR TITLE
Pascal: Add parsing of function/proc signatures

### DIFF
--- a/Units/parser-pascal.r/simple-pascal.d/args.ctags
+++ b/Units/parser-pascal.r/simple-pascal.d/args.ctags
@@ -1,0 +1,2 @@
+--fields=+tS
+--sort=no

--- a/Units/parser-pascal.r/simple-pascal.d/expected.tags
+++ b/Units/parser-pascal.r/simple-pascal.d/expected.tags
@@ -1,0 +1,4 @@
+helloproc	input.pas	/^PROCEDURE helloproc(param1: STRING; param2: BYTE);$/;"	p	signature:(param1: STRING; param2: BYTE)
+max	input.pas	/^FUNCTION max(num1, num2: INTEGER): INTEGER;$/;"	f	typeref:typename:INTEGER	signature:(num1, num2: INTEGER)
+noargs	input.pas	/^FUNCTION noargs: STRING;$/;"	f	typeref:typename:STRING	signature:()
+emptyargs	input.pas	/^FUNCTION emptyargs(): STRING;$/;"	f	typeref:typename:STRING	signature:()

--- a/Units/parser-pascal.r/simple-pascal.d/input.pas
+++ b/Units/parser-pascal.r/simple-pascal.d/input.pas
@@ -1,0 +1,44 @@
+PROGRAM hello;
+
+TYPE
+	simpletype = RECORD
+					one: INTEGER;
+				 END;
+
+
+PROCEDURE helloproc(param1: STRING; param2: BYTE);
+BEGIN
+	writeln('Hello World!');
+END;
+
+
+FUNCTION max(num1, num2: INTEGER): INTEGER;
+VAR
+   result: INTEGER;
+BEGIN
+   if (num1 > num2) then
+      result := num1
+
+   else
+      result := num2;
+   max := result;
+END;
+
+
+FUNCTION noargs: STRING;
+BEGIN
+   noargs := 'functon without arguments';
+END;
+
+FUNCTION emptyargs(): STRING;
+BEGIN
+   emptyargs := 'functon without arguments';
+END;
+
+
+VAR result : INTEGER;
+BEGIN
+	helloproc('ignored', 1);
+	result := max(73, 42);
+	writeln('Result: ', result);
+END.


### PR DESCRIPTION
Parse the signatures and return type for functions and procedures in Pascal.

This features is ported from the Geany Pascal parser where we use this code already for many years and it might be useful for others too.