### PR TITLE
Cxx: detect of variables initialized using macro

### DIFF
--- a/Units/parser-c.r/c-var-initialized-using-macro.d/args.ctags
+++ b/Units/parser-c.r/c-var-initialized-using-macro.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-C=+lp

--- a/Units/parser-c.r/c-var-initialized-using-macro.d/expected.tags
+++ b/Units/parser-c.r/c-var-initialized-using-macro.d/expected.tags
@@ -1,0 +1,6 @@
+INIT	input.c	/^#define INIT(/;"	d	file:
+i	input.c	/^static const int i = INIT(2);$/;"	v	typeref:typename:const int	file:
+j	input.c	/^int j;$/;"	v	typeref:typename:int
+k	input.c	/^int k = 1;$/;"	v	typeref:typename:int
+f	input.c	/^int f(void)$/;"	f	typeref:typename:int
+l	input.c	/^	int l = INIT(3);$/;"	l	function:f	typeref:typename:int	file:

--- a/Units/parser-c.r/c-var-initialized-using-macro.d/input.c
+++ b/Units/parser-c.r/c-var-initialized-using-macro.d/input.c
@@ -1,0 +1,11 @@
+#define INIT(x) x
+
+static const int i = INIT(2);
+int j;
+int k = 1;
+
+int f(void)
+{
+	int l = INIT(3);
+	return l + k + j + i;
+}

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1502,7 +1502,14 @@ void cxxParserAnalyzeOtherStatement(void)
 	const bool bPrototypeParams = cxxTagKindEnabled(CXXTagKindPROTOTYPE) && cxxTagKindEnabled(CXXTagKindPARAMETER);
 check_function_signature:
 
-	if(cxxParserLookForFunctionSignature(g_cxx.pTokenChain,&oInfo,bPrototypeParams?&oParamInfo:NULL))
+	if(
+		cxxParserLookForFunctionSignature(g_cxx.pTokenChain,&oInfo,bPrototypeParams?&oParamInfo:NULL)
+		// Even if we saw "();", we cannot say it is a function prototype; a macro expansion can be used to
+		// initialize a top-level variable like:
+		//   #define INIT() 0
+		//   int i = INIT();"
+		&& ! (oInfo.pTypeEnd && cxxTokenTypeIs(oInfo.pTypeEnd,CXXTokenTypeAssignment))
+		)
 	{
 		CXX_DEBUG_PRINT("Found function prototype");
 


### PR DESCRIPTION
The original code could not extract v as a variable in the top-level
in the following code:

  #define INIT(X) X
  int v = INIT(1);

This is because the parser recognized that INIT() in line 2 was a function
prototype.

Close #3277.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>