### PR TITLE
Basic: various improvements from Geany

### DIFF
--- a/Units/parser-basic.r/simple.bas.d/expected.tags
+++ b/Units/parser-basic.r/simple.bas.d/expected.tags
@@ -7,6 +7,9 @@ f	input.bas	/^Function f()$/;"	f
 g	input.bas	/^dim shared as string g$/;"	v
 h	input.bas	/^dim as string ptr h$/;"	v
 i	input.bas	/^dim as string * 4096 i$/;"	v
+j	input.bas	/^dim j as string="Export_GIR_FULL_"+mid(date,7)+","+mid(date,1,2)+""+mid(date,4,2)+".csv"$/;"	v
+k	input.bas	/^dim as string k="Export_GIR_FULL_"+mid(date(),"(")+","+mid(date,1,2)+""+mid(date,4,2)+".csv", l$/;"	v
+l	input.bas	/^dim as string k="Export_GIR_FULL_"+mid(date(),"(")+","+mid(date,1,2)+""+mid(date,4,2)+".csv", l$/;"	v
 one	input.bas	/^Const one = 1$/;"	c
 start	input.bas	/^start:$/;"	l
 str	input.bas	/^DIM AS STRING str$/;"	v

--- a/Units/parser-basic.r/simple.bas.d/expected.tags
+++ b/Units/parser-basic.r/simple.bas.d/expected.tags
@@ -1,6 +1,12 @@
 a	input.bas	/^Common a As Integer$/;"	v
 b	input.bas	/^Dim b As Integer$/;"	v
+c	input.bas	/^dim as string c(20), d="a", e$/;"	v
+d	input.bas	/^dim as string c(20), d="a", e$/;"	v
+e	input.bas	/^dim as string c(20), d="a", e$/;"	v
 f	input.bas	/^Function f()$/;"	f
+g	input.bas	/^dim shared as string g$/;"	v
+h	input.bas	/^dim as string ptr h$/;"	v
+i	input.bas	/^dim as string * 4096 i$/;"	v
 one	input.bas	/^Const one = 1$/;"	c
 start	input.bas	/^start:$/;"	l
 str	input.bas	/^DIM AS STRING str$/;"	v

--- a/Units/parser-basic.r/simple.bas.d/input.bas
+++ b/Units/parser-basic.r/simple.bas.d/input.bas
@@ -5,6 +5,10 @@ Const one = 1
 Common a As Integer
 Dim b As Integer
 DIM AS STRING str
+dim as string c(20), d="a", e
+dim shared as string g
+dim as string ptr h
+dim as string * 4096 i
 
 Type test
     a As Integer

--- a/Units/parser-basic.r/simple.bas.d/input.bas
+++ b/Units/parser-basic.r/simple.bas.d/input.bas
@@ -9,6 +9,8 @@ dim as string c(20), d="a", e
 dim shared as string g
 dim as string ptr h
 dim as string * 4096 i
+dim j as string="Export_GIR_FULL_"+mid(date,7)+","+mid(date,1,2)+""+mid(date,4,2)+".csv"
+dim as string k="Export_GIR_FULL_"+mid(date(),"(")+","+mid(date,1,2)+""+mid(date,4,2)+".csv", l
 
 Type test
     a As Integer

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -89,7 +89,7 @@ static char const *extract_name (char const *pos, vString * name)
 	while (isspace (*pos))
 		pos++;
 	vStringClear (name);
-	for (; *pos && !isspace (*pos) && *pos != '(' && *pos != ','; pos++)
+	for (; *pos && !isspace (*pos) && *pos != '(' && *pos != ',' && *pos != '='; pos++)
 		vStringPut (name, *pos);
 	return pos;
 }

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -81,6 +81,41 @@ static KeyWord basic_keywords[] = {
  *   FUNCTION DEFINITIONS
  */
 
+static const char *skipToMatching (char begin, char end, const char *pos)
+{
+	int counter = 1;
+	pos++;
+	while (*pos && counter > 0)
+	{
+		if (*pos == end)
+			counter--;
+		else if (*pos == begin)
+			counter++;
+		else if (*pos == '"')
+			pos = skipToMatching ('"', '"', pos) - 1;
+		pos++;
+	}
+	return pos;
+}
+
+static const char *nextPos (const char *pos)
+{
+	if (*pos == '\0')
+		return pos;
+
+	pos++;
+	switch (*pos)
+	{
+		case '(':
+			pos = skipToMatching ('(', ')', pos);
+			break;
+		case '"':
+			pos = skipToMatching ('"', '"', pos);
+			break;
+	}
+	return pos;
+}
+
 static bool isIdentChar (char c)
 {
 	return c && !isspace (c) && c != '(' && c != ',' && c != '=';
@@ -134,7 +169,7 @@ static void extract_dim (char const *pos, BasicKind kind)
 	{
 		/* skip all we don't need(e.g. "..., new_array(5), " we skip "(5)") */
 		while (*pos != ',' && *pos != '\'' && *pos)
-			pos++;
+			pos = nextPos (pos);
 
 		if (*pos == '\'')
 			break; /* break if we are in a comment */

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -37,7 +37,6 @@ typedef enum {
 typedef struct {
 	char const *token;
 	BasicKind kind;
-	int skip;
 } KeyWord;
 
 static kindDefinition BasicKinds[] = {
@@ -51,31 +50,31 @@ static kindDefinition BasicKinds[] = {
 
 static KeyWord basic_keywords[] = {
 	/* freebasic */
-	{"const", K_CONST, 0},
-	{"dim", K_VARIABLE, 0},
-	{"common", K_VARIABLE, 0},
-	{"function", K_FUNCTION, 0},
-	{"sub", K_FUNCTION, 0},
-	{"private sub", K_FUNCTION, 0},
-	{"public sub", K_FUNCTION, 0},
-	{"private function", K_FUNCTION, 0},
-	{"public function", K_FUNCTION, 0},
-	{"property", K_FUNCTION, 0},
-	{"constructor", K_FUNCTION, 0},
-	{"destructor", K_FUNCTION, 0},
-	{"type", K_TYPE, 0},
-	{"enum", K_ENUM, 0},
+	{"const", K_CONST},
+	{"dim", K_VARIABLE},
+	{"common", K_VARIABLE},
+	{"function", K_FUNCTION},
+	{"sub", K_FUNCTION},
+	{"private sub", K_FUNCTION},
+	{"public sub", K_FUNCTION},
+	{"private function", K_FUNCTION},
+	{"public function", K_FUNCTION},
+	{"property", K_FUNCTION},
+	{"constructor", K_FUNCTION},
+	{"destructor", K_FUNCTION},
+	{"type", K_TYPE},
+	{"enum", K_ENUM},
 
 	/* blitzbasic, purebasic */
-	{"global", K_VARIABLE, 0},
+	{"global", K_VARIABLE},
 
 	/* purebasic */
-	{"newlist", K_VARIABLE, 0},
-	{"procedure", K_FUNCTION, 0},
-	{"interface", K_TYPE, 0},
-	{"structure", K_TYPE, 0},
+	{"newlist", K_VARIABLE},
+	{"procedure", K_FUNCTION},
+	{"interface", K_TYPE},
+	{"structure", K_TYPE},
 
-	{NULL, 0, 0}
+	{NULL, 0}
 };
 
 /*
@@ -166,7 +165,6 @@ static int match_keyword (const char *p, KeyWord const *kw)
 {
 	vString *name;
 	size_t i;
-	int j;
 	const char *old_p;
 	for (i = 0; i < strlen (kw->token); i++)
 	{
@@ -190,10 +188,7 @@ static int match_keyword (const char *p, KeyWord const *kw)
 	}
 
 	name = vStringNew ();
-	for (j = 0; j < 1 + kw->skip; j++)
-	{
-		p = extract_name (p, name);
-	}
+	extract_name (p, name);
 	makeSimpleTag (name, kw->kind);
 	vStringDelete (name);
 	return 1;

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -81,6 +81,11 @@ static KeyWord basic_keywords[] = {
  *   FUNCTION DEFINITIONS
  */
 
+static bool isIdentChar (char c)
+{
+	return c && !isspace (c) && c != '(' && c != ',' && c != '=';
+}
+
 /* Match the name of a dim or const starting at pos. */
 static void extract_dim (char const *pos, BasicKind kind)
 {
@@ -120,7 +125,7 @@ static void extract_dim (char const *pos, BasicKind kind)
 			pos++;
 	}
 
-	for (; *pos && !isspace (*pos) && *pos != '(' && *pos != ',' && *pos != '='; pos++)
+	for (; isIdentChar (*pos); pos++)
 		vStringPut (name, *pos);
 	makeSimpleTag (name, kind);
 
@@ -141,7 +146,7 @@ static void extract_dim (char const *pos, BasicKind kind)
 			break; /* break if we are in a comment */
 
 		vStringClear (name);
-		for (; *pos && !isspace (*pos) && *pos != '(' && *pos != ',' && *pos != '='; pos++)
+		for (; isIdentChar (*pos); pos++)
 			vStringPut (name, *pos);
 		makeSimpleTag (name, kind);
 	}
@@ -153,7 +158,7 @@ static void extract_dim (char const *pos, BasicKind kind)
 static void extract_name (char const *pos, BasicKind kind)
 {
 	vString *name = vStringNew ();
-	for (; *pos && !isspace (*pos) && *pos != '(' && *pos != ',' && *pos != '='; pos++)
+	for (; isIdentChar (*pos); pos++)
 		vStringPut (name, *pos);
 	makeSimpleTag (name, kind);
 	vStringDelete (name);

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -187,7 +187,7 @@ static void findBasicTags (void)
 			if (match_keyword (p, kw)) break;
 
 		/* Is it a label? */
-		if (strcmp (extension, "bb") == 0)
+		if (*p == '.')
 			match_dot_label (p);
 		else
 			match_colon_label (p);

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -100,13 +100,23 @@ static int match_keyword (const char *p, KeyWord const *kw)
 	vString *name;
 	size_t i;
 	int j;
+	const char *old_p;
 	for (i = 0; i < strlen (kw->token); i++)
 	{
 		if (tolower (p[i]) != kw->token[i])
 			return 0;
 	}
-	name = vStringNew ();
 	p += i;
+
+	old_p = p;
+	while (isspace (*p))
+		p++;
+
+	/* create tags only if there is some space between the keyword and the identifier */
+	if (old_p == p)
+		return 0;
+
+	name = vStringNew ();
 	for (j = 0; j < 1 + kw->skip; j++)
 	{
 		p = extract_name (p, name);

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -49,26 +49,8 @@ static kindDefinition BasicKinds[] = {
 	{true, 'g', "enum", "enumerations"}
 };
 
-static KeyWord blitzbasic_keywords[] = {
-	{"const", K_CONST, 0},
-	{"global", K_VARIABLE, 0},
-	{"dim", K_VARIABLE, 0},
-	{"function", K_FUNCTION, 0},
-	{"type", K_TYPE, 0},
-	{NULL, 0, 0}
-};
-
-static KeyWord purebasic_keywords[] = {
-	{"newlist", K_VARIABLE, 0},
-	{"global", K_VARIABLE, 0},
-	{"dim", K_VARIABLE, 0},
-	{"procedure", K_FUNCTION, 0},
-	{"interface", K_TYPE, 0},
-	{"structure", K_TYPE, 0},
-	{NULL, 0, 0}
-};
-
-static KeyWord freebasic_keywords[] = {
+static KeyWord basic_keywords[] = {
+	/* freebasic */
 	{"const", K_CONST, 0},
 	{"dim as", K_VARIABLE, 1},
 	{"dim", K_VARIABLE, 0},
@@ -81,6 +63,16 @@ static KeyWord freebasic_keywords[] = {
 	{"public function", K_FUNCTION, 0},
 	{"type", K_TYPE, 0},
 	{"enum", K_ENUM, 0},
+
+	/* blitzbasic, purebasic */
+	{"global", K_VARIABLE, 0},
+
+	/* purebasic */
+	{"newlist", K_VARIABLE, 0},
+	{"procedure", K_FUNCTION, 0},
+	{"interface", K_TYPE, 0},
+	{"structure", K_TYPE, 0},
+
 	{NULL, 0, 0}
 };
 
@@ -151,15 +143,6 @@ static void match_dot_label (char const *p)
 static void findBasicTags (void)
 {
 	const char *line;
-	const char *extension = fileExtension (getInputFileName ());
-	KeyWord *keywords;
-
-	if (strcmp (extension, "bb") == 0)
-		keywords = blitzbasic_keywords;
-	else if (strcmp (extension, "pb") == 0)
-		keywords = purebasic_keywords;
-	else
-		keywords = freebasic_keywords;
 
 	while ((line = (const char *) readLineFromInputFile ()) != NULL)
 	{
@@ -183,7 +166,7 @@ static void findBasicTags (void)
 			continue;
 
 		/* In Basic, keywords always are at the start of the line. */
-		for (kw = keywords; kw->token; kw++)
+		for (kw = basic_keywords; kw->token; kw++)
 			if (match_keyword (p, kw)) break;
 
 		/* Is it a label? */

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -61,6 +61,9 @@ static KeyWord basic_keywords[] = {
 	{"public sub", K_FUNCTION, 0},
 	{"private function", K_FUNCTION, 0},
 	{"public function", K_FUNCTION, 0},
+	{"property", K_FUNCTION, 0},
+	{"constructor", K_FUNCTION, 0},
+	{"destructor", K_FUNCTION, 0},
 	{"type", K_TYPE, 0},
 	{"enum", K_ENUM, 0},
 


### PR DESCRIPTION
There were some improvements in the Geany parser, mostly related to extraction of variables in `dim` statements.

Also, the uctags parser determined the used basic dialect based on file extension which wouldn't work very well for Geany as it parses files using MIO buffer. What the parser did appears quite a non-standard approach with the file extensions and I haven't seen it in any other parser. What I did is that I basically just merged all the basic dialect keywords into one and allowed both labels like `label:` and `.label` for any kind of file - hope it's OK.

I added the `dim` extraction code as it was in Geany and then made a few commits on top of that as there were some minor problems in the code and finally made a commit to cleanup the code a bit.