### PR TITLE
C++: Fix parser for template function return types (issue #3388)

### DIFF
--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -45,6 +45,21 @@ static bool cxxTemplateTokenCheckIsNonTypeAndCompareWord(const CXXToken *t,void 
 	// To be non type the token must NOT be preceded by class/struct/union
 	if(!t->pPrev)
 		return false;
+	// This catches the case where we have a structure like this:
+	// template<typename A, typename B>
+	// A f(void)
+	// {
+  	// return A();
+	// }
+	// here the greater-than sign (>) is not a comparison, but just closes the
+	// template. We know it is a template, because the keyword of the second
+	// template parameter is "typename"
+	// This addresses issue #3388
+
+	if(
+		t->pPrev->pPrev->pPrev->eKeyword == CXXKeywordTYPENAME
+	)
+		return false;
 	if(cxxTokenTypeIs(t->pPrev,CXXTokenTypeKeyword))
 	{
 		if(cxxKeywordIsTypeRefMarker(t->pPrev->eKeyword))

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -51,12 +51,11 @@ static bool cxxTemplateTokenCheckIsNonTypeAndCompareWord(const CXXToken *t,void 
 	// {
   	// return A();
 	// }
+	// (here the parser is at A, before f(void))
 	// here the greater-than sign (>) is not a comparison, but just closes the
 	// template. We know it is a template, because the keyword of the second
 	// template parameter is "typename"
 	// This addresses issue #3388
-	CXX_DEBUG_PRINT("HERE %s ",vStringValue(t->pszWord));
-	CXX_DEBUG_PRINT("t->pPrev->pPrev->pPrev- %s ",vStringValue(t->pPrev->pPrev->pPrev->pszWord));
 	const CXXToken * tmp = t->pPrev;
 	while(tmp){
 		if (tmp->eKeyword  == CXXKeywordTYPENAME)
@@ -66,15 +65,7 @@ static bool cxxTemplateTokenCheckIsNonTypeAndCompareWord(const CXXToken *t,void 
 			break;
 		tmp = tmp->pPrev;
 	}
-	/*
-	if(
-		t->pPrev != NULL &&
-		t->pPrev->pPrev != NULL &&
-		t->pPrev->pPrev->pPrev != NULL &&
-		t->pPrev->pPrev->pPrev->eKeyword == CXXKeywordTYPENAME
-	)
-		return false;
-	*/
+
 	if(cxxTokenTypeIs(t->pPrev,CXXTokenTypeKeyword))
 	{
 		if(cxxKeywordIsTypeRefMarker(t->pPrev->eKeyword))

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -55,11 +55,26 @@ static bool cxxTemplateTokenCheckIsNonTypeAndCompareWord(const CXXToken *t,void 
 	// template. We know it is a template, because the keyword of the second
 	// template parameter is "typename"
 	// This addresses issue #3388
-
+	CXX_DEBUG_PRINT("HERE %s ",vStringValue(t->pszWord));
+	CXX_DEBUG_PRINT("t->pPrev->pPrev->pPrev- %s ",vStringValue(t->pPrev->pPrev->pPrev->pszWord));
+	const CXXToken * tmp = t->pPrev;
+	while(tmp){
+		if (tmp->eKeyword  == CXXKeywordTYPENAME)
+			return false;
+		// should we reach template we went too far back
+		if (tmp->eKeyword  == CXXKeywordTEMPLATE)
+			break;
+		tmp = tmp->pPrev;
+	}
+	/*
 	if(
+		t->pPrev != NULL &&
+		t->pPrev->pPrev != NULL &&
+		t->pPrev->pPrev->pPrev != NULL &&
 		t->pPrev->pPrev->pPrev->eKeyword == CXXKeywordTYPENAME
 	)
 		return false;
+	*/
 	if(cxxTokenTypeIs(t->pPrev,CXXTokenTypeKeyword))
 	{
 		if(cxxKeywordIsTypeRefMarker(t->pPrev->eKeyword))


### PR DESCRIPTION
This commit fixes issue #3388, where the C++ parser does not correctly parse function return types.