### PR TITLE
C++: verify the argument passed to cxxTokenIsPresentInTemplateParamet…

### DIFF
--- a/Units/parser-cxx.r/bug-github-3413.cpp.d/README
+++ b/Units/parser-cxx.r/bug-github-3413.cpp.d/README
@@ -1,0 +1,1 @@
+This is a crash test. So no expected.tags here.

--- a/Units/parser-cxx.r/bug-github-3413.cpp.d/input.hpp
+++ b/Units/parser-cxx.r/bug-github-3413.cpp.d/input.hpp
@@ -1,0 +1,1 @@
+struct S<P<T, <>

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -354,7 +354,10 @@ cxxParserParseTemplateAngleBracketsInternal(bool bCaptureTypeParameters,int iNes
 					// ... 1 < whatever ...
 					cxxTokenTypeIs(pSmallerThan->pPrev,CXXTokenTypeNumber) ||
 					// ... nonTypeParam < whatever ...
-					cxxTokenIsPresentInTemplateParametersAsNonType(pSmallerThan->pPrev)
+					(
+						cxxTokenTypeIsOneOf(pSmallerThan->pPrev,CXXTokenTypeIdentifier) &&
+						cxxTokenIsPresentInTemplateParametersAsNonType(pSmallerThan->pPrev)
+					)
 				)
 				{
 					CXX_DEBUG_PRINT("Treating < as less-than operator");


### PR DESCRIPTION
…ersAsNonType

Close #3413.

An assertion failed because an unexpected argument is passed to
cxxTokenIsPresentInTemplateParametersAsNonType. This can be happen if
a broken C++ input is passed to ctags.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>