### PR TITLE
buildsys: fix ld can not find -liconv on FreeBSD and OpenBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,11 @@ case $host in
             printf "\n%s\n" "macOS not support --enable-static." >&6
             exit 1
         fi
+        ;;
+    *freebsd*|*openbsd*)
+        # https://github.com/universal-ctags/ctags/issues/3338
+        export LDFLAGS="$LDFLAGS -L/usr/local/lib"
+        ;;
 esac
 
 AH_TEMPLATE([PACKAGE], [Package name.])


### PR DESCRIPTION
on FreeBSD and OpenBSD, most libs are install in /usr/local/lib, this location is not searched by linker by default.

Reference:
https://wiki.freebsd.org/WarnerLosh/UsrLocal

Signed-off-by: leleliu008 <leleliu008@gmail.com>

close #3338 