### PR TITLE
appveyor: Download Cygwin's setup-x86_64.exe before starting CI

### DIFF
--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -241,7 +241,7 @@ goto :eof
 :: Using Cygwin, iconv enabled
 @echo on
 appveyor DownloadFile http://cygwin.com/setup-x86_64.exe -FileName c:\cygwin64\setup-x86_64.exe
-c:\cygwin64\setup-x86_64.exe -qnNdO -P dos2unix,libiconv-devel,libjansson-devel,libxml2-devel,libyaml-devel,pcre2,perl
+c:\cygwin64\setup-x86_64.exe -qnNdOg -P dos2unix,libiconv-devel,libjansson-devel,libxml2-devel,libyaml-devel,pcre2,perl
 PATH c:\cygwin64\bin;%PATH%
 set CHERE_INVOKING=yes
 bash -lc "./autogen.sh"

--- a/win32/appveyor.bat
+++ b/win32/appveyor.bat
@@ -240,6 +240,7 @@ goto :eof
 :: ----------------------------------------------------------------------
 :: Using Cygwin, iconv enabled
 @echo on
+appveyor DownloadFile http://cygwin.com/setup-x86_64.exe -FileName c:\cygwin64\setup-x86_64.exe
 c:\cygwin64\setup-x86_64.exe -qnNdO -P dos2unix,libiconv-devel,libjansson-devel,libxml2-devel,libyaml-devel,pcre2,perl
 PATH c:\cygwin64\bin;%PATH%
 set CHERE_INVOKING=yes


### PR DESCRIPTION
Fix the following error on AppVeyor:
```
mbox Parse Errors:  line 12: The current ini file requires at least version 2.903 of setup.
Please download a newer version from https://cygwin.com/setup-x86_64.exe
```