### PR TITLE
utiltest: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ tags.test
 test.*.diff
 tg
 tinst-root
+utiltest
 win32/*.aps
 win32/*.opensdf
 win32/*.sdf


### PR DESCRIPTION
The `utiltest` was not listed in the .gitginore.
Please add it to .gitignore with this pull request.