### PR TITLE
Tcl,TclOO: don't consume input if a subparser extracts something

### DIFF
--- a/Units/parser-itcl.r/simple-itcl.d/expected.tags
+++ b/Units/parser-itcl.r/simple-itcl.d/expected.tags
@@ -30,3 +30,9 @@ commonProtected	input.tcl	/^    protected proc commonProtected "b"$/;"	kind:proc
 SmartToaster::commonProtected	input.tcl	/^    protected proc commonProtected "b"$/;"	kind:procedure	line:48	language:ITcl	scope:class:SmartToaster	access:protected	roles:def	extras:qualified,subparser	end:48
 commonPrivate	input.tcl	/^    private proc commonPrivate "c"$/;"	kind:procedure	line:49	language:ITcl	scope:class:SmartToaster	access:private	roles:def	extras:subparser	end:49
 SmartToaster::commonPrivate	input.tcl	/^    private proc commonPrivate "c"$/;"	kind:procedure	line:49	language:ITcl	scope:class:SmartToaster	access:private	roles:def	extras:qualified,subparser	end:49
+X	input.tcl	/^itcl::class X {$/;"	kind:class	line:51	language:ITcl	roles:def	extras:subparser
+x	input.tcl	/^    variable x 0$/;"	kind:variable	line:52	language:ITcl	scope:class:X	roles:def	extras:subparser	end:52
+X::x	input.tcl	/^    variable x 0$/;"	kind:variable	line:52	language:ITcl	scope:class:X	roles:def	extras:qualified,subparser	end:52
+Y	input.tcl	/^itcl::class Y {$/;"	kind:class	line:54	language:ITcl	roles:def	extras:subparser
+y	input.tcl	/^    variable y 0$/;"	kind:variable	line:55	language:ITcl	scope:class:Y	roles:def	extras:subparser	end:55
+Y::y	input.tcl	/^    variable y 0$/;"	kind:variable	line:55	language:ITcl	scope:class:Y	roles:def	extras:qualified,subparser	end:55

--- a/Units/parser-itcl.r/simple-itcl.d/input.tcl
+++ b/Units/parser-itcl.r/simple-itcl.d/input.tcl
@@ -48,6 +48,12 @@ itcl::class SmartToaster {
     protected proc commonProtected "b"
     private proc commonPrivate "c"
 }
+itcl::class X {
+    variable x 0
+}
+itcl::class Y {
+    variable y 0
+}
 
 set toaster [SmartToaster #auto]
 $toaster toast 2

--- a/Units/parser-tcloo.r/no-empty-line-between-classes.d/args.ctags
+++ b/Units/parser-tcloo.r/no-empty-line-between-classes.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--fields=+li

--- a/Units/parser-tcloo.r/no-empty-line-between-classes.d/expected.tags
+++ b/Units/parser-tcloo.r/no-empty-line-between-classes.d/expected.tags
@@ -1,0 +1,6 @@
+S	input.tcl	/^oo::class create S {$/;"	c	language:TclOO
+sx	input.tcl	/^    method sx {} {$/;"	m	language:TclOO	class:S
+M	input.tcl	/^oo::class create M {$/;"	c	language:TclOO
+mx	input.tcl	/^    method mx {} {$/;"	m	language:TclOO	class:M
+C	input.tcl	/^oo::class create C {$/;"	c	language:TclOO	inherits:S
+cx	input.tcl	/^    method cx {} {$/;"	m	language:TclOO	class:C

--- a/Units/parser-tcloo.r/no-empty-line-between-classes.d/input.tcl
+++ b/Units/parser-tcloo.r/no-empty-line-between-classes.d/input.tcl
@@ -1,0 +1,21 @@
+oo::class create S {
+    variable x
+    method sx {} {
+        set x 0
+    }
+}
+oo::class create M {
+    variable x
+    method mx {} {
+        incr x 3
+    }
+}
+oo::class create C {
+    superclass S
+    mixin M
+    variable x
+    method cx {} {
+        incr x 5
+    }
+}
+# Taken from https://wiki.tcl-lang.org/page/Variables+in+TclOO

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -632,8 +632,9 @@ static void parseNamespace (tokenInfo *const token,
 			parseProc (token, index);
 		else if (tokenIsType (token, TCL_IDENTIFIER))
 		{
-			notifyCommand (token, index);
-			skipToEndOfCmdline(token); /* ??? */
+			int r = notifyCommand (token, index);
+			if (r == CORK_NIL)
+				skipToEndOfCmdline(token);
 		}
 		else if (token->type == '}')
 		{
@@ -682,8 +683,9 @@ static void findTclTags (void)
 			parsePackage (token);
 		else if (tokenIsType (token, TCL_IDENTIFIER))
 		{
-			notifyCommand (token, CORK_NIL);
-			skipToEndOfCmdline(token); /* ??? */
+			int r = notifyCommand (token, CORK_NIL);
+			if (r == CORK_NIL)
+				skipToEndOfCmdline(token);
 		}
 		else
 			skipToEndOfCmdline(token);


### PR DESCRIPTION
A subparser may consume the input upto the end of a command line (EOCL) when the subparser extracts something. So consuming input upto EOCL in the base parser, here Tcl parser, after the extraction causes unexpected skipping.

Calling skipToEndOfCmdline for consuming input should be done only when any subparser extracts nothing.