### PR TITLE
check-gen: run the target only in git repo

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -160,7 +160,15 @@ jobs:
            name: Test
            command: |
              ulimit -c 0
-             make distcheck
+             # Let's trick git.
+             #
+             # "git" running in "make distcheck" may refer $(pwd)/.git of THIS context.
+             # On the other hand, we want to run the test cases in an environment separated
+             # from our git repo.
+             #
+             mkdir __NO_GIT__
+             make distcheck GIT_DIR=__NO_GIT__
+             rmdir __NO_GIT__
 
    ubi8_make:
      working_directory: ~/universal-ctags

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -296,6 +296,7 @@ chkgen_verbose = $(chkgen_verbose_@AM_V@)
 chkgen_verbose_ = $(chkgen_verbose_@AM_DEFAULT_V@)
 chkgen_verbose_0 = @echo CHKGEN "    $@";
 check-genfile:
+if BUILD_IN_GIT_REPO
 # OPTLIB2C_SRCS : committed for win32 build
 	$(chkgen_verbose)rm -f $(OPTLIB2C_SRCS)
 	$(chkgen_verbose)$(MAKE) $(OPTLIB2C_SRCS)
@@ -351,3 +352,4 @@ endif
 	else \
 		echo "Files under win32 are up to date." ; \
 	fi
+endif


### PR DESCRIPTION
Close #3360.

Running check-gen test target makes sense only if the test is run in
git repo.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>