### PR TITLE
RMarkdown: new parser

### DIFF
--- a/Tmain/list-subparsers-all.d/stdout-expected.txt
+++ b/Tmain/list-subparsers-all.d/stdout-expected.txt
@@ -15,6 +15,7 @@ PlistXML             XML        base <> sub {bidirectional}
 PythonLoggingConfig  Iniconf    base <> sub {bidirectional}
 QtMoc                C++        base <> sub {bidirectional}
 R6Class              R          base <> sub {bidirectional}
+RMarkdown            Markdown   base <= sub {dedicated}
 RSpec                Ruby       base => sub {shared}
 RelaxNG              XML        base <> sub {bidirectional}
 S4Class              R          base <> sub {bidirectional}

--- a/Units/parser-markdown.r/footnotes.d/args.ctags
+++ b/Units/parser-markdown.r/footnotes.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--fields=+nK

--- a/Units/parser-markdown.r/footnotes.d/expected.tags
+++ b/Units/parser-markdown.r/footnotes.d/expected.tags
@@ -1,0 +1,2 @@
+1	input.md	/^[^1]: This is the first footnote.$/;"	footnote	line:4
+bignote	input.md	/^[^bignote]: Here's one with multiple paragraphs and code.$/;"	footnote	line:6

--- a/Units/parser-markdown.r/footnotes.d/input.md
+++ b/Units/parser-markdown.r/footnotes.d/input.md
@@ -1,0 +1,12 @@
+<!-- Taken from https://www.markdownguide.org/extended-syntax/#footnotes -->
+Here's a simple footnote,[^1] and here's a longer one.[^bignote]
+
+[^1]: This is the first footnote.
+
+[^bignote]: Here's one with multiple paragraphs and code.
+
+    Indent paragraphs to include them in the footnote.
+
+    `{ my code }`
+
+    Add as many paragraphs as you like.

--- a/Units/parser-rmarkdown.r/simple-rmarkdown.d/args.ctags
+++ b/Units/parser-rmarkdown.r/simple-rmarkdown.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+g
+--fields=+KenlE

--- a/Units/parser-rmarkdown.r/simple-rmarkdown.d/expected.tags
+++ b/Units/parser-rmarkdown.r/simple-rmarkdown.d/expected.tags
@@ -1,0 +1,11 @@
+S1	input.rmd	/^# S1$/;"	chapter	line:1	language:Markdown	end:14
+xyX	input.rmd	/^```{r xyX}$/;"	chunklabel	line:3	language:RMarkdown	extras:subparser
+S2	input.rmd	/^# S2$/;"	chapter	line:15	language:Markdown	end:25
+__anon4a45a9700100	input.rmd	/^```{r, cache = TRUE, dependson = "xyX"}$/;"	chunklabel	line:17	language:RMarkdown	extras:subparser,anonymous
+__anon4a45a9700200	input.rmd	/^```{python}$/;"	chunklabel	line:21	language:RMarkdown	extras:subparser,anonymous
+S3	input.rmd	/^# S3$/;"	chapter	line:26	language:Markdown	end:27
+x	input.rmd	/^x <- 1$/;"	globalVar	line:5	language:R	extras:guest	end:5
+foo	input.rmd	/^foo <- function () {$/;"	function	line:6	language:R	extras:guest	end:9
+y	input.rmd	/^    y <- 2$/;"	functionVar	line:7	language:R	function:foo	extras:guest	end:7
+X	input.rmd	/^X <- func()$/;"	globalVar	line:11	language:R	extras:guest	end:11
+f	input.rmd	/^def f():$/;"	function	line:22	language:Python	extras:guest	end:24

--- a/Units/parser-rmarkdown.r/simple-rmarkdown.d/input.rmd
+++ b/Units/parser-rmarkdown.r/simple-rmarkdown.d/input.rmd
@@ -1,0 +1,27 @@
+# S1
+
+```{r xyX}
+
+x <- 1
+foo <- function () {
+    y <- 2
+    return(y)
+}
+
+X <- func()
+
+```
+
+# S2
+
+```{r, cache = TRUE, dependson = "xyX"}
+mean(X)
+```
+
+```{python}
+def f():
+   g()
+   return 3
+```
+# S3
+

--- a/docs/man/ctags-lang-iPythonCell.7.rst
+++ b/docs/man/ctags-lang-iPythonCell.7.rst
@@ -12,20 +12,20 @@ The man page of the iPythonCell parser for Universal Ctags
 
 SYNOPSIS
 --------
-|	**ctags** ... --extras={subparser} --languages=+iPythonCell,Python \\
+|	**ctags** ... --extras=+{subparser} --languages=+iPythonCell,Python \\
 |                     [--extras-IPythonCell=+{doubleSharps}] \\
 |                     [--regex-IPythonCell=/<PATTERN>/\\n/c/] ...
 
 DESCRIPTION
 -----------
-iPythonCell is a subparser stacked on top of the Python parser.
+iPythonCell parser is a subparser stacked on top of the Python parser.
 It works when:
 
-* The Python parser is enabled,
+* the Python parser is enabled,
 * the ``subparser`` extra is enabled, and
 * the iPythonCell parser itself is enabled.
 
-iPythonCell extracts cells explained as in vim-ipython-cell
+The iPythonCell parser extracts cells explained as in vim-ipython-cell
 (https://github.com/hanschen/vim-ipython-cell/blob/master/README.md).
 
 KIND(S)

--- a/docs/man/ctags-lang-rmarkdown.7.rst
+++ b/docs/man/ctags-lang-rmarkdown.7.rst
@@ -1,0 +1,98 @@
+.. _ctags_lang-rmarkdown(7):
+
+======================================================================
+ctags-lang-rmarkdown
+======================================================================
+
+Random notes about tagging R Markdown source code with Universal Ctags
+
+:Version: 5.9.0
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**ctags** ...--extras=+{subparser}{guest} --languages=+RMarkdown ...
+|	**ctags** ...--extras=+{subparser}{guest} --language-force=RMarkdown ...
+|	**ctags** ...--extras=+{subparser}{guest} --map-RMarkdown=+.rmd ...
+
+DESCRIPTION
+-----------
+RMarkdown parser is an exclusive subparser stacked on top of the Markdown parser.
+It works when:
+
+* the Markdown parser is enabled,
+* the ``subparser`` extra is enabled, and
+* the RMarkdown parser itself is enabled.
+
+The RMarkdown parser extends the way of detecting **codeblocks** from the
+Markdown parser for running guest parsers on **code chunks**.
+
+The Markdown parser expects the following syntax for codeblocks
+
+.. code-block::
+
+	```language-name
+		...
+	```
+
+For an example
+
+.. code-block::
+
+	```r
+		...
+	```
+
+The RMarkdown parser accepts the following syntax for code chunks
+as the markdown parser accepts codeblocks
+
+.. code-block::
+
+	```{language-name chunk-label, ...}
+		...
+	```
+
+For an example
+
+.. code-block::
+
+	```{r precalc fig.height=4}
+		...
+	```
+
+Give `--extras=+{guest}` for enabling ``guest`` to command line if you
+want to run proper parsers on inside code chunks.
+
+The parser extrats chunk labels coming after `language-name` as
+`chunklabel` kind objcts. The kind is enabled by default.
+
+EXAMPLES
+--------
+"input.rmd"
+
+.. code-block:: RMarkdown
+
+	# Section 1
+
+	```{r myblock}
+		zero_fun <- function () {
+			return 0
+		}
+	```
+
+	# Section 2
+
+"output.tags"
+with "--options=NONE --extras=+{guest} --fields=+KZln -o - input.rmd"
+
+.. code-block:: tags
+
+	Section 1	input.rmd	/^# Section 1$/;"	chapter	line:1	language:Markdown
+	Section 2	input.rmd	/^# Section 2$/;"	chapter	line:9	language:Markdown
+	myblock	input.rmd	/^```{r myblock}$/;"	chunklabel	line:3	language:RMarkdown
+	zero_fun	input.rmd	/^	zero_fun <- function () {$/;"	function	line:4	language:R
+
+SEE ALSO
+--------
+:ref:`ctags(1) <ctags(1)>`, :ref:`ctags-client-tools(7) <ctags-client-tools(7)>`, `R Markdown: The Definitive Guide <https://bookdown.org/yihui/rmarkdown/>`_

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -455,6 +455,7 @@ The following parsers have been added:
 * R6Class *R based subparser*
 * RelaxNG *libxml*
 * ReStructuredText
+* RMarkdown *Markdown based subparser*
 * Robot
 * RpmMacros *optlib*
 * RpmSpec

--- a/main/parsers_p.h
+++ b/main/parsers_p.h
@@ -137,6 +137,7 @@
 	PythonLoggingConfigParser, \
 	QemuHXParser, \
 	QtMocParser, \
+	RMarkdownParser, \
 	RParser, \
 	R6ClassParser, \
 	RSpecParser, \

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -35,6 +35,7 @@ GEN_IN_MAN_FILES = \
 	ctags-lang-verilog.7 \
 	ctags-lang-inko.7 \
 	ctags-lang-r.7 \
+	ctags-lang-rmarkdown.7 \
 	ctags-lang-sql.7 \
 	\
 	readtags.1 \

--- a/man/ctags-lang-iPythonCell.7.rst.in
+++ b/man/ctags-lang-iPythonCell.7.rst.in
@@ -12,20 +12,20 @@ The man page of the iPythonCell parser for Universal Ctags
 
 SYNOPSIS
 --------
-|	**@CTAGS_NAME_EXECUTABLE@** ... --extras={subparser} --languages=+iPythonCell,Python \\
+|	**@CTAGS_NAME_EXECUTABLE@** ... --extras=+{subparser} --languages=+iPythonCell,Python \\
 |                     [--extras-IPythonCell=+{doubleSharps}] \\
 |                     [--regex-IPythonCell=/<PATTERN>/\\n/c/] ...
 
 DESCRIPTION
 -----------
-iPythonCell is a subparser stacked on top of the Python parser.
+iPythonCell parser is a subparser stacked on top of the Python parser.
 It works when:
 
-* The Python parser is enabled,
+* the Python parser is enabled,
 * the ``subparser`` extra is enabled, and
 * the iPythonCell parser itself is enabled.
 
-iPythonCell extracts cells explained as in vim-ipython-cell
+The iPythonCell parser extracts cells explained as in vim-ipython-cell
 (https://github.com/hanschen/vim-ipython-cell/blob/master/README.md).
 
 KIND(S)

--- a/man/ctags-lang-rmarkdown.7.rst.in
+++ b/man/ctags-lang-rmarkdown.7.rst.in
@@ -1,0 +1,98 @@
+.. _ctags_lang-rmarkdown(7):
+
+======================================================================
+ctags-lang-rmarkdown
+======================================================================
+-----------------------------------------------------------------------
+Random notes about tagging R Markdown source code with Universal Ctags
+-----------------------------------------------------------------------
+:Version: @VERSION@
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**@CTAGS_NAME_EXECUTABLE@** ...--extras=+{subparser}{guest} --languages=+RMarkdown ...
+|	**@CTAGS_NAME_EXECUTABLE@** ...--extras=+{subparser}{guest} --language-force=RMarkdown ...
+|	**@CTAGS_NAME_EXECUTABLE@** ...--extras=+{subparser}{guest} --map-RMarkdown=+.rmd ...
+
+DESCRIPTION
+-----------
+RMarkdown parser is an exclusive subparser stacked on top of the Markdown parser.
+It works when:
+
+* the Markdown parser is enabled,
+* the ``subparser`` extra is enabled, and
+* the RMarkdown parser itself is enabled.
+
+The RMarkdown parser extends the way of detecting **codeblocks** from the
+Markdown parser for running guest parsers on **code chunks**.
+
+The Markdown parser expects the following syntax for codeblocks
+
+.. code-block::
+
+	```language-name
+		...
+	```
+
+For an example
+
+.. code-block::
+
+	```r
+		...
+	```
+
+The RMarkdown parser accepts the following syntax for code chunks
+as the markdown parser accepts codeblocks
+
+.. code-block::
+
+	```{language-name chunk-label, ...}
+		...
+	```
+
+For an example
+
+.. code-block::
+
+	```{r precalc fig.height=4}
+		...
+	```
+
+Give `--extras=+{guest}` for enabling ``guest`` to command line if you
+want to run proper parsers on inside code chunks.
+
+The parser extrats chunk labels coming after `language-name` as
+`chunklabel` kind objcts. The kind is enabled by default.
+
+EXAMPLES
+--------
+"input.rmd"
+
+.. code-block:: RMarkdown
+
+	# Section 1
+
+	```{r myblock}
+		zero_fun <- function () {
+			return 0
+		}
+	```
+
+	# Section 2
+
+"output.tags"
+with "--options=NONE --extras=+{guest} --fields=+KZln -o - input.rmd"
+
+.. code-block:: tags
+
+	Section 1	input.rmd	/^# Section 1$/;"	chapter	line:1	language:Markdown
+	Section 2	input.rmd	/^# Section 2$/;"	chapter	line:9	language:Markdown
+	myblock	input.rmd	/^```{r myblock}$/;"	chunklabel	line:3	language:RMarkdown
+	zero_fun	input.rmd	/^	zero_fun <- function () {$/;"	function	line:4	language:R
+
+SEE ALSO
+--------
+ctags(1), ctags-client-tools(7), `R Markdown: The Definitive Guide <https://bookdown.org/yihui/rmarkdown/>`_

--- a/parsers/markdown.c
+++ b/parsers/markdown.c
@@ -231,15 +231,14 @@ static void findMarkdownTags (void)
 				{
 					startSourceLineNumber = getSourceLineNumber ();
 					startLineNumber = getInputLineNumber ();
-					vStringClear (codeLang);
-					vStringCatS (codeLang, (const char *)(line + pos + nSame));
+					vStringCopyS (codeLang, (const char *)(line + pos + nSame));
 					vStringStripLeading (codeLang);
 					vStringStripTrailing (codeLang);
 				}
 				else
 				{
 					long endLineNumber = getInputLineNumber () - 1;
-					if (codeLang->size > 0)
+					if (vStringLength (codeLang) > 0)
 						makePromise (vStringValue (codeLang), startLineNumber, 0,
 							endLineNumber, 0, startSourceLineNumber);
 				}

--- a/parsers/markdown.c
+++ b/parsers/markdown.c
@@ -229,7 +229,7 @@ static void findMarkdownTags (void)
 		bool lineProcessed = false;
 		bool indented;
 		int pos = getFirstCharPos (line, lineLen, &indented);
-		int lineNum = getInputLineNumber ();
+		const int lineNum = getInputLineNumber ();
 
 		if (lineNum == 1 || inPreambule)
 		{
@@ -255,16 +255,16 @@ static void findMarkdownTags (void)
 					inCodeChar = 0;
 				else if (inCodeChar)
 				{
-					startSourceLineNumber = getSourceLineNumber ();
-					startLineNumber = getInputLineNumber ();
+					startLineNumber = startSourceLineNumber = lineNum + 1;
 					vStringCopyS (codeLang, (const char *)(line + pos + nSame));
 					vStringStripLeading (codeLang);
 					vStringStripTrailing (codeLang);
 				}
 				else
 				{
-					long endLineNumber = getInputLineNumber () - 1;
-					if (vStringLength (codeLang) > 0)
+					long endLineNumber = lineNum;
+					if (vStringLength (codeLang) > 0
+						&& startLineNumber < endLineNumber)
 						makePromise (vStringValue (codeLang), startLineNumber, 0,
 							endLineNumber, 0, startSourceLineNumber);
 				}

--- a/parsers/markdown.h
+++ b/parsers/markdown.h
@@ -1,0 +1,29 @@
+/*
+*   Copyright (c) 2022, Masatake YAMATO
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   The interface for subparsers of Markdown
+*/
+#ifndef CTAGS_PARSER_MARKDOWN_H
+#define CTAGS_PARSER_MARKDOWN_H
+
+/*
+*   INCLUDE FILES
+*/
+#include "general.h"  /* must always come first */
+
+#include "subparser.h"
+#include "vstring.h"
+
+typedef struct sMarkdownSubparser markdownSubparser;
+
+struct sMarkdownSubparser {
+	subparser subparser;
+	bool (* extractLanguageForCodeBlock) (markdownSubparser *s,
+										  const char *langMarker,
+										  vString *langName);
+};
+
+#endif

--- a/parsers/rmarkdown.c
+++ b/parsers/rmarkdown.c
@@ -1,0 +1,134 @@
+/*
+ *
+ *  Copyright (c) 2022, Masatake YAMATO
+ *
+ *   This source code is released for free distribution under the terms of the
+ *   GNU General Public License version 2 or (at your option) any later version.
+ *
+ * This module contains functions for generating tags for R Markdown files.
+ * https://bookdown.org/yihui/rmarkdown/
+ *
+ */
+
+/*
+ *   INCLUDE FILES
+ */
+#include "general.h"	/* must always come first */
+#include "markdown.h"
+
+#include "entry.h"
+#include "parse.h"
+
+#include <ctype.h>
+#include <string.h>
+
+/*
+ *   DATA DEFINITIONS
+ */
+typedef enum {
+	K_CHUNK_LABEL = 0,
+} rmarkdownKind;
+
+static kindDefinition RMarkdownKinds[] = {
+	{ true, 'l', "chunklabel",       "chunk labels"},
+};
+
+struct sRMarkdownSubparser {
+	markdownSubparser markdown;
+};
+
+/*
+*   FUNCTION DEFINITIONS
+*/
+
+static void findRMarkdownTags (void)
+{
+	scheduleRunningBaseparser (0);
+}
+
+#define skip_space(CP) 	while (*CP == ' ' || *CP == '\t') CP++;
+
+static void makeRMarkdownTag (vString *name, int kindIndex, bool anonymous)
+{
+	tagEntryInfo e;
+	initTagEntry (&e, vStringValue (name), kindIndex);
+	if (anonymous)
+		markTagExtraBit (&e, XTAG_ANONYMOUS);
+	makeTagEntry (&e);
+}
+
+static bool extractLanguageForCodeBlock (markdownSubparser *s,
+										 const char *langMarker,
+										 vString *langName)
+{
+	const char *cp = langMarker;
+
+	if (*cp != '{')
+		return false;
+	cp++;
+
+	const char *end = strpbrk(cp, " \t,}");
+	if (!end)
+		return false;
+
+	if (end - cp == 0)
+		return false;
+
+	vStringNCatS (langName, cp, end - cp);
+
+	cp = end;
+	if (*cp == ',' || *cp == '}')
+	{
+		vString *name = anonGenerateNew("__anon", K_CHUNK_LABEL);
+		makeRMarkdownTag (name, K_CHUNK_LABEL, true);
+		vStringDelete (name);
+		return true;
+	}
+
+	skip_space(cp);
+
+	vString *chunk_label  = vStringNew ();
+	bool anonymous = false;
+	while (isalnum((unsigned char)*cp) || *cp == '-')
+		vStringPut (chunk_label, *cp++);
+
+	if (vStringLength (chunk_label) == 0)
+	{
+		anonGenerate (chunk_label, "__anon", K_CHUNK_LABEL);
+		anonymous = true;
+	}
+
+	skip_space(cp);
+	if (*cp == ',' || *cp == '}')
+		makeRMarkdownTag (chunk_label, K_CHUNK_LABEL, anonymous);
+
+	vStringDelete (chunk_label);
+	return true;
+}
+
+extern parserDefinition* RMarkdownParser (void)
+{
+	static const char *const extensions [] = { "rmd", NULL };
+	static struct sRMarkdownSubparser rmarkdownSubparser = {
+		.markdown = {
+			.subparser = {
+				.direction = SUBPARSER_SUB_RUNS_BASE,
+			},
+			.extractLanguageForCodeBlock = extractLanguageForCodeBlock,
+		},
+	};
+	static parserDependency dependencies [] = {
+		[0] = { DEPTYPE_SUBPARSER, "Markdown", &rmarkdownSubparser },
+	};
+
+	parserDefinition* const def = parserNew ("RMarkdown");
+
+
+	def->dependencies = dependencies;
+	def->dependencyCount = ARRAY_SIZE(dependencies);
+	def->kindTable      = RMarkdownKinds;
+	def->kindCount  = ARRAY_SIZE (RMarkdownKinds);
+	def->extensions = extensions;
+	def->parser     = findRMarkdownTags;
+	return def;
+}

--- a/source.mak
+++ b/source.mak
@@ -261,6 +261,7 @@ PARSER_HEADS = \
 	parsers/iniconf.h \
 	parsers/m4.h \
 	parsers/make.h \
+	parsers/markdown.h \
 	parsers/perl.h \
 	parsers/r.h \
 	parsers/ruby.h \
@@ -356,6 +357,7 @@ PARSER_SRCS =				\
 	parsers/r-s4class.c		\
 	parsers/r.c			\
 	parsers/rexx.c			\
+	parsers/rmarkdown.c		\
 	parsers/robot.c			\
 	parsers/rpmspec.c		\
 	parsers/rspec.c			\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -337,6 +337,7 @@
     <ClCompile Include="..\parsers\r-s4class.c" />
     <ClCompile Include="..\parsers\r.c" />
     <ClCompile Include="..\parsers\rexx.c" />
+    <ClCompile Include="..\parsers\rmarkdown.c" />
     <ClCompile Include="..\parsers\robot.c" />
     <ClCompile Include="..\parsers\rpmspec.c" />
     <ClCompile Include="..\parsers\rspec.c" />
@@ -448,6 +449,7 @@
     <ClInclude Include="..\parsers\iniconf.h" />
     <ClInclude Include="..\parsers\m4.h" />
     <ClInclude Include="..\parsers\make.h" />
+    <ClInclude Include="..\parsers\markdown.h" />
     <ClInclude Include="..\parsers\perl.h" />
     <ClInclude Include="..\parsers\r.h" />
     <ClInclude Include="..\parsers\ruby.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -534,6 +534,9 @@
     <ClCompile Include="..\parsers\rexx.c">
       <Filter>Source Files\parsers</Filter>
     </ClCompile>
+    <ClCompile Include="..\parsers\rmarkdown.c">
+      <Filter>Source Files\parsers</Filter>
+    </ClCompile>
     <ClCompile Include="..\parsers\robot.c">
       <Filter>Source Files\parsers</Filter>
     </ClCompile>
@@ -861,6 +864,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\parsers\make.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\parsers\markdown.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\parsers\perl.h">


### PR DESCRIPTION
The parser supports `{r label}` syntax as described in https://bookdown.org/yihui/rmarkdown/.
`{r` part is parsed to choose a guest.
`label` in `label}` part is tagged as a chunkLabel kind object.