### PR TITLE
GitHub Actions(FreeBSD): catch up with the latest FreeBSD images

### DIFF
--- a/.github/workflows/testing-freebsd.yml
+++ b/.github/workflows/testing-freebsd.yml
@@ -26,7 +26,7 @@ jobs:
         box: generic/freebsd${{ matrix.freebsd-version }}
         log: warn
         run: |
-          run pkg install -y automake pkgconf gmake
+          run pkg install -y automake pkgconf gmake python3
           run freebsd-version
           run cc --version
           run ./autogen.sh

--- a/Tmain/tag-relative-option.d/run.sh
+++ b/Tmain/tag-relative-option.d/run.sh
@@ -5,6 +5,11 @@ CTAGS=$1
 O="--quiet --options=NONE -o - -x "
 P=$(pwd)
 
+if type realpath > /dev/null 2>&1; then
+   P=$(realpath "$P")
+   cd "$P"
+fi
+
 . ../utils.sh
 
 if ! ${CTAGS} $O --help | grep -e --tag-relative | grep --quiet -e always; then


### PR DESCRIPTION
A. install python3 explicitly

B. normalize cwd when running tag-relative-option.d

On vagrant+freebsd platform, /home is a symbolic link targeting
/usr/home. tag-relative-option.d failed because --tag-relative option
of ctags and tag-relative-option.d/run.sh didn't consider the symbolic
link.

This change normalizes `pwd` before running ctags.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>