### PR TITLE
Cxx: add missing NULL check when detecting a constructor

### DIFF
--- a/Units/parser-cxx.r/templates8.d/README
+++ b/Units/parser-cxx.r/templates8.d/README
@@ -1,0 +1,2 @@
+This is a crash test.
+The input is invalid as C++ code.

--- a/Units/parser-cxx.r/templates8.d/input.cpp
+++ b/Units/parser-cxx.r/templates8.d/input.cpp
@@ -1,0 +1,5 @@
+template <class T>
+struct A
+{
+	S<F>();
+};

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -660,6 +660,9 @@ static bool cxxParserisConstructor(const char *szFuncname)
 	const char *szScope = cxxScopeGetName();
 	const char *szTmp = strrstr (szScope, szFuncname);
 
+	if (szTmp == NULL)
+		return false;
+
 	/* szFuncname == "C", szScope == "C" */
 	if (szTmp == szScope)
 		return true;


### PR DESCRIPTION
Close #3417.

The original issue was found when parsing cuda code.
However, the bug is common between cuda and C++.

When detecting a name defined in a class is a constructor
or not, strrstr() is used. The original code assumed the
value returned from strrstr is not NULL. This wrong assumption
caused a crash.

@ijpq made efforts to find an input file causing the crash.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>