### PR TITLE
GitHub Actions: brew upgrade python@3.9 is not needed anymore, because python@3.9 is not pre-installed in latest macos runner image

### DIFF
--- a/.github/workflows/testing-mac.yml
+++ b/.github/workflows/testing-mac.yml
@@ -25,9 +25,7 @@ jobs:
     - name: update package information
       run: brew update
     - name: install tools and libraries
-      run: |
-        brew upgrade python@3.9 || brew link --overwrite python@3.9 || :
-        brew install automake pkg-config bash libxml2 jansson libyaml gdb docutils pcre2
+      run: brew install automake pkg-config bash libxml2 jansson libyaml gdb docutils pcre2
     - name: autogen.sh
       run: ./autogen.sh
     - name: report the version of cc


### PR DESCRIPTION

Signed-off-by: leleliu008 <leleliu008@gmail.com>