### PR TITLE
Kotlin: don't delete vString before making the tag for the string

### DIFF
--- a/Units/parser-kotlin.r/kotlin-backticks.d/expected.tags
+++ b/Units/parser-kotlin.r/kotlin-backticks.d/expected.tags
@@ -1,0 +1,1 @@
+main	input.kt	/^fun `main`(args:Array<String>) {$/;"	m

--- a/Units/parser-kotlin.r/kotlin-backticks.d/input.kt
+++ b/Units/parser-kotlin.r/kotlin-backticks.d/input.kt
@@ -1,0 +1,3 @@
+fun `main`(args:Array<String>) {
+    println("hello, world!")
+}

--- a/peg/kotlin_post.h
+++ b/peg/kotlin_post.h
@@ -31,6 +31,7 @@ static void makeKotlinTag (struct parserCtx *auxil, const char *name, long offse
     int k = PEEK_KIND(auxil);
     if (k == K_IGNORE) return;
     tagEntryInfo e;
+    char *stripped = NULL;
     if (*name != '`')
     {
         initTagEntry(&e, name, k);
@@ -39,9 +40,8 @@ static void makeKotlinTag (struct parserCtx *auxil, const char *name, long offse
         size_t len = strlen(name);
         Assert(len >= 2);
         len -= 2;
-        vString *stripped = vStringNewNInit(name + 1, len);
-        initTagEntry(&e, vStringValue(stripped), k);
-        vStringDelete(stripped);
+        stripped = eStrndup (name + 1, len);
+        initTagEntry(&e, stripped, k);
     }
     e.lineNumber = getInputLineNumberForFileOffset (offset);
     e.filePosition = getInputFilePositionForLine (e.lineNumber);
@@ -51,6 +51,8 @@ static void makeKotlinTag (struct parserCtx *auxil, const char *name, long offse
     {
         SET_SCOPE(auxil, scope_index);
     }
+    if (stripped)
+        eFree (stripped);
 }
 
 #ifdef DEBUG


### PR DESCRIPTION
Valgrind reports the mem error.