### PR TITLE
Elm: roles:imported -> roles:exposed for non-modules

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -40,10 +40,14 @@ DTD            e/element         attOwner           on      attributes owner
 DTD            p/parameterEntity condition          on      conditions
 DTD            p/parameterEntity elementName        on      element names
 DTD            p/parameterEntity partOfAttDef       on      part of attribute definition
-Elm            c/constructor     imported           on      item imported
-Elm            f/function        imported           on      item imported
-Elm            m/module          imported           on      item imported
-Elm            t/type            imported           on      item imported
+Elm            c/constructor     exposed            on      item exposed from a module
+Elm            c/constructor     imported           on      module imported
+Elm            f/function        exposed            on      item exposed from a module
+Elm            f/function        imported           on      module imported
+Elm            m/module          exposed            on      item exposed from a module
+Elm            m/module          imported           on      module imported
+Elm            t/type            exposed            on      item exposed from a module
+Elm            t/type            imported           on      module imported
 Flex           I/import          import             on      imports
 GDScript       c/class           extended           on      used as a base class for extending
 GemSpec        g/gem             develDep           on      specifying development dependency
@@ -148,10 +152,14 @@ DTD            e/element         attOwner           on      attributes owner
 DTD            p/parameterEntity condition          on      conditions
 DTD            p/parameterEntity elementName        on      element names
 DTD            p/parameterEntity partOfAttDef       on      part of attribute definition
-Elm            c/constructor     imported           on      item imported
-Elm            f/function        imported           on      item imported
-Elm            m/module          imported           on      item imported
-Elm            t/type            imported           on      item imported
+Elm            c/constructor     exposed            on      item exposed from a module
+Elm            c/constructor     imported           on      module imported
+Elm            f/function        exposed            on      item exposed from a module
+Elm            f/function        imported           on      module imported
+Elm            m/module          exposed            on      item exposed from a module
+Elm            m/module          imported           on      module imported
+Elm            t/type            exposed            on      item exposed from a module
+Elm            t/type            imported           on      module imported
 Flex           I/import          import             on      imports
 GDScript       c/class           extended           on      used as a base class for extending
 GemSpec        g/gem             develDep           on      specifying development dependency

--- a/Units/parser-elm.r/elm-imports.d/expected.tags
+++ b/Units/parser-elm.r/elm-imports.d/expected.tags
@@ -1,22 +1,22 @@
 SomeMod	input.elm	/^module SomeMod exposing (..)$/;"	m	roles:def
 PlainImport	input.elm	/^import PlainImport$/;"	m	roles:imported
 MyMod	input.elm	/^import MyMod exposing$/;"	m	roles:imported
-map	input.elm	/^    ( map, foldl$/;"	f	module:MyMod	roles:imported
-foldl	input.elm	/^    ( map, foldl$/;"	f	module:MyMod	roles:imported
-Maybe	input.elm	/^    , Maybe, Possibly$/;"	t	module:MyMod	roles:imported
-Possibly	input.elm	/^    , Maybe, Possibly$/;"	t	module:MyMod	roles:imported
-Result	input.elm	/^    , Result(..)$/;"	t	module:MyMod	roles:imported
-MyList	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	t	module:MyMod	roles:imported
-Empty	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	c	type:MyMod.MyList	roles:imported
-Tree	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	t	module:MyMod	roles:imported
-Node	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	c	type:MyMod.Tree	roles:imported
-Value	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	c	type:MyMod.Tree	roles:imported
-Special	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	c	type:MyMod.Tree	roles:imported
+map	input.elm	/^    ( map, foldl$/;"	f	module:MyMod	roles:exposed
+foldl	input.elm	/^    ( map, foldl$/;"	f	module:MyMod	roles:exposed
+Maybe	input.elm	/^    , Maybe, Possibly$/;"	t	module:MyMod	roles:exposed
+Possibly	input.elm	/^    , Maybe, Possibly$/;"	t	module:MyMod	roles:exposed
+Result	input.elm	/^    , Result(..)$/;"	t	module:MyMod	roles:exposed
+MyList	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	t	module:MyMod	roles:exposed
+Empty	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	c	type:MyMod.MyList	roles:exposed
+Tree	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	t	module:MyMod	roles:exposed
+Node	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	c	type:MyMod.Tree	roles:exposed
+Value	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	c	type:MyMod.Tree	roles:exposed
+Special	input.elm	/^    , MyList(Empty), Tree(Node, Value, Special) )$/;"	c	type:MyMod.Tree	roles:exposed
 otherMod	input.elm	/^import otherMod exposing (Coin)$/;"	m	roles:imported
-Coin	input.elm	/^import otherMod exposing (Coin)$/;"	t	module:otherMod	roles:imported
+Coin	input.elm	/^import otherMod exposing (Coin)$/;"	t	module:otherMod	roles:exposed
 Dotted.name.Here	input.elm	/^import Dotted.name.Here exposing (Dot(Cons))$/;"	m	roles:imported
-Dot	input.elm	/^import Dotted.name.Here exposing (Dot(Cons))$/;"	t	module:Dotted.name.Here	roles:imported
-Cons	input.elm	/^import Dotted.name.Here exposing (Dot(Cons))$/;"	c	type:Dotted.name.Here.Dot	roles:imported
+Dot	input.elm	/^import Dotted.name.Here exposing (Dot(Cons))$/;"	t	module:Dotted.name.Here	roles:exposed
+Cons	input.elm	/^import Dotted.name.Here exposing (Dot(Cons))$/;"	c	type:Dotted.name.Here.Dot	roles:exposed
 func	input.elm	/^func x =$/;"	f	module:SomeMod	roles:def
 String	input-1.elm	/^import String$/;"	m	roles:imported
 A	input-1.elm	/^type A = B$/;"	t	roles:def

--- a/Units/parser-elm.r/elm-namespaces.d/expected.tags
+++ b/Units/parser-elm.r/elm-namespaces.d/expected.tags
@@ -1,5 +1,5 @@
 A1Mod	input.elm	/^module A1Mod exposing (..)$/;"	m	roles:def
 A1NameSpace	input.elm	/^import A1Import as A1NameSpace exposing (a1ImpFunc)$/;"	n	module:A1Mod	roles:def	moduleName:A1Import
 A1Import	input.elm	/^import A1Import as A1NameSpace exposing (a1ImpFunc)$/;"	m	roles:imported
-a1ImpFunc	input.elm	/^import A1Import as A1NameSpace exposing (a1ImpFunc)$/;"	f	module:A1Import	roles:imported
+a1ImpFunc	input.elm	/^import A1Import as A1NameSpace exposing (a1ImpFunc)$/;"	f	module:A1Import	roles:exposed
 func	input.elm	/^func a1 =$/;"	f	module:A1Mod	roles:def

--- a/Units/parser-elm.r/elm-optlist-compatibility.d/expected.tags
+++ b/Units/parser-elm.r/elm-optlist-compatibility.d/expected.tags
@@ -1,7 +1,7 @@
 Main	input.elm	/^port module Main exposing (..)$/;"	m	roles:def
 List	input.elm	/^import List$/;"	m	roles:imported
 Maybe	input.elm	/^import Maybe exposing (withDefault)$/;"	m	roles:imported
-withDefault	input.elm	/^import Maybe exposing (withDefault)$/;"	f	module:Maybe	roles:imported
+withDefault	input.elm	/^import Maybe exposing (withDefault)$/;"	f	module:Maybe	roles:exposed
 Je	input.elm	/^import Json.Encode as Je$/;"	n	module:Main	roles:def	moduleName:Json.Encode
 Json.Encode	input.elm	/^import Json.Encode as Je$/;"	m	roles:imported
 Thing	input.elm	/^type Thing$/;"	t	module:Main	roles:def

--- a/docs/man/ctags-lang-elm.7.rst
+++ b/docs/man/ctags-lang-elm.7.rst
@@ -30,9 +30,11 @@ EXAMPLES
 Imports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Imported items are tagged, but their role is "imported", not "def".
+Imported modules are tagged, and their role is "imported", not "def".
+Types, functions, etc which are exposed via imported module have their
+role as "exposed".
 
-Imported items are marked as being in the scope of their own module,
+Exposed items are marked as being in the scope of their own module,
 not the module that's doing the importing.
 
 "input.elm"
@@ -55,11 +57,11 @@ with "--options=NONE -o - --sort=no --extras=+r --fields=+r input.elm"
 
 	SomeMod	input.elm	/^module SomeMod exposing (..)$/;"	m	roles:def
 	MyMod	input.elm	/^import MyMod exposing$/;"	m	roles:imported
-	map	input.elm	/^  ( map$/;"	f	module:MyMod	roles:imported
-	Maybe	input.elm	/^  , Maybe$/;"	t	module:MyMod	roles:imported
-	Result	input.elm	/^  , Result(..)$/;"	t	module:MyMod	roles:imported
-	MyList	input.elm	/^  , MyList(Empty)$/;"	t	module:MyMod	roles:imported
-	Empty	input.elm	/^  , MyList(Empty)$/;"	c	type:MyMod.MyList	roles:imported
+	map	input.elm	/^  ( map$/;"	f	module:MyMod	roles:exposed
+	Maybe	input.elm	/^  , Maybe$/;"	t	module:MyMod	roles:exposed
+	Result	input.elm	/^  , Result(..)$/;"	t	module:MyMod	roles:exposed
+	MyList	input.elm	/^  , MyList(Empty)$/;"	t	module:MyMod	roles:exposed
+	Empty	input.elm	/^  , MyList(Empty)$/;"	c	type:MyMod.MyList	roles:exposed
 
 Namespaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -82,7 +84,7 @@ with "--options=NONE -o - --sort=no --extras=+r --fields=+r input.elm"
 	AMod	input.elm	/^module AMod exposing (..)$/;"	m	roles:def
 	NSpace	input.elm	/^import MyImport as NSpace exposing (impFunc)$/;"	n	module:AMod	roles:def	moduleName:MyImport
 	MyImport	input.elm	/^import MyImport as NSpace exposing (impFunc)$/;"	m	roles:imported
-	impFunc	input.elm	/^import MyImport as NSpace exposing (impFunc)$/;"	f	module:MyImport	roles:imported
+	impFunc	input.elm	/^import MyImport as NSpace exposing (impFunc)$/;"	f	module:MyImport	roles:exposed
 
 Type names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/man/ctags-lang-elm.7.rst.in
+++ b/man/ctags-lang-elm.7.rst.in
@@ -30,9 +30,11 @@ EXAMPLES
 Imports
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Imported items are tagged, but their role is "imported", not "def".
+Imported modules are tagged, and their role is "imported", not "def".
+Types, functions, etc which are exposed via imported module have their
+role as "exposed".
 
-Imported items are marked as being in the scope of their own module,
+Exposed items are marked as being in the scope of their own module,
 not the module that's doing the importing.
 
 "input.elm"
@@ -55,11 +57,11 @@ with "--options=NONE -o - --sort=no --extras=+r --fields=+r input.elm"
 
 	SomeMod	input.elm	/^module SomeMod exposing (..)$/;"	m	roles:def
 	MyMod	input.elm	/^import MyMod exposing$/;"	m	roles:imported
-	map	input.elm	/^  ( map$/;"	f	module:MyMod	roles:imported
-	Maybe	input.elm	/^  , Maybe$/;"	t	module:MyMod	roles:imported
-	Result	input.elm	/^  , Result(..)$/;"	t	module:MyMod	roles:imported
-	MyList	input.elm	/^  , MyList(Empty)$/;"	t	module:MyMod	roles:imported
-	Empty	input.elm	/^  , MyList(Empty)$/;"	c	type:MyMod.MyList	roles:imported
+	map	input.elm	/^  ( map$/;"	f	module:MyMod	roles:exposed
+	Maybe	input.elm	/^  , Maybe$/;"	t	module:MyMod	roles:exposed
+	Result	input.elm	/^  , Result(..)$/;"	t	module:MyMod	roles:exposed
+	MyList	input.elm	/^  , MyList(Empty)$/;"	t	module:MyMod	roles:exposed
+	Empty	input.elm	/^  , MyList(Empty)$/;"	c	type:MyMod.MyList	roles:exposed
 
 Namespaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -82,7 +84,7 @@ with "--options=NONE -o - --sort=no --extras=+r --fields=+r input.elm"
 	AMod	input.elm	/^module AMod exposing (..)$/;"	m	roles:def
 	NSpace	input.elm	/^import MyImport as NSpace exposing (impFunc)$/;"	n	module:AMod	roles:def	moduleName:MyImport
 	MyImport	input.elm	/^import MyImport as NSpace exposing (impFunc)$/;"	m	roles:imported
-	impFunc	input.elm	/^import MyImport as NSpace exposing (impFunc)$/;"	f	module:MyImport	roles:imported
+	impFunc	input.elm	/^import MyImport as NSpace exposing (impFunc)$/;"	f	module:MyImport	roles:exposed
 
 Type names
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/peg/elm.peg
+++ b/peg/elm.peg
@@ -294,7 +294,7 @@ importedItem <-
     / importedItemIgnored
 
 importedFunction <- <lowerStartIdentifier> {
-        makeElmTag(auxil, $1, $1s, K_FUNCTION, ELM_ROLE_IMPORTED);
+        makeElmTag(auxil, $1, $1s, K_FUNCTION, ELM_ROLE_EXPOSED);
     }
 
 # When importing a type and constructors we want the constructors
@@ -304,7 +304,7 @@ importedFunction <- <lowerStartIdentifier> {
 
 importedType <-
     <upperStartIdentifier> {
-        makeElmTagSettingScope(auxil, $1, $1s, K_TYPE, ELM_ROLE_IMPORTED);
+        makeElmTagSettingScope(auxil, $1, $1s, K_TYPE, ELM_ROLE_EXPOSED);
     } (_0_ '(' _0_ importedTypeConstructorList _0_ ')')? {
         // We're done with the type and its constructors, so we can pop it
         POP_SCOPE(auxil);
@@ -317,7 +317,7 @@ importedTypeConstructorList <-
 
 importedTypeConstructor <-
     <upperStartIdentifier> {
-        makeElmTag(auxil, $1, $1s, K_CONSTRUCTOR, ELM_ROLE_IMPORTED);
+        makeElmTag(auxil, $1, $1s, K_CONSTRUCTOR, ELM_ROLE_EXPOSED);
     }
 
 # Function with a type annotation.

--- a/peg/elm_pre.h
+++ b/peg/elm_pre.h
@@ -53,11 +53,13 @@ typedef enum {
 /* We only define roles which aren't def(ined)
  */
 typedef enum {
-	ELM_ROLE_IMPORTED
+	ELM_ROLE_IMPORTED,
+	ELM_ROLE_EXPOSED,
 } elmRoles;
 
 static roleDefinition ElmRoles [] = {
-	{ true, "imported", "item imported" },
+	{ true, "imported", "module imported" },
+	{ true, "exposed", "item exposed from a module" },
 };
 
 typedef enum {


### PR DESCRIPTION
An imported modules still have `roles:imported`, but the items it brings in are listed as `roles:exposed`.

This has been discussed in [#PR3312](https://github.com/universal-ctags/ctags/pull/3312#issuecomment-1083372401) and issue #3319.

Strictly speaking this is a breaking change, as you will see Units/parser-elm.r/elm-optlist-compatibility.d/expected.tags has had to change. However I believe it doesn't actually break anything. The original optlib parser was designed to work with [Vim tagbar](https://github.com/preservim/tagbar). Neither that, nor [the specific configuration](https://github.com/bitterjug/vim-tagbar-ctags-elm/blob/master/ftplugin/elm/tagbar-elm.vim) referenced roles. Therefore I think this is safe to include.

However, if you think it is better to reject this pull request to preserve backwards compatiblity that's okay. Saying a function or a type is "imported" (which is what happens without this change) is still okay.

---
Edited for clarity