### PR TITLE
build-sys: Don't use weak symbols on MSYS2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -510,7 +510,7 @@ case "$host" in
 	AC_DEFINE(MANUAL_GLOBBING)
 	AC_DEFINE(HAVE__FINDFIRST)
 	;;
-  *-cygwin*)
+  *-cygwin | *-msys)
 	gl_cv_have_weak=no
 	;;
 esac
@@ -559,10 +559,6 @@ PRETTY_ARG_VAR([WARNING_CFLAGS], [C compiler warning flags],
 #   Place it further down in the file, typically where you normally check for
 #   header files or functions.
 gl_INIT
-
-AC_DEFINE([GNULIB_REGEX_SINGLE_THREAD], [1],
-  [Define if all programs in this package call functions of the Gnulib
-   'regex' module only from a single thread.])
 
 if test "$REPLACE_FNMATCH" != 0; then
 	AC_DEFINE([USE_GNULIB_FNMATCH])


### PR DESCRIPTION
This replaces #3228.

Weak symbols don't work also on MSYS2. Stop using the feature.

`$host` on Cygwin and MSYS2 looks like `x86_64-pc-cygwin` and
`x86_64-pc-msys`. No need to add an `*` at the end of `*-cygwin`