### PR TITLE
PowerShell,refactor: don't use output parameter as input

### DIFF
--- a/parsers/powershell.c
+++ b/parsers/powershell.c
@@ -303,7 +303,7 @@ static int skipSingleComment (void)
 	return c;
 }
 
-static void readToken (tokenInfo *const token)
+static void readTokenFull (tokenInfo *const token, bool includingScope)
 {
 	int c;
 
@@ -408,8 +408,7 @@ getNextChar:
 				token->type = TOKEN_UNDEFINED;
 			else
 			{
-				if (token->keyword == KEYWORD_function ||
-						token->keyword == KEYWORD_filter)
+				if (includingScope)
 					parseScopeIdentifier (token->string, c);
 				else
 					parseIdentifier (token->string, c);
@@ -422,6 +421,11 @@ getNextChar:
 			}
 			break;
 	}
+}
+
+static void readToken (tokenInfo *const token)
+{
+	readTokenFull (token, false);
 }
 
 static void enterScope (tokenInfo *const parentToken,
@@ -470,7 +474,7 @@ static bool parseFunction (tokenInfo *const token, int kind)
 	tokenInfo *nameFree = NULL;
 	const char *access;
 
-	readToken (token);
+	readTokenFull (token, true);
 
 	if (token->type != TOKEN_IDENTIFIER)
 		return false;


### PR DESCRIPTION
The cross-parser convention of readTags() takes TOKEN as an output parameter. 433c933ad3aa77a35579fc73b361cd026b721baa violates the convention; readTags() refers to a field of TOKEN. This can be a cause of trouble.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>