### PR TITLE
build-sys: use the regex module in gnulib in single thread mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -560,6 +560,10 @@ PRETTY_ARG_VAR([WARNING_CFLAGS], [C compiler warning flags],
 #   header files or functions.
 gl_INIT
 
+AC_DEFINE([GNULIB_REGEX_SINGLE_THREAD], [1],
+  [Define if all programs in this package call functions of the Gnulib
+   'regex' module only from a single thread.])
+
 if test "$REPLACE_FNMATCH" != 0; then
 	AC_DEFINE([USE_GNULIB_FNMATCH])
 fi


### PR DESCRIPTION
On "run units target on MSYS2"/MSYS CI environment, many
Tmain cases are failed with segmentation faults as show in

in regcomp.c of gnulib.

change.

This change is a work-around. The root cause is unknown.

Close #3225, #3226, and #3227.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>