### PR TITLE
Remove GLSL and Ferite from the list of parsers in Geany

### DIFF
--- a/docs/other-projects.rst
+++ b/docs/other-projects.rst
@@ -39,8 +39,6 @@ Changes known by devs worth backporting:
 They have these additional language parsers:
 
 * `DocBook <https://en.wikipedia.org/wiki/DocBook>`_
-* `Ferite (c.c) <https://en.wikipedia.org/wiki/Ferite>`_
-* `GLSL (c.c) <https://en.wikipedia.org/wiki/OpenGL_Shading_Language>`_
 * `Vala (c.c) <https://en.wikipedia.org/wiki/Vala_%28programming_language%29>`_
 
 Software using ctags


### PR DESCRIPTION
The GLSL parser is just a synonym for the C parser, see

https://github.com/geany/geany/pull/3073

The Ferite language is dead and isn't worth supporting, see

https://github.com/geany/geany/pull/3075