### PR TITLE
GemSpec: new parser

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -42,6 +42,8 @@ DTD            p/parameterEntity partOfAttDef       on      part of attribute de
 Elm            m/module          imported           on      imported module
 Flex           I/import          import             on      imports
 GDScript       c/class           extended           on      used as a base class for extending
+GemSpec        g/gem             develDep           on      specifying development dependency
+GemSpec        g/gem             runtimeDep         on      specifying runtime dependency
 Go             p/package         imported           on      imported package
 Go             u/unknown         receiverType       on      receiver type
 HTML           C/stylesheet      extFile            on      referenced as external files
@@ -143,6 +145,8 @@ DTD            p/parameterEntity partOfAttDef       on      part of attribute de
 Elm            m/module          imported           on      imported module
 Flex           I/import          import             on      imports
 GDScript       c/class           extended           on      used as a base class for extending
+GemSpec        g/gem             develDep           on      specifying development dependency
+GemSpec        g/gem             runtimeDep         on      specifying runtime dependency
 Go             p/package         imported           on      imported package
 Go             u/unknown         receiverType       on      receiver type
 HTML           C/stylesheet      extFile            on      referenced as external files

--- a/Tmain/list-subparsers-all.d/stdout-expected.txt
+++ b/Tmain/list-subparsers-all.d/stdout-expected.txt
@@ -4,6 +4,7 @@ Autoconf             M4         base <> sub {bidirectional}
 Automake             Make       base <= sub {dedicated}
 DBusIntrospect       XML        base <> sub {bidirectional}
 FunctionParameters   Perl       base <> sub {bidirectional}
+GemSpec              Ruby       base <= sub {dedicated}
 Glade                XML        base <> sub {bidirectional}
 IPythonCell          Python     base => sub {shared}
 ITcl                 Tcl        base <> sub {bidirectional}

--- a/Units/parser-gemspec.r/simple-gemspec.d/args.ctags
+++ b/Units/parser-gemspec.r/simple-gemspec.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+r
+--fields=+r

--- a/Units/parser-gemspec.r/simple-gemspec.d/expected.tags
+++ b/Units/parser-gemspec.r/simple-gemspec.d/expected.tags
@@ -1,0 +1,12 @@
+rspec/core/version	input.gemspec	/^require "rspec\/core\/version"$/;"	L	roles:required
+rspec-core	input.gemspec	/^  s.name        = "rspec-core"$/;"	g	roles:def
+rspec-support	input.gemspec	/^    s.add_runtime_dependency "rspec-support", "= #{RSpec::Core::Version::STRING}"$/;"	g	roles:runtimeDep
+rspec-support	input.gemspec	/^    s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1/;"	g	roles:runtimeDep
+cucumber	input.gemspec	/^  s.add_development_dependency "cucumber", "~> 1.3"$/;"	g	roles:develDep
+minitest	input.gemspec	/^  s.add_development_dependency "minitest", "~> 5.3"$/;"	g	roles:develDep
+aruba	input.gemspec	/^  s.add_development_dependency "aruba",    "~> 0.14.9"$/;"	g	roles:develDep
+coderay	input.gemspec	/^  s.add_development_dependency "coderay",  "~> 1.1.1"$/;"	g	roles:develDep
+mocha	input.gemspec	/^  s.add_development_dependency "mocha",        "~> 0.13.0"$/;"	g	roles:develDep
+rr	input.gemspec	/^  s.add_development_dependency "rr",           "~> 1.0.4"$/;"	g	roles:develDep
+flexmock	input.gemspec	/^  s.add_development_dependency "flexmock",     "~> 0.9.0"$/;"	g	roles:develDep
+thread_order	input.gemspec	/^  s.add_development_dependency "thread_order", "~> 1.1.0"$/;"	g	roles:develDep

--- a/Units/parser-gemspec.r/simple-gemspec.d/input.gemspec
+++ b/Units/parser-gemspec.r/simple-gemspec.d/input.gemspec
@@ -1,0 +1,60 @@
+# Taken from rspec-core/rspec-core.gemspec
+
+# -*- encoding: utf-8 -*-
+$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
+require "rspec/core/version"
+
+Gem::Specification.new do |s|
+  s.name        = "rspec-core"
+  s.version     = RSpec::Core::Version::STRING
+  s.platform    = Gem::Platform::RUBY
+  s.license     = "MIT"
+  s.authors     = ["Steven Baker", "David Chelimsky", "Chad Humphries", "Myron Marston"]
+  s.email       = "rspec@googlegroups.com"
+  s.homepage    = "https://github.com/rspec/rspec-core"
+  s.summary     = "rspec-core-#{RSpec::Core::Version::STRING}"
+  s.description = "BDD for Ruby. RSpec runner and example groups."
+
+  s.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/rspec/rspec-core/issues',
+    'changelog_uri'     => "https://github.com/rspec/rspec-core/blob/v#{s.version}/Changelog.md",
+    'documentation_uri' => 'https://rspec.info/documentation/',
+    'mailing_list_uri'  => 'https://groups.google.com/forum/#!forum/rspec',
+    'source_code_uri'   => 'https://github.com/rspec/rspec-core',
+  }
+
+  s.files            = `git ls-files -- lib/*`.split("\n")
+  s.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
+  s.test_files       = []
+  s.bindir           = 'exe'
+  s.executables      = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
+  s.rdoc_options     = ["--charset=UTF-8"]
+  s.require_path     = "lib"
+
+  s.required_ruby_version = '>= 1.8.7'
+
+  private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
+  if File.exist?(private_key)
+    s.signing_key = private_key
+    s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
+  end
+
+  if RSpec::Core::Version::STRING =~ /[a-zA-Z]+/
+    # rspec-support is locked to our version when running pre,rc etc
+    s.add_runtime_dependency "rspec-support", "= #{RSpec::Core::Version::STRING}"
+  else
+    # rspec-support must otherwise match our major/minor version
+    s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
+  end
+
+  s.add_development_dependency "cucumber", "~> 1.3"
+  s.add_development_dependency "minitest", "~> 5.3"
+  s.add_development_dependency "aruba",    "~> 0.14.9"
+
+  s.add_development_dependency "coderay",  "~> 1.1.1"
+
+  s.add_development_dependency "mocha",        "~> 0.13.0"
+  s.add_development_dependency "rr",           "~> 1.0.4"
+  s.add_development_dependency "flexmock",     "~> 0.9.0"
+  s.add_development_dependency "thread_order", "~> 1.1.0"
+end

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -414,6 +414,7 @@ The following parsers have been added:
 * Falcon
 * FunctionParameters *perl based subparser*
 * Gdbinit script *optlib*
+* GemSpec *Ruby based subparser*
 * GDScript
 * Glade *libxml*
 * Go

--- a/main/parsers_p.h
+++ b/main/parsers_p.h
@@ -88,6 +88,7 @@
 	FyppParser,	   \
 	GdbinitParser, \
 	GDScriptParser, \
+	GemSpecParser, \
 	GoParser, \
 	HaskellParser, \
 	HaxeParser, \

--- a/parsers/gemspec.c
+++ b/parsers/gemspec.c
@@ -1,0 +1,217 @@
+/*
+* A parser for RUBYGEM's specification
+*
+* Copyright (c) 2021, Red Hat, Inc.
+* Copyright (c) 2021, Masatake YAMATO
+*
+* Author: Masatake YAMATO <yamato@redhat.com>
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+* USA.
+*
+* Reference:
+* - https://guides.rubygems.org/specification-reference/
+*
+* See also:
+* - https://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
+*/
+
+/*
+*   INCLUDE FILES
+*/
+#include "general.h"  /* must always come first */
+
+#include "entry.h"
+#include "parse.h"
+#include "subparser.h"
+
+#include "ruby.h"
+
+#include <string.h>
+
+/*
+* DATA STRUCTURES
+*/
+struct sGemSpecSubparser {
+	rubySubparser ruby;
+	vString *var_name;
+};
+
+typedef enum {
+	K_GEM,
+} gemspecKind;
+
+typedef enum {
+	R_GEM_RUNTIME_DEP,
+	R_GEM_DEVEL_DEP,
+} gemspecGemRole;
+
+static roleDefinition GemSpecGemRoles [] = {
+	{ true, "runtimeDep", "specifying runtime dependency" },
+	{ true, "develDep",   "specifying development dependency" },
+};
+
+static kindDefinition GemSpecKinds [] = {
+	{ true, 'g', "gem", "gems",
+	  .referenceOnly = false, ATTACH_ROLES(GemSpecGemRoles)},
+};
+
+/*
+* FUNCTIONS
+*/
+static void findGemSpecTags (void)
+{
+	scheduleRunningBaseparser (0);
+}
+
+static int lineNotify (rubySubparser *s, const unsigned char **cp)
+{
+	struct sGemSpecSubparser *gemspec = (struct sGemSpecSubparser *)s;
+	const unsigned char *p = *cp;
+
+	if (vStringLength (gemspec->var_name) > 0
+		&& (strncmp ((char *)p, vStringValue (gemspec->var_name),
+					 vStringLength (gemspec->var_name)) == 0))
+	{
+		int kind = K_GEM;
+		int role = ROLE_DEFINITION_INDEX;
+		bool is_attr = true;
+
+		p += vStringLength (gemspec->var_name);
+
+		if (strncmp ((const char *)p, "name", 4) == 0)
+			p += 4;
+		else if (strncmp ((const char *)p, "add_runtime_dependency", 22) == 0)
+		{
+			p += 22;
+			role = R_GEM_RUNTIME_DEP;
+			is_attr = false;
+		}
+		else if (strncmp ((const char *)p, "add_development_dependency", 26) == 0)
+		{
+			p += 26;
+			role = R_GEM_DEVEL_DEP;
+			is_attr = false;
+		}
+		else
+			p = NULL;
+
+		if (p)
+		{
+			rubySkipWhitespace (&p);
+			if ((!is_attr) || *p == '=')
+			{
+				if (is_attr)
+				{
+					p++;
+					rubySkipWhitespace (&p);
+				}
+				if (*p == '"' || *p == '\'')
+				{
+					unsigned char b = *p;
+					vString *gem = vStringNew ();
+					p++;
+					if (rubyParseString (&p, b, gem))
+					{
+						if (role == ROLE_DEFINITION_INDEX)
+							makeSimpleTag (gem, kind);
+						else
+							makeSimpleRefTag (gem, kind, role);
+					}
+					vStringDelete (gem);
+				}
+			}
+		}
+	}
+	else if (rubyCanMatchKeywordWithAssign (&p, "Gem::Specification.new"))
+	{
+		vString *vstr = vStringNew ();
+		bool curly_bracket = false;
+
+		rubySkipWhitespace (&p);
+
+		curly_bracket = (*p == '{');
+		if (curly_bracket
+			|| (rubyParseMethodName (&p, vstr)
+				&& vStringLength (vstr) == 2
+				&& strcmp (vStringValue(vstr), "do") == 0))
+		{
+			if (curly_bracket)
+				p++;
+
+			rubySkipWhitespace (&p);
+			if (*p == '|')
+			{
+				p++;
+				rubySkipWhitespace (&p);
+				vStringClear (vstr);
+				if (rubyParseMethodName (&p, vstr))
+				{
+					vStringPut (vstr, '.');
+					vStringCopy(gemspec->var_name, vstr);
+				}
+			}
+		}
+		vStringDelete (vstr);
+	}
+	return CORK_NIL;
+}
+
+static void inputStart (subparser *s)
+{
+	struct sGemSpecSubparser *gemspec = (struct sGemSpecSubparser *)s;
+
+	gemspec->var_name = vStringNew ();
+}
+
+static void inputEnd (subparser *s)
+{
+	struct sGemSpecSubparser *gemspec = (struct sGemSpecSubparser *)s;
+
+	vStringDelete (gemspec->var_name); /* NULL is acceptable. */
+	gemspec->var_name = NULL;
+}
+
+extern parserDefinition* GemSpecParser (void)
+{
+	static const char *const extensions [] = { "gemspec", NULL };
+	static struct sGemSpecSubparser gemspecSubparser = {
+		.ruby = {
+			.subparser = {
+				.direction = SUBPARSER_SUB_RUNS_BASE,
+				.inputStart = inputStart,
+				.inputEnd = inputEnd,
+			},
+			.lineNotify = lineNotify,
+		},
+		.var_name = NULL,
+	};
+
+	static parserDependency dependencies [] = {
+		[0] = { DEPTYPE_SUBPARSER, "Ruby", &gemspecSubparser },
+	};
+
+	parserDefinition* const def = parserNew ("GemSpec");
+
+	def->dependencies = dependencies;
+	def->dependencyCount = ARRAY_SIZE(dependencies);
+	def->kindTable  = GemSpecKinds;
+	def->kindCount  = ARRAY_SIZE (GemSpecKinds);
+	def->extensions = extensions;
+	def->parser     = findGemSpecTags;
+	def->useCork    = CORK_QUEUE;
+
+	return def;
+}

--- a/source.mak
+++ b/source.mak
@@ -294,6 +294,7 @@ PARSER_SRCS =				\
 	parsers/fortran.c		\
 	parsers/fypp.c			\
 	parsers/gdscript.c		\
+	parsers/gemspec.c		\
 	parsers/go.c			\
 	parsers/haskell.c		\
 	parsers/haxe.c			\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -301,6 +301,7 @@
     <ClCompile Include="..\parsers\fortran.c" />
     <ClCompile Include="..\parsers\fypp.c" />
     <ClCompile Include="..\parsers\gdscript.c" />
+    <ClCompile Include="..\parsers\gemspec.c" />
     <ClCompile Include="..\parsers\go.c" />
     <ClCompile Include="..\parsers\haskell.c" />
     <ClCompile Include="..\parsers\haxe.c" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -426,6 +426,9 @@
     <ClCompile Include="..\parsers\gdscript.c">
       <Filter>Source Files\parsers</Filter>
     </ClCompile>
+    <ClCompile Include="..\parsers\gemspec.c">
+      <Filter>Source Files\parsers</Filter>
+    </ClCompile>
     <ClCompile Include="..\parsers\go.c">
       <Filter>Source Files\parsers</Filter>
     </ClCompile>


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>

Before developing subparser for rails, I'm evaluating the interface for subparsers exported from Ruby parser.
Gemspec subparser works. But scanning "do" in subparser is not a good idea, I think. scanning "do" should be done in Ruby parser, and the parser should call the method of subparsers when "do" is found.

Anyway, having a parser for Gemspec is not bad. So I made this pull request with this incomplete version.
