### PR TITLE
main: experiment to detect memory access behind EOL

### DIFF
--- a/main/read.c
+++ b/main/read.c
@@ -925,6 +925,9 @@ static vString *iFileGetLine (bool chop_newline)
 		if (chopped && !chop_newline)
 			vStringPutNewlinAgainUnsafe (File.line);
 
+		File.line->size = File.line->length == 0 ? 2 : File.line->length + 1;
+		File.line->buffer = xRealloc (File.line->buffer, File.line->size, char);
+
 		return File.line;
 	}
 	else

--- a/main/read.c
+++ b/main/read.c
@@ -926,7 +926,10 @@ static vString *iFileGetLine (bool chop_newline)
 			vStringPutNewlinAgainUnsafe (File.line);
 
 		File.line->size = File.line->length == 0 ? 2 : File.line->length + 1;
-		File.line->buffer = xRealloc (File.line->buffer, File.line->size, char);
+		char *oldbuf = File.line->buffer;
+		File.line->buffer = xMalloc (File.line->size, char);
+		memcpy(File.line->buffer, oldbuf, File.line->size);
+		eFree(oldbuf);
 
 		return File.line;
 	}


### PR DESCRIPTION
Currently when reading the input file, ctags reads it line by line and
maintains a (always growing) vString value for the current line where
characters of the line are stored. Since the string never shrinks,
it may be very long and may contain valid code from previous lines
behind the '\0' character. If parsers contain a bug and read behind
the terminating '\0', this may be undetected by valgrind because
the string is legally allocated.

This experiment re-allocates the string after reading a line to the
exact size of the line which should make valgrind complain if the string
is accessed behind the terminating '\0' by some parser.

Not sure why but the allocated buffer has to be at least 2 bytes long,
otherwise tests start to fail.