### PR TITLE
docs(man): remove unexpected newline from the rendered verilog man page

### DIFF
--- a/docs/man/ctags-lang-verilog.7.rst
+++ b/docs/man/ctags-lang-verilog.7.rst
@@ -179,6 +179,7 @@ SEE ALSO
 - :ref:`ctags(1) <ctags(1)>`
 - :ref:`ctags-client-tools(7) <ctags-client-tools(7)>`
 - Language Reference Manuals (LRM)
+
    - IEEE Standard for SystemVerilog — Unified Hardware Design, Specification, and
      Verification Language, IEEE Std 1800-2017,
      https://ieeexplore.ieee.org/document/8299595

--- a/man/ctags-lang-verilog.7.rst.in
+++ b/man/ctags-lang-verilog.7.rst.in
@@ -179,6 +179,7 @@ SEE ALSO
 - ctags(1)
 - ctags-client-tools(7)
 - Language Reference Manuals (LRM)
+
    - IEEE Standard for SystemVerilog — Unified Hardware Design, Specification, and
      Verification Language, IEEE Std 1800-2017,
      https://ieeexplore.ieee.org/document/8299595


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>