### PR TITLE
CPreProcessor: run Asm parser on the __ASSEMBLER__ (or __ASSEMBLY__) …

### DIFF
--- a/Units/parser-cpreprocessor.r/asm-area.d/args.ctags
+++ b/Units/parser-cpreprocessor.r/asm-area.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--fields=+lE
+--extras=+g

--- a/Units/parser-cpreprocessor.r/asm-area.d/expected.tags
+++ b/Units/parser-cpreprocessor.r/asm-area.d/expected.tags
@@ -1,0 +1,15 @@
+DO_NOTHING_	input.c	/^	.macro	DO_NOTHING_$/;"	m	language:Asm	extras:guest
+DO_NOTHING_0	input-0.c	/^	.macro	DO_NOTHING_0$/;"	m	language:Asm	extras:guest
+do_nothing_1	input-1.c	/^inline void do_nothing_1(void) {}$/;"	f	language:C	typeref:typename:void
+do_nothing_2	input-2.c	/^	inline void do_nothing_2 (void) {}$/;"	f	language:C	typeref:typename:void
+DO_NOTHING_2	input-2.c	/^	.macro	DO_NOTHING_2$/;"	m	language:Asm	extras:guest
+do_nothing_3a	input-3.c	/^	inline void do_nothing_3a (void) {}$/;"	f	language:C	typeref:typename:void
+do_nothing_3b	input-3.c	/^	inline void do_nothing_3b (void) {}$/;"	f	language:C	typeref:typename:void
+DO_NOTHING_3	input-3.c	/^	.macro	DO_NOTHING_3$/;"	m	language:Asm	extras:guest
+do_nothing_4a	input-4.c	/^	inline void do_nothing_4a (void) {}$/;"	f	language:C	typeref:typename:void
+do_nothing_4b	input-4.c	/^	inline void do_nothing_4b (void) {}$/;"	f	language:C	typeref:typename:void
+DO_NOTHING_4	input-4.c	/^	.macro	DO_NOTHING_4$/;"	m	language:Asm	extras:guest
+do_nothing_5	input-5.c	/^inline void do_nothing_5(void) {}$/;"	f	language:C	typeref:typename:void
+DO_NOTHING_5	input-5.c	/^	.macro	DO_NOTHING_5$/;"	m	language:Asm	extras:guest
+do_nothing_6	input-6.c	/^inline void do_nothing_6(void) {}$/;"	f	language:C	typeref:typename:void
+DO_NOTHING_7_NO_GUEST	input-7.asm	/^.macro	DO_NOTHING_7_NO_GUEST$/;"	m	language:Asm

--- a/Units/parser-cpreprocessor.r/asm-area.d/input-0.c
+++ b/Units/parser-cpreprocessor.r/asm-area.d/input-0.c
@@ -1,0 +1,7 @@
+#ifdef __ASSEMBLER__
+
+	.macro	DO_NOTHING_0
+	 nop
+	.endm
+
+#endif

--- a/Units/parser-cpreprocessor.r/asm-area.d/input-1.c
+++ b/Units/parser-cpreprocessor.r/asm-area.d/input-1.c
@@ -1,0 +1,5 @@
+#ifndef __ASSEMBLER__
+
+inline void do_nothing_1(void) {}
+
+#endif

--- a/Units/parser-cpreprocessor.r/asm-area.d/input-2.c
+++ b/Units/parser-cpreprocessor.r/asm-area.d/input-2.c
@@ -1,0 +1,11 @@
+#if __ASSEMBLER__
+
+	.macro	DO_NOTHING_2
+	 nop
+	.endm
+
+#else
+
+	inline void do_nothing_2 (void) {}
+
+#endif

--- a/Units/parser-cpreprocessor.r/asm-area.d/input-3.c
+++ b/Units/parser-cpreprocessor.r/asm-area.d/input-3.c
@@ -1,0 +1,15 @@
+#if __ASSEMBLER__
+
+	.macro	DO_NOTHING_3
+	 nop
+	.endm
+
+#elif CONDITION3
+
+	inline void do_nothing_3a (void) {}
+
+#else
+
+	inline void do_nothing_3b (void) {}
+
+#endif

--- a/Units/parser-cpreprocessor.r/asm-area.d/input-4.c
+++ b/Units/parser-cpreprocessor.r/asm-area.d/input-4.c
@@ -1,0 +1,15 @@
+#ifdef __ASSEMBLER__
+
+	.macro	DO_NOTHING_4
+	 nop
+	.endm
+
+#elif CONDITION4
+
+	inline void do_nothing_4a (void) {}
+
+#else
+
+	inline void do_nothing_4b (void) {}
+
+#endif

--- a/Units/parser-cpreprocessor.r/asm-area.d/input-5.c
+++ b/Units/parser-cpreprocessor.r/asm-area.d/input-5.c
@@ -1,0 +1,11 @@
+#ifndef __ASSEMBLER__
+
+inline void do_nothing_5(void) {}
+
+#else
+
+	.macro	DO_NOTHING_5
+	 nop
+	.endm
+
+#endif

--- a/Units/parser-cpreprocessor.r/asm-area.d/input-6.c
+++ b/Units/parser-cpreprocessor.r/asm-area.d/input-6.c
@@ -1,0 +1,17 @@
+#ifndef __ASSEMBLER__
+
+inline void do_nothing_6(void) {}
+
+#elif CONDITION5
+
+	.macro	DO_NOTHING_6a_this_cannot_be_tagged
+	 nop
+	.endm
+
+#else
+
+	.macro	DO_NOTHING_6b_this_cannot_be_tagged
+	 nop
+	.endm
+
+#endif

--- a/Units/parser-cpreprocessor.r/asm-area.d/input-7.asm
+++ b/Units/parser-cpreprocessor.r/asm-area.d/input-7.asm
@@ -1,0 +1,7 @@
+#ifdef __ASSEMBLER__
+
+.macro	DO_NOTHING_7_NO_GUEST
+ nop
+.endm
+
+#endif

--- a/Units/parser-cpreprocessor.r/asm-area.d/input.c
+++ b/Units/parser-cpreprocessor.r/asm-area.d/input.c
@@ -1,0 +1,7 @@
+#if __ASSEMBLER__
+
+	.macro	DO_NOTHING_
+	 nop
+	.endm
+
+#endif


### PR DESCRIPTION
…areas

The issue fixed with this commit is found in

  https://stackoverflow.com/questions/71174162/cant-generate-tag-mrs-s-from-define-mrs-sv-r-in-a-file-even-using/71228230#71228230

The info page of cpp says:

    '__ASSEMBLER__'
	 This macro is defined with value 1 when preprocessing assembly
	 language.

`__ASSEMBLY__` is the convention used in Linux kernel source tree.

  https://stackoverflow.com/questions/28924355/gcc-assembler-preprocessor-not-compatible-with-standard-headers

The area may define gas macros that can make C/C++ parser confused.
So this change hides the area from C/C++ parser as if '#if 0' is
specified.  Instead, the CPreProcessor runs Asm parser on the area as
a guest.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>