### PR TITLE
lregex: warn if mgroup= flag is not given in --mline-regex-<LANG>=

### DIFF
--- a/Tmain/mline-no-advance.d/stderr-expected.txt
+++ b/Tmain/mline-no-advance.d/stderr-expected.txt
@@ -1,3 +1,4 @@
 ctags: Notice: No options will be read from files or environment
+ctags: Warning: FOO: no {mgroup=N} flag given in --mline-regex-<LANG>=/(.)/\1/{_advanceTo=1start}... (addTagRegexOption)
 ctags: Warning: a multi line regex pattern doesn't advance the input cursor: (.)
 ctags: Warning: Language: FOO, input file: ./input.foo, pos: 0

--- a/Tmain/optlib-message-flag.d/args.ctags
+++ b/Tmain/optlib-message-flag.d/args.ctags
@@ -12,7 +12,7 @@
 
 --mline-regex-FOO=/namespace ([a-zA-Z]+) /\1/m,mlineNamespace/{mgroup=1}{warning="got namespace"}
 --mline-regex-FOO=/var ([a-zA-Z]+) ([a-zA-Z]+);/\2/V,mlineVariable/{warning="got variable '\2' of type \1"}{mgroup=2}
---mline-regex-FOO=/bad multi-line ([a-zA-Z-]+)/\1/x,bad/{fatal="bad='\1'"}
+--mline-regex-FOO=/bad multi-line ([a-zA-Z-]+)/\1/x,bad/{fatal="bad='\1'"}{mgroup=1}
 
 
 --_tabledef-FOO=main

--- a/docs/man/ctags-optlib.7.rst
+++ b/docs/man/ctags-optlib.7.rst
@@ -34,7 +34,7 @@ Following options are for defining (or customizing) a parser:
 * ``--map-<LANG>=[+|-]<extension>|<pattern>``
 * ``--kinddef-<LANG>=<letter>,<name>,<description>``
 * ``--regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/[<flags>]``
-* ``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/[<flags>]``
+* ``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/{mgroup=<N>}[<flags>]``
 
 Following options are for controlling loading parser definition:
 
@@ -117,7 +117,7 @@ Overview for defining a parser
 
    Use ``--regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/[<flags>]``
    option for a single-line regular expression. You can also use
-   ``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/[<flags>]``
+   ``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/{mgroup=<N>}[<flags>]``
    option for a multi-line regular expression.
 
    As *<kind-spec>*, you can use the one-letter flag defined with
@@ -271,11 +271,14 @@ OPTIONS
 ``--list-mline-regex-flags``
 	Lists the flags that can be used in ``--mline-regex-<LANG>`` option.
 
-``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/[<flags>]``
+``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/{mgroup=<N>}[<flags>]``
 	Define a multi-line regular expression.
 
 	This option is similar to ``--regex-<LANG>`` option except the pattern is
 	applied to the whole file’s contents, not line by line.
+
+	See "`FLAGS FOR ``--mline-regex-<LANG>`` OPTION`_" about ``{mgroup=<N>}``.
+	``{mgroup=<N>}`` flag is a must.
 
 ``--_echo=<message>``
 	Print *<message>* to the standard error stream.  This is helpful to
@@ -404,6 +407,20 @@ representation. ``--list-regex-flags`` lists all the flags.
 
 ``fatal=<message>``
 	print the given *<message>* and exit
+
+FLAGS FOR ``--mline-regex-<LANG>`` OPTION
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``mgroup=<N>``
+
+	decide the location of the tag extracted with
+	``--mline-regex-<LANG>`` option.
+
+	*<N>* is the number of a capture group in the pattern, which is
+	used to record the line number location of the tag. ``mgroup=<N>``
+	flag is not an optional. You **must** add an ``mgroup=<N>`` flag,
+	even if the *<N>* is ``0`` (meaning the start position of the
+	whole regex pattern).
 
 EXAMPLES
 -------------

--- a/docs/optlib.rst
+++ b/docs/optlib.rst
@@ -917,7 +917,7 @@ Multiline pattern flags
 
 .. TODO: Q: isn't the above restriction really a bug? I think it is. I should fix it.
    Q to @masatake-san: Do you mean that {mgroup=0} can be omitted? -> #2918 is opened
-
+   A. as proposed in #3514, I made {mgroup=N} be a must flag.
 
 ``{_advanceTo=N[start|end]}``
 

--- a/main/debug.h
+++ b/main/debug.h
@@ -24,6 +24,15 @@
 *   Macros
 */
 
+#if defined _MSC_VER
+/* See https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros */
+# define ASSERT_FUNCTION __FUNCTION__
+#elif defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+# define ASSERT_FUNCTION __func__
+#else
+# define ASSERT_FUNCTION ((const char*)0)
+#endif
+
 #ifdef DEBUG
 # define debug(level)      ((ctags_debugLevel & (long)(level)) != 0)
 # define DebugStatement(x) x
@@ -33,11 +42,6 @@
 #  define AssertNotReached() do {} while(0)
 # else
    /* We expect cc supports c99 standard. */
-#  if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
-#   define ASSERT_FUNCTION __func__
-#  else
-#   define ASSERT_FUNCTION ((const char*)0)
-#  endif
 #  define Assert(c) ((c) ? ((void)0) : debugAssert(#c, __FILE__, __LINE__, ASSERT_FUNCTION))
 #  define AssertNotReached() Assert(!"The control reaches unexpected place")
 # endif

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -1926,7 +1926,6 @@ static bool matchMultilineRegexPattern (struct lregexControlBlock *lcb,
 {
 	const char *start;
 	const char *current;
-	off_t offset = 0;
 	regexPattern* patbuf = entry->pattern;
 	struct mGroupSpec *mgroup = &patbuf->mgroup;
 	struct guestSpec  *guest = &patbuf->guest;
@@ -1958,9 +1957,6 @@ static bool matchMultilineRegexPattern (struct lregexControlBlock *lcb,
 		if (hasMessage(patbuf))
 			printMessage(lcb->owner, patbuf, (current + pmatch[0].rm_so) - start, current, pmatch);
 
-		offset = (current + pmatch [mgroup->forLineNumberDetermination].rm_so)
-				 - start;
-
 		entry->statistics.match++;
 		scriptWindow window = {
 			.line = current,
@@ -1983,6 +1979,8 @@ static bool matchMultilineRegexPattern (struct lregexControlBlock *lcb,
 
 		if (patbuf->type == PTRN_TAG)
 		{
+			off_t offset = (current + pmatch [mgroup->forLineNumberDetermination].rm_so)
+				- start;
 			matchTagPattern (lcb, current, patbuf, pmatch, offset,
 							 (patbuf->optscript && hasNameSlot (patbuf))? &window: NULL);
 			result = true;
@@ -2757,9 +2755,6 @@ static struct regexTable * matchMultitableRegexTable (struct lregexControlBlock 
 		if (match == 0)
 		{
 			entry->statistics.match++;
-			off_t offset_for_tag = (current
-									+ pmatch [ptrn->mgroup.forLineNumberDetermination].rm_so)
-				- cstart;
 			scriptWindow window = {
 				.line = current,
 				.start = cstart,
@@ -2782,6 +2777,9 @@ static struct regexTable * matchMultitableRegexTable (struct lregexControlBlock 
 
 			if (ptrn->type == PTRN_TAG)
 			{
+				off_t offset_for_tag = (current
+										+ pmatch [ptrn->mgroup.forLineNumberDetermination].rm_so)
+					- cstart;
 				matchTagPattern (lcb, current, ptrn, pmatch, offset_for_tag,
 								 (ptrn->optscript && hasNameSlot (ptrn))? &window: NULL);
 

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -1979,6 +1979,7 @@ static bool matchMultilineRegexPattern (struct lregexControlBlock *lcb,
 
 		if (patbuf->type == PTRN_TAG)
 		{
+			Assert (mgroup->forLineNumberDetermination != NO_MULTILINE);
 			off_t offset = (current + pmatch [mgroup->forLineNumberDetermination].rm_so)
 				- start;
 			matchTagPattern (lcb, current, patbuf, pmatch, offset,
@@ -2777,6 +2778,7 @@ static struct regexTable * matchMultitableRegexTable (struct lregexControlBlock 
 
 			if (ptrn->type == PTRN_TAG)
 			{
+				Assert (ptrn->mgroup.forLineNumberDetermination != NO_MULTILINE);
 				off_t offset_for_tag = (current
 										+ pmatch [ptrn->mgroup.forLineNumberDetermination].rm_so)
 					- cstart;

--- a/man/ctags-optlib.7.rst.in
+++ b/man/ctags-optlib.7.rst.in
@@ -34,7 +34,7 @@ Following options are for defining (or customizing) a parser:
 * ``--map-<LANG>=[+|-]<extension>|<pattern>``
 * ``--kinddef-<LANG>=<letter>,<name>,<description>``
 * ``--regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/[<flags>]``
-* ``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/[<flags>]``
+* ``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/{mgroup=<N>}[<flags>]``
 
 Following options are for controlling loading parser definition:
 
@@ -117,7 +117,7 @@ Overview for defining a parser
 
    Use ``--regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/[<flags>]``
    option for a single-line regular expression. You can also use
-   ``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/[<flags>]``
+   ``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/{mgroup=<N>}[<flags>]``
    option for a multi-line regular expression.
 
    As *<kind-spec>*, you can use the one-letter flag defined with
@@ -271,11 +271,14 @@ OPTIONS
 ``--list-mline-regex-flags``
 	Lists the flags that can be used in ``--mline-regex-<LANG>`` option.
 
-``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/[<flags>]``
+``--mline-regex-<LANG>=/<line_pattern>/<name_pattern>/<kind-spec>/{mgroup=<N>}[<flags>]``
 	Define a multi-line regular expression.
 
 	This option is similar to ``--regex-<LANG>`` option except the pattern is
 	applied to the whole file’s contents, not line by line.
+
+	See "`FLAGS FOR ``--mline-regex-<LANG>`` OPTION`_" about ``{mgroup=<N>}``.
+	``{mgroup=<N>}`` flag is a must.
 
 ``--_echo=<message>``
 	Print *<message>* to the standard error stream.  This is helpful to
@@ -404,6 +407,20 @@ representation. ``--list-regex-flags`` lists all the flags.
 
 ``fatal=<message>``
 	print the given *<message>* and exit
+
+FLAGS FOR ``--mline-regex-<LANG>`` OPTION
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``mgroup=<N>``
+
+	decide the location of the tag extracted with
+	``--mline-regex-<LANG>`` option.
+
+	*<N>* is the number of a capture group in the pattern, which is
+	used to record the line number location of the tag. ``mgroup=<N>``
+	flag is not an optional. You **must** add an ``mgroup=<N>`` flag,
+	even if the *<N>* is ``0`` (meaning the start position of the
+	whole regex pattern).
 
 EXAMPLES
 -------------


### PR DESCRIPTION
Close #3513.
Close #2918.
    
Specifying mgroup is a must if --mline-regex-<LANG>= records a tag with \[0-9].

TODO:
- [x] update Q in docs/optlib.rst.
