### PR TITLE
latex: Add reference tags for environment usage introduced by \begin{MyEnv}

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -92,6 +92,7 @@ SystemdUnit    u/unit            RequiredBy         on      referred in Required
 SystemdUnit    u/unit            Requires           on      referred in Requires key
 SystemdUnit    u/unit            WantedBy           on      referred in WantedBy key
 SystemdUnit    u/unit            Wants              on      referred in Wants key
+Tex            e/environment     used               off     environment usage introduced by \begin{MyEnv}
 Tex            i/xinput          bibliography       on      bibliography (.bib) file
 Tex            i/xinput          included           on      external input file specified with \include
 Tex            i/xinput          input              on      external input file specified with \input
@@ -195,6 +196,7 @@ SystemdUnit    u/unit            RequiredBy         on      referred in Required
 SystemdUnit    u/unit            Requires           on      referred in Requires key
 SystemdUnit    u/unit            WantedBy           on      referred in WantedBy key
 SystemdUnit    u/unit            Wants              on      referred in Wants key
+Tex            e/environment     used               off     environment usage introduced by \begin{MyEnv}
 Tex            i/xinput          bibliography       on      bibliography (.bib) file
 Tex            i/xinput          included           on      external input file specified with \include
 Tex            i/xinput          input              on      external input file specified with \input

--- a/Units/parser-tex.r/xinput.d/args.ctags
+++ b/Units/parser-tex.r/xinput.d/args.ctags
@@ -1,3 +1,4 @@
 --extras=+r
 --fields=+r
 --sort=no
+--roles-all.*=*

--- a/Units/parser-tex.r/xinput.d/expected.tags
+++ b/Units/parser-tex.r/xinput.d/expected.tags
@@ -1,3 +1,4 @@
+document	input.tex	/^\\begin{document}$/;"	e	roles:used
 input-1	input.tex	/^\\include{input-1}$/;"	i	roles:included
 input-2	input.tex	/^\\input{input-2}$/;"	i	roles:input
 input-3	input.tex	/^\\bibliography{input-3}$/;"	i	roles:bibliography

--- a/Units/simple-texBeamer.d/args.ctags
+++ b/Units/simple-texBeamer.d/args.ctags
@@ -1,2 +1,5 @@
 --sort=no
 --fields=+K
+--roles-all.*=*
+--extras=+r
+--fields=+r

--- a/Units/simple-texBeamer.d/expected.tags
+++ b/Units/simple-texBeamer.d/expected.tags
@@ -1,9 +1,25 @@
-Concept	input.tex	/^\\begin{frame}{Concept}$/;"	frametitle
-kind	input.tex	/^\\begin{frame}{Concept}{kind}$/;"	framesubtitle	frametitle:Concept
-field	input.tex	/^  \\framesubtitle{field}$/;"	framesubtitle	frametitle:Concept
-extra	input.tex	/^  \\framesubtitle{extra}$/;"	framesubtitle	frametitle:Concept
-pseudo tag	input.tex	/^\\begin{frame}[fragile]{Concept}{pseudo tag}$/;"	framesubtitle	frametitle:Concept
-Options	input.tex	/^\\begin{frame}<1-2>\\frametitle{Options}$/;"	frametitle
-Optlib	input.tex	/^\\begin{frame}<1-2>[fragile]\\frametitle{Optlib}$/;"	frametitle
-Line oriented parser	input.tex	/^\\begin{frame}<1-2>[fragile]\\frametitle{Optlib}\\framesubtitle{Line oriented parser}$/;"	framesubtitle	frametitle:Optlib
-Multiline parser	input.tex	/^\\begin{frame}[<+->][plain]{Optlib}\\framesubtitle{Multiline parser}$/;"	framesubtitle	frametitle:Optlib
+document	input.tex	/^\\begin{document}$/;"	environment	roles:used
+frame	input.tex	/^\\begin{frame}{Concept}$/;"	environment	roles:used
+Concept	input.tex	/^\\begin{frame}{Concept}$/;"	frametitle	roles:def
+frame	input.tex	/^\\begin{frame}{Concept}{kind}$/;"	environment	roles:used
+kind	input.tex	/^\\begin{frame}{Concept}{kind}$/;"	framesubtitle	frametitle:Concept	roles:def
+frame	input.tex	/^\\begin{frame}\\frametitle{Concept}$/;"	environment	roles:used
+field	input.tex	/^  \\framesubtitle{field}$/;"	framesubtitle	frametitle:Concept	roles:def
+frame	input.tex	/^\\begin{frame}{Concept}$/;"	environment	roles:used
+extra	input.tex	/^  \\framesubtitle{extra}$/;"	framesubtitle	frametitle:Concept	roles:def
+frame	input.tex	/^\\begin{frame}[fragile]{Concept}{pseudo tag}$/;"	environment	roles:used
+pseudo tag	input.tex	/^\\begin{frame}[fragile]{Concept}{pseudo tag}$/;"	framesubtitle	frametitle:Concept	roles:def
+frame	input.tex	/^\\begin{frame}<1-2>\\frametitle{Options}$/;"	environment	roles:used
+Options	input.tex	/^\\begin{frame}<1-2>\\frametitle{Options}$/;"	frametitle	roles:def
+itemize	input.tex	/^  \\begin{itemize}$/;"	environment	roles:used
+itemize	input.tex	/^  \\begin{itemize}$/;"	environment	roles:used
+frame	input.tex	/^\\begin{frame}<1-2>[fragile]\\frametitle{Optlib}$/;"	environment	roles:used
+Optlib	input.tex	/^\\begin{frame}<1-2>[fragile]\\frametitle{Optlib}$/;"	frametitle	roles:def
+itemize	input.tex	/^  \\begin{itemize}$/;"	environment	roles:used
+itemize	input.tex	/^  \\begin{itemize}$/;"	environment	roles:used
+frame	input.tex	/^\\begin{frame}<1-2>[fragile]\\frametitle{Optlib}\\framesubtitle{Line oriented parser}$/;"	environment	roles:used
+Line oriented parser	input.tex	/^\\begin{frame}<1-2>[fragile]\\frametitle{Optlib}\\framesubtitle{Line oriented parser}$/;"	framesubtitle	frametitle:Optlib	roles:def
+itemize	input.tex	/^  \\begin{itemize}$/;"	environment	roles:used
+frame	input.tex	/^\\begin{frame}[<+->][plain]{Optlib}\\framesubtitle{Multiline parser}$/;"	environment	roles:used
+Multiline parser	input.tex	/^\\begin{frame}[<+->][plain]{Optlib}\\framesubtitle{Multiline parser}$/;"	framesubtitle	frametitle:Optlib	roles:def
+itemize	input.tex	/^\\begin{itemize}$/;"	environment	roles:used

--- a/parsers/tex.c
+++ b/parsers/tex.c
@@ -137,6 +137,10 @@ typedef enum {
 	TEX_XINPUT_BIBLIOGRAPHY,
 } texInputRole;
 
+typedef enum {
+	TEX_ENVIRONMENT_USED,
+} texEnvironmentRole;
+
 static roleDefinition TexInputRoles [] = {
 	{ true, "included",
 	  "external input file specified with \\include" },
@@ -144,6 +148,10 @@ static roleDefinition TexInputRoles [] = {
 	  "external input file specified with \\input" },
 	{ true, "bibliography",
 	  "bibliography (.bib) file" },
+};
+
+static roleDefinition TexEnvironmentRoles [] = {
+	{ false, "used", "environment usage introduced by \\begin{MyEnv}" },
 };
 
 static kindDefinition TexKinds [] = {
@@ -160,7 +168,8 @@ static kindDefinition TexKinds [] = {
 	{ true,  'B', "bibitem",		  "bibliography items" },
 	{ true,  'C', "command",		  "command created with \\newcommand" },
 	{ true,  'o', "operator",		  "math operator created with \\DeclareMathOperator" },
-	{ true,  'e', "environment",	  "environment created with \\newenvironment" },
+	{ true,  'e', "environment",	  "environment created with \\newenvironment",
+	  .referenceOnly = false, ATTACH_ROLES(TexEnvironmentRoles) },
 	{ true,  't', "theorem",		  "theorem created with \\newtheorem" },
 	{ true,  'N', "counter",		  "counter created with \\newcounter" },
 };
@@ -799,7 +808,8 @@ static bool parseEnv (tokenInfo *const token, bool begin, bool *tokenUnprocessed
 		{
 			.type = '{',
 			.flags = TEX_NAME_FLAG_INCLUDING_WHITESPACE,
-			.kindIndex = KIND_GHOST_INDEX,
+			.kindIndex = begin ? TEXTAG_ENVIRONMENT : KIND_GHOST_INDEX,
+			.roleIndex = TEX_ENVIRONMENT_USED,
 			.name = envName,
 		},
 		{


### PR DESCRIPTION
In Geany we also have environment usages reported by the current parser. I'm not sure if it's interesting for uctags too - I created this pull request where I added these as reference tags. I'm not sure about whether I used the right naming for the role. Also, I made these disabled by default - not sure what the current convention enabling/disabling these kinds of tags is - please check.