### PR TITLE
JavaScript,style: add ',' at the end of the last enumerator

### DIFF
--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -124,7 +124,7 @@ typedef enum eTokenType {
 	 * Used only in readTokenFull or lower functions. */
 	TOKEN_ATMARK,
 	TOKEN_BINARY_OPERATOR,
-	TOKEN_ARROW
+	TOKEN_ARROW,
 } tokenType;
 
 typedef struct sTokenInfo {


### PR DESCRIPTION
See the review comments of #3434.

Adding ',' at the end of the last element in a list is a good practice
because a future diff adding a new element at the end of the list can
be smaller; when adding TOKEN_foo, just adding a line is what we have
to do like:

```diff
    TOKEN_arrow,
+   TOKEN_foo,
```

We will not have to do like:

```diff
-    TOKEN_arrow
+    TOKEN_arrow,
+    TOKEN_foo
```

With this technique, we can make the diff two lines smaller.
Generally, smaller diff helps people understand the diff.

This is a popular technique:
* https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/netlink.h#n186
* https://sourceware.org/git/?p=glibc.git;a=blob;f=include/stdio.h;h=a6f7fd43cb664eb55f4987dfa830466bba38aa5b;hb=HEAD#l149
* https://github.com/llvm/llvm-project/blob/41fba3c107a5bc99065f3bf8b9f5b9d52eab2d98/llvm/include/llvm/BinaryFormat/ELF.h#L322

It is popular technique even in ctags:
* https://github.com/universal-ctags/ctags/blob/master/parsers/jscript.c#L97
* https://github.com/universal-ctags/ctags/blob/2052bbfcb2e06a4728417010bfa6fbb00e16a5bf/parsers/jscript.c#L254
* https://github.com/universal-ctags/ctags/blob/2052bbfcb2e06a4728417010bfa6fbb00e16a5bf/parsers/jscript.c#L281

Signed-off-by: Masatake YAMATO <yamato@redhat.com>