### PR TITLE
Elm: fix wrongly shared role definitions between kinds

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -41,13 +41,9 @@ DTD            p/parameterEntity condition          on      conditions
 DTD            p/parameterEntity elementName        on      element names
 DTD            p/parameterEntity partOfAttDef       on      part of attribute definition
 Elm            c/constructor     exposed            on      item exposed from a module
-Elm            c/constructor     imported           on      module imported
 Elm            f/function        exposed            on      item exposed from a module
-Elm            f/function        imported           on      module imported
-Elm            m/module          exposed            on      item exposed from a module
 Elm            m/module          imported           on      module imported
 Elm            t/type            exposed            on      item exposed from a module
-Elm            t/type            imported           on      module imported
 Flex           I/import          import             on      imports
 GDScript       c/class           extended           on      used as a base class for extending
 GemSpec        g/gem             develDep           on      specifying development dependency
@@ -153,13 +149,9 @@ DTD            p/parameterEntity condition          on      conditions
 DTD            p/parameterEntity elementName        on      element names
 DTD            p/parameterEntity partOfAttDef       on      part of attribute definition
 Elm            c/constructor     exposed            on      item exposed from a module
-Elm            c/constructor     imported           on      module imported
 Elm            f/function        exposed            on      item exposed from a module
-Elm            f/function        imported           on      module imported
-Elm            m/module          exposed            on      item exposed from a module
 Elm            m/module          imported           on      module imported
 Elm            t/type            exposed            on      item exposed from a module
-Elm            t/type            imported           on      module imported
 Flex           I/import          import             on      imports
 GDScript       c/class           extended           on      used as a base class for extending
 GemSpec        g/gem             develDep           on      specifying development dependency

--- a/peg/elm.peg
+++ b/peg/elm.peg
@@ -281,7 +281,7 @@ importStatement <-
         // Now make the tag for the imported module, as it lives outside
         // the scope of the file module
         ELM_SAVE_MODULE_SCOPE;
-        makeElmTagSettingScope(auxil, $1, $1s, K_MODULE, ELM_ROLE_IMPORTED);
+        makeElmTagSettingScope(auxil, $1, $1s, K_MODULE, ELM_MODULE_IMPORTED);
     } (_1_ 'exposing' _0_ '(' _0_ importedList _0_ ')')? EOS {
         ELM_RESTORE_MODULE_SCOPE;
     }
@@ -294,7 +294,7 @@ importedItem <-
     / importedItemIgnored
 
 importedFunction <- <lowerStartIdentifier> {
-        makeElmTag(auxil, $1, $1s, K_FUNCTION, ELM_ROLE_EXPOSED);
+        makeElmTag(auxil, $1, $1s, K_FUNCTION, ELM_FUNCTION_EXPOSED);
     }
 
 # When importing a type and constructors we want the constructors
@@ -304,7 +304,7 @@ importedFunction <- <lowerStartIdentifier> {
 
 importedType <-
     <upperStartIdentifier> {
-        makeElmTagSettingScope(auxil, $1, $1s, K_TYPE, ELM_ROLE_EXPOSED);
+        makeElmTagSettingScope(auxil, $1, $1s, K_TYPE, ELM_TYPE_EXPOSED);
     } (_0_ '(' _0_ importedTypeConstructorList _0_ ')')? {
         // We're done with the type and its constructors, so we can pop it
         POP_SCOPE(auxil);
@@ -317,7 +317,7 @@ importedTypeConstructorList <-
 
 importedTypeConstructor <-
     <upperStartIdentifier> {
-        makeElmTag(auxil, $1, $1s, K_CONSTRUCTOR, ELM_ROLE_EXPOSED);
+        makeElmTag(auxil, $1, $1s, K_CONSTRUCTOR, ELM_CONSTRUCTOR_EXPOSED);
     }
 
 # Function with a type annotation.

--- a/peg/elm_pre.h
+++ b/peg/elm_pre.h
@@ -53,14 +53,23 @@ typedef enum {
 /* We only define roles which aren't def(ined)
  */
 typedef enum {
-	ELM_ROLE_IMPORTED,
-	ELM_ROLE_EXPOSED,
-} elmRoles;
+	ELM_MODULE_IMPORTED,
+} elmModuleRoles;
 
-static roleDefinition ElmRoles [] = {
+static roleDefinition ElmModuleRoles [] = {
 	{ true, "imported", "module imported" },
-	{ true, "exposed", "item exposed from a module" },
 };
+
+#define define_elm_role(NAME,Name)							\
+	typedef enum {											\
+		ELM_##NAME##_EXPOSED,								\
+	} elm##Name##Roleds;									\
+	static roleDefinition Elm##Name##Roles [] = {			\
+		{ true, "exposed", "item exposed from a module" },	\
+	}
+define_elm_role(TYPE,Type);
+define_elm_role(CONSTRUCTOR,Constructor);
+define_elm_role(FUNCTION,Function);
 
 typedef enum {
 	F_MODULENAME,
@@ -78,16 +87,16 @@ static fieldDefinition ElmFields [COUNT_FIELDS] = {
  */
 static kindDefinition ElmKinds [COUNT_KINDS] = {
 	{ true, 'm', "module", "modules",
-	  .referenceOnly = false, ATTACH_ROLES (ElmRoles) },
+	  .referenceOnly = false, ATTACH_ROLES (ElmModuleRoles) },
 	{ true, 'n', "namespace", "modules renamed", },
 	{ true, 't', "type", "types",
-	  .referenceOnly = false, ATTACH_ROLES (ElmRoles) },
+	  .referenceOnly = false, ATTACH_ROLES (ElmTypeRoles) },
 	{ true, 'c', "constructor", "constructors",
-	  .referenceOnly = false, ATTACH_ROLES (ElmRoles) },
+	  .referenceOnly = false, ATTACH_ROLES (ElmConstructorRoles) },
 	{ true, 'a', "alias", "aliases", },
 	{ true, 'p', "port", "ports", },
 	{ true, 'f', "function", "functions",
-	  .referenceOnly = false, ATTACH_ROLES (ElmRoles) },
+	  .referenceOnly = false, ATTACH_ROLES (ElmFunctionRoles) },
 };
 
 struct parserCtx {


### PR DESCRIPTION
@niksilver, I forgot one important thing in the last review; roles must be defined per kind.
Kinds cannot share a role definition.

```
$ ./ctags --list-roles=Elm
#KIND(L/N)     NAME     ENABLED DESCRIPTION
c/constructor  exposed  on      item exposed from a module
f/function     exposed  on      item exposed from a module
m/module       imported on      module imported
t/type         exposed  on      item exposed from a module
```
is better than
```
$ ./ctags --list-roles=Elm
#KIND(L/N)     NAME     ENABLED DESCRIPTION
c/constructor  exposed  on      item exposed from a module
c/constructor  imported on      module imported
f/function     exposed  on      item exposed from a module
f/function     imported on      module imported
m/module       exposed  on      item exposed from a module
m/module       imported on      module imported
t/type         exposed  on      item exposed from a module
t/type         imported on      module imported
```
, isn't it?