### PR TITLE
GitHub Actions: migrate macos environment from 10.15 to 12

### DIFF
--- a/.github/workflows/cross-compile-android-ndk.yml
+++ b/.github/workflows/cross-compile-android-ndk.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [ubuntu-22.04, ubuntu-20.04, macos-10.15, macos-11]
+        build-machine-os: [ubuntu-22.04, ubuntu-20.04, macos-12, macos-11]
 
     runs-on: ${{ matrix.build-machine-os }}
 

--- a/.github/workflows/cross-compile-mingw-w64.yml
+++ b/.github/workflows/cross-compile-mingw-w64.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [ubuntu-22.04, ubuntu-20.04, macos-10.15, macos-11]
+        build-machine-os: [ubuntu-22.04, ubuntu-20.04, macos-12, macos-11]
         target: [i686-w64-mingw32,x86_64-w64-mingw32]
 
     runs-on: ${{ matrix.build-machine-os }}

--- a/.github/workflows/testing-bsds.yml
+++ b/.github/workflows/testing-bsds.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   freebsd:
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     strategy:
       fail-fast: false
@@ -40,7 +40,7 @@ jobs:
 
   openbsd:
     needs: freebsd
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v2
@@ -76,7 +76,7 @@ jobs:
 
   netbsd:
     needs: openbsd
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing-freebsd.yml.bak
+++ b/.github/workflows/testing-freebsd.yml.bak
@@ -8,7 +8,7 @@ on:
 
 jobs:
   testing:
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     strategy:
       fail-fast: false

--- a/.github/workflows/testing-mac.yml
+++ b/.github/workflows/testing-mac.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, macos-10.15]
+        os: [macos-11, macos-12]
         compiler: [gcc, clang]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/testing-netbsd.yml.bak
+++ b/.github/workflows/testing-netbsd.yml.bak
@@ -8,7 +8,7 @@ on:
 
 jobs:
   testing:
-    runs-on: macos-10.15
+    runs-on: macos-12
     
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/testing-openbsd.yml.bak
+++ b/.github/workflows/testing-openbsd.yml.bak
@@ -8,7 +8,7 @@ on:
 
 jobs:
   testing:
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
macos-10.15 Actions runner image is deprecated since 2022-05-31 and will be fully unsupported by 2022-08-31
macos-12 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Actions runner image is available  &nbsp;&nbsp;&nbsp;&nbsp;since 2022-04-27

Reference:
https://github.com/actions/runner-images/issues/5583
https://github.com/actions/runner-images/issues/5446

Signed-off-by: leleliu008 <leleliu008@gmail.com>