### PR TITLE
Yaml,OpenAPI: make OpenAPI parser's stack related code reusable

### DIFF
--- a/Units/parser-openapi.r/openapi.d/expected.tags
+++ b/Units/parser-openapi.r/openapi.d/expected.tags
@@ -7,3 +7,5 @@ NullableFieldStringEnum	input.yaml	/^        NullableFieldStringEnum:$/;"	d
 CustomHeader	input.yaml	/^        CustomHeader:$/;"	P
 Response1	input.yaml	/^        Response1:$/;"	R
 Response2	input.yaml	/^        Response2:$/;"	R
+android_handler	input.yaml	/^  - name: android_handler$/;"	T
+ios_handler	input.yaml	/^  - name: ios_handler$/;"	T

--- a/Units/parser-openapi.r/openapi.d/input.yaml
+++ b/Units/parser-openapi.r/openapi.d/input.yaml
@@ -53,3 +53,9 @@ components:
                     schema:
                         type: object
                         properties: {}
+
+tags:
+  - name: android_handler
+    description: Handler for Android clients
+  - name: ios_handler
+    description: Handler for iOS clients

--- a/parsers/openapi.c
+++ b/parsers/openapi.c
@@ -41,41 +41,6 @@ static kindDefinition OpenAPIKinds [] = {
 	{ true, 's', "server", "servers (or hosts in swagger)" },
 };
 
-#define KEY_UNKNOWN KEYWORD_NONE
-enum openapiKeys {
-	KEY_PATHS,
-	KEY_COMPONENTS,
-	KEY_SCHEMAS,
-	KEY_PARAMETERS,
-	KEY_RESPONSES,
-	KEY_DEFINITIONS,
-	KEY_INFO,
-	KEY_TITLE,
-	KEY_SERVERS,
-	KEY_URL,
-	KEY_HOST,
-};
-
-static const keywordTable OpenAPIKeywordTable[] = {
-	{ "paths",       KEY_PATHS       },
-	{ "components",  KEY_COMPONENTS  },
-	{ "schemas",     KEY_SCHEMAS     },
-	{ "parameters",  KEY_PARAMETERS  },
-	{ "responses",   KEY_RESPONSES   },
-	{ "definitions", KEY_DEFINITIONS },
-	{ "info",        KEY_INFO },
-	{ "title",       KEY_TITLE },
-	{ "servers",     KEY_SERVERS },
-	{ "url",         KEY_URL },
-	{ "host",        KEY_HOST },
-};
-
-struct yamlBlockTypeStack {
-	yaml_token_type_t type;
-	enum openapiKeys key;
-	struct yamlBlockTypeStack *next;
-};
-
 /* - name: "THE NAME" */
 enum openapiPlayDetectingState {
 	DSTAT_LAST_KEY,
@@ -86,238 +51,37 @@ enum openapiPlayDetectingState {
 
 struct sOpenAPISubparser {
 	yamlSubparser yaml;
-	struct yamlBlockTypeStack *type_stack;
 	enum openapiPlayDetectingState play_detection_state;
 };
 
-static void pushBlockType (struct sOpenAPISubparser *openapi, yaml_token_type_t t)
-{
-	struct yamlBlockTypeStack *s;
-
-	s = xMalloc (1, struct yamlBlockTypeStack);
-
-	s->next = openapi->type_stack;
-	openapi->type_stack = s;
-
-	s->type = t;
-	s->key = KEY_UNKNOWN;
-}
-
-static void popBlockType (struct sOpenAPISubparser *openapi)
-{
-	struct yamlBlockTypeStack *s;
-
-	s = openapi->type_stack;
-	openapi->type_stack = s->next;
-
-	s->next = NULL;
-
-	eFree (s);
-}
-
-static void popAllBlockType (struct sOpenAPISubparser *openapi)
-{
-	while (openapi->type_stack)
-		popBlockType (openapi);
-}
-
-static bool stateStackMatch (struct yamlBlockTypeStack *stack,
-							 const enum openapiKeys *expectation,
-							 unsigned int length)
-{
-	if (length == 0)
-	{
-		if (stack == NULL)
-			return true;
-		else
-			return false;
-	}
-
-	if (stack == NULL)
-		return false;
-
-	if (stack->key == expectation[0])
-		return stateStackMatch (stack->next, expectation + 1, length - 1);
-	else
-		return false;
-}
-
-static enum openapiKeys parseKey(yaml_token_t *token)
-{
-	static langType langType = LANG_IGNORE;
-	if (langType == LANG_IGNORE)
-		langType = getInputLanguage ();
-
-	return lookupKeyword ((char *)token->data.scalar.value, langType);
-}
-
-#ifdef DO_TRACING
-static void printStack(struct yamlBlockTypeStack* stack)
-{
-	if (!stack)
-	{
-		TRACE_PRINT_NEWLINE();
-		return;
-	}
-
-	tracePrintFmt("[%d] - ", stack->key);
-	printStack(stack->next);
-}
-#endif
-
-struct tagSource {
-	openapiKind kind;
-	const enum openapiKeys* keys;
-	size_t countKeys;
+static tagYpathTable ypathTables [] = {
+	{ "paths/*",
+	  DSTAT_LAST_KEY,   KIND_PATH,      },
+	{ "components/responses/*",
+	  DSTAT_LAST_KEY,   KIND_RESPONSE,  },
+	{ "responses/*",
+	  DSTAT_LAST_KEY,   KIND_RESPONSE,  },
+	{ "components/parameters/*",
+	  DSTAT_LAST_KEY,   KIND_PARAMETER, },
+	{ "parameters/*",
+	  DSTAT_LAST_KEY,   KIND_PARAMETER, },
+	{ "components/schemas/*",
+	  DSTAT_LAST_KEY,   KIND_SCHEMA,    },
+	{ "definitions/*",
+	  DSTAT_LAST_KEY,   KIND_SCHEMA,    },
+	{ "info/title",
+	  DSTAT_LAST_VALUE, KIND_TITLE,     },
+	{ "servers/*/url",
+	  DSTAT_LAST_VALUE, KIND_SERVER,    },
+	{ "host",
+	  DSTAT_LAST_VALUE, KIND_SERVER,    },
 };
-
-static const enum openapiKeys pathKeys[] = {
-	KEY_UNKNOWN,
-	KEY_PATHS,
-};
-
-static const enum openapiKeys responses3Keys[] = {
-	KEY_UNKNOWN,
-	KEY_RESPONSES,
-	KEY_COMPONENTS,
-};
-
-static const enum openapiKeys responses2Keys[] = {
-	KEY_UNKNOWN,
-	KEY_RESPONSES,
-};
-
-static const enum openapiKeys parameters3Keys[] = {
-	KEY_UNKNOWN,
-	KEY_PARAMETERS,
-	KEY_COMPONENTS,
-};
-
-static const enum openapiKeys parameters2Keys[] = {
-	KEY_UNKNOWN,
-	KEY_PARAMETERS,
-};
-
-static const enum openapiKeys schemas3Keys[] = {
-	KEY_UNKNOWN,
-	KEY_SCHEMAS,
-	KEY_COMPONENTS,
-};
-
-static const enum openapiKeys definitions2Keys[] = {
-	KEY_UNKNOWN,
-	KEY_DEFINITIONS,
-};
-
-static const enum openapiKeys title3Keys[] = {
-	KEY_TITLE,
-	KEY_INFO,
-};
-
-static const enum openapiKeys server3Keys[] = {
-	KEY_URL,
-	KEY_UNKNOWN,
-	KEY_SERVERS,
-};
-
-static const enum openapiKeys host2Keys[] = {
-	KEY_HOST,
-};
-
-static const struct tagSource tagSources[] = {
-	{
-		KIND_PATH,
-		pathKeys,
-		ARRAY_SIZE (pathKeys),
-	},
-	{
-		KIND_RESPONSE,
-		responses3Keys,
-		ARRAY_SIZE (responses3Keys),
-	},
-	{
-		KIND_RESPONSE,
-		responses2Keys,
-		ARRAY_SIZE (responses2Keys),
-	},
-	{
-		KIND_PARAMETER,
-		parameters3Keys,
-		ARRAY_SIZE (parameters3Keys),
-	},
-	{
-		KIND_PARAMETER,
-		parameters2Keys,
-		ARRAY_SIZE (parameters2Keys),
-	},
-	{
-		KIND_SCHEMA,
-		schemas3Keys,
-		ARRAY_SIZE (schemas3Keys),
-	},
-	{
-		KIND_SCHEMA,
-		definitions2Keys,
-		ARRAY_SIZE (definitions2Keys),
-	},
-};
-
-static const struct tagSource tagValueSources[] = {
-	{
-		KIND_TITLE,
-		title3Keys,
-		ARRAY_SIZE (title3Keys),
-	},
-	{
-		KIND_SERVER,
-		server3Keys,
-		ARRAY_SIZE (server3Keys),
-	},
-	{
-		KIND_SERVER,
-		host2Keys,
-		ARRAY_SIZE (host2Keys),
-	}
-};
-
-static void handleToken(struct sOpenAPISubparser *openapi, yaml_token_t *token,
-						const struct tagSource *tss, size_t ts_count)
-{
-	for (int i = 0; i < ts_count; i++)
-	{
-		const struct tagSource* ts = &tss[i];
-
-		if (stateStackMatch(openapi->type_stack,
-							ts->keys, ts->countKeys))
-		{
-
-			tagEntryInfo tag;
-			initTagEntry (&tag, (char *)token->data.scalar.value, ts->kind);
-			attachYamlPosition (&tag, token, false);
-
-			makeTagEntry (&tag);
-			break;
-		}
-	}
-}
-
-static void handleKey(struct sOpenAPISubparser *openapi,
-					  yaml_token_t *token)
-{
-	handleToken (openapi, token, tagSources, ARRAY_SIZE (tagSources));
-}
-
-static void handleValue(struct sOpenAPISubparser *openapi,
-						yaml_token_t *token)
-{
-	handleToken (openapi, token, tagValueSources, ARRAY_SIZE (tagValueSources));
-}
 
 static void	openapiPlayStateMachine (struct sOpenAPISubparser *openapi,
 									 yaml_token_t *token)
 {
 #ifdef DO_TRACING
-	printStack(openapi->type_stack);
+	ypathPrintTypeStack (YAML(openapi));
 #endif
 
 	switch (token->type)
@@ -329,17 +93,14 @@ static void	openapiPlayStateMachine (struct sOpenAPISubparser *openapi,
 		switch (openapi->play_detection_state)
 		{
 		case DSTAT_LAST_KEY:
-			TRACE_PRINT("  key: %s", (char*)token->data.scalar.value);
-			if (openapi->type_stack)
-			{
-				openapi->type_stack->key = parseKey(token);
-				handleKey (openapi, token);
-			}
-			break;
+			ypathFillKeywordOfTokenMaybe (YAML(openapi), token, getInputLanguage ());
+			/* FALL THROUGH */
 		case DSTAT_LAST_VALUE:
-			TRACE_PRINT("  value: %s", (char*)token->data.scalar.value);
-			if (openapi->type_stack)
-				handleValue (openapi, token);
+			TRACE_PRINT("token-callback: %s: %s",
+						(openapi->play_detection_state == DSTAT_LAST_KEY)? "key": "value",
+						(char*)token->data.scalar.value);
+			ypathHandleToken (YAML(openapi), token, openapi->play_detection_state,
+							  ypathTables, ARRAY_SIZE (ypathTables));
 			break;
 		default:
 			break;
@@ -362,30 +123,41 @@ static void newTokenCallback (yamlSubparser *s, yaml_token_t *token)
 {
 	if (token->type == YAML_BLOCK_SEQUENCE_START_TOKEN
 		|| token->type == YAML_BLOCK_MAPPING_START_TOKEN)
-		pushBlockType ((struct sOpenAPISubparser *)s, token->type);
+		ypathPushType (s, token);
 
 	openapiPlayStateMachine ((struct sOpenAPISubparser *)s, token);
 
 	if (token->type == YAML_BLOCK_END_TOKEN)
-		popBlockType ((struct sOpenAPISubparser *)s);
+		ypathPopType (s);
 	else if (token->type == YAML_STREAM_END_TOKEN)
-		popAllBlockType ((struct sOpenAPISubparser *)s);
+		ypathPopAllTypes (s);
 }
 
 static void inputStart(subparser *s)
 {
 	((struct sOpenAPISubparser*)s)->play_detection_state = DSTAT_INITIAL;
-	((struct sOpenAPISubparser*)s)->type_stack = NULL;
+	((yamlSubparser*)s)->ypathTypeStack = NULL;
 }
 
 static void inputEnd(subparser *s)
 {
-	Assert (((struct sOpenAPISubparser*)s)->type_stack == NULL);
+	Assert (((yamlSubparser*)s)->ypathTypeStack == NULL);
 }
 
 static void findOpenAPITags (void)
 {
 	scheduleRunningBaseparser (0);
+}
+
+static void initialize (langType language)
+{
+	ypathCompileTables (language, ypathTables, ARRAY_SIZE (ypathTables), 0);
+}
+
+static void finalize (langType language, bool initialized)
+{
+	if (initialized)
+		ypathCompiledCodeDelete (ypathTables, ARRAY_SIZE (ypathTables));
 }
 
 extern parserDefinition* OpenAPIParser (void)
@@ -412,11 +184,10 @@ extern parserDefinition* OpenAPIParser (void)
 	def->dependencies = dependencies;
 	def->dependencyCount = ARRAY_SIZE (dependencies);
 
-	def->keywordTable = OpenAPIKeywordTable;
-	def->keywordCount = ARRAY_SIZE (OpenAPIKeywordTable);
-
 	def->kindTable	= OpenAPIKinds;
 	def->kindCount = ARRAY_SIZE (OpenAPIKinds);
 	def->parser	= findOpenAPITags;
+	def->initialize = initialize;
+	def->finalize = finalize;
 	return def;
 }

--- a/parsers/openapi.c
+++ b/parsers/openapi.c
@@ -30,6 +30,7 @@ typedef enum {
 	KIND_PARAMETER,
 	KIND_TITLE,
 	KIND_SERVER,
+	KIND_TAG,
 } openapiKind;
 
 static kindDefinition OpenAPIKinds [] = {
@@ -39,6 +40,7 @@ static kindDefinition OpenAPIKinds [] = {
 	{ true, 'P', "parameter", "parameters" },
 	{ true, 't', "title", "titles" },
 	{ true, 's', "server", "servers (or hosts in swagger)" },
+	{ true, 'T', "tag", "tags"},
 };
 
 /* - name: "THE NAME" */
@@ -75,6 +77,8 @@ static tagYpathTable ypathTables [] = {
 	  DSTAT_LAST_VALUE, KIND_SERVER,    },
 	{ "host",
 	  DSTAT_LAST_VALUE, KIND_SERVER,    },
+	{ "tags/*/name",
+	  DSTAT_LAST_VALUE, KIND_TAG,       },
 };
 
 static void	openapiPlayStateMachine (struct sOpenAPISubparser *openapi,

--- a/parsers/yaml.c
+++ b/parsers/yaml.c
@@ -121,7 +121,6 @@ static void handlYamlToken (yaml_token_t *token)
 		attachYamlPosition (&tag, token, false);
 		makeTagEntry (&tag);
 	}
-
 }
 
 static void findYamlTags (void)
@@ -178,10 +177,10 @@ extern parserDefinition* YamlParser (void)
 
 	def->kindTable = YamlKinds;
 	def->extensions = extensions;
-	def->parser     = findYamlTags;
-	def->useCork    = CORK_QUEUE;
-	def->kindTable         = YamlKinds;
-	def->kindCount     = ARRAY_SIZE (YamlKinds);
+	def->parser = findYamlTags;
+	def->useCork = CORK_QUEUE;
+	def->kindTable = YamlKinds;
+	def->kindCount = ARRAY_SIZE (YamlKinds);
 	def->useMemoryStreamInput = true;
 
 	return def;

--- a/parsers/yaml.h
+++ b/parsers/yaml.h
@@ -2,6 +2,7 @@
  *
  *   Copyright (c) 2016, Masatake YAMATO
  *   Copyright (c) 2016, Red Hat, K.K.
+ *   Copyright (c) 2022, Vasily Kulikov
  *
  *   This source code is released for free distribution under the terms of the
  *   GNU General Public License version 2 or (at your option) any later version.
@@ -21,12 +22,38 @@
 #define yaml_token_t void
 #endif
 
+struct ypathTypeStack;
+
 typedef struct sYamlSubparser yamlSubparser;
 struct sYamlSubparser {
 	subparser subparser;
 	void (* newTokenNotfify) (yamlSubparser *s, yaml_token_t *token);
+	struct ypathTypeStack *ypathTypeStack;
 };
+#define YAML(S) ((yamlSubparser *)S)
 
 extern void attachYamlPosition (tagEntryInfo *tag, yaml_token_t *token, bool asEndPosition);
 
+/*
+ * Experimental Ypath code
+ */
+typedef struct sTagYpathTable {
+	const char * ypath;
+	int expected_state;
+	int kind;
+	void *code;
+} tagYpathTable;
+
+extern int ypathCompileTable (langType language, tagYpathTable *table, int keywordId);
+extern void ypathCompileTables (langType language, tagYpathTable tables[], size_t count, int keywordId);
+extern void ypathCompiledCodeDelete (tagYpathTable tables[], size_t count);
+
+extern void ypathHandleToken (yamlSubparser *yaml, yaml_token_t *token, int state, tagYpathTable tables[], size_t count);
+
+extern void ypathPushType (yamlSubparser *yaml, yaml_token_t *token);
+extern void ypathPopType (yamlSubparser *yaml);
+extern void ypathPopAllTypes (yamlSubparser *yaml);
+extern void ypathFillKeywordOfTokenMaybe (yamlSubparser *yaml, yaml_token_t *token, langType lang);
+
+extern void ypathPrintTypeStack(yamlSubparser *yaml);
 #endif


### PR DESCRIPTION
The technique used in OpenAPI may be helpful to implement another YAML subparser.
So, I moved the code implementing the technique to the YAML parser experimentally in this change.

The original code uses an array of keywords for pointing out interesting tokens.
This change uses a string for the same purpose. The routines in this change convert the string to an array of keywords.
Till a real specification and its implementation becomes available, we call the format of the string Ypath.