### PR TITLE
libutil: revise functions for updating the value for a given key

### DIFF
--- a/dsl/optscript.c
+++ b/dsl/optscript.c
@@ -2129,7 +2129,11 @@ dict_op_def (EsObject* dict, EsObject *key, EsObject *val)
 	key = es_object_ref (key);
 	val = es_object_ref (val);
 
-	hashTableUpdateItem (t, key, val);
+	if (hashTableUpdateOrPutItem (t, key, val))
+	{
+		/* A key in the hashtable is reused. */
+		es_object_unref (key);
+	}
 }
 
 static bool

--- a/extra-cmds/utiltest.c
+++ b/extra-cmds/utiltest.c
@@ -8,8 +8,25 @@
 #include "general.h"
 
 #include "acutest.h"
+#include "htable.h"
 #include "routines.h"
 #include <string.h>
+
+void test_htable_update(void)
+{
+	hashTable *htable = hashTableNew (3, hashCstrhash, hashCstreq,
+									  eFree, NULL);
+	TEST_CHECK(htable != NULL);
+
+	hashTablePutItem (htable, strdup("a"), "A");
+	TEST_CHECK (hashTableUpdateItem (htable,  "a", "B") == true);
+	TEST_CHECK (hashTableUpdateItem (htable,  "b", "B") == false);
+	TEST_CHECK (strcmp (hashTableGetItem (htable, "a"), "B") == 0);
+	TEST_CHECK (hashTableUpdateOrPutItem (htable,  "a", "C") == true);
+	TEST_CHECK (hashTableUpdateOrPutItem (htable,  strdup("x"), "X") == false);
+	TEST_CHECK (strcmp (hashTableGetItem (htable, "x"), "X") == 0);
+	hashTableDelete(htable);
+}
 
 void test_routines_strrstr(void)
 {
@@ -17,6 +34,7 @@ void test_routines_strrstr(void)
 }
 
 TEST_LIST = {
+   { "htable/update",    test_htable_update    },
    { "routines/strrstr", test_routines_strrstr },
    { NULL, NULL }     /* zeroed record marking the end of the list */
 };

--- a/main/htable.h
+++ b/main/htable.h
@@ -70,7 +70,19 @@ extern void       hashTablePutItem     (hashTable *htable, void *key, void *valu
 extern void*      hashTableGetItem     (hashTable *htable, const void * key);
 extern bool    hashTableHasItem     (hashTable * htable, const void * key);
 extern bool    hashTableDeleteItem  (hashTable *htable, const void *key);
-extern bool       hashTableUpdateItem  (hashTable *htable, void *key, void *value);
+
+/* If KEY is found, this function updates the value for KEY and returns true.
+ * If KEY is not found, this function just returns false.
+ *
+ * KEY is just referred. The HTABLE takes the ownership of VALUE when KEY is found. */
+extern bool       hashTableUpdateItem  (hashTable *htable, const void *key, void *value);
+
+/* If KEY is found, this function updates the value for KEY and returns true.
+ * If KEY is not found, this function adds KEY and VALUE and returns false.
+ *
+ * The HTABLE takes the ownership of KEY only if KEY is not found.
+ * The HTABLE takes the ownership of VALUE either when KEY is found or not. */
+extern bool       hashTableUpdateOrPutItem  (hashTable *htable, void *key, void *value);
 
 /* Return true if proc never returns false; proc returns true for all
  * the items, or htable holds no item.


### PR DESCRIPTION
The original hashTableUpdateItem() replaces not only the value but the key. So we cannot add "const" modifier to the key parameter.

This change revises the function.

The new hashTableUpdateItem() never replaces the key; if key is not found, it just returns false. So we can add the const modifier to the key parameter.

In addition we introduces a new function, hashTableUpdateOrPutItem(). hashTableUpdateOrPutItem() don't replace the key as far as the key exits in the hash table. However, we don't add the const modifier to the key parameter because the key and the value is put to the the hash table if the key doesn't exist in the hash table.

These two are tested in tutil target.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>