### PR TITLE
html: parse javascript broken by php

### DIFF
--- a/Units/parser-php.r/run-guest-nested.d/args.ctags
+++ b/Units/parser-php.r/run-guest-nested.d/args.ctags
@@ -1,0 +1,4 @@
+--sort=yes
+--extras=+rg
+--fields=+rln
+--language-force=html

--- a/Units/parser-php.r/run-guest-nested.d/expected.tags
+++ b/Units/parser-php.r/run-guest-nested.d/expected.tags
@@ -1,0 +1,9 @@
+.blarg	input.php	/^.blarg {$/;"	c	line:31	language:CSS	roles:def
+My Home Page	input.php	/^    <title>My Home Page<\/title>$/;"	j	line:8	language:HTML	roles:def
+X	input.php	/^<html><head><title>X<\/title>$/;"	j	line:1	language:HTML	roles:def
+css/general.css	input.php	/^    <link rel="stylesheet" href="css\/general.css" type="text\/css">$/;"	C	line:9	language:HTML	roles:extFile
+draw	input.php	/^  function draw($x) {$/;"	f	line:3	language:PHP	roles:def
+f1	input.php	/^    var f1 = function (n) {$/;"	f	line:21	language:JavaScript	roles:def
+f2	input.php	/^    var f2 = function (m) {$/;"	f	line:26	language:JavaScript	roles:def
+nothing	input.php	/^  function nothing($x) {$/;"	f	line:36	language:PHP	roles:def
+stuff	input.php	/^    <h1>stuff<\/h1>$/;"	h	line:13	language:HTML	roles:def

--- a/Units/parser-php.r/run-guest-nested.d/input.php
+++ b/Units/parser-php.r/run-guest-nested.d/input.php
@@ -1,0 +1,39 @@
+<html><head><title>X</title>
+<?php // This test input is derived from #2256 submitted by @StephenWall.
+  function draw($x) {
+      echo "$x";
+  }
+?>
+    <meta http-equiv="content-type" content="text/html; charset=ISO-8859-1">
+    <title>My Home Page</title>
+    <link rel="stylesheet" href="css/general.css" type="text/css">
+    <style type="text/css"></stylE>
+  </head>
+  <body>
+    <h1>stuff</h1>
+    <a href="/blah">nowhere</a>
+    <?=draw('nowhere')?>
+    <a href="/blech">somewhere</a>
+    <?=draw('somewhere')?>
+  </body>
+</html>
+<script>
+    var f1 = function (n) {
+	return n + <?php /* some value */ ?>;
+    }
+</script>
+<script>
+    var f2 = function (m) {
+	return m + <% /* some value from JSP */ %>;
+    }
+</script>
+<style>
+.blarg {
+    position: relative;
+}
+</style>
+<?php
+  function nothing($x) {
+      ;
+  }
+?>

--- a/main/promise.c
+++ b/main/promise.c
@@ -71,15 +71,21 @@ int  makePromise   (const char *parser,
 	int r;
 	langType lang = LANG_IGNORE;
 
+	const bool is_thin_stream_spec =
+		isThinStreamSpec(startLine, startCharOffset,
+						 endLine, endCharOffset,
+						 sourceLineOffset);
+
+	if (!is_thin_stream_spec
+		&& (startLine > endLine
+			|| (startLine == endLine && startCharOffset >= endCharOffset)))
+		return -1;
+
 	verbose("makePromise: %s start(line: %lu, offset: %ld, srcline: %lu), end(line: %lu, offset: %ld)\n",
 			parser? parser: "*", startLine, startCharOffset, sourceLineOffset,
 			endLine, endCharOffset);
 
-	if ((!isThinStreamSpec(startLine,
-						   startCharOffset,
-						   endLine,
-						   endCharOffset,
-						   sourceLineOffset))
+	if ((!is_thin_stream_spec)
 		&& ( !isXtagEnabled (XTAG_GUEST)))
 		return -1;
 

--- a/parsers/html.c
+++ b/parsers/html.c
@@ -158,8 +158,8 @@ typedef enum {
 	TOKEN_NAME,			/* tag and attribute names */
 	TOKEN_STRING,		/* single- or double-quoted attribute value */
 	TOKEN_TEXT,
-	TOKEN_TAG_START,	/* <  */
-	TOKEN_TAG_START2,	/* </ */
+	TOKEN_OPEN_TAG_START,	/* <  */
+	TOKEN_CLOSE_TAG_START,	/* </ */
 	TOKEN_TAG_END,		/* >  */
 	TOKEN_TAG_END2,		/* /> */
 	TOKEN_EQUAL,
@@ -289,11 +289,11 @@ getNextChar:
 			else if (d == '?')
 				token->type = TOKEN_OTHER;
 			else if (d == '/')
-				token->type = TOKEN_TAG_START2;
+				token->type = TOKEN_CLOSE_TAG_START;
 			else
 			{
 				ungetcToInputFile (d);
-				token->type = TOKEN_TAG_START;
+				token->type = TOKEN_OPEN_TAG_START;
 			}
 			break;
 		}
@@ -378,19 +378,19 @@ static bool readTagContent (tokenInfo *token, vString *text, long *line, long *l
 		*lineOffset = getInputLineOffset ();
 		readToken (token, false);
 		type = token->type;
-		if (type == TOKEN_TAG_START)
+		if (type == TOKEN_OPEN_TAG_START)
 			readTag (token, text, depth + 1);
-		if (type == TOKEN_COMMENT || type == TOKEN_TAG_START)
+		if (type == TOKEN_COMMENT || type == TOKEN_OPEN_TAG_START)
 		{
 			readTokenText (token, text != NULL);
 			appendText (text, token->string);
 		}
 	}
-	while (type == TOKEN_COMMENT || type == TOKEN_TAG_START);
+	while (type == TOKEN_COMMENT || type == TOKEN_OPEN_TAG_START);
 
 	TRACE_LEAVE_TEXT("is_close_tag? %d", type == TOKEN_CLOSE_TAG_START);
 
-	return type == TOKEN_TAG_START2;
+	return type == TOKEN_CLOSE_TAG_START;
 }
 
 static bool skipScriptContent (tokenInfo *token, long *line, long *lineOffset)
@@ -413,7 +413,7 @@ static bool skipScriptContent (tokenInfo *token, long *line, long *lineOffset)
 		readToken (token, false);
 		type = token->type;
 
-		if (type == TOKEN_TAG_START2)
+		if (type == TOKEN_CLOSE_TAG_START)
 		{
 			found_start = true;
 			line_tmp[1] = line_tmp[0];
@@ -657,7 +657,7 @@ static void findHtmlTags (void)
 	do
 	{
 		readToken (&token, true);
-		if (token.type == TOKEN_TAG_START)
+		if (token.type == TOKEN_OPEN_TAG_START)
 			readTag (&token, NULL, 0);
 	}
 	while (token.type != TOKEN_EOF);

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -913,10 +913,8 @@ getNextChar:
 		unsigned long endLineNumber = getInputLineNumber ();
 		int endLineOffset = getInputLineOffset ();
 
-		if ((startLineNumber != endLineNumber)
-			|| (startLineOffset != endLineOffset))
-			makePromise ("HTML", startLineNumber, startLineOffset,
-						 endLineNumber, endLineOffset, startSourceLineNumber);
+		makePromise ("HTML", startLineNumber, startLineOffset,
+					 endLineNumber, endLineOffset, startSourceLineNumber);
 	}
 	else
 		c = getcFromInputFile ();

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -933,7 +933,7 @@ getNextChar:
 	if (! InPhp)
 	{
 		unsigned long startSourceLineNumber = getSourceLineNumber ();
-		unsigned long startLineNumber = startSourceLineNumber;
+		unsigned long startLineNumber = getInputLineNumber ();
 		int startLineOffset = getInputLineOffset ();
 
 		c = findPhpStart ();


### PR DESCRIPTION
The html parser needs to be able to use php as a guest parser.