### PR TITLE
[SELF-INCOMPATIBLE] RpmMacros: remove (macros.*) from the map

### DIFF
--- a/optlib/rpmMacros.c
+++ b/optlib/rpmMacros.c
@@ -63,7 +63,6 @@ extern parserDefinition* RpmMacrosParser (void)
 	};
 
 	static const char *const patterns [] = {
-		"macros.*",
 		NULL
 	};
 

--- a/optlib/rpmMacros.ctags
+++ b/optlib/rpmMacros.ctags
@@ -16,7 +16,10 @@
 # - Run Lua parser as a subparser
 #
 --langdef=RpmMacros
---map-RpmMacros=+(macros.*)
+
+# This map is too generic.
+# e.g. "macros.h" of C language input matches this pattern.
+# --map-RpmMacros=+(macros.*)
 
 # This one is too general.
 # --map-RpmMacros=+(macros)


### PR DESCRIPTION
With this map (macros.\*), ctags could not choose C++ parser
when macros.h is specified as input.
(macros.\*) is too generic as a pattern.

Close #3286.