### PR TITLE
build-sys: force regenerating aclocal.m4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ depcomp
 gdb-backtrace.txt
 GNUmakefile.in
 install-sh
+last-aclocal.m4
 libctags.a
 libutil.a
 Makefile.in

--- a/autogen.sh
+++ b/autogen.sh
@@ -12,6 +12,12 @@ for t in autoreconf aclocal pkg-config autoconf automake; do
 	echo '##################################################################'
 done
 
+if [ -e ./aclocal.m4 ]; then
+	echo '#             Renaming aclocal.m4 to last-aclocal.m4             #'
+	mv ./aclocal.m4 ./last-aclocal.m4
+	echo '##################################################################'
+fi
+
 echo '#                        Generating files                        #'
 echo '##################################################################'
 


### PR DESCRIPTION
Close #3378.

Inspired from #3378 reported by @Shane-XB-Qian.

It seems that aclocal.m4 generated in the last time when
autogen.sh run can be a trouble of building.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>