### PR TITLE
Fortran parser improvements from Geany

### DIFF
--- a/Units/parser-fortran.r/fortran-abstract-interface.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-abstract-interface.d/expected.tags
@@ -1,3 +1,4 @@
+__anonadfcf4320105	input.f90	/^  abstract interface$/;"	i	module:test
 add	input.f90	/^    procedure(suba), deferred :: add$/;"	M	type:atype
 atype	input.f90	/^  type, abstract :: atype$/;"	t	module:test
 b	input.f90	/^      class(atype) :: self, b$/;"	L	prototype:suba	file:

--- a/Units/parser-fortran.r/fortran-abstract-interface.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-abstract-interface.d/expected.tags
@@ -6,5 +6,5 @@ btype	input.f90	/^  type, abstract, extends(atype) :: btype$/;"	t	module:test
 c	input.f90	/^      integer c,/;"	L	prototype:suba	file:
 d	input.f90	/^      integer c, d$/;"	L	prototype:suba	file:
 self	input.f90	/^      class(atype) :: self,/;"	L	prototype:suba	file:
-suba	input.f90	/^    subroutine suba(/;"	P	module:test
+suba	input.f90	/^    subroutine suba(/;"	P	interface:__anonadfcf4320105
 test	input.f90	/^module test$/;"	m

--- a/Units/parser-fortran.r/fortran-bind-c.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-bind-c.d/expected.tags
@@ -2,5 +2,5 @@ __anon73f11bcd0105	input.f90	/^  interface$/;"	i	module:test_bind_c
 a	input.f90	/^    real/;"	k	type:atype
 atype	input.f90	/^  type, bind(c) :: atype$/;"	t	module:test_bind_c
 global_flag	input.f90	/^  integer(C_INT), bind(C, name="_MyProject_flags") :: global_flag$/;"	v	module:test_bind_c
-print_c	input.f90	/^    subroutine print_c(/;"	P	module:test_bind_c
+print_c	input.f90	/^    subroutine print_c(/;"	P	interface:__anon73f11bcd0105
 test_bind_c	input.f90	/^module test_bind_c$/;"	m

--- a/Units/parser-fortran.r/fortran-bind-c.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-bind-c.d/expected.tags
@@ -1,3 +1,4 @@
+__anon73f11bcd0105	input.f90	/^  interface$/;"	i	module:test_bind_c
 a	input.f90	/^    real/;"	k	type:atype
 atype	input.f90	/^  type, bind(c) :: atype$/;"	t	module:test_bind_c
 global_flag	input.f90	/^  integer(C_INT), bind(C, name="_MyProject_flags") :: global_flag$/;"	v	module:test_bind_c

--- a/Units/parser-fortran.r/fortran-enum.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-enum.d/expected.tags
@@ -7,6 +7,8 @@ Named4	input.f90	/^  enum*8 Named4$/;"	E	module:Constants
 Named5	input.f90	/^  enum(8) :: Named5$/;"	E	module:Constants
 Named6	input.f90	/^  enum*8 :: Named6$/;"	E	module:Constants
 Named7	input.f90	/^  enum, bind(c) :: Named7$/;"	E	module:Constants
+__anoncfbded350103	input.f90	/^  enum, bind(c) ! unnamed 1$/;"	E	module:Constants
+__anoncfbded350203	input.f90	/^  enum ! unnamed 2$/;"	E	module:Constants
 a	input.f90	/^    enumerat/;"	N	module:Constants
 b	input.f90	/^    enumerator :: a, b,/;"	N	module:Constants
 black	input.f90	/^    enumerator :: red =1, blue, black /;"	N	module:Constants

--- a/Units/parser-fortran.r/fortran-enum.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-enum.d/expected.tags
@@ -9,39 +9,39 @@ Named6	input.f90	/^  enum*8 :: Named6$/;"	E	module:Constants
 Named7	input.f90	/^  enum, bind(c) :: Named7$/;"	E	module:Constants
 __anoncfbded350103	input.f90	/^  enum, bind(c) ! unnamed 1$/;"	E	module:Constants
 __anoncfbded350203	input.f90	/^  enum ! unnamed 2$/;"	E	module:Constants
-a	input.f90	/^    enumerat/;"	N	module:Constants
-b	input.f90	/^    enumerator :: a, b,/;"	N	module:Constants
-black	input.f90	/^    enumerator :: red =1, blue, black /;"	N	module:Constants
-blue	input.f90	/^    enumerator :: red =1, blue,/;"	N	module:Constants
-bronze	input.f90	/^    enumerator gold, silver, bronze$/;"	N	module:Constants
-c	input.f90	/^    enumerator :: a, b, c$/;"	N	module:Constants
-gold	input.f90	/^    enumerator gold,/;"	N	module:Constants
+a	input.f90	/^    enumerat/;"	N	enum:__anoncfbded350203
+b	input.f90	/^    enumerator :: a, b,/;"	N	enum:__anoncfbded350203
+black	input.f90	/^    enumerator :: red =1, blue, black /;"	N	enum:__anoncfbded350103
+blue	input.f90	/^    enumerator :: red =1, blue,/;"	N	enum:__anoncfbded350103
+bronze	input.f90	/^    enumerator gold, silver, bronze$/;"	N	enum:__anoncfbded350103
+c	input.f90	/^    enumerator :: a, b, c$/;"	N	enum:__anoncfbded350203
+gold	input.f90	/^    enumerator gold,/;"	N	enum:__anoncfbded350103
 hc	input.f90	/^  real, parameter :: hc /;"	v	module:Constants
-lavender	input.f90	/^    enumerator :: pink, lavender$/;"	N	module:Constants
+lavender	input.f90	/^    enumerator :: pink, lavender$/;"	N	enum:__anoncfbded350103
 pi	input.f90	/^  real, parameter :: pi /;"	v	module:Constants
-pink	input.f90	/^    enumerator :: pink,/;"	N	module:Constants
-purple	input.f90	/^    enumerator :: purple$/;"	N	module:Constants
-red	input.f90	/^    enumerator :: red /;"	N	module:Constants
-silver	input.f90	/^    enumerator gold, silver,/;"	N	module:Constants
-x1	input.f90	/^    enumerator :: x1,/;"	N	module:Constants
-x2	input.f90	/^    enumerator :: x2,/;"	N	module:Constants
-x3	input.f90	/^    enumerator :: x3,/;"	N	module:Constants
-x4	input.f90	/^    enumerator :: x4,/;"	N	module:Constants
-x5	input.f90	/^    enumerator :: x5,/;"	N	module:Constants
-x6	input.f90	/^    enumerator :: x6,/;"	N	module:Constants
-x7	input.f90	/^    enumerator :: x7,/;"	N	module:Constants
-y1	input.f90	/^    enumerator :: x1, y1,/;"	N	module:Constants
-y2	input.f90	/^    enumerator :: x2, y2,/;"	N	module:Constants
-y3	input.f90	/^    enumerator :: x3, y3,/;"	N	module:Constants
-y4	input.f90	/^    enumerator :: x4, y4,/;"	N	module:Constants
-y5	input.f90	/^    enumerator :: x5, y5,/;"	N	module:Constants
-y6	input.f90	/^    enumerator :: x6, y6,/;"	N	module:Constants
-y7	input.f90	/^    enumerator :: x7, y7,/;"	N	module:Constants
-yellow	input.f90	/^    enumerator yellow$/;"	N	module:Constants
-z1	input.f90	/^    enumerator :: x1, y1, z1$/;"	N	module:Constants
-z2	input.f90	/^    enumerator :: x2, y2, z2$/;"	N	module:Constants
-z3	input.f90	/^    enumerator :: x3, y3, z3$/;"	N	module:Constants
-z4	input.f90	/^    enumerator :: x4, y4, z4$/;"	N	module:Constants
-z5	input.f90	/^    enumerator :: x5, y5, z5$/;"	N	module:Constants
-z6	input.f90	/^    enumerator :: x6, y6, z6$/;"	N	module:Constants
-z7	input.f90	/^    enumerator :: x7, y7, z7$/;"	N	module:Constants
+pink	input.f90	/^    enumerator :: pink,/;"	N	enum:__anoncfbded350103
+purple	input.f90	/^    enumerator :: purple$/;"	N	enum:__anoncfbded350103
+red	input.f90	/^    enumerator :: red /;"	N	enum:__anoncfbded350103
+silver	input.f90	/^    enumerator gold, silver,/;"	N	enum:__anoncfbded350103
+x1	input.f90	/^    enumerator :: x1,/;"	N	enum:Named1
+x2	input.f90	/^    enumerator :: x2,/;"	N	enum:Named2
+x3	input.f90	/^    enumerator :: x3,/;"	N	enum:Named3
+x4	input.f90	/^    enumerator :: x4,/;"	N	enum:Named4
+x5	input.f90	/^    enumerator :: x5,/;"	N	enum:Named5
+x6	input.f90	/^    enumerator :: x6,/;"	N	enum:Named6
+x7	input.f90	/^    enumerator :: x7,/;"	N	enum:Named7
+y1	input.f90	/^    enumerator :: x1, y1,/;"	N	enum:Named1
+y2	input.f90	/^    enumerator :: x2, y2,/;"	N	enum:Named2
+y3	input.f90	/^    enumerator :: x3, y3,/;"	N	enum:Named3
+y4	input.f90	/^    enumerator :: x4, y4,/;"	N	enum:Named4
+y5	input.f90	/^    enumerator :: x5, y5,/;"	N	enum:Named5
+y6	input.f90	/^    enumerator :: x6, y6,/;"	N	enum:Named6
+y7	input.f90	/^    enumerator :: x7, y7,/;"	N	enum:Named7
+yellow	input.f90	/^    enumerator yellow$/;"	N	enum:__anoncfbded350103
+z1	input.f90	/^    enumerator :: x1, y1, z1$/;"	N	enum:Named1
+z2	input.f90	/^    enumerator :: x2, y2, z2$/;"	N	enum:Named2
+z3	input.f90	/^    enumerator :: x3, y3, z3$/;"	N	enum:Named3
+z4	input.f90	/^    enumerator :: x4, y4, z4$/;"	N	enum:Named4
+z5	input.f90	/^    enumerator :: x5, y5, z5$/;"	N	enum:Named5
+z6	input.f90	/^    enumerator :: x6, y6, z6$/;"	N	enum:Named6
+z7	input.f90	/^    enumerator :: x7, y7, z7$/;"	N	enum:Named7

--- a/Units/parser-fortran.r/fortran-interface.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-interface.d/expected.tags
@@ -5,6 +5,6 @@ atype	input.f90	/^  type atype$/;"	t	module:test_interface
 get	input.f90	/^  interface get$/;"	i	module:test_interface
 get_1d	input.f90	/^  subroutine get_1d(/;"	s	module:test_interface
 get_2d	input.f90	/^  subroutine get_2d(/;"	s	module:test_interface
-suba	input.f90	/^    subroutine suba(/;"	P	module:test_interface
-subb	input.f90	/^    subroutine subb(/;"	P	module:test_interface
+suba	input.f90	/^    subroutine suba(/;"	P	interface:__anon502b83b10105
+subb	input.f90	/^    subroutine subb(/;"	P	interface:__anon502b83b10105
 test_interface	input.f90	/^module test_interface$/;"	m

--- a/Units/parser-fortran.r/fortran-interface.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-interface.d/expected.tags
@@ -1,4 +1,5 @@
 +	input.f90	/^  interface operator(+)/;"	i	module:test_interface
+__anon502b83b10105	input.f90	/^  interface ! anonymous interface$/;"	i	module:test_interface
 add	input.f90	/^    type(atype) function add(/;"	P	module:test_interface
 atype	input.f90	/^  type atype$/;"	t	module:test_interface
 get	input.f90	/^  interface get$/;"	i	module:test_interface

--- a/Units/parser-fortran.r/fortran-signature.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-signature.d/expected.tags
@@ -6,5 +6,5 @@ b	input.f90	/^    integer a, b$/;"	L	subroutine:suba	file:
 fna	input.f90	/^  real function fna(/;"	f	module:test_signature
 fnb	input.f90	/^  subroutine fnb$/;"	s	module:test_signature
 suba	input.f90	/^  subroutine suba /;"	s	module:test_signature	signature:(a, b)
-subb	input.f90	/^    subroutine subb /;"	P	module:test_signature	signature:(arg)
+subb	input.f90	/^    subroutine subb /;"	P	interface:__anon06616a720105	signature:(arg)
 test_signature	input.f90	/^module test_signature$/;"	m

--- a/Units/parser-fortran.r/fortran-signature.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-signature.d/expected.tags
@@ -1,3 +1,4 @@
+__anon06616a720105	input.f90	/^  interface$/;"	i	module:test_signature
 a	input.f90	/^    integer :: a$/;"	L	subroutine:fnb	file:
 a	input.f90	/^    integer a,/;"	L	subroutine:suba	file:
 arg	input.f90	/^      type(atype) :: arg$/;"	L	prototype:subb	file:

--- a/Units/parser-fortran.r/fortran-submodule.d/expected.tags
+++ b/Units/parser-fortran.r/fortran-submodule.d/expected.tags
@@ -2,5 +2,6 @@ example_smod	input.f90	/^submodule (example_mod) example_smod$/;"	submodule	inhe
 g	input.f90	/^    module function g(/;"	function	submodule:example_smod
 example_ssmod	input.f90	/^submodule (example_mod:example_smod) example_ssmod$/;"	submodule	inherits:example_mod:example_smod
 g2	input.f90	/^    module function g2(/;"	function	submodule:example_ssmod
-x	input.f90	/^        integer :: x,/;"	variable
-y	input.f90	/^        integer :: x,y$/;"	variable
+function	input.f90	/^    module function /;"	module
+x	input.f90	/^        integer :: x,/;"	variable	module:function
+y	input.f90	/^        integer :: x,y$/;"	variable	module:function

--- a/Units/parser-fortran.r/numlib.f90.d/expected.tags
+++ b/Units/parser-fortran.r/numlib.f90.d/expected.tags
@@ -1,6 +1,6 @@
 __anon1963f93b0305	input.f90	/^      interface$/;"	i	module:numerical_libraries
 __anon1963f93b0405	input.f90	/^      interface$/;"	i	prototype:b2lsf
-a2ald	input.f90	/^      subroutine a2ald /;"	P	module:numerical_libraries
-b2lsf	input.f90	/^      subroutine b2lsf /;"	P	module:numerical_libraries
-fcn	input.f90	/^         subroutine fcn(/;"	P	prototype:b2lsf
+a2ald	input.f90	/^      subroutine a2ald /;"	P	interface:__anon1963f93b0305
+b2lsf	input.f90	/^      subroutine b2lsf /;"	P	interface:__anon1963f93b0305
+fcn	input.f90	/^         subroutine fcn(/;"	P	interface:__anon1963f93b0405
 numerical_libraries	input.f90	/^      module numerical_libraries$/;"	m

--- a/Units/parser-fortran.r/numlib.f90.d/expected.tags
+++ b/Units/parser-fortran.r/numlib.f90.d/expected.tags
@@ -1,3 +1,5 @@
+__anon1963f93b0305	input.f90	/^      interface$/;"	i	module:numerical_libraries
+__anon1963f93b0405	input.f90	/^      interface$/;"	i	prototype:b2lsf
 a2ald	input.f90	/^      subroutine a2ald /;"	P	module:numerical_libraries
 b2lsf	input.f90	/^      subroutine b2lsf /;"	P	module:numerical_libraries
 fcn	input.f90	/^         subroutine fcn(/;"	P	prototype:b2lsf

--- a/Units/parser-fortran.r/recursive.f95.d/expected.tags
+++ b/Units/parser-fortran.r/recursive.f95.d/expected.tags
@@ -2,14 +2,14 @@ __anon8fb642160105	input.f95	/^		$/;"	i	module:approx
 __anon8fb642160205	input.f95	/^	$/;"	i	module:approx2
 approx	input.f95	/^	MODULE approx$/;"	m
 approx2	input.f95	/^	MODULE approx2$/;"	m
-arcsin	input.f95	/^	recursive function arcsin /;"	P	module:approx
-arcsin1	input.f95	/^	recursive function arcsin1 /;"	P	module:approx
-arcsin2	input.f95	/^	double precision recursive function arcsin2 /;"	P	module:approx
-arcsin3	input.f95	/^	recursive double precision function arcsin3 /;"	P	module:approx
-as	input.f95	/^	double precision recursive function as /;"	P	module:approx2
-as1	input.f95	/^	recursive double precision function as1 /;"	P	module:approx2
-as2	input.f95	/^	recursive function as2 /;"	P	module:approx2
-as3	input.f95	/^	recursive function as3 /;"	P	module:approx2
+arcsin	input.f95	/^	recursive function arcsin /;"	P	interface:__anon8fb642160105
+arcsin1	input.f95	/^	recursive function arcsin1 /;"	P	interface:__anon8fb642160105
+arcsin2	input.f95	/^	double precision recursive function arcsin2 /;"	P	interface:__anon8fb642160105
+arcsin3	input.f95	/^	recursive double precision function arcsin3 /;"	P	interface:__anon8fb642160105
+as	input.f95	/^	double precision recursive function as /;"	P	interface:__anon8fb642160205
+as1	input.f95	/^	recursive double precision function as1 /;"	P	interface:__anon8fb642160205
+as2	input.f95	/^	recursive function as2 /;"	P	interface:__anon8fb642160205
+as3	input.f95	/^	recursive function as3 /;"	P	interface:__anon8fb642160205
 parts	input.f95	/^	integer :: parts$/;"	v	module:approx
 parts2	input.f95	/^	integer :: parts2$/;"	v	module:approx2
 y	input.f95	/^	double precision :: y$/;"	v	module:approx

--- a/Units/parser-fortran.r/recursive.f95.d/expected.tags
+++ b/Units/parser-fortran.r/recursive.f95.d/expected.tags
@@ -1,3 +1,5 @@
+__anon8fb642160105	input.f95	/^		$/;"	i	module:approx
+__anon8fb642160205	input.f95	/^	$/;"	i	module:approx2
 approx	input.f95	/^	MODULE approx$/;"	m
 approx2	input.f95	/^	MODULE approx2$/;"	m
 arcsin	input.f95	/^	recursive function arcsin /;"	P	module:approx

--- a/Units/parser-fortran.r/structure.f.d/expected.tags
+++ b/Units/parser-fortran.r/structure.f.d/expected.tags
@@ -1,4 +1,5 @@
-a	input.f	/^                    integer a$/;"	k	type:anonymous
+__anon76fabc930106	input.f	/^                structure level3a, level3b$/;"	t	type:nested
+a	input.f	/^                    integer a$/;"	k	type:__anon76fabc930106
 clouds	input.f	/^                character*20  clouds /;"	k	type:weather
 clouds	input.f	/^        character*20   clouds$/;"	k	type:weather
 day	input.f	/^                integer*1     month \/08\/, day /;"	k	type:weather

--- a/Units/parser-fypp.r/run-guest.d/expected.tags
+++ b/Units/parser-fypp.r/run-guest.d/expected.tags
@@ -8,6 +8,6 @@ get_1d	input.fy	/^  subroutine get_1d(/;"	s	line:55	module:test_interface
 get_2d	input.fy	/^  subroutine get_2d(/;"	s	line:62	module:test_interface
 helloworld	input.fy	/^program helloworld$/;"	p	line:17
 repeat_code	input.fy	/^#:def repeat_code(code, repeat)$/;"	m	line:23	end:27
-suba	input.fy	/^    subroutine suba(/;"	P	line:40	module:test_interface
-subb	input.fy	/^    subroutine subb(/;"	P	line:42	module:test_interface
+suba	input.fy	/^    subroutine suba(/;"	P	line:40	interface:__anonca2bcf340105
+subb	input.fy	/^    subroutine subb(/;"	P	line:42	interface:__anonca2bcf340105
 test_interface	input.fy	/^module test_interface$/;"	m	line:21

--- a/Units/parser-fypp.r/run-guest.d/expected.tags
+++ b/Units/parser-fypp.r/run-guest.d/expected.tags
@@ -1,4 +1,5 @@
 +	input.fy	/^  interface operator(+)/;"	i	line:31	module:test_interface
+__anonca2bcf340105	input.fy	/^  interface ! anonymous interface$/;"	i	line:39	module:test_interface
 add	input.fy	/^    type(atype) function add(/;"	P	line:33	module:test_interface
 atype	input.fy	/^  type atype$/;"	t	line:28	module:test_interface
 debug_code	input.fy	/^#:def debug_code(code)$/;"	m	line:4	end:8

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -469,22 +469,26 @@ static tokenInfo *newToken (void)
 	return token;
 }
 
-static tokenInfo *newTokenFrom (tokenInfo *const token)
+static tokenInfo *newTokenFromFull (tokenInfo *const token, bool copyStr)
 {
 	tokenInfo *result = xMalloc (1, tokenInfo);
 	*result = *token;
-	result->string = vStringNewCopy (token->string);
+	result->string = copyStr? vStringNewCopy (token->string): vStringNew();
 	token->secondary = NULL;
 	token->parentType = NULL;
 	token->signature = NULL;
 	return result;
 }
 
+static tokenInfo *newTokenFrom (tokenInfo *const token)
+{
+	return newTokenFromFull (token, true);
+}
+
 static tokenInfo *newAnonTokenFrom (tokenInfo *const token, unsigned int uTagKind)
 {
-	tokenInfo *result = newTokenFrom (token);
+	tokenInfo *result = newTokenFromFull (token, false);
 	result->anonymous = true;
-	vStringClear (result->string);
 	anonGenerate (result->string, "__anon", uTagKind);
 	return result;
 }

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -1181,7 +1181,7 @@ static void skipOverParens (tokenInfo *const token)
 	skipOverParensFull (token, NULL, NULL);
 }
 
-static void skipOverSqaures (tokenInfo *const token)
+static void skipOverSquares (tokenInfo *const token)
 {
 	skipOverSquaresFull (token, NULL, NULL);
 }
@@ -1470,7 +1470,7 @@ static tokenInfo *parseQualifierSpecList (tokenInfo *const token)
 
 			case KEYWORD_codimension:
 				readToken (token);
-				skipOverSqaures (token);
+				skipOverSquares (token);
 				break;
 
 			default: skipToToken (token, TOKEN_STATEMENT_END); break;
@@ -1522,7 +1522,7 @@ static void parseEntityDecl (tokenInfo *const token,
 	if (isType (token, TOKEN_PAREN_OPEN))
 		skipOverParens (token);
 	if (isType (token, TOKEN_SQUARE_OPEN))
-		skipOverSqaures (token);
+		skipOverSquares (token);
 	if (isType (token, TOKEN_OPERATOR) &&
 			strcmp (vStringValue (token->string), "*") == 0)
 	{
@@ -1551,7 +1551,7 @@ static void parseEntityDecl (tokenInfo *const token,
 				if (isType (token, TOKEN_PAREN_OPEN))
 					skipOverParens (token);
 				if (isType (token, TOKEN_SQUARE_OPEN))
-					skipOverSqaures (token);
+					skipOverSquares (token);
 			}
 		}
 	}

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -1764,7 +1764,7 @@ static void parseStructureStmt (tokenInfo *const token)
 		strcmp (vStringValue (token->string), "/") == 0)
 	{  /* read structure name */
 		readToken (token);
-		if (isType (token, TOKEN_IDENTIFIER))
+		if (isType (token, TOKEN_IDENTIFIER) || isType (token, TOKEN_KEYWORD))
 		{
 			name = newTokenFrom (token);
 			name->type = TOKEN_IDENTIFIER;
@@ -1933,8 +1933,9 @@ static void parseDerivedTypeDef (tokenInfo *const token)
 		qualifierToken = parseQualifierSpecList (token);
 	if (isType (token, TOKEN_DOUBLE_COLON))
 		readToken (token);
-	if (isType (token, TOKEN_IDENTIFIER))
+	if (isType (token, TOKEN_IDENTIFIER) || isType (token, TOKEN_KEYWORD))
 	{
+		token->type = TOKEN_IDENTIFIER;
 		if (qualifierToken)
 		{
 			if (qualifierToken->parentType)
@@ -2002,7 +2003,7 @@ static void parseInterfaceBlock (tokenInfo *const token)
 		if (isType (token, TOKEN_OPERATOR))
 			name = newTokenFrom (token);
 	}
-	else if (isType (token, TOKEN_IDENTIFIER))
+	else if (isType (token, TOKEN_IDENTIFIER) || isType (token, TOKEN_KEYWORD))
 	{
 		name = newTokenFrom (token);
 		name->type = TOKEN_IDENTIFIER;
@@ -2062,7 +2063,7 @@ static void parseEnumBlock (tokenInfo *const token)
 	parseKindSelector (token);
 	if (isType (token, TOKEN_DOUBLE_COLON))
 		readToken (token);
-	if (isType (token, TOKEN_IDENTIFIER))
+	if (isType (token, TOKEN_IDENTIFIER) || isType (token, TOKEN_KEYWORD))
 	{
 		name = newTokenFrom (token);
 		name->type = TOKEN_IDENTIFIER;
@@ -2402,8 +2403,9 @@ static void parseModule (tokenInfo *const token, bool isSubmodule)
 	}
 
 	readToken (token);
-	if (isType (token, TOKEN_IDENTIFIER))
+	if (isType (token, TOKEN_IDENTIFIER) || isType (token, TOKEN_KEYWORD))
 	{
+		token->type = TOKEN_IDENTIFIER;
 		if (isSubmodule)
 		{
 			attachParentType (token, parentIdentifier);
@@ -2517,9 +2519,10 @@ static void parseSubprogramFull (tokenInfo *const token, const tagType tag)
 			isKeyword (token, KEYWORD_function) ||
 			isKeyword (token, KEYWORD_subroutine));
 	readToken (token);
-	if (isType (token, TOKEN_IDENTIFIER))
+	if (isType (token, TOKEN_IDENTIFIER) || isType (token, TOKEN_KEYWORD))
 	{
 		tokenInfo* name = newTokenFrom (token);
+		token->type = TOKEN_IDENTIFIER;
 		if (tag == TAG_SUBROUTINE ||
 			tag == TAG_PROTOTYPE)
 			name->signature = parseSignature (token);

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -409,8 +409,7 @@ static const tokenInfo* ancestorScope (void)
 	{
 		tokenInfo *const token = Ancestors.list + i - 1;
 		if (token->type == TOKEN_IDENTIFIER &&
-			token->tag != TAG_UNDEFINED  && token->tag != TAG_INTERFACE &&
-			token->tag != TAG_ENUM)
+			token->tag != TAG_UNDEFINED)
 			result = token;
 	}
 	return result;

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -209,6 +209,7 @@ typedef struct sTokenInfo {
 	struct sTokenInfo *secondary;
 	unsigned long lineNumber;
 	MIOPos filePosition;
+	bool anonymous;
 } tokenInfo;
 
 /*
@@ -464,6 +465,7 @@ static tokenInfo *newToken (void)
 	token->isMethod     = false;
 	token->lineNumber   = getInputLineNumber ();
 	token->filePosition = getInputFilePosition ();
+	token->anonymous    = false;
 
 	return token;
 }
@@ -476,6 +478,15 @@ static tokenInfo *newTokenFrom (tokenInfo *const token)
 	token->secondary = NULL;
 	token->parentType = NULL;
 	token->signature = NULL;
+	return result;
+}
+
+static tokenInfo *newAnonTokenFrom (tokenInfo *const token, unsigned int uTagKind)
+{
+	tokenInfo *result = newTokenFrom (token);
+	result->anonymous = true;
+	vStringClear (result->string);
+	anonGenerate (result->string, "__anon", uTagKind);
 	return result;
 }
 
@@ -529,6 +540,9 @@ static void makeFortranTag (tokenInfo *const token, tagType tag)
 
 		if (token->tag == TAG_COMMON_BLOCK)
 			e.lineNumberEntry = canUseLineNumberAsLocator();
+
+		if (token->anonymous)
+			markTagExtraBit (&e, XTAG_ANONYMOUS);
 
 		e.lineNumber	= token->lineNumber;
 		e.filePosition	= token->filePosition;
@@ -1743,7 +1757,7 @@ static void parseUnionStmt (tokenInfo *const token)
  */
 static void parseStructureStmt (tokenInfo *const token)
 {
-	tokenInfo *name;
+	tokenInfo *name = NULL;
 	Assert (isKeyword (token, KEYWORD_structure));
 	readToken (token);
 	if (isType (token, TOKEN_OPERATOR) &&
@@ -1751,17 +1765,19 @@ static void parseStructureStmt (tokenInfo *const token)
 	{  /* read structure name */
 		readToken (token);
 		if (isType (token, TOKEN_IDENTIFIER))
-			makeFortranTag (token, TAG_DERIVED_TYPE);
-		name = newTokenFrom (token);
+		{
+			name = newTokenFrom (token);
+			name->type = TOKEN_IDENTIFIER;
+		}
 		skipPast (token, TOKEN_OPERATOR);
 	}
-	else
+	if (name == NULL)
 	{  /* fake out anonymous structure */
-		name = newToken ();
+		name = newAnonTokenFrom (token, TAG_COMPONENT);
 		name->type = TOKEN_IDENTIFIER;
 		name->tag = TAG_DERIVED_TYPE;
-		vStringCopyS (name->string, "anonymous");
 	}
+	makeFortranTag (name, TAG_DERIVED_TYPE);
 	while (isType (token, TOKEN_IDENTIFIER))
 	{  /* read field names */
 		makeFortranTag (token, TAG_COMPONENT);
@@ -1977,29 +1993,27 @@ static void parseInterfaceBlock (tokenInfo *const token)
 	tokenInfo *name = NULL;
 	Assert (isKeyword (token, KEYWORD_interface));
 	readToken (token);
-	if (isType (token, TOKEN_IDENTIFIER))
-	{
-		makeFortranTag (token, TAG_INTERFACE);
-		name = newTokenFrom (token);
-	}
-	else if (isKeyword (token, KEYWORD_assignment) ||
+	if (isKeyword (token, KEYWORD_assignment) ||
 			 isKeyword (token, KEYWORD_operator))
 	{
 		readToken (token);
 		if (isType (token, TOKEN_PAREN_OPEN))
 			readToken (token);
 		if (isType (token, TOKEN_OPERATOR))
-		{
-			makeFortranTag (token, TAG_INTERFACE);
 			name = newTokenFrom (token);
-		}
+	}
+	else if (isType (token, TOKEN_IDENTIFIER))
+	{
+		name = newTokenFrom (token);
+		name->type = TOKEN_IDENTIFIER;
 	}
 	if (name == NULL)
 	{
-		name = newToken ();
+		name = newAnonTokenFrom (token, TAG_INTERFACE);
 		name->type = TOKEN_IDENTIFIER;
 		name->tag = TAG_INTERFACE;
 	}
+	makeFortranTag (name, TAG_INTERFACE);
 	ancestorPush (name);
 	while (! isKeyword (token, KEYWORD_end) &&
 		   ! isType (token, TOKEN_EOF))
@@ -2049,15 +2063,17 @@ static void parseEnumBlock (tokenInfo *const token)
 	if (isType (token, TOKEN_DOUBLE_COLON))
 		readToken (token);
 	if (isType (token, TOKEN_IDENTIFIER))
+	{
 		name = newTokenFrom (token);
+		name->type = TOKEN_IDENTIFIER;
+	}
 	if (name == NULL)
 	{
-		name = newToken ();
+		name = newAnonTokenFrom (token, TAG_ENUM);
 		name->type = TOKEN_IDENTIFIER;
 		name->tag = TAG_ENUM;
 	}
-	else
-		makeFortranTag (name, TAG_ENUM);
+	makeFortranTag (name, TAG_ENUM);
 	skipToNextStatement (token);
 	ancestorPush (name);
 	while (! isKeyword (token, KEYWORD_end) &&


### PR DESCRIPTION
These are various improvements we had in Geany for the Fortran parser:

- reporting of anonymous tags
- reporting scopes for interfaces and enums
- allowing keyword names to be used as names of various Fortran types

Note: I don't know what I'm doing much, I don't know Fortran and it's possible I'm doing something wrong - the patches are just based on what is present in Geany to allow us to use the uctags Fortran parser with correct scope information.