### PR TITLE
GitHub Actions: migrate ubuntu environment from 18.04 to 22.04

### DIFF
--- a/.github/workflows/cross-compile-android-ndk.yml
+++ b/.github/workflows/cross-compile-android-ndk.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11]
+        build-machine-os: [ubuntu-22.04, ubuntu-20.04, macos-10.15, macos-11]
 
     runs-on: ${{ matrix.build-machine-os }}
 

--- a/.github/workflows/cross-compile-mingw-w64.yml
+++ b/.github/workflows/cross-compile-mingw-w64.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11]
+        build-machine-os: [ubuntu-22.04, ubuntu-20.04, macos-10.15, macos-11]
         target: [i686-w64-mingw32,x86_64-w64-mingw32]
 
     runs-on: ${{ matrix.build-machine-os }}

--- a/.github/workflows/testing-big-endian.yml
+++ b/.github/workflows/testing-big-endian.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   s390x_job:
-    runs-on: ubuntu-18.04
-    name: Build on ubuntu-18.04 s390x
+    runs-on: ubuntu-22.04
+    name: Build on ubuntu-22.04 s390x
     steps:
       - uses: actions/checkout@v2.1.0
       - uses: uraimo/run-on-arch-action@v2

--- a/.github/workflows/testing-gnulinux.yml
+++ b/.github/workflows/testing-gnulinux.yml
@@ -11,8 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        # os: [ubuntu-18.04, ubuntu-20.04]
-        os: [ubuntu-18.04, ubuntu-20.04]
+        # os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-22.04, ubuntu-20.04]
         compiler: [gcc, clang]
 
     runs-on: ${{ matrix.os }}
@@ -33,7 +33,14 @@ jobs:
     - name: update package information
       run: sudo apt-get -y -o APT::Immediate-Configure=false update
     - name: install tools and libraries
-      run: sudo apt-get -y -o APT::Immediate-Configure=false install valgrind pkg-config automake bash libjansson-dev libyaml-dev libseccomp-dev libxml2-dev gdb python3-docutils libpcre2-dev
+      run: sudo apt-get -y -o APT::Immediate-Configure=false install pkg-config automake bash libjansson-dev libyaml-dev libseccomp-dev libxml2-dev gdb python3-docutils libpcre2-dev
+    - name: install valgrind
+      if: matrix.compiler == 'clang' && matrix.os == 'ubuntu-22.04'
+      # valgrind doesn't work well with an executable built with clang 14.
+      # https://forum.manjaro.org/t/valgrind-fails-possibly-corrupted-debuginfo-file/118156
+      run: |
+        type clang > /dev/null && clang --version | head -1 | grep -q 14 \
+        || sudo apt-get -y -o APT::Immediate-Configure=false install valgrind
     - name: install rubygems and lcov
       if: matrix.compiler == 'gcc' && matrix.os == 'ubuntu-20.04'
       #run: sudo apt-get -y -o APT::Immediate-Configure=false install rubygems lcov


### PR DESCRIPTION
ubuntu-18.04 Actions runner image is deprecated since 2022-08-08
ubuntu-22.04 Actions runner image is available  since 2022-08-08

Reference:
https://github.com/actions/runner-images/issues/6002
https://github.com/actions/runner-images/issues/5998

Signed-off-by: leleliu008 <leleliu008@gmail.com>