### PR TITLE
Tex: parse some more latex macros

### DIFF
--- a/Units/parser-tex.r/newcommand.d/expected.tags
+++ b/Units/parser-tex.r/newcommand.d/expected.tags
@@ -1,3 +1,5 @@
+\\bar	input.tex	/^\\providecommand{\\bar}{\\section{#1}}$/;"	C
+\\foo	input.tex	/^\\renewcommand{\\foo}{\\section{#1}}$/;"	C
 \\mysection0	input.tex	/^\\newcommand{\\mysection0}{\\section{#1}}$/;"	C
 \\mysection1	input.tex	/^\\newcommand{\\mysection1}[1]{\\section{#1}}$/;"	C
 \\mysection2	input.tex	/^\\newcommand{\\mysection2}[1][1]{\\section{#1}}$/;"	C

--- a/Units/parser-tex.r/newcommand.d/expected.tags
+++ b/Units/parser-tex.r/newcommand.d/expected.tags
@@ -4,3 +4,4 @@
 \\mysection0	input.tex	/^\\newcommand{\\mysection0}{\\section{#1}}$/;"	C
 \\mysection1	input.tex	/^\\newcommand{\\mysection1}[1]{\\section{#1}}$/;"	C
 \\mysection2	input.tex	/^\\newcommand{\\mysection2}[1][1]{\\section{#1}}$/;"	C
+\\op	input.tex	/^\\DeclareMathOperator{\\op}{foo}$/;"	o

--- a/Units/parser-tex.r/newcommand.d/expected.tags
+++ b/Units/parser-tex.r/newcommand.d/expected.tags
@@ -1,4 +1,5 @@
 \\bar	input.tex	/^\\providecommand{\\bar}{\\section{#1}}$/;"	C
+\\baz	input.tex	/^\\def\\baz{\\section{#1}}$/;"	C
 \\foo	input.tex	/^\\renewcommand{\\foo}{\\section{#1}}$/;"	C
 \\mysection0	input.tex	/^\\newcommand{\\mysection0}{\\section{#1}}$/;"	C
 \\mysection1	input.tex	/^\\newcommand{\\mysection1}[1]{\\section{#1}}$/;"	C

--- a/Units/parser-tex.r/newcommand.d/expected.tags
+++ b/Units/parser-tex.r/newcommand.d/expected.tags
@@ -4,4 +4,5 @@
 \\mysection0	input.tex	/^\\newcommand{\\mysection0}{\\section{#1}}$/;"	C
 \\mysection1	input.tex	/^\\newcommand{\\mysection1}[1]{\\section{#1}}$/;"	C
 \\mysection2	input.tex	/^\\newcommand{\\mysection2}[1][1]{\\section{#1}}$/;"	C
+\\mysection3	input.tex	/^\\newcommand\\mysection3[1][1]{\\section{#1}}$/;"	C
 \\op	input.tex	/^\\DeclareMathOperator{\\op}{foo}$/;"	o

--- a/Units/parser-tex.r/newcommand.d/input.tex
+++ b/Units/parser-tex.r/newcommand.d/input.tex
@@ -4,6 +4,7 @@
 \newcommand{\mysection2}[1][1]{\section{#1}}
 \renewcommand{\foo}{\section{#1}}
 \providecommand{\bar}{\section{#1}}
+\def\baz{\section{#1}}
 \begin{document}
 \mysection0{ABC}
 \mysection1{EFG}

--- a/Units/parser-tex.r/newcommand.d/input.tex
+++ b/Units/parser-tex.r/newcommand.d/input.tex
@@ -2,6 +2,7 @@
 \newcommand{\mysection0}{\section{#1}}
 \newcommand{\mysection1}[1]{\section{#1}}
 \newcommand{\mysection2}[1][1]{\section{#1}}
+\newcommand\mysection3[1][1]{\section{#1}}
 \renewcommand{\foo}{\section{#1}}
 \providecommand{\bar}{\section{#1}}
 \def\baz{\section{#1}}

--- a/Units/parser-tex.r/newcommand.d/input.tex
+++ b/Units/parser-tex.r/newcommand.d/input.tex
@@ -2,6 +2,8 @@
 \newcommand{\mysection0}{\section{#1}}
 \newcommand{\mysection1}[1]{\section{#1}}
 \newcommand{\mysection2}[1][1]{\section{#1}}
+\renewcommand{\foo}{\section{#1}}
+\providecommand{\bar}{\section{#1}}
 \begin{document}
 \mysection0{ABC}
 \mysection1{EFG}

--- a/Units/parser-tex.r/newcommand.d/input.tex
+++ b/Units/parser-tex.r/newcommand.d/input.tex
@@ -5,6 +5,7 @@
 \renewcommand{\foo}{\section{#1}}
 \providecommand{\bar}{\section{#1}}
 \def\baz{\section{#1}}
+\DeclareMathOperator{\op}{foo}
 \begin{document}
 \mysection0{ABC}
 \mysection1{EFG}

--- a/Units/parser-tex.r/newenvironment.d/expected.tags
+++ b/Units/parser-tex.r/newenvironment.d/expected.tags
@@ -1,0 +1,2 @@
+boxed	input.tex	/^\\newenvironment{boxed}$/;"	e
+boxedA	input.tex	/^\\renewenvironment{boxedA}$/;"	e

--- a/Units/parser-tex.r/newenvironment.d/expected.tags
+++ b/Units/parser-tex.r/newenvironment.d/expected.tags
@@ -1,3 +1,4 @@
 boxed	input.tex	/^\\newenvironment{boxed}$/;"	e
 boxedA	input.tex	/^\\renewenvironment{boxedA}$/;"	e
 theorem	input.tex	/^\\newtheorem{theorem}{Theorem}$/;"	t
+theoremA	input.tex	/^\\newtheorem{theoremA}{Theorem A}$/;"	t

--- a/Units/parser-tex.r/newenvironment.d/expected.tags
+++ b/Units/parser-tex.r/newenvironment.d/expected.tags
@@ -1,2 +1,3 @@
 boxed	input.tex	/^\\newenvironment{boxed}$/;"	e
 boxedA	input.tex	/^\\renewenvironment{boxedA}$/;"	e
+theorem	input.tex	/^\\newtheorem{theorem}{Theorem}$/;"	t

--- a/Units/parser-tex.r/newenvironment.d/input.tex
+++ b/Units/parser-tex.r/newenvironment.d/input.tex
@@ -1,0 +1,29 @@
+\documentclass{article}
+\newenvironment{boxed}
+    {\begin{center}
+    \begin{tabular}{|p{0.9\textwidth}|}
+    \hline\\
+    }
+    { 
+    \\\\\hline
+    \end{tabular} 
+    \end{center}
+    }
+\renewenvironment{boxedA}
+    {\begin{center}
+    \begin{tabular}{|p{0.9\textwidth}|}
+    \hline\\
+    }
+    { 
+    \\\\\hline
+    \end{tabular} 
+    \end{center}
+    }
+\begin{document}
+\begin{boxed}
+foo
+\end{boxed}
+\begin{boxedA}
+foo
+\end{boxedA}
+\end{document}

--- a/Units/parser-tex.r/newenvironment.d/input.tex
+++ b/Units/parser-tex.r/newenvironment.d/input.tex
@@ -19,6 +19,7 @@
     \end{tabular} 
     \end{center}
     }
+\newtheorem{theorem}{Theorem}
 \begin{document}
 \begin{boxed}
 foo
@@ -26,4 +27,7 @@ foo
 \begin{boxedA}
 foo
 \end{boxedA}
+\begin{theorem}
+bar
+\end{theorem}
 \end{document}

--- a/Units/parser-tex.r/newenvironment.d/input.tex
+++ b/Units/parser-tex.r/newenvironment.d/input.tex
@@ -1,4 +1,5 @@
 \documentclass{article}
+\newtheorem{theoremA}{Theorem A}
 \newenvironment{boxed}
     {\begin{center}
     \begin{tabular}{|p{0.9\textwidth}|}

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -693,6 +693,10 @@ static bool parseWithStrategy (tokenInfo *token,
 		}
 	}
 
+	/* The last token is optional and not present - let the caller know */
+	if (!next_token)
+		*tokenUnprocessed = true;
+
 	if (name)
 		deleteToken (name);
 
@@ -991,7 +995,7 @@ static bool parseNewTheorem (tokenInfo *const token, bool *tokenUnprocessed)
 static bool parseNewcounter (tokenInfo *const token, bool *tokenUnprocessed)
 {
 	bool eof = false;
-	/* \newccounter {counter}[parentCounter] */
+	/* \newcounter {counter}[parentCounter] */
 	struct TexParseStrategy strategy [] = {
 		{
 			.type = '{',
@@ -1003,7 +1007,7 @@ static bool parseNewcounter (tokenInfo *const token, bool *tokenUnprocessed)
 		},
 		{
 			.type = '[',
-			.flags = 0,
+			.flags = TEX_NAME_FLAG_OPTIONAL,
 			.kindIndex = KIND_GHOST_INDEX,
 			.name = NULL,
 		},

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -66,6 +66,7 @@ enum eKeywordId {
 	KEYWORD_renewcommand,
 	KEYWORD_providecommand,
 	KEYWORD_def,
+	KEYWORD_declaremathoperator,
 	KEYWORD_newcounter,
 };
 typedef int keywordId; /* to allow KEYWORD_NONE */
@@ -120,6 +121,7 @@ typedef enum {
 	TEXTAG_XINPUT,
 	TEXTAG_BIBITEM,
 	TEXTAG_COMMAND,
+	TEXTAG_OPERATOR,
 	TEXTAG_COUNTER,
 	TEXTAG_COUNT
 } texKind;
@@ -152,6 +154,7 @@ static kindDefinition TexKinds [] = {
 	  .referenceOnly = true, ATTACH_ROLES(TexInputRoles)   },
 	{ true,  'B', "bibitem",		  "bibliography items" },
 	{ true,  'C', "command",		  "command created with \\newcommand" },
+	{ true,  'o', "operator",		  "math operator created with \\DeclareMathOperator" },
 	{ true,  'N', "counter",		  "counter created with \\newcounter" },
 };
 
@@ -175,6 +178,7 @@ static const keywordTable TexKeywordTable [] = {
 	{ "renewcommand",	KEYWORD_renewcommand		},
 	{ "providecommand",	KEYWORD_providecommand		},
 	{ "def",			KEYWORD_def					},
+	{ "DeclareMathOperator",	KEYWORD_declaremathoperator	},
 	{ "newcounter",		KEYWORD_newcounter			},
 };
 
@@ -809,7 +813,7 @@ static bool parseEnv (tokenInfo *const token, bool begin, bool *tokenUnprocessed
 
 }
 
-static bool parseNewcommand (tokenInfo *const token, bool *tokenUnprocessed)
+static bool parseNewcommandFull (tokenInfo *const token, bool *tokenUnprocessed, texKind kind)
 {
 	bool eof = false;
 
@@ -818,7 +822,7 @@ static bool parseNewcommand (tokenInfo *const token, bool *tokenUnprocessed)
 		{
 			.type = '{',
 			.flags = 0,
-			.kindIndex = TEXTAG_COMMAND,
+			.kindIndex = kind,
 			.roleIndex = ROLE_DEFINITION_INDEX,
 			.name = NULL,
 			.unique = false,
@@ -850,6 +854,11 @@ static bool parseNewcommand (tokenInfo *const token, bool *tokenUnprocessed)
 		eof = true;
 
 	return eof;
+}
+
+static bool parseNewcommand (tokenInfo *const token, bool *tokenUnprocessed)
+{
+	return parseNewcommandFull (token, tokenUnprocessed, TEXTAG_COMMAND);
 }
 
 static bool parseDef (tokenInfo *const token, bool *tokenUnprocessed)
@@ -982,6 +991,9 @@ static void parseTexFile (tokenInfo *const token)
 					break;
 				case KEYWORD_def:
 					eof = parseDef (token, &tokenUnprocessed);
+					break;
+				case KEYWORD_declaremathoperator:
+					eof = parseNewcommandFull (token, &tokenUnprocessed, TEXTAG_OPERATOR);
 					break;
 				case KEYWORD_newcounter:
 					eof = parseNewcounter (token, &tokenUnprocessed);

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -63,6 +63,8 @@ enum eKeywordId {
 	KEYWORD_bibitem,
 	KEYWORD_bibliography,
 	KEYWORD_newcommand,
+	KEYWORD_renewcommand,
+	KEYWORD_providecommand,
 	KEYWORD_newcounter,
 };
 typedef int keywordId; /* to allow KEYWORD_NONE */
@@ -169,6 +171,8 @@ static const keywordTable TexKeywordTable [] = {
 	{ "bibitem",		KEYWORD_bibitem				},
 	{ "bibliography",	KEYWORD_bibliography		},
 	{ "newcommand",		KEYWORD_newcommand			},
+	{ "renewcommand",	KEYWORD_renewcommand		},
+	{ "providecommand",	KEYWORD_providecommand		},
 	{ "newcounter",		KEYWORD_newcounter			},
 };
 
@@ -934,6 +938,8 @@ static void parseTexFile (tokenInfo *const token)
 										false, &tokenUnprocessed);
 					break;
 				case KEYWORD_newcommand:
+				case KEYWORD_renewcommand:
+				case KEYWORD_providecommand:
 					eof = parseNewcommand (token, &tokenUnprocessed);
 					break;
 				case KEYWORD_newcounter:

--- a/parsers/tex.h
+++ b/parsers/tex.h
@@ -42,8 +42,8 @@ enum TexNameFlag {
 };
 
 struct TexParseStrategy {
-	/* Expected token type '<', '[', '*', and '{' are supported.
-	 * 0 means the end of strategies.
+	/* Expected token type '<', '[', '*', '{', and '\\' are supported.
+	 * 0 means the end of strategies. '\\' means {} pair may be omitted.
 	 *
 	 * A string between <>, [], or {} (pairs) can be tagged or store to
 	 * a vString. See kindIndex and name field of this structure.


### PR DESCRIPTION
In addition to the macros already parsed, the old Geany readline-based parser also parses the following latex macros which may be useful:
- `\renewcommand`, `\providecommand`
- tex `\def\cmd{param}`
- `\DeclareMathOperator`
- `\newenvironment`, `\renewenvironment`
- `\newtheorem`

This pul request adds these and introduces the corresponding kinds for them.