### PR TITLE
GithubActions: migrate openbsd version from 6 to 7

### DIFF
--- a/.github/workflows/testing-bsds.yml
+++ b/.github/workflows/testing-bsds.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: leleliu008/github-actions-vagrant@v2
       with:
         mem: 2048
-        box: generic/openbsd6
+        box: generic/openbsd7
         log: warn
         run: |
           export AUTOCONF_VERSION=2.69


### PR DESCRIPTION
 OpenBSD-6.9 has reached end-of-life.

Reference: https://endoflife.date/openbsd

Signed-off-by: leleliu008 <leleliu008@gmail.com>