### PR TITLE
main: extend the bucket array of hashTable dynamically

### DIFF
--- a/Tmain/optscript.d/arrayx.expected
+++ b/Tmain/optscript.d/arrayx.expected
@@ -1,0 +1,2 @@
+unmatchedmark
+null

--- a/Tmain/optscript.d/arrayx.ps
+++ b/Tmain/optscript.d/arrayx.ps
@@ -1,0 +1,8 @@
+clear
+{
+    { ] } stopped {
+        _errorname =
+        stop
+    } if
+} stopped pop
+_errorname =

--- a/Tmain/optscript.d/dictx.expected
+++ b/Tmain/optscript.d/dictx.expected
@@ -1,0 +1,17 @@
+-dict:0-
+-dict:1-
+-dict:0-
+-dict:1-
+-dict:0-
+-dict:1-
+rangecheck
+null
+-dict:0-
+-dict:1-
+-dict:1-
+-dict:2-
+-dict:2-
+-dict:3-
+unmatchedmark
+rangecheck
+null

--- a/Tmain/optscript.d/dictx.ps
+++ b/Tmain/optscript.d/dictx.ps
@@ -1,0 +1,38 @@
+0 dict == clear
+0 dict dup /x 1 put == clear
+1 dict ==
+1 dict dup /y 2 put == clear
+2 dict ==
+2 dict dup /z 2 put == clear
+
+{
+    { -1 dict } stopped {
+        _errorname =
+        stop
+    } if
+} stopped pop
+_errorname =
+
+<< >> == clear
+<<>> dup /x 0 put == clear
+
+<< /x 0 >> ==
+<</x 0>> dup /y 1 put == clear
+
+<< /x 0 /y 1 >> ==
+<< /x 0 /y 1 >> dup /z 2 put == clear
+
+{
+    { >> } stopped {
+               _errorname =
+               stop
+           } if
+}  stopped pop
+
+{
+    { << /a >> } stopped {
+        _errorname =
+        stop
+    } if
+} stopped pop
+_errorname =

--- a/Tmain/optscript.d/stdout-expected.txt
+++ b/Tmain/optscript.d/stdout-expected.txt
@@ -1,8 +1,10 @@
 arithmetic.ps...0
 array.ps...0
+arrayx.ps...0
 compound.ps...0
 control.ps...0
 dict.ps...0
+dictx.ps...0
 error-undefined-if-if.ps...1
 error-undefined-if.ps...1
 misc.ps...0

--- a/dsl/optscript.c
+++ b/dsl/optscript.c
@@ -2464,7 +2464,14 @@ op__make_dict (OptVM *vm, EsObject *name)
 			return OPT_ERR_TYPECHECK;
 	}
 
-	EsObject *d = dict_new (n > 0? (n / 2): 1, ATTR_READABLE|ATTR_WRITABLE);
+	/* A hashtable grows automatically when its filling rate is
+	 * grater than 80%. If we put elements between `<<' and `>>' to a dictionary
+	 * initialized with the size equal to the number of elements, the dictionary
+	 * grows once during putting them. Making a 1/0.8 times larger dictionary can
+	 * avoid the predictable growing. */
+	int size = (10 * (n > 0? (n / 2): 1)) / 8;
+
+	EsObject *d = dict_new (size, ATTR_READABLE|ATTR_WRITABLE);
 	for (int i = 0; i < (n / 2); i++)
 	{
 		EsObject *val = ptrArrayLast (vm->ostack);

--- a/dsl/optscript.c
+++ b/dsl/optscript.c
@@ -475,8 +475,8 @@ opt_init (void)
 
 	defOP (opt_system_dict, op_mark,           "<<",  0,  "- << mark");
 	defOP (opt_system_dict, op_mark,           "[",   0,  "- [ mark");
-	defOP (opt_system_dict, op__make_array,    "]",   1,  "[ any1 ... anyn ] array");
-	defOP (opt_system_dict, op__make_dict ,    ">>",  1, "<< key1 value1 ... keyn valuen >> dict");
+	defOP (opt_system_dict, op__make_array,    "]",   0,  "[ any1 ... anyn ] array");
+	defOP (opt_system_dict, op__make_dict ,    ">>",  0, "<< key1 value1 ... keyn valuen >> dict");
 
 	defop (opt_system_dict, _help,  0, "- _HELP -");
 	defop (opt_system_dict, pstack, 0, "|- any1 ... anyn PSTACK |- any1 ... anyn");

--- a/dsl/optscript.c
+++ b/dsl/optscript.c
@@ -3029,8 +3029,10 @@ op_dict (OptVM *vm, EsObject *name)
 		return OPT_ERR_TYPECHECK;
 
 	int n = es_integer_get (nobj);
-	if (n < 1)
+	if (n < 0)
 		return OPT_ERR_RANGECHECK;
+	else if (n == 0)
+		n = 1;
 
 	ptrArrayDeleteLast (vm->ostack);
 


### PR DESCRIPTION
There is a plan to store much more items in a hashtable (htable).

The current implementation, allocating a bucket array of a htable with the size specified when initializing the htable, doesn't fit the purpose because proper size is not predictable.

With this change, the htable itself extends the size of the array twice dynamically when the approximate filling rate of the bucket array of the htable is greater than 80%.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>