### PR TITLE
LdScript: expand C preprocessor macros

### DIFF
--- a/Units/parser-ldscript.r/lds-macro-expansion.d/args.ctags
+++ b/Units/parser-ldscript.r/lds-macro-expansion.d/args.ctags
@@ -1,0 +1,5 @@
+--sort=no
+--param-CPreProcessor._expand=1
+--fields=+{signature}{roles}
+--fields-CPreProcessor=+{macrodef}
+--extras=+r

--- a/Units/parser-ldscript.r/lds-macro-expansion.d/expected.tags
+++ b/Units/parser-ldscript.r/lds-macro-expansion.d/expected.tags
@@ -1,0 +1,10 @@
+MEM_DISCARD	input.lds.S	/^#define MEM_DISCARD(/;"	d	file:	signature:(sec)	roles:def	macrodef:*(.mem##sec)
+INIT_TEXT	input.lds.S	/^#define INIT_TEXT(/;"	d	file:	signature:(X,A)	roles:def	macrodef:*A *X MEM_DISCARD(init.text*)
+INIT_TEXT_SECTION	input.lds.S	/^#define INIT_TEXT_SECTION(/;"	d	file:	signature:(inittext_align,Y,B)	roles:def	macrodef:. = ALIGN(inittext_align); .init.text : AT(ADDR(.init.text) - LOAD_OFFSET) { _sinittext = .; INIT_TEXT(Y,B) _einittext = .; }
+.init.text	input.lds.S	/^	INIT_TEXT_SECTION(PAGE_SIZE,(.text.startup),(.init.text .init.text.*))$/;"	S	roles:def
+_sinittext	input.lds.S	/^	INIT_TEXT_SECTION(PAGE_SIZE,(.text.startup),(.init.text .init.text.*))$/;"	s	section:.init.text	roles:def
+.init.text	input.lds.S	/^	INIT_TEXT_SECTION(PAGE_SIZE,(.text.startup),(.init.text .init.text.*))$/;"	i	section:.init.text	roles:mapped
+.init.text.	input.lds.S	/^	INIT_TEXT_SECTION(PAGE_SIZE,(.text.startup),(.init.text .init.text.*))$/;"	i	section:.init.text	roles:mapped
+.text.startup	input.lds.S	/^	INIT_TEXT_SECTION(PAGE_SIZE,(.text.startup),(.init.text .init.text.*))$/;"	i	section:.init.text	roles:mapped
+.meminit.text	input.lds.S	/^	INIT_TEXT_SECTION(PAGE_SIZE,(.text.startup),(.init.text .init.text.*))$/;"	i	section:.init.text	roles:mapped
+_einittext	input.lds.S	/^	INIT_TEXT_SECTION(PAGE_SIZE,(.text.startup),(.init.text .init.text.*))$/;"	s	section:.init.text	roles:def

--- a/Units/parser-ldscript.r/lds-macro-expansion.d/input.lds.S
+++ b/Units/parser-ldscript.r/lds-macro-expansion.d/input.lds.S
@@ -1,0 +1,27 @@
+/* Based on linux/include/asm-generic/vmlinux.lds.h and
+ * linux/arch/x86/kernel/vmlinux.lds.S */
+
+#define MEM_DISCARD(sec) *(.mem##sec)
+
+#define INIT_TEXT(X,A)				\
+	*A					\
+	*X					\
+	MEM_DISCARD(init.text*)
+
+#define INIT_TEXT_SECTION(inittext_align,Y,B)				\
+	. = ALIGN(inittext_align);					\
+	.init.text : AT(ADDR(.init.text) - LOAD_OFFSET) {		\
+		_sinittext = .;						\
+		INIT_TEXT(Y,B)						\
+		_einittext = .;						\
+	}
+
+
+SECTIONS
+{
+	INIT_TEXT_SECTION(PAGE_SIZE,(.text.startup),(.init.text .init.text.*))
+#ifdef CONFIG_X86_64
+	:init
+#endif
+}
+

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -1925,7 +1925,7 @@ static bool buildMacroInfoFromTagEntry (int corkIndex,
 {
 	cppMacroInfo **info = data;
 
-	if (entry->langType == Cpp.clientLang
+	if ((entry->langType == Cpp.clientLang || entry->langType == Cpp.lang)
 		&& entry->kindIndex == Cpp.defineMacroKindIndex
 		&& isRoleAssigned (entry, ROLE_DEFINITION_INDEX))
 	{

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -2093,8 +2093,8 @@ static void saveIgnoreToken(const char * ignoreToken)
 	}
 	info->useCount = 0;
 	info->next = NULL;
-
-	hashTablePutItem(cmdlineMacroTable,eStrndup(tokenBegin,tokenEnd - tokenBegin),info);
+	info->name = eStrndup(tokenBegin,tokenEnd - tokenBegin);
+	hashTablePutItem(cmdlineMacroTable,info->name,info);
 
 	verbose ("    ignore token: %s\n", ignoreToken);
 }
@@ -2389,7 +2389,8 @@ static cppMacroInfo * saveMacro(hashTable *table, const char * macro)
 			ADD_CONSTANT_REPLACEMENT(begin,c - begin);
 	}
 
-	hashTablePutItem(table,eStrndup(identifierBegin,identifierEnd - identifierBegin),info);
+	info->name = eStrndup(identifierBegin,identifierEnd - identifierBegin);
+	hashTablePutItem(table,info->name,info);
 	CXX_DEBUG_LEAVE();
 
 	return info;
@@ -2408,6 +2409,7 @@ static void freeMacroInfo(cppMacroInfo * info)
 		pPart = pPart->next;
 		eFree(pPartToDelete);
 	}
+	eFree(info->name);
 	eFree(info);
 }
 
@@ -2417,7 +2419,7 @@ static hashTable *makeMacroTable (void)
 		1024,
 		hashCstrhash,
 		hashCstreq,
-		eFree,
+		NULL,					/* Keys refers values' name fields. */
 		(void (*)(void *))freeMacroInfo
 		);
 }

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -13,6 +13,7 @@
 *   INCLUDE FILES
 */
 #include "general.h"  /* must always come first */
+#include "ptrarray.h"
 #include "types.h"
 #include "vstring.h"
 
@@ -136,5 +137,11 @@ extern vString * cppBuildMacroReplacement(
 		const char ** parameters, /* may be NULL */
 		int parameterCount
 	);
+
+/* Do the same as cppBuildMacroReplacement with ptrArray<const char*>,
+ * and unget the result of expansion to input cpp stream. */
+extern void cppBuildMacroReplacementWithPtrArrayAndUngetResult(
+		cppMacroInfo * macro,
+		const ptrArray * args);
 
 #endif  /* CTAGS_MAIN_GET_H */

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -115,6 +115,7 @@ typedef struct sCppMacroReplacementPartInfo {
 } cppMacroReplacementPartInfo;
 
 typedef struct sCppMacroInfo {
+	char *name;			/* the name of macro. Useful for debugging. */
 	bool hasParameterList; /* true if the macro has a trailing () */
 	cppMacroReplacementPartInfo * replacements;
 	int useCount;

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -1350,7 +1350,7 @@ bool cxxParserParseNextToken(void)
 			if(pMacro && (pMacro->useCount < CXX_PARSER_MAXIMUM_MACRO_USE_COUNT))
 			{
 				CXX_DEBUG_PRINT("Macro %s <%p> useCount: %d", vStringValue(t->pszWord),
-								pMacro, pMacro? pMacro->useCount: -1);
+								pMacro, pMacro->useCount);
 
 				cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -1341,7 +1341,7 @@ bool cxxParserParseNextToken(void)
 			{
 				/* If the macro is overly used, report it here. */
 				CXX_DEBUG_PRINT("Overly uesd macro %s <%p> useCount: %d (> %d)",
-								vStringValue(t->pszWord),
+								pMacro->name,
 								pMacro, pMacro->useCount,
 								CXX_PARSER_MAXIMUM_MACRO_USE_COUNT);
 			}
@@ -1349,7 +1349,7 @@ bool cxxParserParseNextToken(void)
 
 			if(pMacro && (pMacro->useCount < CXX_PARSER_MAXIMUM_MACRO_USE_COUNT))
 			{
-				CXX_DEBUG_PRINT("Macro %s <%p> useCount: %d", vStringValue(t->pszWord),
+				CXX_DEBUG_PRINT("Macro %s <%p> useCount: %d", pMacro->name,
 								pMacro, pMacro->useCount);
 
 				cxxTokenChainDestroyLast(g_cxx.pTokenChain);

--- a/parsers/fypp.c
+++ b/parsers/fypp.c
@@ -450,9 +450,10 @@ static void fyppSetGuestParser (const langType language CTAGS_ATTR_UNUSED,
 }
 
 static parameterHandlerTable FyppParameterHandlerTable [] = {
-	{ .name = "guest",
-	  .desc = "parser run after Fypp parser parses the original input (\"NONE\" or a parser name [Fortran])" ,
-	  .handleParameter = fyppSetGuestParser,
+	{
+		.name = "guest",
+		.desc = "parser run after Fypp parser parses the original input (\"NONE\" or a parser name [Fortran])" ,
+		.handleParameter = fyppSetGuestParser,
 	},
 };
 


### PR DESCRIPTION
    Following options are neede for expansion:
    
      --fields=+{signature}
      --fields-CPreProcessor=+{macrodef}
    
    -D option is for defining a macro and its definiton from
    command line.
    
    If --param-CPreProcessor._expand=1 option is given, macros
    defined in the same input file are expanded.
    
    Ths code is mostly based on Cxx parser.
