### PR TITLE
win32: Set eol only for win32 directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 *	text=auto
 
-*.bat	text eol=crlf
-*.sln	text eol=crlf
-*.vcxproj	text eol=crlf
-*.vcxproj.filters	text eol=crlf
+/win32/*.bat	text eol=crlf
+/win32/*.sln	text eol=crlf
+/win32/*.vcxproj	text eol=crlf
+/win32/*.vcxproj.filters	text eol=crlf


### PR DESCRIPTION
`.gitattributes` also affected the Visual Stdio files in `misc/packcc/`.
But, that should set in the packcc repository if needed.

Restrict the setting only for the `win32` directory.