### PR TITLE
CircleCI: Skip checkgen for win32 on CentOS 7

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -245,7 +245,7 @@ jobs:
        - run:
            name: Test
            command: |
-             make check
+             make check SKIP_CHECKGEN_WIN32=yes
 
    centos7_make_roundtrip:
      working_directory: ~/universal-ctags

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -346,9 +346,14 @@ endif
 		$(MAKE) -BC win32 ; \
 	fi
 	$(chkgen_verbose)if ! git diff --exit-code -- win32; then \
-		echo "Files under win32/ are not up to date." ; \
-		echo "Please execute 'make -BC win32' and commit them." ; \
-		exit 1 ; \
+		if test "$(SKIP_CHECKGEN_WIN32)" = "yes"; then \
+			echo "Skip checking the files under win32." ; \
+			exit 0 ; \
+		else \
+			echo "Files under win32/ are not up to date." ; \
+			echo "Please execute 'make -BC win32' and commit them." ; \
+			exit 1 ; \
+		fi \
 	else \
 		echo "Files under win32 are up to date." ; \
 	fi


### PR DESCRIPTION
Git on CentOS 7 is very old and doesn't support `eol=crlf` in `.gitattributes`.
Skip `make check-genfile` for the win32 directory.