### PR TITLE
Cxx: fill  "nth:" field for  "member" and "enum" kind

### DIFF
--- a/Units/parser-cxx.r/field-nth.d/expected.tags
+++ b/Units/parser-cxx.r/field-nth.d/expected.tags
@@ -8,3 +8,11 @@ C	input.h	/^class C {};$/;"	c	template:<class T1,class T2,int I>
 T1	input.h	/^template<class T1, class T2, int I>$/;"	Z	class:C	typeref:meta:class	nth:0
 T2	input.h	/^template<class T1, class T2, int I>$/;"	Z	class:C	typeref:meta:class	nth:1
 I	input.h	/^template<class T1, class T2, int I>$/;"	Z	class:C	typeref:typename:int	nth:2
+D	input.h	/^class D {$/;"	c
+i	input.h	/^	int i, j;$/;"	m	class:D	typeref:typename:int	nth:0
+j	input.h	/^	int i, j;$/;"	m	class:D	typeref:typename:int	nth:1
+c	input.h	/^	char c;$/;"	m	class:D	typeref:typename:char	nth:2
+color	input.h	/^enum color {$/;"	g
+red	input.h	/^	red, green, blue,$/;"	e	enum:color	nth:0
+green	input.h	/^	red, green, blue,$/;"	e	enum:color	nth:1
+blue	input.h	/^	red, green, blue,$/;"	e	enum:color	nth:2

--- a/Units/parser-cxx.r/field-nth.d/input.h
+++ b/Units/parser-cxx.r/field-nth.d/input.h
@@ -3,3 +3,12 @@ inline void f(int x, int y) {}
 
 template<class T1, class T2, int I>
 class C {};
+
+class D {
+	int i, j;
+	char c;
+};
+
+enum color {
+	red, green, blue,
+};

--- a/main/entry.c
+++ b/main/entry.c
@@ -1338,6 +1338,43 @@ extern bool foreachEntriesInScope (int corkIndex,
 	return true;
 }
 
+struct countData {
+	bool onlyDefinitionTag;
+	unsigned int count;
+	entryForeachFunc func;
+	void *cbData;
+};
+
+static bool countEntryMaybe (int corkIndex, tagEntryInfo *entry, void *cbData)
+{
+	struct countData *data = cbData;
+	if (data->onlyDefinitionTag
+		&& !isRoleAssigned (entry, ROLE_DEFINITION_INDEX))
+		return true;
+
+	if (data->func == NULL
+		|| data->func (corkIndex, entry, data->cbData))
+		data->count++;
+	return true;
+}
+
+unsigned int countEntriesInScope (int corkIndex, bool onlyDefinitionTag,
+								  entryForeachFunc func, void *cbData)
+{
+	struct countData data = {
+		.onlyDefinitionTag = onlyDefinitionTag,
+		.count = 0,
+		.func = func,
+		.cbData = cbData,
+	};
+
+	foreachEntriesInScope (corkIndex, NULL,
+						   &countEntryMaybe,
+						   &data);
+
+	return data.count;
+}
+
 struct anyEntryInScopeData {
 	int index;
 	bool onlyDefinitionTag;

--- a/main/entry.h
+++ b/main/entry.h
@@ -192,6 +192,9 @@ bool          foreachEntriesInScope (int corkIndex,
 									 entryForeachFunc func,
 									 void *data);
 
+unsigned int countEntriesInScope    (int corkIndex, bool onlyDefinitionTag,
+									 entryForeachFunc func, void *data);
+
 /* Return the cork index for NAME in the scope specified with CORKINDEX.
  * Even if more than one entries for NAME are in the scope, this function
  * just returns one of them. Returning CORK_NIL means there is no entry

--- a/main/entry.h
+++ b/main/entry.h
@@ -81,7 +81,9 @@ struct sTagEntryInfo {
 		int         scopeIndex;   /* cork queue entry for upper scope tag.
 					     This field is meaningful if the value
 					     is not CORK_NIL, scopeKindIndex is KIND_GHOST_INDEX,
-					     and scopeName is NULL. */
+					     and scopeName is NULL.
+					     CXX parser violates this rule; see the comment inside
+					     cxxTagBegin(). */
 
 		const char* signature;
 

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -880,6 +880,7 @@ bool cxxParserParseEnum(void)
 			pszProperties = cxxTagSetProperties(CXXTagPropertyScopedEnum);
 
 		iCorkQueueIndex = cxxTagCommit(&iCorkQueueIndexFQ);
+		cxxTagUseTokenAsPartOfDefTag(iCorkQueueIndex, pEnumName);
 
 		if (pszProperties)
 			vStringDelete (pszProperties);
@@ -1352,6 +1353,7 @@ static bool cxxParserParseClassStructOrUnionInternal(
 		tag->isFileScope = !isInputHeaderFile();
 
 		iCorkQueueIndex = cxxTagCommit(&iCorkQueueIndexFQ);
+		cxxTagUseTokenAsPartOfDefTag(iCorkQueueIndex, pClassName);
 
 	}
 

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -304,6 +304,7 @@ int cxxParserMaybeParseKnRStyleFunctionDefinition(void)
 			tag->extensionFields.signature = vStringValue(pszSignature);
 
 		iCorkQueueIndex = cxxTagCommit(&iCorkQueueIndexFQ);
+		cxxTagUseTokenAsPartOfDefTag(iCorkQueueIndex, pIdentifier);
 
 		if(pszSignature)
 			vStringDelete(pszSignature);
@@ -1757,6 +1758,7 @@ int cxxParserEmitFunctionTags(
 		}
 
 		int iCorkQueueIndex = cxxTagCommit(piCorkQueueIndexFQ);
+		cxxTagUseTokenAsPartOfDefTag(iCorkQueueIndex, pIdentifier);
 
 		if(piCorkQueueIndex)
 			*piCorkQueueIndex = iCorkQueueIndex;

--- a/parsers/cxx/cxx_parser_function.c
+++ b/parsers/cxx/cxx_parser_function.c
@@ -1925,7 +1925,6 @@ void cxxParserEmitFunctionParameterTags(CXXTypedVariableSet * pInfo)
 		} else {
 			pTypeName = NULL;
 		}
-		tag->extensionFields.nth = i;
 
 		tag->isFileScope = true;
 

--- a/parsers/cxx/cxx_parser_lambda.c
+++ b/parsers/cxx/cxx_parser_lambda.c
@@ -268,6 +268,7 @@ bool cxxParserHandleLambda(CXXToken * pParenthesis)
 			tag->extensionFields.signature = vStringValue(pszSignature);
 
 		iCorkQueueIndex = cxxTagCommit(&iCorkQueueIndexFQ);
+		cxxTagUseTokenAsPartOfDefTag(iCorkQueueIndex, pIdentifier);
 
 		if(pTypeName)
 			cxxTokenDestroy(pTypeName);

--- a/parsers/cxx/cxx_parser_template.c
+++ b/parsers/cxx/cxx_parser_template.c
@@ -823,8 +823,6 @@ void cxxParserEmitTemplateParameterTags(void)
 		if(!tag)
 			continue;
 
-		tag->extensionFields.nth = (short)i;
-
 		CXXToken * pTypeToken = cxxTagCheckAndSetTypeField(
 				g_cxx.oTemplateParameters.aTypeStarts[i],
 				g_cxx.oTemplateParameters.aTypeEnds[i]

--- a/parsers/cxx/cxx_parser_typedef.c
+++ b/parsers/cxx/cxx_parser_typedef.c
@@ -442,7 +442,8 @@ skip_to_comma_or_end:
 			if(bGotTemplate)
 				cxxTagHandleTemplateFields();
 
-			cxxTagCommit(NULL);
+			int iCorkQueueIndex = cxxTagCommit(NULL);
+			cxxTagUseTokenAsPartOfDefTag(iCorkQueueIndex, t);
 
 			if (
 					bGotTemplate &&

--- a/parsers/cxx/cxx_parser_variable.c
+++ b/parsers/cxx/cxx_parser_variable.c
@@ -767,6 +767,7 @@ got_identifier:
 				cxxTagHandleTemplateFields();
 
 			iCorkIndex = cxxTagCommit(&iCorkIndexFQ);
+			cxxTagUseTokenAsPartOfDefTag(iCorkIndexFQ, pIdentifier);
 
 			if(pTypeToken)
 				cxxTokenDestroy(pTypeToken);

--- a/parsers/cxx/cxx_scope.c
+++ b/parsers/cxx/cxx_scope.c
@@ -135,6 +135,13 @@ const char * cxxScopeGetName(void)
 	return vStringValue(g_pScope->pTail->pszWord);
 }
 
+int cxxScopeGetDefTag(void)
+{
+	if(g_pScope->iCount < 1)
+		return CORK_NIL;
+	return g_pScope->pTail->iCorkIndex;
+}
+
 int cxxScopeGetSize(void)
 {
 	return g_pScope->iCount;

--- a/parsers/cxx/cxx_scope.c
+++ b/parsers/cxx/cxx_scope.c
@@ -151,10 +151,7 @@ const char * cxxScopeGetFullName(void)
 		return NULL;
 	}
 
-	if(g_szScopeName)
-		vStringClear(g_szScopeName);
-	else
-		g_szScopeName = vStringNew();
+	g_szScopeName = vStringNewOrClear(g_szScopeName);
 
 	cxxTokenChainJoinInString(
 			g_pScope,
@@ -182,10 +179,7 @@ vString * cxxScopeGetFullNameAsString(void)
 	if(g_pScope->iCount < 1)
 		return NULL;
 
-	if(g_szScopeName)
-		vStringClear(g_szScopeName);
-	else
-		g_szScopeName = vStringNew();
+	g_szScopeName = vStringNewOrClear(g_szScopeName);
 
 	cxxTokenChainJoinInString(
 			g_pScope,

--- a/parsers/cxx/cxx_scope.c
+++ b/parsers/cxx/cxx_scope.c
@@ -143,7 +143,7 @@ int cxxScopeGetSize(void)
 const char * cxxScopeGetFullName(void)
 {
 	if(!g_bScopeNameDirty)
-		return g_szScopeName ? g_szScopeName->buffer : NULL;
+		return g_szScopeName ? vStringValue(g_szScopeName): NULL;
 
 	if(g_pScope->iCount < 1)
 	{
@@ -161,7 +161,7 @@ const char * cxxScopeGetFullName(void)
 		);
 
 	g_bScopeNameDirty = false;
-	return g_szScopeName->buffer;
+	return vStringValue(g_szScopeName);
 }
 
 vString * cxxScopeGetFullNameAsString(void)

--- a/parsers/cxx/cxx_scope.h
+++ b/parsers/cxx/cxx_scope.h
@@ -48,6 +48,10 @@ const char * cxxScopeGetFullName(void);
 // it is always a single identifier.
 const char * cxxScopeGetName(void);
 
+// Return the corkIndex of the token representing currently scope.
+// This can be CORK_NIL.
+int cxxScopeGetDefTag(void);
+
 // Return the number of components of the scope name.
 int cxxScopeGetSize(void);
 

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -298,7 +298,8 @@ tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken)
 		g_oCXXTag.extensionFields.scopeIndex = cxxScopeGetDefTag();
 		if (g_oCXXTag.extensionFields.scopeIndex != CORK_NIL)
 		{
-			if (uKind == CXXTagKindMEMBER || uKind == CXXTagKindENUMERATOR)
+			if (uKind == CXXTagKindMEMBER || uKind == CXXTagKindENUMERATOR
+				|| uKind == CXXTagKindPARAMETER || CXXTagCPPKindTEMPLATEPARAM)
 				g_oCXXTag.extensionFields.nth =
 					(short) countEntriesInScope(g_oCXXTag.extensionFields.scopeIndex,
 												true,

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -282,8 +282,12 @@ tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken)
 
 	if(!cxxScopeIsGlobal())
 	{
+		// scopeKindIndex and scopeName are used for printing the scope field
+		// in a tags file.
 		g_oCXXTag.extensionFields.scopeKindIndex = cxxScopeGetKind();
 		g_oCXXTag.extensionFields.scopeName = cxxScopeGetFullName();
+		// scopeIndex is used in the parser internally.
+		g_oCXXTag.extensionFields.scopeIndex = cxxScopeGetDefTag();
 	}
 
 	// FIXME: meaning of "is file scope" is quite debatable...

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -244,6 +244,21 @@ bool cxxTagFieldEnabled(unsigned int uField)
 
 static tagEntryInfo g_oCXXTag;
 
+void cxxTagUseTokenAsPartOfDefTag(int iCorkIndex, CXXToken * pToken)
+{
+	Assert (pToken->iCorkIndex == CORK_NIL);
+	pToken->iCorkIndex = iCorkIndex;
+}
+
+void cxxTagUseTokensInRangeAsPartOfDefTags(int iCorkIndex, CXXToken * pFrom, CXXToken * pTo)
+{
+	cxxTagUseTokenAsPartOfDefTag(iCorkIndex, pFrom);
+	while (pFrom != pTo)
+	{
+		pFrom = pFrom->pNext;
+		cxxTagUseTokenAsPartOfDefTag(iCorkIndex, pFrom);
+	}
+}
 
 tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken)
 {

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -202,4 +202,7 @@ typedef enum {
 // Must be called before attempting to access the kind options.
 void cxxTagInitForLanguage(langType eLangType);
 
+// Functions for filling iCorkIndex field of tokens.
+void cxxTagUseTokensInRangeAsPartOfDefTags(int iCorkIndex, CXXToken * pFrom, CXXToken * pTo);
+void cxxTagUseTokenAsPartOfDefTag(int iCorkIndex, CXXToken * pToken);
 #endif //!_cxxTag_h_

--- a/parsers/cxx/cxx_token.c
+++ b/parsers/cxx/cxx_token.c
@@ -31,6 +31,7 @@ static CXXToken *createToken(void *createArg CTAGS_ATTR_UNUSED)
 	// we almost always want a string, and since this token
 	// is being reused..well.. we always want it
 	t->pszWord = vStringNew();
+	t->iCorkIndex = CORK_NIL;
 	return t;
 }
 
@@ -53,6 +54,8 @@ static void clearToken(CXXToken *t)
 	t->pChain = NULL;
 	t->pNext = NULL;
 	t->pPrev = NULL;
+
+	t->iCorkIndex = CORK_NIL;
 }
 
 void cxxTokenAPIInit(void)
@@ -119,6 +122,7 @@ CXXToken * cxxTokenCopy(CXXToken * pToken)
 	pRetToken->eKeyword = pToken->eKeyword;
 	pRetToken->bFollowedBySpace = pToken->bFollowedBySpace;
 	vStringCat(pRetToken->pszWord,pToken->pszWord);
+	pRetToken->iCorkIndex = pToken->iCorkIndex;
 
 	return pRetToken;
 }

--- a/parsers/cxx/cxx_token.h
+++ b/parsers/cxx/cxx_token.h
@@ -87,6 +87,8 @@ typedef struct _CXXToken
 	// uninitialized and must be treated as undefined.
 	unsigned char uInternalScopeType;
 	unsigned char uInternalScopeAccess;
+
+	int iCorkIndex;
 } CXXToken;
 
 CXXToken * cxxTokenCreate(void);


### PR DESCRIPTION
nth: field of member kinds in C language is useful to find super-classes.

The following command line is for reporting sub-classes of GtkWidget.

```
   $ ./ctags --fields=+'{nth}{scope}' -o - /usr/include/gtk-3.0/gtk/*.h  \
     | ./readtags -t - \
	    -Q '(and (eq? $nth 0) (eq? $typeref-name "GtkWidget"))' \
		-F '(list $scope-name " is a subclass of " $typeref-name #t)' \
		-l
   _GtkLevelBar is a subclass of GtkWidget
   _GtkProgressBar is a subclass of GtkWidget
   _GtkSpinner is a subclass of GtkWidget
   _GtkCellView is a subclass of GtkWidget
   _GtkEntry is a subclass of GtkWidget
   ...
```

TODO: write the above technique in readtags(1).
