### PR TITLE
Verilog: fix bug caused by double colon ("::")

### DIFF
--- a/Units/parser-verilog.r/systemverilog-github3462.d/args.ctags
+++ b/Units/parser-verilog.r/systemverilog-github3462.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-systemverilog=+Q

--- a/Units/parser-verilog.r/systemverilog-github3462.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-github3462.d/expected.tags
@@ -1,0 +1,3 @@
+foo	input.sv	/^package foo;$/;"	K
+import_func	input.sv	/^  import "DPI-C" context function int import_func (string str);$/;"	Q	package:foo
+str	input.sv	/^  import "DPI-C" context function int import_func (string str);$/;"	p	prototype:foo.import_func

--- a/Units/parser-verilog.r/systemverilog-github3462.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-github3462.d/input.sv
@@ -1,0 +1,14 @@
+// SystemVerilog: "assertions" parsing error when encountered "::" #3462
+// https://github.com/universal-ctags/ctags/issues/3462
+
+import uvm_pkg::*;
+// something
+assert (foo) else do something;
+// something
+someclass::method();
+// something
+assert (bar) else do something;
+
+package foo;
+  import "DPI-C" context function int import_func (string str);
+endpackage

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1399,6 +1399,25 @@ static int processAssertion (tokenInfo *const token, int c)
 	return c;
 }
 
+// data_declaration ::=
+//   ...
+//   import < package_identifier :: identifier | package_identifier :: * > ; 
+// dpi_import_export ::=
+//   import ( "DPI-C" | "DPI" ) [ context | pure ] [ c_identifier = ] function data_type_or_void function_identifier [ ( [ tf_port_list ] ) ] ;
+// | import ( "DPI-C" | "DPI" ) [ context ]        [ c_identifier = ] task task_identifier [ ( [ tf_port_list ] ) ] ;
+// | export ( "DPI-C" | "DPI" ) [ c_identifier = ] function function_identifier ;
+// | export ( "DPI-C" | "DPI" ) [ c_identifier = ] task     task_identifier ;
+static int processImport (tokenInfo *const token, int c)
+{
+	if (c == '"') {	// dpi_import: we don't care about export.
+		currentContext->prototype = true;
+	} else {
+		c = skipToSemiColon (c);
+		c = skipWhite (vGetc ());	// skip semicolon
+	}
+	return c;
+}
+
 // non-ANSI type
 // ( module | interface | program ) [ static | automatic ] identifier { package_import_declaration } [ parameter_port_list ] ( port { , port } ) ;
 // ANSI type
@@ -1893,8 +1912,10 @@ static int findTag (tokenInfo *const token, int c)
 		case K_STRUCT:
 			c = processStruct (token, c);
 			break;
-		case K_PROTOTYPE:
 		case K_IMPORT:
+			c = processImport (token, c);
+			break;
+		case K_PROTOTYPE:
 		case K_WITH:
 			currentContext->prototype = true;
 			break;

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1824,7 +1824,7 @@ static int tagIdentifierList (tokenInfo *const token, int c, verilogKind kind, b
 static int tagNameList (tokenInfo* token, int c, verilogKind kind)
 {
 	c = skipClassType (token, c);
-	if (c == ':' || c == ';')	// ## (cycle delay) or unexpected input
+	if (c == ';')
 		return c;
 
 	// skip drive|charge strength or type_reference, dimensions, and delay for net
@@ -1833,7 +1833,7 @@ static int tagNameList (tokenInfo* token, int c, verilogKind kind)
 	c = skipDimension (c);
 	if (c == '.')
 		return c;	// foo[...].bar = ..;
-	c = skipDelay (token, c);
+	c = skipDelay (token, c);	// ## (cycle delay)
 
 	while (c != EOF)
 	{

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1131,17 +1131,11 @@ static int processFunction (tokenInfo *const token, int c)
 		c = skipParameterAssignment (c);
 
 		/* Identify class type prefixes and create respective context*/
-		if (isInputLanguage (Lang_systemverilog) && c == ':')
+		if (isInputLanguage (Lang_systemverilog) && isDoubleColon(c))
 		{
-			c = vGetc ();
-			if (c == ':')
-			{
-				verbose ("Found function declaration with class type %s\n", vStringValue (token->name));
-				createContext (K_CLASS, token->name);
-				currentContext->classScope = true;
-			}
-			else
-				vUngetc (c);
+			verbose ("Found function declaration with class type %s\n", vStringValue (token->name));
+			createContext (K_CLASS, token->name);
+			currentContext->classScope = true;
 		}
 	}
 	verbose ("Found function: %s\n", vStringValue (token->name));
@@ -1736,12 +1730,10 @@ static int skipClassType (tokenInfo* token, int c)
 		}
 		else if (c == ':')
 		{
-			c = skipWhite (vGetc ());
-			if (c != ':')
+			if (!isDoubleColon(c))
 			{
 				VERBOSE ("Unexpected input.\n");
-				vUngetc (c);
-				return ':';
+				return c;
 			}
 			c = skipWhite (vGetc ());
 			if (isWordToken (c))

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -692,6 +692,20 @@ static bool isIdentifierCharacter (const int c)
 	return (isalnum (c) || c == '_' || c == '`' || c == '$');
 }
 
+// check if double colon.
+static bool isDoubleColon (int c)
+{
+	if (c != ':')
+		return false;
+	c = vGetc ();
+	if (c == ':') {
+		return true;
+	} else {
+		vUngetc (c);
+		return false;
+	}
+}
+
 static int skipWhite (int c)
 {
 	while (isspace (c))
@@ -1981,7 +1995,8 @@ static void findVerilogTags (void)
 			case ':':
 				/* Store current block name whenever a : is found
 				 * This is used later by any tag type that requires this information */
-				vStringCopy (currentContext->blockName, token->name);
+				if (!isDoubleColon(c))
+					vStringCopy (currentContext->blockName, token->name);
 				c = skipWhite (vGetc ());
 				break;
 			case ';':


### PR DESCRIPTION
This is the fix for #3462.

There were two bugs.
Some refactoring fixes are also included.