### PR TITLE
GitHub Actions: serialize the testing on BSDs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,3 +45,6 @@ end_of_line = crlf
 
 [win32/*.vcxproj*]
 insert_final_newline = false
+
+[.github/workflows/*.yml]
+trim_trailing_whitespace = true

--- a/.github/workflows/cross-compile-android-ndk.yml
+++ b/.github/workflows/cross-compile-android-ndk.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - run: brew install gcc make automake autoconf file
-      
+
       - run: ./autogen.sh
 
       - name: Run ./configure ...
@@ -36,7 +36,7 @@ jobs:
           TOOLCHAIN_BASE_DIR=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$BUILD_MACHINE_OS_TYPE-$BUILD_MACHINE_OS_ARCH
           TOOLCHAIN_BIN_DIR=$TOOLCHAIN_BASE_DIR/bin
           SYSROOT=$TOOLCHAIN_BASE_DIR/sysroot
-          
+
           export CC=$TOOLCHAIN_BIN_DIR/armv7a-linux-androideabi21-clang
           export AR=$TOOLCHAIN_BIN_DIR/llvm-ar
           export RANLIB=$TOOLCHAIN_BIN_DIR/llvm-ranlib
@@ -44,22 +44,22 @@ jobs:
           export CFLAGS="--sysroot $SYSROOT -Qunused-arguments -Os -fpic"
           export CPPFLAGS="--sysroot $SYSROOT -Qunused-arguments"
           export LDFLAGS="--sysroot $SYSROOT"
-          
+
           TARGET=armv7a-linux-androideabi
-          
+
           COLOR_PURPLE='\033[0;35m'       # Purple
           COLOR_GREEN='\033[0;32m'        # Green
           COLOR_OFF='\033[0m'             # Reset
-          
+
           echo() {
             printf "%b\n" "$*"
           }
-          
+
           run() {
             echo "$COLOR_PURPLE==>$COLOR_OFF $COLOR_GREEN$@$COLOR_OFF"
             eval "$*"
           }
-           
+
           run ./configure \
               --host=$TARGET \
               --disable-iconv \
@@ -73,7 +73,7 @@ jobs:
               LDFLAGS="\"$LDFLAGS\"" \
               AR=$AR \
               RANLIB=$RANLIB
-      
+
       - run: make V=1
-      
+
       - run: file ctags | grep 'ELF 32-bit LSB pie executable, ARM, EABI5'

--- a/.github/workflows/cross-compile-mingw-w64.yml
+++ b/.github/workflows/cross-compile-mingw-w64.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - run: brew install mingw-w64 gcc make automake autoconf file
 
       - run: ./autogen.sh
@@ -37,7 +37,7 @@ jobs:
               AR=${{ matrix.target }}-ar \
               RANLIB=${{ matrix.target }}-ranlib \
               WINDRES=${{ matrix.target }}-windres
-      
+
       - run: make V=1
-      
+
       - run: file ctags.exe | grep PE32

--- a/.github/workflows/testing-cygwin.yml
+++ b/.github/workflows/testing-cygwin.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  testing:  
+  testing:
     runs-on: windows-latest
 
     defaults:
@@ -17,12 +17,12 @@ jobs:
     steps:
     - run: choco install -y --source cygwin gcc-g++ make automake autoconf pkg-config dos2unix libiconv-devel libjansson-devel libxml2-devel libyaml-devel
       shell: pwsh
-    
+
     - run: git config --global core.autocrlf input
       shell: bash
 
     - uses: actions/checkout@v2
-    
+
     - run: printf 'cd %s' "$(cygpath '${{ github.workspace }}')" >> ~/.bashrc
 
     - run: ./autogen.sh

--- a/.github/workflows/testing-msys2.yml
+++ b/.github/workflows/testing-msys2.yml
@@ -36,7 +36,7 @@ jobs:
 
     - run: ln -s /usr/bin/automake-1.16 /usr/bin/automake
     - run: ln -s /usr/bin/aclocal-1.16  /usr/bin/aclocal
-    
+
     - run: git config --global core.autocrlf input
       shell: bash
     - uses: actions/checkout@v2
@@ -47,9 +47,9 @@ jobs:
     - run: make install
     - run: file /usr/bin/ctags
     - run: ctags --version
-    
+
     - run: make check V=1
-     
+
     # FAILED: "./readtags.exe" -t "/d/a/ctags2/ctags2/Units/parser-asciidoc.r/utf8-asciidoc.d/expected.tags" - "@Ѐ–𐀀"
     # The raw tag name was "@Ѐ–𐀀"
     - if:  matrix.msystem == 'MSYS'

--- a/.github/workflows/testing-netbsd.yml
+++ b/.github/workflows/testing-netbsd.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   testing:
     runs-on: macos-10.15
-    
+
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/testing-netbsd.yml
+++ b/.github/workflows/testing-netbsd.yml
@@ -1,10 +1,11 @@
 name: run units target on NetBSD
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  # For avoiding the burst access to vagrant-cloud.
+  workflow_run:
+    workflows: ["run units target on OpenBSD"]
+    types:
+      - completed
 
 jobs:
   testing:

--- a/.github/workflows/testing-openbsd.yml
+++ b/.github/workflows/testing-openbsd.yml
@@ -21,17 +21,17 @@ jobs:
         run: |
           export AUTOCONF_VERSION=2.69
           export AUTOMAKE_VERSION=1.16
-              
+
           export CFLAGS='-I/usr/local/include -L/usr/local/lib'
-              
+
           if [ ! -f /usr/local/lib/libiconv.so ] ; then
             sudo ln -s /usr/local/lib/libiconv.so.* /usr/local/lib/libiconv.so
           fi
-              
+
           run sudo pkg_add automake-1.16.3 gmake
 
           run cc --version
-            
+
           run ./autogen.sh
           run ./configure --prefix=/usr
           run gmake

--- a/.github/workflows/testing-openbsd.yml
+++ b/.github/workflows/testing-openbsd.yml
@@ -1,10 +1,11 @@
 name: run units target on OpenBSD
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  # For avoiding the burst access to vagrant-cloud.
+  workflow_run:
+    workflows: ["run units target on FreeBSD"]
+    types:
+      - completed
 
 jobs:
   testing:


### PR DESCRIPTION
We have gotten "429 Too Many Requests" failures when running test cases
on the BSD instances.

While monitoring which one fails, I found an ambiguous rule. We have 4
BSD targets. Only one or two of them got the 429.

My guess of the reason for 429 is that multiple BSD targets start at
the same time or within a short period; the volume of the download
access from vagrant cloud reaches the limit formulated by Vaygrant
Cloud.

This experimental change serializes the execution of tests on BSDs
to limit the volume.

@leleliu008 provides the actual way for serializing at
https://github.com/universal-ctags/ctags/pull/3439#issuecomment-1183709443