### PR TITLE
JavaScript: fix the definition of a class

### DIFF
--- a/Units/extra-anonymous.d/expected.tags
+++ b/Units/extra-anonymous.d/expected.tags
@@ -4,16 +4,16 @@ __anonf6b77c20020a	input.c	/^union {$/;"	u	file:	extras:fileScope,anonymous
 x	input.c	/^  int x;$/;"	m	union:__anonf6b77c20020a	typeref:typename:int	file:	extras:fileScope
 __anonf6b77c200303	input.c	/^enum {$/;"	g	file:	extras:fileScope,anonymous
 X	input.c	/^  X;$/;"	e	enum:__anonf6b77c200303	file:	extras:fileScope
-c2m1	input-0.js	/^  this.c2m1 = function() {$/;"	m	class:class2
-AnonymousFunctiond33a4a170100	input-0.js	/^    c2m3(function() {$/;"	f	method:class2.c2m1	extras:anonymous
-class2	input-0.js	/^var class2 = function() {$/;"	c
-c3m1	input-0.js	/^  this.c3m1 = function() {$/;"	m	class:class3
-AnonymousFunctiond33a4a170200	input-0.js	/^    return function(n) {$/;"	f	method:class3.c3m1	extras:anonymous
-class3	input-0.js	/^var class3 = function() {$/;"	c
-AnonymousFunctiond33a4a170300	input-0.js	/^  return function(x) {$/;"	f	function:f1	extras:anonymous
+Class2	input-0.js	/^var Class2 = function() {$/;"	c
+c2m1	input-0.js	/^  this.c2m1 = function() {$/;"	m	class:Class2
+anonymousFunctiond33a4a170100	input-0.js	/^    c2m3(function() {$/;"	f	method:Class2.c2m1	extras:anonymous
+Class3	input-0.js	/^var Class3 = function() {$/;"	c
+c3m1	input-0.js	/^  this.c3m1 = function() {$/;"	m	class:Class3
+anonymousFunctiond33a4a170200	input-0.js	/^    return function(n) {$/;"	f	method:Class3.c3m1	extras:anonymous
 f1	input-0.js	/^function f1(y) {$/;"	f
-AnonymousClassd33a4a170401	input-0.js	/^  return class extends superclass {$/;"	c	function:Mixin	extras:anonymous
+anonymousFunctiond33a4a170300	input-0.js	/^  return function(x) {$/;"	f	function:f1	extras:anonymous
+Mixin	input-0.js	/^function Mixin(superclass) {$/;"	c
+AnonymousClassd33a4a170401	input-0.js	/^  return class extends superclass {$/;"	c	class:Mixin	extras:anonymous
 hello	input-0.js	/^    hello() {$/;"	m	class:Mixin.AnonymousClassd33a4a170401
-Mixin	input-0.js	/^function Mixin(superclass) {$/;"	f
 AnonymousClassd33a4a170501	input-0.js	/^class {$/;"	c	extras:anonymous
 method8	input-0.js	/^	method8(n) { return n * n; }$/;"	m	class:AnonymousClassd33a4a170501

--- a/Units/extra-anonymous.d/input-0.js
+++ b/Units/extra-anonymous.d/input-0.js
@@ -1,4 +1,4 @@
-var class2 = function() {
+var Class2 = function() {
   this.c2m1 = function() {
     c2m3(function() {
       return { 'test': {} };
@@ -6,7 +6,7 @@ var class2 = function() {
   };
 };
 
-var class3 = function() {
+var Class3 = function() {
   this.c3m1 = function() {
     return function(n) {
       if (n == 42) {

--- a/Units/extra-disabling-anonymous.d/expected.tags
+++ b/Units/extra-disabling-anonymous.d/expected.tags
@@ -1,11 +1,11 @@
 x	input.c	/^  int x;$/;"	m	struct:__anon335cadda0108	typeref:typename:int	file:	extras:fileScope
 x	input.c	/^  int x;$/;"	m	union:__anon335cadda020a	typeref:typename:int	file:	extras:fileScope
 X	input.c	/^  X;$/;"	e	enum:__anon335cadda0303	file:	extras:fileScope
-c2m1	input-0.js	/^  this.c2m1 = function() {$/;"	m	class:class2
-class2	input-0.js	/^var class2 = function() {$/;"	c
-c3m1	input-0.js	/^  this.c3m1 = function() {$/;"	m	class:class3
-class3	input-0.js	/^var class3 = function() {$/;"	c
+Class2	input-0.js	/^var Class2 = function() {$/;"	c
+c2m1	input-0.js	/^  this.c2m1 = function() {$/;"	m	class:Class2
+Class3	input-0.js	/^var Class3 = function() {$/;"	c
+c3m1	input-0.js	/^  this.c3m1 = function() {$/;"	m	class:Class3
 f1	input-0.js	/^function f1(y) {$/;"	f
+Mixin	input-0.js	/^function Mixin(superclass) {$/;"	c
 hello	input-0.js	/^    hello() {$/;"	m	class:Mixin.AnonymousClass2503d9910401
-Mixin	input-0.js	/^function Mixin(superclass) {$/;"	f
 method8	input-0.js	/^	method8(n) { return n * n; }$/;"	m	class:AnonymousClass2503d9910501

--- a/Units/extra-disabling-anonymous.d/input-0.js
+++ b/Units/extra-disabling-anonymous.d/input-0.js
@@ -1,4 +1,4 @@
-var class2 = function() {
+var Class2 = function() {
   this.c2m1 = function() {
     c2m3(function() {
       return { 'test': {} };
@@ -6,7 +6,7 @@ var class2 = function() {
   };
 };
 
-var class3 = function() {
+var Class3 = function() {
   this.c3m1 = function() {
     return function(n) {
       if (n == 42) {

--- a/Units/parser-javascript.r/1795612.js.d/expected.tags
+++ b/Units/parser-javascript.r/1795612.js.d/expected.tags
@@ -1,4 +1,4 @@
-RPC	input.js	/^Test.RPC =$/;"	c	class:Test
-asyncMethod	input.js	/^	asyncMethod: function($/;"	m	class:Test.RPC
-asyncRequest	input.js	/^	asyncRequest: function($/;"	m	class:Test.RPC
-request_id	input.js	/^	request_id: 0,$/;"	p	class:Test.RPC
+Test.RPC	input.js	/^Test.RPC =$/;"	p
+asyncMethod	input.js	/^	asyncMethod: function($/;"	m	property:Test.RPC
+asyncRequest	input.js	/^	asyncRequest: function($/;"	m	property:Test.RPC
+request_id	input.js	/^	request_id: 0,$/;"	p	property:Test.RPC

--- a/Units/parser-javascript.r/1850914.js.d/expected.tags
+++ b/Units/parser-javascript.r/1850914.js.d/expected.tags
@@ -1,3 +1,3 @@
-objLiteralMethod	input.js	/^objLiteralMethod : function(){}$/;"	m	class:objectLiteral
-objLiteralProperty	input.js	/^objLiteralProperty : 1,$/;"	p	class:objectLiteral
-objectLiteral	input.js	/^var objectLiteral = {$/;"	c
+objLiteralMethod	input.js	/^objLiteralMethod : function(){}$/;"	m	variable:objectLiteral
+objLiteralProperty	input.js	/^objLiteralProperty : 1,$/;"	p	variable:objectLiteral
+objectLiteral	input.js	/^var objectLiteral = {$/;"	v

--- a/Units/parser-javascript.r/1878155.js.d/expected.tags
+++ b/Units/parser-javascript.r/1878155.js.d/expected.tags
@@ -1,4 +1,4 @@
-RE	input.js	/^var RE={"bar":\/foo\\"\/};$/;"	c
-bar	input.js	/^var RE={"bar":\/foo\\"\/};$/;"	p	class:RE
+RE	input.js	/^var RE={"bar":\/foo\\"\/};$/;"	v
+bar	input.js	/^var RE={"bar":\/foo\\"\/};$/;"	p	variable:RE
 foo	input.js	/^var foo="foo \\" some other stuff";$/;"	v
 my_function	input.js	/^function my_function() {$/;"	f

--- a/Units/parser-javascript.r/1880687.js.d/expected.tags
+++ b/Units/parser-javascript.r/1880687.js.d/expected.tags
@@ -1,6 +1,6 @@
-MyClass	input.js	/^MyClass = {$/;"	c
-MyClass_sub1	input.js	/^    MyClass_sub1: function(x){$/;"	m	class:MyClass
-MyClass_sub2	input.js	/^    MyClass_sub2: function(x){$/;"	m	class:MyClass
+MyClass	input.js	/^MyClass = {$/;"	v
+MyClass_sub1	input.js	/^    MyClass_sub1: function(x){$/;"	m	variable:MyClass
+MyClass_sub2	input.js	/^    MyClass_sub2: function(x){$/;"	m	variable:MyClass
 a	input.js	/^function a(flag){$/;"	f
 aa	input.js	/^function aa(){$/;"	f
 aa_sub1	input.js	/^    function aa_sub1(){$/;"	f	function:aa

--- a/Units/parser-javascript.r/3470609.js.d/expected.tags
+++ b/Units/parser-javascript.r/3470609.js.d/expected.tags
@@ -1,12 +1,12 @@
-array	input.js	/^    'array' : [1, 2, 3],$/;"	p	class:root
-decimal	input.js	/^    'decimal' : 1.3,$/;"	p	class:root
+array	input.js	/^    'array' : [1, 2, 3],$/;"	p	variable:root
+decimal	input.js	/^    'decimal' : 1.3,$/;"	p	variable:root
 f	input.js	/^function f() {$/;"	f
-id	input.js	/^    'id' : 1,$/;"	p	class:root
-method	input.js	/^    'method' : function() {$/;"	m	class:root
-neg	input.js	/^    'neg' : -1,$/;"	p	class:root
-parentheses	input.js	/^    'parentheses' : (2 * (2 + 3))$/;"	p	class:root
-root	input.js	/^var root = {$/;"	c
-string	input.js	/^    'string' : 'hello world',$/;"	p	class:root
-subFunction	input.js	/^        'subFunction': function() {$/;"	m	class:root.subObject
-subObject	input.js	/^    'subObject' : {$/;"	c	class:root
-subProperty	input.js	/^        'subProperty': 42,$/;"	p	class:root.subObject
+id	input.js	/^    'id' : 1,$/;"	p	variable:root
+method	input.js	/^    'method' : function() {$/;"	m	variable:root
+neg	input.js	/^    'neg' : -1,$/;"	p	variable:root
+parentheses	input.js	/^    'parentheses' : (2 * (2 + 3))$/;"	p	variable:root
+root	input.js	/^var root = {$/;"	v
+string	input.js	/^    'string' : 'hello world',$/;"	p	variable:root
+subFunction	input.js	/^        'subFunction': function() {$/;"	m	property:root.subObject
+subObject	input.js	/^    'subObject' : {$/;"	p	variable:root
+subProperty	input.js	/^        'subProperty': 42,$/;"	p	property:root.subObject

--- a/Units/parser-javascript.r/bug1950327.js.d/expected.tags
+++ b/Units/parser-javascript.r/bug1950327.js.d/expected.tags
@@ -1,13 +1,13 @@
-*	input.js	/^		container.dirtyTab = {'url': false, 'title':false, 'snapshot':false, '*': false}		$/;"	p	class:container.dirtyTab
+*	input.js	/^		container.dirtyTab = {'url': false, 'title':false, 'snapshot':false, '*': false}		$/;"	p	property:container.dirtyTab
 Different	input.js	/^Different.prototype = {$/;"	c
 TabChrome	input.js	/^TabChrome.prototype = {$/;"	c
+container.dirtyTab	input.js	/^		container.dirtyTab = {'url': false, 'title':false, 'snapshot':false, '*': false}		$/;"	p
 createTabTile	input.js	/^	createTabTile: function(browser) $/;"	m	class:Different
 createTabTile	input.js	/^	createTabTile: function(browser) $/;"	m	class:TabChrome
 destroyTabTile	input.js	/^	destroyTabTile: function(tile)$/;"	m	class:Different
 destroyTabTile	input.js	/^	destroyTabTile: function(tile)$/;"	m	class:TabChrome
-dirtyTab	input.js	/^		container.dirtyTab = {'url': false, 'title':false, 'snapshot':false, '*': false}		$/;"	c	class:container
 init	input.js	/^	init: function() $/;"	m	class:Different
 init	input.js	/^	init: function() $/;"	m	class:TabChrome
-snapshot	input.js	/^		container.dirtyTab = {'url': false, 'title':false, 'snapshot':false, '*': false}		$/;"	p	class:container.dirtyTab
-title	input.js	/^		container.dirtyTab = {'url': false, 'title':false, 'snapshot':false, '*': false}		$/;"	p	class:container.dirtyTab
-url	input.js	/^		container.dirtyTab = {'url': false, 'title':false, 'snapshot':false, '*': false}		$/;"	p	class:container.dirtyTab
+snapshot	input.js	/^		container.dirtyTab = {'url': false, 'title':false, 'snapshot':false, '*': false}		$/;"	p	property:container.dirtyTab
+title	input.js	/^		container.dirtyTab = {'url': false, 'title':false, 'snapshot':false, '*': false}		$/;"	p	property:container.dirtyTab
+url	input.js	/^		container.dirtyTab = {'url': false, 'title':false, 'snapshot':false, '*': false}		$/;"	p	property:container.dirtyTab

--- a/Units/parser-javascript.r/bug3571233.js.d/expected.tags
+++ b/Units/parser-javascript.r/bug3571233.js.d/expected.tags
@@ -1,5 +1,4 @@
-MyClass	input.js	/^MyClass.prototype.method2 = function() {$/;"	c
-MyClass	input.js	/^function MyClass() {$/;"	f
+MyClass	input.js	/^function MyClass() {$/;"	c
 function1	input.js	/^function function1() {$/;"	f
 function2	input.js	/^function2 = function() {$/;"	f
 method2	input.js	/^MyClass.prototype.method2 = function() {$/;"	m	class:MyClass

--- a/Units/parser-javascript.r/generators.d/expected.tags
+++ b/Units/parser-javascript.r/generators.d/expected.tags
@@ -1,8 +1,8 @@
-g1	input.js	/^  g1: function*() {$/;"	g	class:obj1
+g1	input.js	/^  g1: function*() {$/;"	g	variable:obj1
 g2	input.js	/^function *g2() {$/;"	g
 g3	input.js	/^var g3 = function*g4(x) {$/;"	g
 g4	input.js	/^var g3 = function*g4(x) {$/;"	g
-g5	input.js	/^  this.g5 = function*g6() {$/;"	g	class:obj2
-g6	input.js	/^  this.g5 = function*g6() {$/;"	g	class:obj2
-obj1	input.js	/^var obj1 = {$/;"	c
-obj2	input.js	/^var obj2 = function() {$/;"	c
+g5	input.js	/^  this.g5 = function*g6() {$/;"	g	function:obj2
+g6	input.js	/^  this.g5 = function*g6() {$/;"	g	function:obj2
+obj1	input.js	/^var obj1 = {$/;"	v
+obj2	input.js	/^var obj2 = function() {$/;"	f

--- a/Units/parser-javascript.r/github-issue-1389.d/expected.tags
+++ b/Units/parser-javascript.r/github-issue-1389.d/expected.tags
@@ -1,4 +1,4 @@
-AnonymousClass80ca49fb0101	input.js	/^var Namespace = Ember.Namespace = Ember.Object.extend=({$/;"	c
 Namespace	input.js	/^var Namespace = Ember.Namespace = Ember.Object.extend=({$/;"	v
-init	input.js	/^  init: function() {$/;"	m	class:AnonymousClass80ca49fb0101
-isNamespace	input.js	/^  isNamespace: true,$/;"	p	class:AnonymousClass80ca49fb0101
+anonymousObject80ca49fb0105	input.js	/^var Namespace = Ember.Namespace = Ember.Object.extend=({$/;"	v
+init	input.js	/^  init: function() {$/;"	m	variable:anonymousObject80ca49fb0105
+isNamespace	input.js	/^  isNamespace: true,$/;"	p	variable:anonymousObject80ca49fb0105

--- a/Units/parser-javascript.r/github-issue-1933.d/expected.tags
+++ b/Units/parser-javascript.r/github-issue-1933.d/expected.tags
@@ -1,4 +1,4 @@
-func1	input.js	/^  func1: () => {$/;"	m	class:testobj	signature:()
-func2	input.js	/^  func2: () => {$/;"	m	class:testobj	signature:()
-func3	input.js	/^  func3: x => {$/;"	m	class:testobj	signature:(x)
-testobj	input.js	/^testobj = {$/;"	c
+func1	input.js	/^  func1: () => {$/;"	m	variable:testobj	signature:()
+func2	input.js	/^  func2: () => {$/;"	m	variable:testobj	signature:()
+func3	input.js	/^  func3: x => {$/;"	m	variable:testobj	signature:(x)
+testobj	input.js	/^testobj = {$/;"	v

--- a/Units/parser-javascript.r/github-issue-780.d/expected.tags
+++ b/Units/parser-javascript.r/github-issue-780.d/expected.tags
@@ -1,3 +1,3 @@
-AnonymousClass6b70cce50101	input.js	/^const Bar = Foo.create({$/;"	c
 Bar	input.js	/^const Bar = Foo.create({$/;"	C
-jump	input.js	/^  jump() {$/;"	m	class:AnonymousClass6b70cce50101
+anonymousObject6b70cce50105	input.js	/^const Bar = Foo.create({$/;"	v
+jump	input.js	/^  jump() {$/;"	m	variable:anonymousObject6b70cce50105

--- a/Units/parser-javascript.r/js-arraylist.d/expected.tags
+++ b/Units/parser-javascript.r/js-arraylist.d/expected.tags
@@ -1,21 +1,21 @@
-AnonymousClassecad86450101	input.js	/^  { a: "hello", b: 42 },$/;"	c
-AnonymousClassecad86450201	input.js	/^  { a: "hi", b: 41 }$/;"	c
-AnonymousClassecad86450301	input.js	/^    { a: {}, b: {} },$/;"	c	class:class
-AnonymousClassecad86450401	input.js	/^    { a: {}, b: {} }$/;"	c	class:class
-a	input.js	/^    { a: {}, b: {} }$/;"	p	class:class.AnonymousClassecad86450401
-a	input.js	/^    { a: {}, b: {} },$/;"	p	class:class.AnonymousClassecad86450301
-a	input.js	/^  { a: "hello", b: 42 },$/;"	p	class:AnonymousClassecad86450101
-a	input.js	/^  { a: "hi", b: 41 }$/;"	p	class:AnonymousClassecad86450201
+a	input.js	/^    { a: {}, b: {} }$/;"	p	variable:class.anonymousObjectecad86450405
+a	input.js	/^    { a: {}, b: {} },$/;"	p	variable:class.anonymousObjectecad86450305
+a	input.js	/^  { a: "hello", b: 42 },$/;"	p	variable:anonymousObjectecad86450105
+a	input.js	/^  { a: "hi", b: 41 }$/;"	p	variable:anonymousObjectecad86450205
 a	input.js	/^var a = [];$/;"	v
-b	input.js	/^    { a: {}, b: {} }$/;"	p	class:class.AnonymousClassecad86450401
-b	input.js	/^    { a: {}, b: {} },$/;"	p	class:class.AnonymousClassecad86450301
-b	input.js	/^  { a: "hello", b: 42 },$/;"	p	class:AnonymousClassecad86450101
-b	input.js	/^  { a: "hi", b: 41 }$/;"	p	class:AnonymousClassecad86450201
+anonymousObjectecad86450105	input.js	/^  { a: "hello", b: 42 },$/;"	v
+anonymousObjectecad86450205	input.js	/^  { a: "hi", b: 41 }$/;"	v
+anonymousObjectecad86450305	input.js	/^    { a: {}, b: {} },$/;"	v	function:class
+anonymousObjectecad86450405	input.js	/^    { a: {}, b: {} }$/;"	v	function:class
+b	input.js	/^    { a: {}, b: {} }$/;"	p	variable:class.anonymousObjectecad86450405
+b	input.js	/^    { a: {}, b: {} },$/;"	p	variable:class.anonymousObjectecad86450305
+b	input.js	/^  { a: "hello", b: 42 },$/;"	p	variable:anonymousObjectecad86450105
+b	input.js	/^  { a: "hi", b: 41 }$/;"	p	variable:anonymousObjectecad86450205
 b	input.js	/^var b = [1, 2, 3];$/;"	v
-bar	input.js	/^    bar: [ 4, 5, 9]$/;"	p	class:class.test1
+bar	input.js	/^    bar: [ 4, 5, 9]$/;"	p	variable:class.test1
 c	input.js	/^var c = [$/;"	v
-class	input.js	/^var class = function() {$/;"	c
+class	input.js	/^var class = function() {$/;"	f
 d	input.js	/^var d = [$/;"	v
-foo	input.js	/^    foo: [ 1, 2, 3],$/;"	p	class:class.test1
-test1	input.js	/^  this.test1 = {$/;"	c	class:class
-test3	input.js	/^  this.test3 = function() {}$/;"	m	class:class
+foo	input.js	/^    foo: [ 1, 2, 3],$/;"	p	variable:class.test1
+test1	input.js	/^  this.test1 = {$/;"	v	function:class
+test3	input.js	/^  this.test3 = function() {}$/;"	m	function:class

--- a/Units/parser-javascript.r/js-async2.d/expected.tags
+++ b/Units/parser-javascript.r/js-async2.d/expected.tags
@@ -1,9 +1,9 @@
-Class	input.js	/^var Class = {$/;"	c
+Class	input.js	/^var Class = {$/;"	v
 ES6Class	input.js	/^class ES6Class {$/;"	c
 asyncAnonymousFunc	input.js	/^var asyncAnonymousFunc = async function() {$/;"	f
 es6AsyncMethod	input.js	/^  async es6AsyncMethod() {}$/;"	m	class:ES6Class
 es6Method	input.js	/^  es6Method() {}$/;"	m	class:ES6Class
-method1	input.js	/^  method1 : function() {$/;"	m	class:Class
-method2	input.js	/^  method2 : async function() {$/;"	m	class:Class
-method3	input.js	/^  method3() {$/;"	m	class:Class
-method4	input.js	/^  async method4() {$/;"	m	class:Class
+method1	input.js	/^  method1 : function() {$/;"	m	variable:Class
+method2	input.js	/^  method2 : async function() {$/;"	m	variable:Class
+method3	input.js	/^  method3() {$/;"	m	variable:Class
+method4	input.js	/^  async method4() {$/;"	m	variable:Class

--- a/Units/parser-javascript.r/js-class-related-unterminated.d/expected.tags
+++ b/Units/parser-javascript.r/js-class-related-unterminated.d/expected.tags
@@ -1,7 +1,7 @@
-A	input.js	/^  A: {}$/;"	p	class:Cls
-B	input.js	/^Cls.B = function(a, b) {$/;"	c	class:Cls
-C	input.js	/^Cls.C = function () {$/;"	c	class:Cls
-Cls	input.js	/^var Cls = {$/;"	c
+A	input.js	/^  A: {}$/;"	p	variable:Cls
+B	input.js	/^Cls.B = function(a, b) {$/;"	c	variable:Cls
+C	input.js	/^Cls.C = function () {$/;"	c	variable:Cls
+Cls	input.js	/^var Cls = {$/;"	v
 Sub	input.js	/^Cls.B.Sub = function() {$/;"	c	class:Cls.B
 dyn1	input.js	/^  Cls.B.Sub.prototype.dyn1 = this.m4$/;"	m	class:Cls.B.Sub
 m1	input.js	/^Cls.B.prototype.m1 = function(a) {$/;"	m	class:Cls.B

--- a/Units/parser-javascript.r/js-class-related-unterminated.d/input.js
+++ b/Units/parser-javascript.r/js-class-related-unterminated.d/input.js
@@ -1,6 +1,5 @@
 
 var Cls = {
-  // add a member just so Cls is recognized as a class from the start
   A: {}
 }
 

--- a/Units/parser-javascript.r/js-comma-at-end-of-object.d/expected.tags
+++ b/Units/parser-javascript.r/js-comma-at-end-of-object.d/expected.tags
@@ -1,5 +1,5 @@
-one	input.js	/^	var one = {$/;"	c	function:test
+one	input.js	/^	var one = {$/;"	v	function:test
 test	input.js	/^function test () {$/;"	f
-two	input.js	/^	var two = {$/;"	c	function:test
-val	input.js	/^		val: 1$/;"	p	class:test.one
-val	input.js	/^		val: 2,$/;"	p	class:test.two
+two	input.js	/^	var two = {$/;"	v	function:test
+val	input.js	/^		val: 1$/;"	p	variable:test.one
+val	input.js	/^		val: 2,$/;"	p	variable:test.two

--- a/Units/parser-javascript.r/js-complex-return.d/expected.tags
+++ b/Units/parser-javascript.r/js-complex-return.d/expected.tags
@@ -1,19 +1,19 @@
-AnonymousFunctiona815156f0100	input.js	/^    c2m3(function() {$/;"	f	method:class2.c2m1
-AnonymousFunctiona815156f0200	input.js	/^    return function(n) {$/;"	f	method:class3.c3m1
-c2m1	input.js	/^  this.c2m1 = function() {$/;"	m	class:class2
-c2m2	input.js	/^  this.c2m2 = function(f) {$/;"	m	class:class2
-c2m3	input.js	/^  this.c2m3 = function(f) {$/;"	m	class:class2
-c3m1	input.js	/^  this.c3m1 = function() {$/;"	m	class:class3
-c3m2	input.js	/^  this.c3m2 = function() {$/;"	m	class:class3
-class1	input.js	/^var class1 = function() {$/;"	c
-class2	input.js	/^var class2 = function() {$/;"	c
-class3	input.js	/^var class3 = function() {$/;"	c
-class4	input.js	/^var class4 = function() {$/;"	c
+Class1	input.js	/^var Class1 = function() {$/;"	c
+Class2	input.js	/^var Class2 = function() {$/;"	c
+Class3	input.js	/^var Class3 = function() {$/;"	c
+Class4	input.js	/^var Class4 = function() {$/;"	c
+anonymousFunctiona815156f0100	input.js	/^    c2m3(function() {$/;"	f	method:Class2.c2m1
+anonymousFunctiona815156f0200	input.js	/^    return function(n) {$/;"	f	method:Class3.c3m1
+c2m1	input.js	/^  this.c2m1 = function() {$/;"	m	class:Class2
+c2m2	input.js	/^  this.c2m2 = function(f) {$/;"	m	class:Class2
+c2m3	input.js	/^  this.c2m3 = function(f) {$/;"	m	class:Class2
+c3m1	input.js	/^  this.c3m1 = function() {$/;"	m	class:Class3
+c3m2	input.js	/^  this.c3m2 = function() {$/;"	m	class:Class3
 func1	input.js	/^function func1() {$/;"	f
 func2	input.js	/^function func2() {$/;"	f
-method1	input.js	/^  this.method1 = function() {$/;"	m	class:class1
-method1	input.js	/^  this.method1 = function() {$/;"	m	class:class4
-method2	input.js	/^  this.method2 = function() {$/;"	m	class:class1
-method2	input.js	/^  this.method2 = function() {$/;"	m	class:class4
-method3	input.js	/^  this.method3 = function() {$/;"	m	class:class1
-method4	input.js	/^  this.method4 = function() {$/;"	m	class:class1
+method1	input.js	/^  this.method1 = function() {$/;"	m	class:Class1
+method1	input.js	/^  this.method1 = function() {$/;"	m	class:Class4
+method2	input.js	/^  this.method2 = function() {$/;"	m	class:Class1
+method2	input.js	/^  this.method2 = function() {$/;"	m	class:Class4
+method3	input.js	/^  this.method3 = function() {$/;"	m	class:Class1
+method4	input.js	/^  this.method4 = function() {$/;"	m	class:Class1

--- a/Units/parser-javascript.r/js-complex-return.d/input.js
+++ b/Units/parser-javascript.r/js-complex-return.d/input.js
@@ -7,7 +7,7 @@ function func2() {
   return 42;
 }
 
-var class1 = function() {
+var Class1 = function() {
   this.method1 = function() {
     return 42;
   };
@@ -22,7 +22,7 @@ var class1 = function() {
   };
 };
 
-var class2 = function() {
+var Class2 = function() {
   this.c2m1 = function() {
     c2m3(function() {
       return { 'test': {} };
@@ -36,7 +36,7 @@ var class2 = function() {
   };
 };
 
-var class3 = function() {
+var Class3 = function() {
   this.c3m1 = function() {
     return function(n) {
       if (n == 42) {
@@ -51,7 +51,7 @@ var class3 = function() {
   };
 }
 
-var class4 = function() {
+var Class4 = function() {
   this.method1 = function() {
     return [{a:1, b:2}, {a:3, b:4}, {a:5, b:6}];
   };

--- a/Units/parser-javascript.r/js-computed-propname.d/expected.tags
+++ b/Units/parser-javascript.r/js-computed-propname.d/expected.tags
@@ -1,16 +1,16 @@
 prop	input.js	/^var prop = 'foo';$/;"	v
 x	input.js	/^var x = 'c';$/;"	v
 y	input.js	/^var y = ['d', 'e'];$/;"	v
-['a' + y [0]]	input.js	/^    ['a' + y [0]]: {},$/;"	p	class:o
-a	input.js	/^    ['a']: {},			\/\/ Tagging$/;"	p	class:o
-['a' + 'b']	input.js	/^    ['a' + 'b']: {},		\/\/ Tagging whole    \\$/;"	p	class:o
-[x]	input.js	/^    [x]: {},			\/\/ expressions with \\$/;"	p	class:o
-['a' + x]	input.js	/^    ['a' + x]: {},        	\/\/ `[' and `]'$/;"	p	class:o
-o	input.js	/^var o = {$/;"	c
+['a' + y [0]]	input.js	/^    ['a' + y [0]]: {},$/;"	p	variable:o
+a	input.js	/^    ['a']: {},			\/\/ Tagging$/;"	p	variable:o
+['a' + 'b']	input.js	/^    ['a' + 'b']: {},		\/\/ Tagging whole    \\$/;"	p	variable:o
+[x]	input.js	/^    [x]: {},			\/\/ expressions with \\$/;"	p	variable:o
+['a' + x]	input.js	/^    ['a' + x]: {},        	\/\/ `[' and `]'$/;"	p	variable:o
+o	input.js	/^var o = {$/;"	v
 Model	input.js	/^class Model {$/;"	c
 User	input.js	/^class User extends Model {$/;"	c
 tableName	input.js	/^  static get tableName() {$/;"	G	class:User
 json-schema	input.js	/^  static get ["json-schema"]() {$/;"	G	class:User
-subnum	input.js	/^		subnum: function (){}$/;"	m	class:p.[(1+2)*3]
-[(1+2)*3]	input.js	/^	[(1+2)*3]: {$/;"	c	class:p
-p	input.js	/^var p = {$/;"	c
+subnum	input.js	/^		subnum: function (){}$/;"	m	property:p.[(1+2)*3]
+[(1+2)*3]	input.js	/^	[(1+2)*3]: {$/;"	p	variable:p
+p	input.js	/^var p = {$/;"	v

--- a/Units/parser-javascript.r/js-const.d/expected.tags
+++ b/Units/parser-javascript.r/js-const.d/expected.tags
@@ -1,7 +1,7 @@
 A	input.js	/^const A = 1;$/;"	C
 B	input.js	/^const B = 1;$/;"	C
-Group	input.js	/^const Group = {$/;"	c
-X	input.js	/^  X:1,$/;"	p	class:Group
-Y	input.js	/^  Y:2,$/;"	p	class:Group
-Z	input.js	/^  Z:3$/;"	p	class:Group
+Group	input.js	/^const Group = {$/;"	v
+X	input.js	/^  X:1,$/;"	p	variable:Group
+Y	input.js	/^  Y:2,$/;"	p	variable:Group
+Z	input.js	/^  Z:3$/;"	p	variable:Group
 func	input.js	/^const func = function () {}$/;"	f

--- a/Units/parser-javascript.r/js-crlf.d/expected.tags
+++ b/Units/parser-javascript.r/js-crlf.d/expected.tags
@@ -3,10 +3,10 @@ v2	input.js	/^var v1, v2$/;"	v
 v3	input.js	/^var v3 = 1$/;"	v
 v4	input.js	/^,   v4 = 2$/;"	v
 v5	input.js	/^,   v5 = 3$/;"	v
-f1_c1_m1	input.js	/^    f1_c1_m1:$/;"	m	class:f1.f1_c1
-f1_c1_m2	input.js	/^    f1_c1_m2$/;"	m	class:f1.f1_c1
-f1_c1	input.js	/^  var f1_c1 = {$/;"	c	function:f1
 f1	input.js	/^function f1() {$/;"	f
+f1_c1_m1	input.js	/^    f1_c1_m1:$/;"	m	variable:f1.f1_c1
+f1_c1_m2	input.js	/^    f1_c1_m2$/;"	m	variable:f1.f1_c1
+f1_c1	input.js	/^  var f1_c1 = {$/;"	v	function:f1
 v6	input.js	/^var v6 = "hello\\$/;"	v
 v7	input.js	/^var v7 = "hello\\$/;"	v
 v8	input.js	/^var v8;$/;"	v

--- a/Units/parser-javascript.r/js-empty-class-name.d/expected.tags
+++ b/Units/parser-javascript.r/js-empty-class-name.d/expected.tags
@@ -1,2 +1,2 @@
-prop	input.js	/^var {prop} = { prop: "value" };$/;"	p	class:AnonymousClass4ca5b60a0101
-AnonymousClass4ca5b60a0101	input.js	/^var {prop} = { prop: "value" };$/;"	c
+prop	input.js	/^var {prop} = { prop: "value" };$/;"	p	variable:anonymousObject4ca5b60a0105
+anonymousObject4ca5b60a0105	input.js	/^var {prop} = { prop: "value" };$/;"	v

--- a/Units/parser-javascript.r/js-es6-mixin.d/expected.tags
+++ b/Units/parser-javascript.r/js-es6-mixin.d/expected.tags
@@ -1,8 +1,8 @@
-AnonymousClasse9b77f6a0101	input.js	/^  return class extends superclass {$/;"	c	function:Mixin	inherits:superclass
+AnonymousClasse9b77f6a0101	input.js	/^  return class extends superclass {$/;"	c	class:Mixin	inherits:superclass
 Bar	input.js	/^class Bar extends Foo {$/;"	c	inherits:Foo
 Baz	input.js	/^class Baz extends Mixin(Bar) {$/;"	c	inherits:Mixin(Bar)
 Foo	input.js	/^class Foo {$/;"	c
-Mixin	input.js	/^function Mixin(superclass) {$/;"	f
+Mixin	input.js	/^function Mixin(superclass) {$/;"	c
 bar	input.js	/^  bar() { return "bar"; }$/;"	m	class:Bar
 foo	input.js	/^  foo() { return "foo"; }$/;"	m	class:Foo
 hello	input.js	/^    hello() {$/;"	m	class:Mixin.AnonymousClasse9b77f6a0101

--- a/Units/parser-javascript.r/js-get-and-set.d/expected.tags
+++ b/Units/parser-javascript.r/js-get-and-set.d/expected.tags
@@ -1,6 +1,6 @@
-get	input.js	/^  get() {$/;"	method	class:obj
-log	input.js	/^  log: ['a', 'b', 'c'],$/;"	property	class:obj
-log	input.js	/^  log: []$/;"	property	class:o
-o	input.js	/^var o = {$/;"	class
-obj	input.js	/^var obj = {$/;"	class
-set	input.js	/^  set(str) {$/;"	method	class:o
+get	input.js	/^  get() {$/;"	method	variable:obj
+log	input.js	/^  log: ['a', 'b', 'c'],$/;"	property	variable:obj
+log	input.js	/^  log: []$/;"	property	variable:o
+o	input.js	/^var o = {$/;"	variable
+obj	input.js	/^var obj = {$/;"	variable
+set	input.js	/^  set(str) {$/;"	method	variable:o

--- a/Units/parser-javascript.r/js-getter-and-setter.d/expected.tags
+++ b/Units/parser-javascript.r/js-getter-and-setter.d/expected.tags
@@ -1,6 +1,6 @@
-current	input.js	/^  set current (str) {$/;"	setter	class:o
-latest	input.js	/^  get latest() {$/;"	getter	class:obj
-log	input.js	/^  log: ['a', 'b', 'c'],$/;"	property	class:obj
-log	input.js	/^  log: []$/;"	property	class:o
-o	input.js	/^var o = {$/;"	class
-obj	input.js	/^var obj = {$/;"	class
+current	input.js	/^  set current (str) {$/;"	setter	variable:o
+latest	input.js	/^  get latest() {$/;"	getter	variable:obj
+log	input.js	/^  log: ['a', 'b', 'c'],$/;"	property	variable:obj
+log	input.js	/^  log: []$/;"	property	variable:o
+o	input.js	/^var o = {$/;"	variable
+obj	input.js	/^var obj = {$/;"	variable

--- a/Units/parser-javascript.r/js-let.d/expected.tags
+++ b/Units/parser-javascript.r/js-let.d/expected.tags
@@ -1,7 +1,7 @@
 a	input.js	/^let a = 1;$/;"	v
 b	input.js	/^let b = 0;$/;"	v
 func	input.js	/^let func = function(){}$/;"	f
-group	input.js	/^let group = {$/;"	c
-x	input.js	/^  x:1,$/;"	p	class:group
-y	input.js	/^  y:1,$/;"	p	class:group
-z	input.js	/^  z:1,$/;"	p	class:group
+group	input.js	/^let group = {$/;"	v
+x	input.js	/^  x:1,$/;"	p	variable:group
+y	input.js	/^  y:1,$/;"	p	variable:group
+z	input.js	/^  z:1,$/;"	p	variable:group

--- a/Units/parser-javascript.r/js-many-functions.d/expected.tags
+++ b/Units/parser-javascript.r/js-many-functions.d/expected.tags
@@ -1,7 +1,7 @@
-AnonymousFunction8797a7c50100	input.js	/^  return function(x) {$/;"	f	function:f1
-C1	input.js	/^var C1 = {$/;"	c
+C1	input.js	/^var C1 = {$/;"	v
 K1	input.js	/^class K1 {$/;"	c
 a	input.js	/^function a() {$/;"	f
+anonymousFunction8797a7c50100	input.js	/^  return function(x) {$/;"	f	function:f1
 b	input.js	/^  function b() {$/;"	f	function:a
 c	input.js	/^    function c() {$/;"	f	function:a.b
 f1	input.js	/^function f1(y) {$/;"	f
@@ -12,5 +12,5 @@ fi1	input.js	/^    function fi1(x) {$/;"	f	method:C1.m2
 gi1	input.js	/^    function gi1(x) {$/;"	f	method:K1.l2
 l1	input.js	/^  l1() {$/;"	m	class:K1
 l2	input.js	/^  l2(n) {$/;"	m	class:K1
-m1	input.js	/^  m1: function() {$/;"	m	class:C1
-m2	input.js	/^  m2: function(n) {$/;"	m	class:C1
+m1	input.js	/^  m1: function() {$/;"	m	variable:C1
+m2	input.js	/^  m2: function(n) {$/;"	m	variable:C1

--- a/Units/parser-javascript.r/js-methods.d/expected.tags
+++ b/Units/parser-javascript.r/js-methods.d/expected.tags
@@ -1,3 +1,3 @@
-Obj	input.js	/^var Obj = {$/;"	c
-myGenerator	input.js	/^    *myGenerator(a, b) {$/;"	g	class:Obj
-myMethod	input.js	/^    myMethod(a, b) {$/;"	m	class:Obj
+Obj	input.js	/^var Obj = {$/;"	v
+myGenerator	input.js	/^    *myGenerator(a, b) {$/;"	g	variable:Obj
+myMethod	input.js	/^    myMethod(a, b) {$/;"	m	variable:Obj

--- a/Units/parser-javascript.r/js-null-tag-for-broken-input1.d/expected.tags
+++ b/Units/parser-javascript.r/js-null-tag-for-broken-input1.d/expected.tags
@@ -1,2 +1,2 @@
-.	input.js	/^X = {'.': 1};$/;"	p	class:X
-X	input.js	/^X = {'.': 1};$/;"	c
+.	input.js	/^X = {'.': 1};$/;"	p	variable:X
+X	input.js	/^X = {'.': 1};$/;"	v

--- a/Units/parser-javascript.r/js-odd-method-names.d/expected.tags
+++ b/Units/parser-javascript.r/js-odd-method-names.d/expected.tags
@@ -1,12 +1,12 @@
-\x21hello	input.js	/^  '!hello': function(){},$/;"	m	class:object
-\x20hello	input.js	/^  ' hello': function(){},$/;"	m	class:object
-<hello	input.js	/^  '<hello': function(){},$/;"	m	class:object
->hello	input.js	/^  '>hello': function(){},$/;"	m	class:object
-\thello	input.js	/^  '	hello': function(){},$/;"	m	class:object
-\\hello	input.js	/^  '\\\\hello': function(){},$/;"	m	class:object
-;"hello	input.js	/^  ';"hello': function(){},$/;"	m	class:object
-"hello	input.js	/^  '"hello': function(){},$/;"	m	class:object
-'hello	input.js	/^  "'hello": function(){},$/;"	m	class:object
-hello!	input.js	/^  'hello!': function(){},$/;"	m	class:object
-hello 	input.js	/^  'hello ': function(){},$/;"	m	class:object
-object	input.js	/^var object = {$/;"	c
+\x21hello	input.js	/^  '!hello': function(){},$/;"	m	variable:object
+\x20hello	input.js	/^  ' hello': function(){},$/;"	m	variable:object
+<hello	input.js	/^  '<hello': function(){},$/;"	m	variable:object
+>hello	input.js	/^  '>hello': function(){},$/;"	m	variable:object
+\thello	input.js	/^  '	hello': function(){},$/;"	m	variable:object
+\\hello	input.js	/^  '\\\\hello': function(){},$/;"	m	variable:object
+;"hello	input.js	/^  ';"hello': function(){},$/;"	m	variable:object
+"hello	input.js	/^  '"hello': function(){},$/;"	m	variable:object
+'hello	input.js	/^  "'hello": function(){},$/;"	m	variable:object
+hello!	input.js	/^  'hello!': function(){},$/;"	m	variable:object
+hello 	input.js	/^  'hello ': function(){},$/;"	m	variable:object
+object	input.js	/^var object = {$/;"	v

--- a/Units/parser-javascript.r/js-parenthesis-rvalue.d/expected.tags
+++ b/Units/parser-javascript.r/js-parenthesis-rvalue.d/expected.tags
@@ -1,9 +1,9 @@
-a	input.js	/^var d1 = {a:'hello',b:'hi'};$/;"	p	class:d1
-a	input.js	/^var d2 = ({a:'hello',b:'hi'});$/;"	p	class:d2
+a	input.js	/^var d1 = {a:'hello',b:'hi'};$/;"	p	variable:d1
+a	input.js	/^var d2 = ({a:'hello',b:'hi'});$/;"	p	variable:d2
 a1	input.js	/^var a1 = 42;$/;"	v
 a2	input.js	/^var a2 = (42);$/;"	v
-b	input.js	/^var d1 = {a:'hello',b:'hi'};$/;"	p	class:d1
-b	input.js	/^var d2 = ({a:'hello',b:'hi'});$/;"	p	class:d2
+b	input.js	/^var d1 = {a:'hello',b:'hi'};$/;"	p	variable:d1
+b	input.js	/^var d2 = ({a:'hello',b:'hi'});$/;"	p	variable:d2
 b1	input.js	/^var b1 = function(){$/;"	f
 b1sub	input.js	/^  function b1sub(){}$/;"	f	function:b1
 b2	input.js	/^var b2 = (function(){$/;"	f
@@ -12,8 +12,8 @@ b3	input.js	/^var b3 = ((function(){$/;"	f
 b3sub	input.js	/^  function b3sub(){}$/;"	f	function:b3
 c1	input.js	/^var c1 = {};$/;"	v
 c2	input.js	/^var c2 = ({});$/;"	v
-d1	input.js	/^var d1 = {a:'hello',b:'hi'};$/;"	c
-d2	input.js	/^var d2 = ({a:'hello',b:'hi'});$/;"	c
+d1	input.js	/^var d1 = {a:'hello',b:'hi'};$/;"	v
+d2	input.js	/^var d2 = ({a:'hello',b:'hi'});$/;"	v
 e1	input.js	/^var e1 = function(){$/;"	f
 e1sub	input.js	/^  function e1sub(){}$/;"	f	function:e1
 e2	input.js	/^var e2 = (function(){$/;"	f

--- a/Units/parser-javascript.r/js-parse-function-block.d/expected.tags
+++ b/Units/parser-javascript.r/js-parse-function-block.d/expected.tags
@@ -1,3 +1,3 @@
-AnonymousFunctionf0f039f00100	input.js	/^A.add('X', function(Y) {$/;"	function
+anonymousFunctionf0f039f00100	input.js	/^A.add('X', function(Y) {$/;"	function
 c	input.js	/^B.c = function(type, field)$/;"	function	function:B
 d	input.js	/^B.d = function(id)$/;"	function	function:B

--- a/Units/parser-javascript.r/js-string-continuation.d/expected.tags
+++ b/Units/parser-javascript.r/js-string-continuation.d/expected.tags
@@ -1,5 +1,5 @@
-first	input.js	/^  "first": function(){},$/;"	m	class:o
-fourth	input.js	/^  "fourth": function(){},$/;"	m	class:o
-o	input.js	/^var o = {$/;"	c
-second	input.js	/^ond": function(){},$/;"	m	class:o
-third	input.js	/^": function(){},$/;"	m	class:o
+first	input.js	/^  "first": function(){},$/;"	m	variable:o
+fourth	input.js	/^  "fourth": function(){},$/;"	m	variable:o
+o	input.js	/^var o = {$/;"	v
+second	input.js	/^ond": function(){},$/;"	m	variable:o
+third	input.js	/^": function(){},$/;"	m	variable:o

--- a/Units/parser-javascript.r/js-unicode-escape-iconv.d/expected.tags
+++ b/Units/parser-javascript.r/js-unicode-escape-iconv.d/expected.tags
@@ -4,7 +4,7 @@
 é_4	input.js	/^function \\u{e9}_4() {}$/;"	f
 é_5	input.js	/^function \\u{0000000000000000000e9}_5() {}$/;"	f
 é_6	input.js	/^function \\u{65}\\u0301_6() {}$/;"	f
-𐌀_1	input.js	/^  '𐌀_1': function(){},$/;"	m	class:object
-𐌀_2	input.js	/^  '\\uD800\\uDF00_2': function(){},$/;"	m	class:object
-𐌀_3	input.js	/^  '\\u{10300}_3': function(){},$/;"	m	class:object
-object	input.js	/^var object = {$/;"	c
+𐌀_1	input.js	/^  '𐌀_1': function(){},$/;"	m	variable:object
+𐌀_2	input.js	/^  '\\uD800\\uDF00_2': function(){},$/;"	m	variable:object
+𐌀_3	input.js	/^  '\\u{10300}_3': function(){},$/;"	m	variable:object
+object	input.js	/^var object = {$/;"	v

--- a/Units/parser-javascript.r/js-unicode-escape-naked-surrogate.d/expected.tags
+++ b/Units/parser-javascript.r/js-unicode-escape-naked-surrogate.d/expected.tags
@@ -1,12 +1,12 @@
-Ì†Ä	input.js	/^  '\\uD800': function() {},$/;"	m	class:object
-ÌºÄ	input.js	/^  '\\uDF00': function() {},$/;"	m	class:object
-ÌºÄÌ†Ä	input.js	/^  '\\uDF00\\uD800': function() {},$/;"	m	class:object
-ÌºÄêåÄ	input.js	/^  '\\uDF00\\uD800\\uDF00': function() {},$/;"	m	class:object
-Ì†ÄêåÄ	input.js	/^  '\\uD800\\uD800\\uDF00': function() {},$/;"	m	class:object
-Ì†Äa1	input.js	/^  '\\uD800a1': function() {},$/;"	m	class:object
-Ì†Äa2	input.js	/^  '\\uD800\\u{61}2': function() {},$/;"	m	class:object
-ÌºÄa1	input.js	/^  '\\uDF00a1': function() {},$/;"	m	class:object
-ÌºÄa2	input.js	/^  '\\uDF00\\u{61}2': function() {},$/;"	m	class:object
-ÌºÄÌ†Äa1	input.js	/^  '\\uDF00\\uD800a1': function() {},$/;"	m	class:object
-ÌºÄÌ†Äa2	input.js	/^  '\\uDF00\\uD800\\u{61}2': function() {},$/;"	m	class:object
-object	input.js	/^var object = {$/;"	c
+Ì†Ä	input.js	/^  '\\uD800': function() {},$/;"	m	variable:object
+ÌºÄ	input.js	/^  '\\uDF00': function() {},$/;"	m	variable:object
+ÌºÄÌ†Ä	input.js	/^  '\\uDF00\\uD800': function() {},$/;"	m	variable:object
+ÌºÄêåÄ	input.js	/^  '\\uDF00\\uD800\\uDF00': function() {},$/;"	m	variable:object
+Ì†ÄêåÄ	input.js	/^  '\\uD800\\uD800\\uDF00': function() {},$/;"	m	variable:object
+Ì†Äa1	input.js	/^  '\\uD800a1': function() {},$/;"	m	variable:object
+Ì†Äa2	input.js	/^  '\\uD800\\u{61}2': function() {},$/;"	m	variable:object
+ÌºÄa1	input.js	/^  '\\uDF00a1': function() {},$/;"	m	variable:object
+ÌºÄa2	input.js	/^  '\\uDF00\\u{61}2': function() {},$/;"	m	variable:object
+ÌºÄÌ†Äa1	input.js	/^  '\\uDF00\\uD800a1': function() {},$/;"	m	variable:object
+ÌºÄÌ†Äa2	input.js	/^  '\\uDF00\\uD800\\u{61}2': function() {},$/;"	m	variable:object
+object	input.js	/^var object = {$/;"	v

--- a/Units/parser-javascript.r/js-unicode-escape.d/expected.tags
+++ b/Units/parser-javascript.r/js-unicode-escape.d/expected.tags
@@ -4,7 +4,7 @@
 é_4	input.js	/^function \\u{e9}_4() {}$/;"	f
 é_5	input.js	/^function \\u{0000000000000000000e9}_5() {}$/;"	f
 é_6	input.js	/^function \\u{65}\\u0301_6() {}$/;"	f
-𐌀_1	input.js	/^  '𐌀_1': function(){},$/;"	m	class:object
-𐌀_2	input.js	/^  '\\uD800\\uDF00_2': function(){},$/;"	m	class:object
-𐌀_3	input.js	/^  '\\u{10300}_3': function(){},$/;"	m	class:object
-object	input.js	/^var object = {$/;"	c
+𐌀_1	input.js	/^  '𐌀_1': function(){},$/;"	m	variable:object
+𐌀_2	input.js	/^  '\\uD800\\uDF00_2': function(){},$/;"	m	variable:object
+𐌀_3	input.js	/^  '\\u{10300}_3': function(){},$/;"	m	variable:object
+object	input.js	/^var object = {$/;"	v

--- a/Units/parser-javascript.r/js-unknown-construct-nesting.d/expected.tags
+++ b/Units/parser-javascript.r/js-unknown-construct-nesting.d/expected.tags
@@ -1,4 +1,4 @@
-aa	input.js	/^  aa: function () {$/;"	m	class:o
-bb	input.js	/^  bb: function (a) {$/;"	m	class:o
-cc	input.js	/^  cc: function() {}$/;"	m	class:o
-o	input.js	/^var o = {$/;"	c
+aa	input.js	/^  aa: function () {$/;"	m	variable:o
+bb	input.js	/^  bb: function (a) {$/;"	m	variable:o
+cc	input.js	/^  cc: function() {}$/;"	m	variable:o
+o	input.js	/^var o = {$/;"	v

--- a/Units/parser-javascript.r/jsFunc_tutorial.js.d/expected.tags
+++ b/Units/parser-javascript.r/jsFunc_tutorial.js.d/expected.tags
@@ -1,15 +1,15 @@
-Ball1	input.js	/^function Ball1()       \/\/ it may seem odd, but this declaration$/;"	f
-Ball3	input.js	/^function Ball3()       \/\/ it may seem odd, but declaration$/;"	f
-D1	input.js	/^function D1(a, b) $/;"	f
-D2	input.js	/^var D2=function(a, b) $/;"	f
-D2A	input.js	/^var D2A=function theAdd(a, b) $/;"	f
-D3	input.js	/^var D3=new Function("a", "b", "return a+b;");$/;"	f
-D4	input.js	/^var D4=new Function("a", "b", $/;"	f
-D5	input.js	/^function D5(myOperator)$/;"	f
-DT1	input.js	/^function DT1()$/;"	f
-DT2	input.js	/^function DT2(message)$/;"	f
-DT2A	input.js	/^function DT2A(message)$/;"	f
-DT3	input.js	/^function DT3()$/;"	f
+Ball1	input.js	/^function Ball1()       \/\/ it may seem odd, but this declaration$/;"	c
+Ball3	input.js	/^function Ball3()       \/\/ it may seem odd, but declaration$/;"	c
+D1	input.js	/^function D1(a, b) $/;"	c
+D2	input.js	/^var D2=function(a, b) $/;"	c
+D2A	input.js	/^var D2A=function theAdd(a, b) $/;"	c
+D3	input.js	/^var D3=new Function("a", "b", "return a+b;");$/;"	c
+D4	input.js	/^var D4=new Function("a", "b", $/;"	c
+D5	input.js	/^function D5(myOperator)$/;"	c
+DT1	input.js	/^function DT1()$/;"	c
+DT2	input.js	/^function DT2(message)$/;"	c
+DT2A	input.js	/^function DT2A(message)$/;"	c
+DT3	input.js	/^function DT3()$/;"	c
 DT4	input.js	/^function DT4(message, specifiedName)$/;"	c
 DT5	input.js	/^function DT5(color, specifiedName, owner, weight)$/;"	c
 DT6	input.js	/^function DT6(name, salary, mySupervisor)$/;"	c
@@ -17,16 +17,16 @@ DT7	input.js	/^function DT7(name, salary)$/;"	c
 DT7A	input.js	/^function DT7A(name, salary)$/;"	c
 DT8	input.js	/^function DT8(name, salary)$/;"	c
 DT9	input.js	/^function DT9(name, salary)$/;"	c
-PT1	input.js	/^function PT1()$/;"	f
+PT1	input.js	/^function PT1()$/;"	c
 PT2	input.js	/^function PT2(name, color)$/;"	c
 PT3	input.js	/^function PT3(name, salary)$/;"	c
-add	input.js	/^myObject.add=function(a,b){return a+b};  $/;"	f	class:myObject
+add	input.js	/^myObject.add=function(a,b){return a+b};  $/;"	f	variable:myObject
 addSalary	input.js	/^PT3.prototype.addSalary=function addSalaryFunction(addition)$/;"	m	class:PT3
-addSalaryFunction	input.js	/^function addSalaryFunction(addition)$/;"	c
-addSalaryFunctionDT9	input.js	/^function addSalaryFunctionDT9(addition)$/;"	c
+addSalaryFunction	input.js	/^function addSalaryFunction(addition)$/;"	f
+addSalaryFunctionDT9	input.js	/^function addSalaryFunctionDT9(addition)$/;"	f
 ball0	input.js	/^var ball0=new DT1(); \/\/ ball0 now points to a new object$/;"	v
 ball1	input.js	/^var ball1=new DT2("creating new Ball");  \/\/ creates object & $/;"	v
-ball2	input.js	/^var ball2=new Object();$/;"	c
+ball2	input.js	/^var ball2=new Object();$/;"	v
 ball3	input.js	/^var ball3=new DT3(); \/\/ ball0 now points to a new instance of type Ball$/;"	v
 ball4	input.js	/^var ball4=new DT3();$/;"	v
 ball5	input.js	/^var ball5=new DT3();$/;"	v
@@ -61,11 +61,11 @@ myFunction6A	input.js	/^function myFunction6A() $/;"	f
 myFunction6AE	input.js	/^myFunction6AE=function()$/;"	f
 myFunction6B	input.js	/^function myFunction6B() $/;"	f
 myFunction6E	input.js	/^myFunction6E=function()$/;"	f
-myObject	input.js	/^var myObject=new Object();$/;"	c
+myObject	input.js	/^var myObject=new Object();$/;"	v
 my_global_var1	input.js	/^var my_global_var1 = 'global';$/;"	v
-object1	input.js	/^var object1=new Object();      \/\/ creates 3 objects$/;"	c
-object2	input.js	/^var object2=new Object();$/;"	c
-object3	input.js	/^var object3=new Object();$/;"	c
+object1	input.js	/^var object1=new Object();      \/\/ creates 3 objects$/;"	v
+object2	input.js	/^var object2=new Object();$/;"	v
+object3	input.js	/^var object3=new Object();$/;"	v
 price	input.js	/^PT2.prototype.price=20;$/;"	m	class:PT2
 savedFunc6B	input.js	/^savedFunc6B=function()$/;"	f
 sayName4A	input.js	/^function sayName4A(name) $/;"	f

--- a/Units/parser-javascript.r/secondary_fcn_name.js.d/expected.tags
+++ b/Units/parser-javascript.r/secondary_fcn_name.js.d/expected.tags
@@ -1,5 +1,5 @@
-D1	input.js	/^function D1(a, b) $/;"	f
-D2	input.js	/^var D2=function(a, b) $/;"	f
-D2A	input.js	/^var D2A=function theAdd(a, b) $/;"	f
+D1	input.js	/^function D1(a, b) $/;"	c
+D2	input.js	/^var D2=function(a, b) $/;"	c
+D2A	input.js	/^var D2A=function theAdd(a, b) $/;"	c
 my_global_var1	input.js	/^var my_global_var1 = 'global';$/;"	v
 theAdd	input.js	/^var D2A=function theAdd(a, b) $/;"	f


### PR DESCRIPTION
Before ES6, there was no way to tell if an individual function was a class constructor.  This is why the convention was set that class names start with uppercase, and function names start with lowercase.

This patch also stops tagging objects as classes.  Objects in JavaScript are just like any other value.  One cannot "new" an object, only a constructor function.