### PR TITLE
Tmain(tag-relative-option-in-etags.d): use direq_maybe helper shell function

### DIFF
--- a/Tmain/tag-relative-option-in-etags.d/run.sh
+++ b/Tmain/tag-relative-option-in-etags.d/run.sh
@@ -12,7 +12,7 @@ for x in no yes default; do
     touch $BUILDDIR/${x}-$O
 done
 
-if ! direq $BUILDDIR .; then
+if ! direq_maybe $BUILDDIR .; then
 	cp -r indirect $BUILDDIR
 	copied=yes
 fi


### PR DESCRIPTION
eb101098a6ae97785df01e372082c4be71f038f7 renamed direq defined in
utils.sh to direq_maybe. Though e-ctags-output.d used the function,
the renaming was not reflected to the test case. As a result,
the input file, run.sh deleted indirect/src/input.c unexpectedly.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>