### PR TITLE
Rake: accept symbols defined with single and double quote characters

### DIFF
--- a/Units/parser-rake.r/xtasks.d/expected.tags
+++ b/Units/parser-rake.r/xtasks.d/expected.tags
@@ -15,3 +15,5 @@ verify_private_key_present	input.rake	/^task :verify_private_key_present do$/;"	
 build	input.rake	/^task :build => :verify_private_key_present$/;"	task
 default	input-0.rake	/^task :default => :test$/;"	task
 test	input-0.rake	/^Rake::TestTask.new 'test' do |t|$/;"	xtask	typeref:typename:Rake::TestTask.new
+spec:rcovSingle	input-1.rake	/^RSpec::Core::RakeTask.new(:'spec:rcovSingle') do |t|$/;"	xtask	typeref:typename:RSpec::Core::RakeTask.new
+spec:rcovDouble	input-1.rake	/^RSpec::Core::RakeTask.new(:"spec:rcovDouble") do |t|$/;"	xtask	typeref:typename:RSpec::Core::RakeTask.new

--- a/Units/parser-rake.r/xtasks.d/input-1.rake
+++ b/Units/parser-rake.r/xtasks.d/input-1.rake
@@ -1,0 +1,19 @@
+# https://raw.githubusercontent.com/apache/thrift/master/lib/rb/Rakefile
+RSpec::Core::RakeTask.new(:'spec:rcovSingle') do |t|
+  t.rspec_opts = ['--color', '--format d']
+  t.rcov = true
+  t.rcov_opts = ['--exclude', '^spec,/gems/']
+end
+
+RSpec::Core::RakeTask.new(:"spec:rcovDouble") do |t|
+  t.rspec_opts = ['--color', '--format d']
+  t.rcov = true
+  t.rcov_opts = ['--exclude', '^spec,/gems/']
+end
+
+# The next one may be extracted.
+RSpec::Core::RakeTask.new(:) do |t|
+  t.rspec_opts = ['--color', '--format d']
+  t.rcov = true
+  t.rcov_opts = ['--exclude', '^spec,/gems/']
+end

--- a/parsers/rake.c
+++ b/parsers/rake.c
@@ -184,8 +184,11 @@ static int parseXTask (rubySubparser *s, struct taskType *xtask, const unsigned 
 			int r = makeSimpleRakeTag (vstr, xtask->kind, s, variable);
 			vStringDelete (vstr);
 			tagEntryInfo *e = getEntryInCorkQueue (r);
-			e->extensionFields.typeRef [0] = eStrdup ("typename");
-			e->extensionFields.typeRef [1] = eStrdup (xtask->keyword);
+			if (e)
+			{
+				e->extensionFields.typeRef [0] = eStrdup ("typename");
+				e->extensionFields.typeRef [1] = eStrdup (xtask->keyword);
+			}
 			return r;
 		}
 	}

--- a/parsers/rake.c
+++ b/parsers/rake.c
@@ -93,7 +93,6 @@ static vString *readTask (const unsigned char **cp, bool *variable)
 		}
 		break;
 	case ':':
-		++*cp;
 		vstr = vStringNew ();
 		if (!rubyParseMethodName (cp, vstr))
 		{

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -463,18 +463,23 @@ static rubyKind parseIdentifier (
 	}
 
 	/* Copy the identifier into 'name'. */
-	if (**cp == ':' && (*((*cp) + 1) == '"' || *((*cp) + 1) == '\''))
+	if (**cp == ':')
 	{
-		/* The symbol is defined with string literal like:
-		   ----
-		   :"[]"
-		   :"[]="
-		   ----
-		*/
-		unsigned char b = *(++*cp);
+		if (*((*cp) + 1) == '"' || *((*cp) + 1) == '\'')
+		{
+			/* The symbol is defined with string literal like:
+			   ----
+			   :"[]"
+			   :"[]="
+			   ----
+			*/
+			unsigned char b = *(++*cp);
+			++*cp;
+			parseString (cp, b, name);
+			return kind;
+		}
+		/* May be symbol like :name. Skip the first character. */
 		++*cp;
-		parseString (cp, b, name);
-		return kind;
 	}
 
 	while (**cp != 0 && (**cp == ':' || isIdentChar (**cp) || charIsIn (**cp, also_ok)))
@@ -810,7 +815,6 @@ static void readAttrsAndEmitTags (const unsigned char **cp, bool reader, bool wr
 		skipWhitespace (cp);
 		if (**cp == ':')
 		{
-			++*cp;
 			if (K_METHOD == parseIdentifier (cp, a, K_METHOD))
 			{
 				emitRubyAccessorTags (a, reader, writer);
@@ -854,7 +858,6 @@ static int readAliasMethodAndEmitTags (const unsigned char **cp)
 	skipWhitespace (cp);
 	if (**cp == ':')
 	{
-		++*cp;
 		if (K_METHOD != parseIdentifier (cp, a, K_METHOD))
 			vStringClear (a);
 	}


### PR DESCRIPTION
    Close #3474.
    
    A symbol defined with single and double quote characters like :'name'
    and :"name" caused a crash of the Rake prser.
    
    The original code handled the initial character, <:> of a name like
    <:name> in the Rake parser side. The Rake passed the rest of string
    (<name>) to rubyParseMethodName() exported from the Ruby parser.
    
    However, rubyParseMethodName() itself has an ability to handle the initial
    character. So this commit makes the Rake parser pass whole <:name> to
    rubyParseMethodName(). The single and double quote characters after <:>
    is handled in rubyParseMethodName().
