### PR TITLE
tmain: suppress the error message reported when running "iconv -l" 

### DIFF
--- a/Tmain/utils.sh
+++ b/Tmain/utils.sh
@@ -138,7 +138,7 @@ direq_maybe ()
 
 check_encoding()
 {
-    if iconv -l | grep -qi "$1"; then
+    if iconv -l 2> /dev/null | grep -qi "$1"; then
 		return 0
 	fi
 	skip "iconv doesn't know about the encoding: $1"


### PR DESCRIPTION
"ioconv -l" of Cygwin running on Git Hub Actions reports "I/O erorr".
The message may come from https://git.savannah.gnu.org/gitweb/?p=libiconv.git;a=blob;f=src/iconv.c;h=e3932e5f18e0484972aa1f92c797e5f13ae52937;hb=HEAD#l1130 .

As far as reading the condition surrounding the code for printing the messasge,
we can ignore it.
