### PR TITLE
Github Actions: speed up s390x workflow

### DIFF
--- a/.github/workflows/testing-big-endian.yml
+++ b/.github/workflows/testing-big-endian.yml
@@ -7,32 +7,100 @@ on:
     branches: [ master ]
 
 jobs:
-  s390x_job:
-    runs-on: ubuntu-22.04
-    name: Build on ubuntu-22.04 s390x
+  s390x:
+    runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2.1.0
-      - uses: uraimo/run-on-arch-action@v2
-        name: Run commands
-        id: runcmd
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        id:   restore-cache
         with:
-          arch: s390x
-          distro: fedora_latest
-          #
-          # We don't install libseccomp-devel because sandbox related test cases fail.
-          #
-          # Adjust safe.directory because we got following messages when running make check-genfile:
-          #
-          #     fatal: unsafe repository ('/home/runner/work/ctags/ctags' is owned by someone else)
-          #     To add an exception for this directory, call:
-          #     git config --global --add safe.directory /home/runner/work/ctags/ctags
-          #
-          install: |
-            dnf -y install git gdb procps-ng gcc automake autoconf pkgconfig make libxml2-devel jansson-devel libyaml-devel pcre2-devel findutils diffutils sudo
-          run: |
-            bash ./autogen.sh
-            ./configure --enable-debugging
-            make -j 2
-            readelf -h ctags
-            git config --global --add safe.directory $(pwd)
-            make check
+          path: /home/runner/linux-s390x-glibc
+          key:          dependent-packages-linux-s390x-glibc
+          restore-keys: dependent-packages-linux-s390x-glibc
+
+      - if: ${{ steps.restore-cache.outputs.cache-hit != 'true' }}
+        run: |
+          set -x
+
+          mkdir -p /home/runner/linux-s390x-glibc
+
+          curl -L -o lastest.json https://api.github.com/repos/leleliu008/uppm-package-repository-linux-s390x-glibc/releases/latest
+
+          unset RELEASE_TAG_NAME_
+          unset RELEASE_FILENAMES
+
+          RELEASE_TAG_NAME_=$(jq -r '.tag_name'      lastest.json)
+          RELEASE_FILENAMES=$(jq -r '.assets[].name' lastest.json)
+
+          for filename in $RELEASE_FILENAMES
+          do
+              case $filename in
+                   jansson-*-linux-s390x-glibc.tar.xz) ;;
+                  libiconv-*-linux-s390x-glibc.tar.xz) ;;
+                   libxml2-*-linux-s390x-glibc.tar.xz) ;;
+                   libyaml-*-linux-s390x-glibc.tar.xz) ;;
+                     pcre2-*-linux-s390x-glibc.tar.xz) ;;
+                      zlib-*-linux-s390x-glibc.tar.xz) ;;
+                  *) continue ;;
+              esac
+              curl -LO https://github.com/leleliu008/uppm-package-repository-linux-s390x-glibc/releases/download/${RELEASE_TAG_NAME_}/${filename}
+              tar xf ${filename} -C /home/runner/linux-s390x-glibc --strip-components=1
+          done
+
+          rm -rf /home/runner/linux-s390x-glibc/share/log
+          rm -rf /home/runner/linux-s390x-glibc/share/man
+          rm -rf /home/runner/linux-s390x-glibc/share/doc
+          rm -rf /home/runner/linux-s390x-glibc/share/gtk-doc
+          rm -rf /home/runner/linux-s390x-glibc/lib/libz.so*
+          rm -rf /home/runner/linux-s390x-glibc/lib/lib*.la
+          rm -rf /home/runner/linux-s390x-glibc/installed-files
+          rm -rf /home/runner/linux-s390x-glibc/installed-metadata-ppkg
+
+      - run: sudo apt-get -y update
+      - run: sudo apt-get -y install automake autoconf pkg-config make gcc-s390x-linux-gnu
+
+      - run: ./autogen.sh
+      - run: |
+            export CC=/usr/bin/s390x-linux-gnu-gcc
+            export CPPFLAGS=-I/home/runner/linux-s390x-glibc/include
+            export LDFLAGS=-L/home/runner/linux-s390x-glibc/lib
+            export PKG_CONFIG_PATH=/home/runner/linux-s390x-glibc/lib/pkgconfig
+            ./configure --host=s390x-ibm-linux-gnu --enable-debugging || (cat config.log; exit 1)
+      - run: make -j$(nproc)
+
+      - run: /usr/bin/s390x-linux-gnu-readelf -h ctags
+      - run: /usr/bin/s390x-linux-gnu-readelf -d ctags
+
+      - run: |
+          cat > run.sh <<EOF
+          set -e
+
+          COLOR_GREEN='\033[0;32m'        # Green
+          COLOR_PURPLE='\033[0;35m'       # Purple
+          COLOR_OFF='\033[0m'             # Reset
+
+          echo() {
+              printf '%b\n' "\$*"
+          }
+
+          run() {
+              echo "\${COLOR_PURPLE}==>\${COLOR_OFF} \${COLOR_GREEN}\$@\${COLOR_OFF}"
+              eval "\$*"
+          }
+
+          run uname -a
+
+          run apt-get -y update
+          run apt-get -y install make python3
+
+          run make tmain CI=1 CTAGS_DEP= READTAGS_DEP= OPTSCRIPT_DEP=
+          run make units CI=1 CTAGS_DEP=
+          EOF
+
+          chmod +x run.sh
+
+      # https://github.com/multiarch/qemu-user-static
+      - run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      - run: docker run -v $PWD:$PWD -w $PWD s390x/ubuntu bash run.sh


### PR DESCRIPTION
origin s390x workflow is very slow, sometimes even consume time over 1 hours.

to speed up this workflow, I changed to following:

1. cross-compile s390x on build-machine, this will save about 15 minitus.
2. use prebuild dependencies.
3. only do `misc/units.py tmain` and `misc/units.py run`

Signed-off-by: leleliu008 <leleliu008@gmail.com>