### PR TITLE
Verilog: fill typeref fields of instances

### DIFF
--- a/Units/parser-verilog.r/verilog-instance.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-instance.d/expected.tags
@@ -14,22 +14,22 @@ b	input.v	/^   input                b;                      \/\/ To uut3 of foo.
 top.b	input.v	/^   input                b;                      \/\/ To uut3 of foo.v$/;"	p	module:top
 unused_pin	input.v	/^   wire unused_pin;$/;"	n	module:top
 top.unused_pin	input.v	/^   wire unused_pin;$/;"	n	module:top
-uut1	input.v	/^   foo uut1 ($/;"	i	module:top
-top.uut1	input.v	/^   foo uut1 ($/;"	i	module:top
-uut2	input.v	/^     uut2 ($/;"	i	module:top
-top.uut2	input.v	/^     uut2 ($/;"	i	module:top
-uut3	input.v	/^   foo uut3 (\/*AUTOINST*\/$/;"	i	module:top
-top.uut3	input.v	/^   foo uut3 (\/*AUTOINST*\/$/;"	i	module:top
-uut4	input.v	/^   uut4 (\/*AUTOINST*\/$/;"	i	module:top
-top.uut4	input.v	/^   uut4 (\/*AUTOINST*\/$/;"	i	module:top
-uut5	input.v	/^   uut5 (\/*AUTOINST*\/$/;"	i	module:top
-top.uut5	input.v	/^   uut5 (\/*AUTOINST*\/$/;"	i	module:top
-uut6	input.v	/^   foo uut6 [10:0]();$/;"	i	module:top
-top.uut6	input.v	/^   foo uut6 [10:0]();$/;"	i	module:top
-uut7	input.v	/^   foo uut7 [1:0][10:0]();$/;"	i	module:top
-top.uut7	input.v	/^   foo uut7 [1:0][10:0]();$/;"	i	module:top
-uut8	input.v	/^   foo uut8 () ;$/;"	i	module:top
-top.uut8	input.v	/^   foo uut8 () ;$/;"	i	module:top
+uut1	input.v	/^   foo uut1 ($/;"	i	module:top	typeref:module:foo
+top.uut1	input.v	/^   foo uut1 ($/;"	i	module:top	typeref:module:foo
+uut2	input.v	/^     uut2 ($/;"	i	module:top	typeref:module:foo
+top.uut2	input.v	/^     uut2 ($/;"	i	module:top	typeref:module:foo
+uut3	input.v	/^   foo uut3 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+top.uut3	input.v	/^   foo uut3 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+uut4	input.v	/^   uut4 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+top.uut4	input.v	/^   uut4 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+uut5	input.v	/^   uut5 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+top.uut5	input.v	/^   uut5 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+uut6	input.v	/^   foo uut6 [10:0]();$/;"	i	module:top	typeref:module:foo
+top.uut6	input.v	/^   foo uut6 [10:0]();$/;"	i	module:top	typeref:module:foo
+uut7	input.v	/^   foo uut7 [1:0][10:0]();$/;"	i	module:top	typeref:module:foo
+top.uut7	input.v	/^   foo uut7 [1:0][10:0]();$/;"	i	module:top	typeref:module:foo
+uut8	input.v	/^   foo uut8 () ;$/;"	i	module:top	typeref:module:foo
+top.uut8	input.v	/^   foo uut8 () ;$/;"	i	module:top	typeref:module:foo
 func_foo	input.v	/^   function void func_foo(int a);$/;"	f	module:top
 top.func_foo	input.v	/^   function void func_foo(int a);$/;"	f	module:top
 a	input.v	/^   function void func_foo(int a);$/;"	p	function:top.func_foo

--- a/Units/parser-verilog.r/verilog-module-ref.d/args.ctags
+++ b/Units/parser-verilog.r/verilog-module-ref.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+r
+--fields=+r

--- a/Units/parser-verilog.r/verilog-module-ref.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-module-ref.d/expected.tags
@@ -1,0 +1,10 @@
+test	input.v	/^module test (\/*AUTOARG*\/);$/;"	m	roles:def
+i_a	input.v	/^   input i_a, i_b;$/;"	p	module:test	roles:def
+i_b	input.v	/^   input i_a, i_b;$/;"	p	module:test	roles:def
+o_c	input.v	/^   output o_c;$/;"	p	module:test	roles:def
+ref1	input.v	/^   ref1 int1 ();$/;"	m	module:test	roles:defInstance
+int1	input.v	/^   ref1 int1 ();$/;"	i	module:test	typeref:module:ref1	roles:def
+ref1	input.v	/^   ref1 int2 ();$/;"	m	module:test	roles:defInstance
+int2	input.v	/^   ref1 int2 ();$/;"	i	module:test	typeref:module:ref1	roles:def
+ref3	input.v	/^   ref3 # (.A (aaa),$/;"	m	module:test	roles:defInstance
+int3	input.v	/^   int3 ();$/;"	i	module:test	typeref:module:ref3	roles:def

--- a/Units/parser-verilog.r/verilog-module-ref.d/input.v
+++ b/Units/parser-verilog.r/verilog-module-ref.d/input.v
@@ -1,0 +1,12 @@
+// Taken from #3469 submitted by @my2817
+module test (/*AUTOARG*/);
+   input i_a, i_b;
+   output o_c;
+
+   ref1 int1 ();
+   ref1 int2 ();
+   ref3 # (.A (aaa),
+           .B (bbb))
+   int3 ();
+
+endmodule // test


### PR DESCRIPTION
This one is conceptually based on
https://github.com/universal-ctags/ctags/compare/master...my2817:ctags:master
reported and written by @my2817 at #3469.

The test case is also taken from #3469 submitted by @my2817.

This commit does two things:

* fill typeref fields of instances with module names, and
* extract the module names used for defining instances as
  defInstance role of module kind.

TODO: Update ctags-lang-verilog(7).