### PR TITLE
build-sys: add clean-tlib and clean-gcov to the dependecy list of clean-local

### DIFF
--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -8,8 +8,7 @@ MAN_TEST_TMPDIR = ManTest
 check: tmain units tlib man-test check-genfile tutil
 
 # We may use CLEANFILES, DISTCLEANFILES, or etc.
-# clean-tlib and clean-gcov are not included
-clean-local: clean-units clean-tmain clean-man-test
+clean-local: clean-units clean-tmain clean-man-test clean-tlib clean-gcov
 
 CTAGS_TEST = ./ctags$(EXEEXT)
 READTAGS_TEST = ./readtags$(EXEEXT)


### PR DESCRIPTION
See https://github.com/universal-ctags/ctags/pull/3535#discussion_r1022831854.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>