### PR TITLE
Python: add more weak keywords

### DIFF
--- a/Units/parser-python.r/reserved-words.d/args.ctags
+++ b/Units/parser-python.r/reserved-words.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-Python=*

--- a/Units/parser-python.r/reserved-words.d/expected.tags
+++ b/Units/parser-python.r/reserved-words.d/expected.tags
@@ -1,0 +1,5 @@
+x	input.py	/^    x = 1$/;"	v
+x	input.py	/^    x = 2$/;"	v
+f	input.py	/^def f(text, pat):$/;"	f
+text	input.py	/^def f(text, pat):$/;"	z	function:f	file:
+pat	input.py	/^def f(text, pat):$/;"	z	function:f	file:

--- a/Units/parser-python.r/reserved-words.d/input.py
+++ b/Units/parser-python.r/reserved-words.d/input.py
@@ -1,0 +1,9 @@
+if True:
+    x = 1
+else:
+    x = 2
+
+def f(text, pat):
+    if "." in text:
+        return []
+    try: regexp = pat

--- a/Units/parser-python.r/variable-annotations.d/expected.tags
+++ b/Units/parser-python.r/variable-annotations.d/expected.tags
@@ -1,6 +1,7 @@
 primes	input.py	/^primes: List[int] = []$/;"	v	typeref:typename:List[int]
 some_list	input.py	/^some_list: List[int] = []  # variable with initial value$/;"	v	typeref:typename:List[int]
 sane_world	input.py	/^    sane_world = True$/;"	v
+sane_world	input.py	/^    sane_world = False$/;"	v
 t	input.py	/^t: Tuple[int, ...] = (1, 2, 3)$/;"	v	typeref:typename:Tuple[int, ...]
 header	input.py	/^header, kind, body = message$/;"	v
 kind	input.py	/^header, kind, body = message$/;"	v

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -44,6 +44,7 @@ enum {
 	KEYWORD_lambda,
 	KEYWORD_pass,
 	KEYWORD_return,
+	KEYWORD_REST
 };
 typedef int keywordId; /* to allow KEYWORD_NONE */
 
@@ -162,6 +163,22 @@ static const keywordTable PythonKeywordTable[] = {
 	{ "lambda",			KEYWORD_lambda			},
 	{ "pass",			KEYWORD_pass			},
 	{ "return",			KEYWORD_return			},
+};
+
+/* Taken from https://docs.python.org/3/reference/lexical_analysis.html#keywords */
+const static struct keywordGroup PythonRestKeywords = {
+	.value = KEYWORD_REST,
+	.addingUnlessExisting = true,
+	.keywords = {
+		"False",      "await",      "else",       "import",     "pass",
+		"None",       "break",      "except",     "in",         "raise",
+		"True",       "class",      "finally",    "is",         "return",
+		"and",        "continue",   "for",        "lambda",     "try",
+		"as",         "def",        "from",       "nonlocal",   "while",
+		"assert",     "del",        "global",     "not",        "with",
+		"async",      "elif",       "if",         "or",         "yield",
+		NULL
+	},
 };
 
 typedef enum eTokenType {
@@ -1718,6 +1735,7 @@ static void initialize (const langType language)
 	Lang_python = language;
 
 	TokenPool = objPoolNew (16, newPoolToken, deletePoolToken, clearPoolToken, NULL);
+	addKeywordGroup (&PythonRestKeywords, Lang_python);
 }
 
 static void finalize (langType language CTAGS_ATTR_UNUSED, bool initialized)


### PR DESCRIPTION
The parser extacted keywords like "else" and "try" as tags.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>