### PR TITLE
Reset protobuf syntax

### DIFF
--- a/parsers/protobuf.c
+++ b/parsers/protobuf.c
@@ -661,6 +661,8 @@ static void findProtobufTags (void)
 			 FIELD_UNKNOWN);
 	token.value = vStringNew ();
 
+	syntax = SYNTAX_UNKNOWN;
+
 	nextToken ();
 	findProtobufTags0 (false, CORK_NIL);
 


### PR DESCRIPTION
Prior to this change, parsing a proto3 file (with `syntax = "proto3";`) then a proto2 file (without a syntax directive) would incorrectly interpret the proto2 file as a proto3 file. That was happening because the syntax version wasn't getting reset between files.

Example failure:

```proto
syntax = "proto3";
```

```proto
message Data {
	required uint64 MaxNodeID = 7;
}
```

ctags would find a symbol named `uint64` when it should have found `MaxNodeID`.