### PR TITLE
GitHub Actions: use apt-get instead of brew on Ubuntu

### DIFF
--- a/.github/workflows/cross-compile-android-ndk-on-mac.yml
+++ b/.github/workflows/cross-compile-android-ndk-on-mac.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - run: brew install gcc make automake autoconf file
-      
+
       - run: ./autogen.sh
 
       - name: Run ./configure ...
@@ -36,7 +36,7 @@ jobs:
           TOOLCHAIN_BASE_DIR=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$BUILD_MACHINE_OS_TYPE-$BUILD_MACHINE_OS_ARCH
           TOOLCHAIN_BIN_DIR=$TOOLCHAIN_BASE_DIR/bin
           SYSROOT=$TOOLCHAIN_BASE_DIR/sysroot
-          
+
           export CC=$TOOLCHAIN_BIN_DIR/armv7a-linux-androideabi21-clang
           export AR=$TOOLCHAIN_BIN_DIR/llvm-ar
           export RANLIB=$TOOLCHAIN_BIN_DIR/llvm-ranlib
@@ -44,22 +44,22 @@ jobs:
           export CFLAGS="--sysroot $SYSROOT -Qunused-arguments -Os -fpic"
           export CPPFLAGS="--sysroot $SYSROOT -Qunused-arguments"
           export LDFLAGS="--sysroot $SYSROOT"
-          
+
           TARGET=armv7a-linux-androideabi
-          
+
           COLOR_PURPLE='\033[0;35m'       # Purple
           COLOR_GREEN='\033[0;32m'        # Green
           COLOR_OFF='\033[0m'             # Reset
-          
+
           echo() {
             printf "%b\n" "$*"
           }
-          
+
           run() {
             echo "$COLOR_PURPLE==>$COLOR_OFF $COLOR_GREEN$@$COLOR_OFF"
             eval "$*"
           }
-           
+
           run ./configure \
               --host=$TARGET \
               --disable-iconv \
@@ -73,7 +73,7 @@ jobs:
               LDFLAGS="\"$LDFLAGS\"" \
               AR=$AR \
               RANLIB=$RANLIB
-      
+
       - run: make V=1
-      
+
       - run: file ctags | grep 'ELF 32-bit LSB pie executable, ARM, EABI5'

--- a/.github/workflows/cross-compile-android-ndk-on-mac.yml
+++ b/.github/workflows/cross-compile-android-ndk-on-mac.yml
@@ -1,0 +1,79 @@
+name: cross compile with android-ndk on mac
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  cross-compile:
+    strategy:
+      fail-fast: false
+      matrix:
+        build-machine-os: [macos-12, macos-11]
+
+    runs-on: ${{ matrix.build-machine-os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      
+      - run: brew install gcc make automake autoconf file
+      
+      - run: ./autogen.sh
+
+      - name: Run ./configure ...
+        run: |
+          # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#environment-variables-3
+          [ -n "$ANDROID_NDK_LATEST_HOME" ] && {
+            export ANDROID_NDK_HOME="$ANDROID_NDK_LATEST_HOME"
+            export ANDROID_NDK_ROOT="$ANDROID_NDK_LATEST_HOME"
+          }
+
+          BUILD_MACHINE_OS_TYPE=$(uname | tr A-Z a-z)
+          BUILD_MACHINE_OS_ARCH=$(uname -m)
+
+          TOOLCHAIN_BASE_DIR=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$BUILD_MACHINE_OS_TYPE-$BUILD_MACHINE_OS_ARCH
+          TOOLCHAIN_BIN_DIR=$TOOLCHAIN_BASE_DIR/bin
+          SYSROOT=$TOOLCHAIN_BASE_DIR/sysroot
+          
+          export CC=$TOOLCHAIN_BIN_DIR/armv7a-linux-androideabi21-clang
+          export AR=$TOOLCHAIN_BIN_DIR/llvm-ar
+          export RANLIB=$TOOLCHAIN_BIN_DIR/llvm-ranlib
+
+          export CFLAGS="--sysroot $SYSROOT -Qunused-arguments -Os -fpic"
+          export CPPFLAGS="--sysroot $SYSROOT -Qunused-arguments"
+          export LDFLAGS="--sysroot $SYSROOT"
+          
+          TARGET=armv7a-linux-androideabi
+          
+          COLOR_PURPLE='\033[0;35m'       # Purple
+          COLOR_GREEN='\033[0;32m'        # Green
+          COLOR_OFF='\033[0m'             # Reset
+          
+          echo() {
+            printf "%b\n" "$*"
+          }
+          
+          run() {
+            echo "$COLOR_PURPLE==>$COLOR_OFF $COLOR_GREEN$@$COLOR_OFF"
+            eval "$*"
+          }
+           
+          run ./configure \
+              --host=$TARGET \
+              --disable-iconv \
+              --disable-xml \
+              --disable-json \
+              --disable-yaml \
+              --disable-pcre2 \
+              CC="$CC" \
+              CFLAGS="\"$CFLAGS\"" \
+              CPPFLAGS="\"$CPPFLAGS\"" \
+              LDFLAGS="\"$LDFLAGS\"" \
+              AR=$AR \
+              RANLIB=$RANLIB
+      
+      - run: make V=1
+      
+      - run: file ctags | grep 'ELF 32-bit LSB pie executable, ARM, EABI5'

--- a/.github/workflows/cross-compile-android-ndk-on-ubuntu.yml
+++ b/.github/workflows/cross-compile-android-ndk-on-ubuntu.yml
@@ -77,4 +77,5 @@ jobs:
 
       - run: make V=1
 
-      - run: file ctags | grep "ELF 32-bit LSB pie executable, ARM, EABI5"
+      # pie executable or shared object
+      - run: file ctags | grep 'ELF 32-bit LSB .*, ARM, EABI5'

--- a/.github/workflows/cross-compile-android-ndk-on-ubuntu.yml
+++ b/.github/workflows/cross-compile-android-ndk-on-ubuntu.yml
@@ -1,4 +1,4 @@
-name: cross compile with android-ndk
+name: cross compile with android-ndk on ubuntu
 
 on:
   push:
@@ -11,15 +11,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [ubuntu-22.04, ubuntu-20.04, macos-12, macos-11]
+        build-machine-os: [ubuntu-22.04, ubuntu-20.04]
 
     runs-on: ${{ matrix.build-machine-os }}
 
     steps:
       - uses: actions/checkout@v2
-      
-      - run: brew install gcc make automake autoconf file
-      
+
+      - run: sudo apt-get -y -o APT::Immediate-Configure=false update
+      - run: sudo apt-get -y -o APT::Immediate-Configure=false install gcc make automake autoconf file
+
       - run: ./autogen.sh
 
       - name: Run ./configure ...
@@ -36,7 +37,7 @@ jobs:
           TOOLCHAIN_BASE_DIR=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$BUILD_MACHINE_OS_TYPE-$BUILD_MACHINE_OS_ARCH
           TOOLCHAIN_BIN_DIR=$TOOLCHAIN_BASE_DIR/bin
           SYSROOT=$TOOLCHAIN_BASE_DIR/sysroot
-          
+
           export CC=$TOOLCHAIN_BIN_DIR/armv7a-linux-androideabi21-clang
           export AR=$TOOLCHAIN_BIN_DIR/llvm-ar
           export RANLIB=$TOOLCHAIN_BIN_DIR/llvm-ranlib
@@ -44,22 +45,22 @@ jobs:
           export CFLAGS="--sysroot $SYSROOT -Qunused-arguments -Os -fpic"
           export CPPFLAGS="--sysroot $SYSROOT -Qunused-arguments"
           export LDFLAGS="--sysroot $SYSROOT"
-          
+
           TARGET=armv7a-linux-androideabi
-          
+
           COLOR_PURPLE='\033[0;35m'       # Purple
           COLOR_GREEN='\033[0;32m'        # Green
           COLOR_OFF='\033[0m'             # Reset
-          
+
           echo() {
             printf "%b\n" "$*"
           }
-          
+
           run() {
             echo "$COLOR_PURPLE==>$COLOR_OFF $COLOR_GREEN$@$COLOR_OFF"
             eval "$*"
           }
-           
+
           run ./configure \
               --host=$TARGET \
               --disable-iconv \
@@ -73,7 +74,7 @@ jobs:
               LDFLAGS="\"$LDFLAGS\"" \
               AR=$AR \
               RANLIB=$RANLIB
-      
+
       - run: make V=1
-      
-      - run: file ctags | grep 'ELF 32-bit LSB pie executable, ARM, EABI5'
+
+      - run: file ctags | grep "ELF 32-bit LSB pie executable, ARM, EABI5"

--- a/.github/workflows/cross-compile-mingw-w64-on-mac.yml
+++ b/.github/workflows/cross-compile-mingw-w64-on-mac.yml
@@ -1,4 +1,4 @@
-name: cross compile with mingw-w64
+name: cross compile with mingw-w64 on mac
 
 on:
   push:
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [ubuntu-22.04, ubuntu-20.04, macos-12, macos-11]
+        build-machine-os: [macos-12, macos-11]
         target: [i686-w64-mingw32,x86_64-w64-mingw32]
 
     runs-on: ${{ matrix.build-machine-os }}

--- a/.github/workflows/cross-compile-mingw-w64-on-mac.yml
+++ b/.github/workflows/cross-compile-mingw-w64-on-mac.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      
+
       - run: brew install mingw-w64 gcc make automake autoconf file
 
       - run: ./autogen.sh
@@ -37,7 +37,7 @@ jobs:
               AR=${{ matrix.target }}-ar \
               RANLIB=${{ matrix.target }}-ranlib \
               WINDRES=${{ matrix.target }}-windres
-      
+
       - run: make V=1
-      
+
       - run: file ctags.exe | grep PE32

--- a/.github/workflows/cross-compile-mingw-w64-on-ubuntu.yml
+++ b/.github/workflows/cross-compile-mingw-w64-on-ubuntu.yml
@@ -1,0 +1,44 @@
+name: cross compile with mingw-w64 on ubuntu
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  cross-compile:
+    strategy:
+      fail-fast: false
+      matrix:
+        build-machine-os: [ubuntu-22.04, ubuntu-20.04]
+        target: [i686-w64-mingw32,x86_64-w64-mingw32]
+
+    runs-on: ${{ matrix.build-machine-os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: sudo apt-get -y -o APT::Immediate-Configure=false update
+      - run: sudo apt-get -y -o APT::Immediate-Configure=false install mingw-w64 gcc make automake autoconf file
+
+      - run: ./autogen.sh
+
+      - name: Run ./configure ...
+        run: |
+          ./configure \
+              --host=${{ matrix.target }} \
+              --disable-iconv \
+              --disable-xml \
+              --disable-json \
+              --disable-yaml \
+              --disable-pcre2 \
+              CC=${{ matrix.target }}-gcc \
+              CFLAGS='-v' \
+              AR=${{ matrix.target }}-ar \
+              RANLIB=${{ matrix.target }}-ranlib \
+              WINDRES=${{ matrix.target }}-windres
+
+      - run: make V=1
+
+      - run: file ctags.exe | grep PE32


### PR DESCRIPTION
It seems that brew command is not available on Ubuntu these days.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>