### PR TITLE
appveyor: Disable Cygwin tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ environment:
     #- compiler: msvc
     #  ARCH: x86
     - compiler: mingw
-    - compiler: cygwin
+    #- compiler: cygwin
 
 build_script:
   - '%APPVEYOR_BUILD_FOLDER%\win32\appveyor.bat build'


### PR DESCRIPTION
Currently, the Cygwin tests are failing because of this error:

```
mbox Parse Errors:  line 12: The current ini file requires at least version 2.903 of setup.
Please download a newer version from https://cygwin.com/setup-x86_64.exe
```

And, even after setup-x86_64.exe has been updated, they are failing with
this error (see #3394):

```
CHKGEN     check-genfile
warning: Not a git repository. Use --no-index to compare two paths outside a working tree
usage: git diff --no-index [<options>] <path> <path>
```

I have no ideas how to fix this.

We already run the Cygwin tests also on GitHub Actions. Running the same
tests on AppVeyor is redundant.

Disable the Cygwin tests on AppVeyor for now.