### PR TITLE
main: fix reading outside malloced area.

### DIFF
--- a/main/numarray.c
+++ b/main/numarray.c
@@ -146,7 +146,7 @@
 	extern void prefix##ArrayDeleteItem (prefix##Array* const current, unsigned int indx) \
 	{																	\
 		memmove (current->array + indx, current->array + indx + 1,		\
-				 (current->count - indx) * sizeof (*current->array));	\
+				 (current->count - indx - 1) * sizeof (*current->array)); \
 		--current->count;												\
 	}																	\
 	static int prefix##GreaterThan(const void *a, const void *b)		\

--- a/main/ptrarray.c
+++ b/main/ptrarray.c
@@ -199,7 +199,7 @@ extern void ptrArrayDeleteItem (ptrArray* const current, unsigned int indx)
 		current->deleteFunc (ptr);
 
 	memmove (current->array + indx, current->array + indx + 1,
-			(current->count - indx) * sizeof (*current->array));
+			(current->count - indx - 1) * sizeof (*current->array));
 	--current->count;
 }
 
@@ -208,7 +208,7 @@ extern void*ptrArrayRemoveItem (ptrArray* const current, unsigned int indx)
 	void *ptr = current->array[indx];
 
 	memmove (current->array + indx, current->array + indx + 1,
-			(current->count - indx) * sizeof (*current->array));
+			(current->count - indx - 1) * sizeof (*current->array));
 	--current->count;
 
 	return ptr;


### PR DESCRIPTION
Calling ptrArrayDeleteItem in a situation where the allocated array is fully used
 (curent-> count == current-> max) caused memmove to access outside the malloced area.

ptrArrayRemoveItem and {char,uchar,int,uint,long,ulong}ArrayDeleteItem have the same problem.

```
$ LD_PRELOAD=libefence.so EF_ALLOW_MALLOC_0=1 ctags --langmap=c:.c.h --version

  Electric Fence 2.2 Copyright (C) 1987-1999 Bruce Perens <bruce@perens.com>
Segmentation fault (core dumped)
```

```
$ valgrind  ctags --langmap=c:.c.h --version
==4870== Memcheck, a memory error detector
==4870== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==4870== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==4870== Command: ctags --langmap=c:.c.h --version
==4870==
==4870== Invalid read of size 8
==4870==    at 0x4842AE4: memmove (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==4870==    by 0x143905: memmove (string_fortified.h:40)
==4870==    by 0x143905: ptrArrayDeleteItem (ptrarray.c:201)
==4870==    by 0x145CC9: stringListDeleteItemExtension (strlist.c:191)
==4870==    by 0x13AF6D: removeLanguageExtensionMap1 (parse.c:1702)
==4870==    by 0x13AFEC: removeLanguageExtensionMap.part.0 (parse.c:1718)
==4870==    by 0x13D4FF: removeLanguageExtensionMap (parse.c:1714)
==4870==    by 0x13D4FF: addLanguageExtensionMap (parse.c:1732)
==4870==    by 0x135F24: addLanguageMap (options.c:1808)
==4870==    by 0x136C33: processLanguageMap (options.c:1877)
==4870==    by 0x136C33: processLanguageMapOption (options.c:1901)
==4870==    by 0x13875A: processParametricOption (options.c:2960)
==4870==    by 0x13875A: processLongOption (options.c:3316)
==4870==    by 0x13875A: parseOption.part.0 (options.c:3485)
==4870==    by 0x138A1A: parseOption (options.c:3482)
==4870==    by 0x138A1A: parseOptions (options.c:3500)
==4870==    by 0x133ECC: ctags_cli_main (main.c:583)
==4870==    by 0x4AAB0B2: (below main) (libc-start.c:308)
==4870==  Address 0x6d6c860 is 0 bytes after a block of size 128 alloc'd
==4870==    at 0x483DFAF: realloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==4870==    by 0x215247: eRealloc (routines.c:245)
==4870==    by 0x143550: ptrArrayAdd (ptrarray.c:53)
==4870==    by 0x145AEB: stringListAdd (strlist.c:34)
==4870==    by 0x145AEB: stringListNewFromArgv (strlist.c:55)
==4870==    by 0x13D074: installLanguageMapDefault (parse.c:1587)
==4870==    by 0x13D1F9: installLanguageMapDefaults (parse.c:1603)
==4870==    by 0x139195: initOptions (options.c:3823)
==4870==    by 0x133EAC: ctags_cli_main (main.c:579)
==4870==    by 0x4AAB0B2: (below main) (libc-start.c:308)
==4870==
Universal Ctags 5.9.0(d9064889), Copyright (C) 2015-2022 Universal Ctags Team
Universal Ctags is derived from Exuberant Ctags.
Exuberant Ctags 5.8, Copyright (C) 1996-2009 Darren Hiebert
  Compiled: May  4 2022, 22:07:19
  URL: https://ctags.io/
  Optional compiled features: +wildcards, +regex, +gnulib_regex, +iconv, +option-directory, +xpath, +json, +interactive, +sandbox, +yaml, +packcc, +optscript
==4870==
==4870== HEAP SUMMARY:
==4870==     in use at exit: 346,648 bytes in 8,332 blocks
==4870==   total heap usage: 9,150 allocs, 818 frees, 479,560 bytes allocated
==4870==
==4870== LEAK SUMMARY:
==4870==    definitely lost: 0 bytes in 0 blocks
==4870==    indirectly lost: 0 bytes in 0 blocks
==4870==      possibly lost: 0 bytes in 0 blocks
==4870==    still reachable: 346,648 bytes in 8,332 blocks
==4870==         suppressed: 0 bytes in 0 blocks
==4870== Rerun with --leak-check=full to see details of leaked memory
==4870==
==4870== For lists of detected and suppressed errors, rerun with: -s
==4870== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```