### PR TITLE
win32: Fix link errors after VC++ 2015 or later

### DIFF
--- a/win32/config_mvc.h
+++ b/win32/config_mvc.h
@@ -421,7 +421,7 @@
 
 
 /* Define to 1 if the compiler supports the keyword '__inline'. */
-/* !!!#define HAVE___INLINE 1 */
+#define HAVE___INLINE 1
 
 /* Define this value if the platform uses "lib" as prefix for iconv functions.
    */


### PR DESCRIPTION
Fix #3380

The printf and scanf functions are defined inline in VC++ 2015 or later:
https://devblogs.microsoft.com/cppblog/c-runtime-crt-features-fixes-and-breaking-changes-in-visual-studio-14-ctp1/

The wrong definition in win32/config_mvc.h that disables the `__inline`
keyword breaks these inline definitions.

Define `HAVE___INLINE` to 1 to enable the `__inline` keyword.