### PR TITLE
Tmain: check the availability of iconv encodings

### DIFF
--- a/Tmain/input-encoding-option.d/run.sh
+++ b/Tmain/input-encoding-option.d/run.sh
@@ -9,6 +9,9 @@ BUILDDIR=$2
 . ../utils.sh
 
 if ${CTAGS} --quiet --options=NONE --list-features | grep -q iconv; then
+  check_encoding shift_jis
+  check_encoding euc-jp
+  check_encoding utf-8
   if ${CTAGS} --quiet --options=NONE \
 	      --pseudo-tags=-TAG_PROC_CWD \
 	      --input-encoding=utf-8 --input-encoding-java=shift_jis --input-encoding-javascript=euc-jp \

--- a/Tmain/invalid-encoding-option.d/run.sh
+++ b/Tmain/invalid-encoding-option.d/run.sh
@@ -8,6 +8,7 @@ CTAGS=$1
 . ../utils.sh
 
 if ${CTAGS} --quiet --options=NONE --list-features | grep -q iconv; then
+  check_encoding euc-jp
   ${CTAGS} --quiet --options=NONE --input-encoding-java=invalid	--input-encoding-javascript=euc-jp -o - input.js input.java
   exit $?
 else

--- a/Tmain/no-input-encoding-option.d/run.sh
+++ b/Tmain/no-input-encoding-option.d/run.sh
@@ -8,6 +8,7 @@ BUILDDIR=$2
 . ../utils.sh
 
 if ${CTAGS} --quiet --options=NONE --list-features | grep -q iconv; then
+  check_encoding utf-8
   ${CTAGS} --quiet --options=NONE --output-encoding=utf-8 -o $BUILDDIR/tags input.js input.java
   exit $?
 else

--- a/Tmain/output-encoding-option.d/run.sh
+++ b/Tmain/output-encoding-option.d/run.sh
@@ -8,6 +8,9 @@ BUILDDIR=$2
 . ../utils.sh
 
 if ${CTAGS} --quiet --options=NONE --list-features | grep -q iconv; then
+  check_encoding shift_jis
+  check_encoding utf-8
+  check_encoding euc-jp
   if ${CTAGS}  --quiet --options=NONE \
 	       --pseudo-tags=-TAG_PROC_CWD \
 	       --output-encoding=shift_jis --input-encoding=utf-8 --input-encoding-javascript=euc-jp \

--- a/Tmain/utils.sh
+++ b/Tmain/utils.sh
@@ -135,3 +135,11 @@ direq_maybe ()
     [ "$(cd ${1} && pwd)" = "$(cd ${2} && pwd)" ]
     return $?
 }
+
+check_encoding()
+{
+    if iconv -l | grep -qi "$1"; then
+		return 0
+	fi
+	skip "iconv doesn't know about the encoding: $1"
+}


### PR DESCRIPTION
Though iconv command is available, there is a case
that encodings used in test cases are not available.

e.g. the ubi8 container doesn't provide shift_jis
encoding unless installing glibc-langpack-ja package.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>