### PR TITLE
Verilog: fill typeref fields of instances

### DIFF
--- a/Units/parser-verilog.r/systemverilog-assertion.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-assertion.d/expected.tags
@@ -49,8 +49,8 @@ sva_svtb	input.sv	/^module sva_svtb;$/;"	m
 clk	input.sv	/^    bit clk;$/;"	r	module:sva_svtb
 a	input.sv	/^    logic a, b;$/;"	r	module:sva_svtb
 b	input.sv	/^    logic a, b;$/;"	r	module:sva_svtb
-dut	input.sv	/^    dut dut (.*);$/;"	i	module:sva_svtb
-tb	input.sv	/^    tb tb (.*);$/;"	i	module:sva_svtb
+dut	input.sv	/^    dut dut (.*);$/;"	i	module:sva_svtb	typeref:module:dut
+tb	input.sv	/^    tb tb (.*);$/;"	i	module:sva_svtb	typeref:module:tb
 m	input.sv	/^module m (input a, b);$/;"	m
 a	input.sv	/^module m (input a, b);$/;"	p	module:m
 b	input.sv	/^module m (input a, b);$/;"	p	module:m

--- a/Units/parser-verilog.r/systemverilog-checker.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-checker.d/expected.tags
@@ -38,7 +38,7 @@ bus	input.sv	/^module m(wire [31:0] bus, logic clk);$/;"	p	module:m
 clk	input.sv	/^module m(wire [31:0] bus, logic clk);$/;"	p	module:m
 res	input.sv	/^    logic res, scan;$/;"	r	module:m
 scan	input.sv	/^    logic res, scan;$/;"	r	module:m
-check_bus	input.sv	/^    mutex check_bus(bus, posedge clk, res);$/;"	i	module:m
+check_bus	input.sv	/^    mutex check_bus(bus, posedge clk, res);$/;"	i	module:m	typeref:module:mutex
 c1	input.sv	/^checker c1(event clk, logic[7:0] a, b);$/;"	H
 clk	input.sv	/^checker c1(event clk, logic[7:0] a, b);$/;"	p	checker:c1
 a	input.sv	/^checker c1(event clk, logic[7:0] a, b);$/;"	p	checker:c1
@@ -55,10 +55,10 @@ en	input.sv	/^module m(input logic rst, clk, logic en, logic[7:0] in1, in2,$/;"	
 in1	input.sv	/^module m(input logic rst, clk, logic en, logic[7:0] in1, in2,$/;"	p	module:m
 in2	input.sv	/^module m(input logic rst, clk, logic en, logic[7:0] in1, in2,$/;"	p	module:m
 in_array	input.sv	/^         in_array [20:0]);$/;"	p	module:m
-check_outside	input.sv	/^    c1 check_outside(posedge clk, in1, in2);$/;"	i	module:m
+check_outside	input.sv	/^    c1 check_outside(posedge clk, in1, in2);$/;"	i	module:m	typeref:module:c1
 v1	input.sv	/^        automatic logic [7:0] v1=0;$/;"	r	module:m
-check_inside	input.sv	/^            c1 check_inside(posedge clk, in1, v1);$/;"	i	module:m
-check_loop	input.sv	/^                c1 check_loop(posedge clk, in1, in_array[v1]);$/;"	i	module:m
+check_inside	input.sv	/^            c1 check_inside(posedge clk, in1, v1);$/;"	i	module:m	typeref:module:c1
+check_loop	input.sv	/^                c1 check_loop(posedge clk, in1, in_array[v1]);$/;"	i	module:m	typeref:module:c1
 counter_model	input.sv	/^checker counter_model(logic flag);$/;"	H
 flag	input.sv	/^checker counter_model(logic flag);$/;"	p	checker:counter_model
 counter	input.sv	/^    bit [2:0] counter = '0;$/;"	r	checker:counter_model

--- a/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
@@ -8,13 +8,13 @@ vw	input.sv	/^  logic vw; \/\/ no initial assignment$/;"	r	module:net_decl
 circ	input.sv	/^  real circ;$/;"	r	module:net_decl
 top	input.sv	/^module top();$/;"	m
 iBus	input.sv	/^  interconnect [0:1] iBus;$/;"	n	module:top
-l1	input.sv	/^  lDriver l1(iBus[0]);$/;"	i	module:top
-r1	input.sv	/^  rDriver r1(iBus[1]);$/;"	i	module:top
-m1	input.sv	/^  rlMod m1(iBus);$/;"	i	module:top
+l1	input.sv	/^  lDriver l1(iBus[0]);$/;"	i	module:top	typeref:module:lDriver
+r1	input.sv	/^  rDriver r1(iBus[1]);$/;"	i	module:top	typeref:module:rDriver
+m1	input.sv	/^  rlMod m1(iBus);$/;"	i	module:top	typeref:module:rlMod
 rlMod	input.sv	/^module rlMod(input interconnect [0:1] iBus);$/;"	m
 iBus	input.sv	/^module rlMod(input interconnect [0:1] iBus);$/;"	p	module:rlMod
-l1	input.sv	/^  lMod l1(iBus[0]);$/;"	i	module:rlMod
-r1	input.sv	/^  rMod r1(iBus[1]);$/;"	i	module:rlMod
+l1	input.sv	/^  lMod l1(iBus[0]);$/;"	i	module:rlMod	typeref:module:lMod
+r1	input.sv	/^  rMod r1(iBus[1]);$/;"	i	module:rlMod	typeref:module:rMod
 Net_declarations	input.sv	/^module Net_declarations;$/;"	m
 cap1	input.sv	/^  trireg (large) logic #(0,0,0) cap1;$/;"	n	module:Net_declarations
 addressT	input.sv	/^  typedef logic [31:0] addressT;$/;"	T	module:Net_declarations

--- a/Units/parser-verilog.r/verilog-instance.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-instance.d/expected.tags
@@ -14,22 +14,22 @@ b	input.v	/^   input                b;                      \/\/ To uut3 of foo.
 top.b	input.v	/^   input                b;                      \/\/ To uut3 of foo.v$/;"	p	module:top
 unused_pin	input.v	/^   wire unused_pin;$/;"	n	module:top
 top.unused_pin	input.v	/^   wire unused_pin;$/;"	n	module:top
-uut1	input.v	/^   foo uut1 ($/;"	i	module:top
-top.uut1	input.v	/^   foo uut1 ($/;"	i	module:top
-uut2	input.v	/^     uut2 ($/;"	i	module:top
-top.uut2	input.v	/^     uut2 ($/;"	i	module:top
-uut3	input.v	/^   foo uut3 (\/*AUTOINST*\/$/;"	i	module:top
-top.uut3	input.v	/^   foo uut3 (\/*AUTOINST*\/$/;"	i	module:top
-uut4	input.v	/^   uut4 (\/*AUTOINST*\/$/;"	i	module:top
-top.uut4	input.v	/^   uut4 (\/*AUTOINST*\/$/;"	i	module:top
-uut5	input.v	/^   uut5 (\/*AUTOINST*\/$/;"	i	module:top
-top.uut5	input.v	/^   uut5 (\/*AUTOINST*\/$/;"	i	module:top
-uut6	input.v	/^   foo uut6 [10:0]();$/;"	i	module:top
-top.uut6	input.v	/^   foo uut6 [10:0]();$/;"	i	module:top
-uut7	input.v	/^   foo uut7 [1:0][10:0]();$/;"	i	module:top
-top.uut7	input.v	/^   foo uut7 [1:0][10:0]();$/;"	i	module:top
-uut8	input.v	/^   foo uut8 () ;$/;"	i	module:top
-top.uut8	input.v	/^   foo uut8 () ;$/;"	i	module:top
+uut1	input.v	/^   foo uut1 ($/;"	i	module:top	typeref:module:foo
+top.uut1	input.v	/^   foo uut1 ($/;"	i	module:top	typeref:module:foo
+uut2	input.v	/^     uut2 ($/;"	i	module:top	typeref:module:foo
+top.uut2	input.v	/^     uut2 ($/;"	i	module:top	typeref:module:foo
+uut3	input.v	/^   foo uut3 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+top.uut3	input.v	/^   foo uut3 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+uut4	input.v	/^   uut4 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+top.uut4	input.v	/^   uut4 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+uut5	input.v	/^   uut5 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+top.uut5	input.v	/^   uut5 (\/*AUTOINST*\/$/;"	i	module:top	typeref:module:foo
+uut6	input.v	/^   foo uut6 [10:0]();$/;"	i	module:top	typeref:module:foo
+top.uut6	input.v	/^   foo uut6 [10:0]();$/;"	i	module:top	typeref:module:foo
+uut7	input.v	/^   foo uut7 [1:0][10:0]();$/;"	i	module:top	typeref:module:foo
+top.uut7	input.v	/^   foo uut7 [1:0][10:0]();$/;"	i	module:top	typeref:module:foo
+uut8	input.v	/^   foo uut8 () ;$/;"	i	module:top	typeref:module:foo
+top.uut8	input.v	/^   foo uut8 () ;$/;"	i	module:top	typeref:module:foo
 func_foo	input.v	/^   function void func_foo(int a);$/;"	f	module:top
 top.func_foo	input.v	/^   function void func_foo(int a);$/;"	f	module:top
 a	input.v	/^   function void func_foo(int a);$/;"	p	function:top.func_foo

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -949,7 +949,7 @@ static int dropEndContext (tokenInfo *const token, int c)
 }
 
 
-static void createTag (tokenInfo *const token, verilogKind kind)
+static void createTagWithTypeRef (tokenInfo *const token, verilogKind kind, tokenInfo *const typeref)
 {
 	tagEntryInfo tag;
 
@@ -1000,6 +1000,12 @@ static void createTag (tokenInfo *const token, verilogKind kind)
 		verbose ("Class %s extends %s\n", vStringValue (token->name), tag.extensionFields.inheritance);
 	}
 
+	if (typeref)
+	{
+		tag.extensionFields.typeRef [0] = getNameForKind (typeref->kind);
+		tag.extensionFields.typeRef [1] = vStringValue (typeref->name);
+	}
+
 	if (token->parameter)
 		attachParserField (&tag, false, fieldTable [F_PARAMETER].ftype, "");
 
@@ -1031,7 +1037,7 @@ static void createTag (tokenInfo *const token, verilogKind kind)
 		for (unsigned int i = 0; i < ptrArrayCount (tagContents); i++)
 		{
 			tokenInfo *content = ptrArrayItem (tagContents, i);
-			createTag (content, content->kind);
+			createTagWithTypeRef (content, content->kind, NULL);
 		}
 
 		/* Drop temporary contexts */
@@ -1041,6 +1047,11 @@ static void createTag (tokenInfo *const token, verilogKind kind)
 
 	/* Clear no longer required inheritance information */
 	vStringClear (token->inheritance);
+}
+
+static void createTag (tokenInfo *const token, verilogKind kind)
+{
+	createTagWithTypeRef (token, kind, NULL);
 }
 
 static int skipBlockName (tokenInfo *const token, int c)
@@ -1836,6 +1847,7 @@ static int tagIdsInDataDecl (tokenInfo* token, int c, verilogKind kind)
 		return c;	// foo[...].bar = ..;
 	c = skipDelay (token, c);	// ## (cycle delay)
 
+	tokenInfo *tokenSaved = dupToken(token); // maybe a module_identifier
 	while (c != EOF)
 	{
 		bool with = false;
@@ -1858,8 +1870,9 @@ static int tagIdsInDataDecl (tokenInfo* token, int c, verilogKind kind)
 			// var `add_t(foo) = '0;
 			if (c == ';' || c == ',')
 			{
+				tokenSaved->kind = K_MODULE;   // for typeRef field
 				verbose ("find instance: %s with kind %s\n", vStringValue (token->name), getNameForKind (K_INSTANCE));
-				createTag (token, K_INSTANCE);
+				createTagWithTypeRef (token, K_INSTANCE, tokenSaved);
 			}
 		}
 		c = skipMacro (c, token);	// `ifdef, `else, `endif, etc. (before comma)
@@ -1868,6 +1881,7 @@ static int tagIdsInDataDecl (tokenInfo* token, int c, verilogKind kind)
 		c = skipWhite (vGetc ());	// skip ','
 		c = skipMacro (c, token);	// `ifdef, `else, `endif, etc. (after comma)
 	}
+	deleteToken (tokenSaved);
 	return c;
 }
 

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1849,7 +1849,7 @@ static int tagIdsInDataDecl (tokenInfo* token, int c, verilogKind kind)
 			if (c == '=')
 				c = skipExpression (c);
 		}
-		else if (c == '(' || c == '[')	// should be instance
+		else if (c == '(' || c == '[')	// should be an instance
 		{
 			c = skipDimension (c); // name_of_instance {unpacked_dimension}
 			c = skipPastMatch ("()"); // list_of_port_connections

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1409,7 +1409,7 @@ static int processAssertion (tokenInfo *const token, int c)
 
 // data_declaration ::=
 //   ...
-//   import < package_identifier :: identifier | package_identifier :: * > ; 
+//   import < package_identifier :: identifier | package_identifier :: * > ;
 // dpi_import_export ::=
 //   import ( "DPI-C" | "DPI" ) [ context | pure ] [ c_identifier = ] function data_type_or_void function_identifier [ ( [ tf_port_list ] ) ] ;
 // | import ( "DPI-C" | "DPI" ) [ context ]        [ c_identifier = ] task task_identifier [ ( [ tf_port_list ] ) ] ;


### PR DESCRIPTION
Verilog: fill typeref fields of instances
    
This one is partially based on
https://github.com/universal-ctags/ctags/compare/master...my2817:ctags:master
reported and written by @my2817 at #3469.
    
Capturing the module names of instances is also proposed in #3469.
However, it is not in the scope of this commit.
