### PR TITLE
Verilog: extract module names used for defining instances as reference tags

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -92,6 +92,7 @@ Ruby           L/library         required           on      loaded by "require" 
 Ruby           L/library         requiredRel        on      loaded by "require_relative" method
 Sh             h/heredoc         endmarker          on      end marker
 Sh             s/script          loaded             on      loaded
+SystemVerilog  m/module          decl               on      declaring instances
 SystemdUnit    u/unit            After              on      referred in After key
 SystemdUnit    u/unit            Before             on      referred in Before key
 SystemdUnit    u/unit            RequiredBy         on      referred in RequiredBy key
@@ -108,6 +109,7 @@ Vera           d/macro           condition          off     used in part of #if/
 Vera           d/macro           undef              on      undefined
 Vera           h/header          local              on      local header
 Vera           h/header          system             on      system header
+Verilog        m/module          decl               on      declaring instances
 
 #
 # all.*
@@ -202,6 +204,7 @@ Ruby           L/library         required           on      loaded by "require" 
 Ruby           L/library         requiredRel        on      loaded by "require_relative" method
 Sh             h/heredoc         endmarker          on      end marker
 Sh             s/script          loaded             on      loaded
+SystemVerilog  m/module          decl               on      declaring instances
 SystemdUnit    u/unit            After              on      referred in After key
 SystemdUnit    u/unit            Before             on      referred in Before key
 SystemdUnit    u/unit            RequiredBy         on      referred in RequiredBy key
@@ -218,6 +221,7 @@ Vera           d/macro           condition          off     used in part of #if/
 Vera           d/macro           undef              on      undefined
 Vera           h/header          local              on      local header
 Vera           h/header          system             on      system header
+Verilog        m/module          decl               on      declaring instances
 
 #
 # C.*

--- a/Units/parser-verilog.r/verilog-module-ref.d/args.ctags
+++ b/Units/parser-verilog.r/verilog-module-ref.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+r
+--fields=+r

--- a/Units/parser-verilog.r/verilog-module-ref.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-module-ref.d/expected.tags
@@ -1,0 +1,10 @@
+test	input.v	/^module test (\/*AUTOARG*\/);$/;"	m	roles:def
+i_a	input.v	/^   input i_a, i_b;$/;"	p	module:test	roles:def
+i_b	input.v	/^   input i_a, i_b;$/;"	p	module:test	roles:def
+o_c	input.v	/^   output o_c;$/;"	p	module:test	roles:def
+int1	input.v	/^   ref1 int1 ();$/;"	i	module:test	typeref:module:ref1	roles:def
+ref1	input.v	/^   ref1 int1 ();$/;"	m	module:test	roles:decl
+int2	input.v	/^   ref1 int2 ();$/;"	i	module:test	typeref:module:ref1	roles:def
+ref1	input.v	/^   ref1 int2 ();$/;"	m	module:test	roles:decl
+int3	input.v	/^   int3 ();$/;"	i	module:test	typeref:module:ref3	roles:def
+ref3	input.v	/^   ref3 # (.A (aaa),$/;"	m	module:test	roles:decl

--- a/Units/parser-verilog.r/verilog-module-ref.d/input.v
+++ b/Units/parser-verilog.r/verilog-module-ref.d/input.v
@@ -1,0 +1,12 @@
+// Taken from #3469 submitted by @my2817
+module test (/*AUTOARG*/);
+   input i_a, i_b;
+   output o_c;
+
+   ref1 int1 ();
+   ref1 int2 ();
+   ref3 # (.A (aaa),
+           .B (bbb))
+   int3 ();
+
+endmodule // test

--- a/docs/man/ctags-lang-verilog.7.rst
+++ b/docs/man/ctags-lang-verilog.7.rst
@@ -162,6 +162,28 @@ because they cannot be overridden.
 	P3	input.sv	/^	parameter  P3 = "parameter";$/;"	c	module:no_parameter_port_list	parameter:
 	L7	input.sv	/^	localparam L7 = "localparam";$/;"	c	module:no_parameter_port_list
 
+Supported Roles
+~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+	$ ./ctags --list-roles=SystemVerilog
+	#KIND(L/N) NAME ENABLED DESCRIPTION
+	m/module   decl on      declaring instances
+
+	$ ./ctags --list-roles=Verilog
+	#KIND(L/N) NAME ENABLED DESCRIPTION
+	m/module   decl on      declaring instances
+
+The parser extracts names of modules used in instance declarations as
+reference tags. ``decl`` is the role for the tags. See "TAG ENTRIES"
+section of :ref:`ctags(1) <ctags(1)>` about reference tags and roles.
+
+.. warning::
+
+   The support for references in Universal Ctags is still
+   experimental; the names of the roles may be changed in the future.
+
 TIPS
 ~~~~
 

--- a/man/ctags-lang-verilog.7.rst.in
+++ b/man/ctags-lang-verilog.7.rst.in
@@ -162,6 +162,28 @@ because they cannot be overridden.
 	P3	input.sv	/^	parameter  P3 = "parameter";$/;"	c	module:no_parameter_port_list	parameter:
 	L7	input.sv	/^	localparam L7 = "localparam";$/;"	c	module:no_parameter_port_list
 
+Supported Roles
+~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+	$ ./ctags --list-roles=SystemVerilog
+	#KIND(L/N) NAME ENABLED DESCRIPTION
+	m/module   decl on      declaring instances
+
+	$ ./ctags --list-roles=Verilog
+	#KIND(L/N) NAME ENABLED DESCRIPTION
+	m/module   decl on      declaring instances
+
+The parser extracts names of modules used in instance declarations as
+reference tags. ``decl`` is the role for the tags. See "TAG ENTRIES"
+section of ctags(1) about reference tags and roles.
+
+.. warning::
+
+   The support for references in Universal Ctags is still
+   experimental; the names of the roles may be changed in the future.
+
 TIPS
 ~~~~
 


### PR DESCRIPTION
 This one is conceptually based on
https://github.com/universal-ctags/ctags/compare/master...my2817:ctags:master
reported and written by @my2817 at #3469.

The test case is also taken from #3469 submitted by @my2817.