### PR TITLE
[SELF-INCOMPATIBLE] EmacsLisp,Go,Julia,Lisp,Lua,Python: change the kind letter for "unknown" to 'Y'

### DIFF
--- a/Tmain/json-output-format.d/stdout-expected.txt
+++ b/Tmain/json-output-format.d/stdout-expected.txt
@@ -60,6 +60,7 @@
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "C", "path": "v,variable", "pattern": "variable definitions"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Go", "path": "M,anonMember", "pattern": "struct anonymous members"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Go", "path": "P,packageName", "pattern": "name for specifying imported package"}
+{"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Go", "path": "Y,unknown", "pattern": "unknown"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Go", "path": "a,talias", "pattern": "type aliases"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Go", "path": "c,const", "pattern": "constants"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Go", "path": "f,func", "pattern": "functions"}
@@ -69,18 +70,17 @@
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Go", "path": "p,package", "pattern": "packages"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Go", "path": "s,struct", "pattern": "structs"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Go", "path": "t,type", "pattern": "types"}
-{"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Go", "path": "u,unknown", "pattern": "unknown"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Go", "path": "v,var", "pattern": "variables"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Man", "path": "S,subsection", "pattern": "sub sections"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Man", "path": "s,section", "pattern": "sections"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Man", "path": "t,title", "pattern": "titles"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Python", "path": "I,namespace", "pattern": "name referring a module defined in other file"}
+{"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Python", "path": "Y,unknown", "pattern": "name referring a class\\/variable\\/function\\/module defined in other module"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Python", "path": "c,class", "pattern": "classes"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Python", "path": "f,function", "pattern": "functions"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Python", "path": "i,module", "pattern": "modules"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Python", "path": "m,member", "pattern": "class members"}
 {"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Python", "path": "v,variable", "pattern": "variables"}
-{"_type": "ptag", "name": "TAG_KIND_DESCRIPTION", "parserName": "Python", "path": "x,unknown", "pattern": "name referring a class\\/variable\\/function\\/module defined in other module"}
 {"_type": "ptag", "name": "TAG_OUTPUT_EXCMD", "path": "mixed", "pattern": "number, pattern, mixed, or combineV2"}
 {"_type": "ptag", "name": "TAG_PATTERN_LENGTH_LIMIT", "path": "96", "pattern": "0 for no limit"}
 {"_type": "ptag", "name": "TAG_PROGRAM_AUTHOR", "path": "Universal Ctags Team", "pattern": ""}

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -49,24 +49,24 @@ Flex           I/import          import             on      imports
 GDScript       c/class           extended           on      used as a base class for extending
 GemSpec        g/gem             develDep           on      specifying development dependency
 GemSpec        g/gem             runtimeDep         on      specifying runtime dependency
+Go             Y/unknown         receiverType       on      receiver type
 Go             p/package         imported           on      imported package
-Go             u/unknown         receiverType       on      receiver type
 HTML           C/stylesheet      extFile            on      referenced as external files
 HTML           J/script          extFile            on      referenced as external files
 HTML           c/class           attribute          on      assigned as attributes
 Java           p/package         imported           on      imported package
 JavaScript     c/class           chainElt           off     (EXPERIMENTAL)used as an element in a name chain like a.b.c
 JavaScript     v/variable        chainElt           off     (EXPERIMENTAL)used as an element in a name chain like a.b.c
+Julia          Y/unknown         imported           on      loaded by "import"
+Julia          Y/unknown         used               on      loaded by "using"
 Julia          n/module          imported           on      loaded by "import"
 Julia          n/module          namespace          on      only some symbols in it are imported
 Julia          n/module          used               on      loaded by "using"
-Julia          x/unknown         imported           on      loaded by "import"
-Julia          x/unknown         used               on      loaded by "using"
 Kconfig        k/kconfig         source             on      kconfig file loaded with source directive
 LdScript       i/inputSection    discarded          on      discarded when linking
 LdScript       i/inputSection    mapped             on      mapped to output section
 LdScript       s/symbol          entrypoint         on      entry points
-Lua            X/unknown         referenced         off     referenced somehow
+Lua            Y/unknown         referenced         off     referenced somehow
 M4             I/macrofile       included           on      included macro
 M4             I/macrofile       sincluded          on      silently included macro
 M4             d/macro           undef              on      undefined
@@ -79,11 +79,11 @@ Perl           M/module          used               on      specified in `use' b
 Perl           h/heredoc         endmarker          on      end marker
 Protobuf       D/protodef        imported           on      imported
 Protobuf       m/message         extension          on      extending the message
+Python         Y/unknown         imported           on      imported from the other module
+Python         Y/unknown         indirectlyImported on      classes/variables/functions/modules imported in alternative name
 Python         i/module          imported           on      imported modules
 Python         i/module          indirectlyImported on      module imported in alternative name
 Python         i/module          namespace          on      namespace from where classes/variables/functions are imported
-Python         x/unknown         imported           on      imported from the other module
-Python         x/unknown         indirectlyImported on      classes/variables/functions/modules imported in alternative name
 R              l/library         library            on      library attached by library function
 R              l/library         require            on      library attached by require function
 R              s/source          source             on      source loaded by source fucntion
@@ -167,24 +167,24 @@ Flex           I/import          import             on      imports
 GDScript       c/class           extended           on      used as a base class for extending
 GemSpec        g/gem             develDep           on      specifying development dependency
 GemSpec        g/gem             runtimeDep         on      specifying runtime dependency
+Go             Y/unknown         receiverType       on      receiver type
 Go             p/package         imported           on      imported package
-Go             u/unknown         receiverType       on      receiver type
 HTML           C/stylesheet      extFile            on      referenced as external files
 HTML           J/script          extFile            on      referenced as external files
 HTML           c/class           attribute          on      assigned as attributes
 Java           p/package         imported           on      imported package
 JavaScript     c/class           chainElt           off     (EXPERIMENTAL)used as an element in a name chain like a.b.c
 JavaScript     v/variable        chainElt           off     (EXPERIMENTAL)used as an element in a name chain like a.b.c
+Julia          Y/unknown         imported           on      loaded by "import"
+Julia          Y/unknown         used               on      loaded by "using"
 Julia          n/module          imported           on      loaded by "import"
 Julia          n/module          namespace          on      only some symbols in it are imported
 Julia          n/module          used               on      loaded by "using"
-Julia          x/unknown         imported           on      loaded by "import"
-Julia          x/unknown         used               on      loaded by "using"
 Kconfig        k/kconfig         source             on      kconfig file loaded with source directive
 LdScript       i/inputSection    discarded          on      discarded when linking
 LdScript       i/inputSection    mapped             on      mapped to output section
 LdScript       s/symbol          entrypoint         on      entry points
-Lua            X/unknown         referenced         off     referenced somehow
+Lua            Y/unknown         referenced         off     referenced somehow
 M4             I/macrofile       included           on      included macro
 M4             I/macrofile       sincluded          on      silently included macro
 M4             d/macro           undef              on      undefined
@@ -197,11 +197,11 @@ Perl           M/module          used               on      specified in `use' b
 Perl           h/heredoc         endmarker          on      end marker
 Protobuf       D/protodef        imported           on      imported
 Protobuf       m/message         extension          on      extending the message
+Python         Y/unknown         imported           on      imported from the other module
+Python         Y/unknown         indirectlyImported on      classes/variables/functions/modules imported in alternative name
 Python         i/module          imported           on      imported modules
 Python         i/module          indirectlyImported on      module imported in alternative name
 Python         i/module          namespace          on      namespace from where classes/variables/functions are imported
-Python         x/unknown         imported           on      imported from the other module
-Python         x/unknown         indirectlyImported on      classes/variables/functions/modules imported in alternative name
 R              l/library         library            on      library attached by library function
 R              l/library         require            on      library attached by require function
 R              s/source          source             on      source loaded by source fucntion

--- a/Tmain/pretend-option.d/stdout-expected.txt
+++ b/Tmain/pretend-option.d/stdout-expected.txt
@@ -1,4 +1,4 @@
-u  unknown type of definitions
+Y  unknown type of definitions
 f  functions
 v  variables
 m  macros

--- a/Units/parser-iPythonCell.r/default-formats.d/expected.tags
+++ b/Units/parser-iPythonCell.r/default-formats.d/expected.tags
@@ -1,5 +1,5 @@
 np	input.py	/^import numpy as np$/;"	I	language:Python	nameref:module:numpy
-plt	input.py	/^from matplotlib import pyplot as plt$/;"	x	language:Python	nameref:unknown:pyplot
+plt	input.py	/^from matplotlib import pyplot as plt$/;"	Y	language:Python	nameref:unknown:pyplot
 generate sound	input.py	/^# %% generate sound$/;"	c	language:IPythonCell
 f	input.py	/^f = 12000$/;"	v	language:Python
 fs	input.py	/^fs = 44100$/;"	v	language:Python

--- a/Units/parser-iPythonCell.r/double-sharps.d/expected.tags
+++ b/Units/parser-iPythonCell.r/double-sharps.d/expected.tags
@@ -1,5 +1,5 @@
 np	input.py	/^import numpy as np$/;"	I	language:Python	nameref:module:numpy
-plt	input.py	/^from matplotlib import pyplot as plt$/;"	x	language:Python	nameref:unknown:pyplot
+plt	input.py	/^from matplotlib import pyplot as plt$/;"	Y	language:Python	nameref:unknown:pyplot
 generate sound	input.py	/^## generate sound$/;"	c	language:IPythonCell	extras:subparser,doubleSharps
 f	input.py	/^f = 12000$/;"	v	language:Python
 fs	input.py	/^fs = 44100$/;"	v	language:Python

--- a/Units/parser-lisp.r/simple-lisp.d/expected.tags
+++ b/Units/parser-lisp.r/simple-lisp.d/expected.tags
@@ -6,4 +6,4 @@ c0	input.l	/^(defconstant c0 5)$/;"	c
 C1	input.l	/^(DEFCONSTANT C1 6)$/;"	c
 defunknown0	input.l	/^(defmacro defunknown0 (s)$/;"	m
 DEFUNKNOWN1	input.l	/^(DEFMACRO DEFUNKNOWN1 (s)$/;"	m
-unknown	input.l	/^(defunknown1 unknown)$/;"	u
+unknown	input.l	/^(defunknown1 unknown)$/;"	Y

--- a/Units/parser-python.r/python-dot-in-import.d/expected.tags
+++ b/Units/parser-python.r/python-dot-in-import.d/expected.tags
@@ -1,12 +1,12 @@
 A.B	input.py	/^from A.B import C as D$/;"	i	roles:namespace
-C	input.py	/^from A.B import C as D$/;"	x	module:A.B	roles:indirectlyImported
-D	input.py	/^from A.B import C as D$/;"	x	roles:def	nameref:unknown:C
+C	input.py	/^from A.B import C as D$/;"	Y	module:A.B	roles:indirectlyImported
+D	input.py	/^from A.B import C as D$/;"	Y	roles:def	nameref:unknown:C
 .	input.py	/^from . import E$/;"	i	roles:namespace
-E	input.py	/^from . import E$/;"	x	module:.	roles:imported
+E	input.py	/^from . import E$/;"	Y	module:.	roles:imported
 .F	input.py	/^from .F import G$/;"	i	roles:namespace
-G	input.py	/^from .F import G$/;"	x	module:.F	roles:imported
+G	input.py	/^from .F import G$/;"	Y	module:.F	roles:imported
 H.I	input.py	/^import H.I$/;"	i	roles:imported
 .J.K	input.py	/^from .J.K import L$/;"	i	roles:namespace
-L	input.py	/^from .J.K import L$/;"	x	module:.J.K	roles:imported
+L	input.py	/^from .J.K import L$/;"	Y	module:.J.K	roles:imported
 ..M.N	input.py	/^from ..M.N import O$/;"	i	roles:namespace
-O	input.py	/^from ..M.N import O$/;"	x	module:..M.N	roles:imported
+O	input.py	/^from ..M.N import O$/;"	Y	module:..M.N	roles:imported

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -2092,6 +2092,19 @@ identical.
 
 This can be avoided by use of the ``--excmd=n`` option.
 
+INCOMPATIBLE CHANGES
+--------------------
+See :ref:`ctags-incompatibilities(7) <ctags-incompatibilities(7)>` about incompatibilities between Universal
+Ctags and Exuberant Ctags.
+
+This section describes major incompatibilities within versions of Universal
+Ctags.
+
+Unifying the kind Letter for ``unknown`` kinds
+	Some parsers used different kind letters for ``unknown`` kinds.
+	EmacsLisp used ``u``. Go used ``u``. Julian used ``x``. Lisp used ``u``.
+	Lua used ``X``. and Python used ``x``. They were unified to ``Y`` in
+	the during development of version 5.9.x.
 
 BUGS
 ----

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -2092,6 +2092,19 @@ identical.
 
 This can be avoided by use of the ``--excmd=n`` option.
 
+INCOMPATIBLE CHANGES
+--------------------
+See ctags-incompatibilities(7) about incompatibilities between Universal
+Ctags and Exuberant Ctags.
+
+This section describes major incompatibilities within versions of Universal
+Ctags.
+
+Unifying the kind Letter for ``unknown`` kinds
+	Some parsers used different kind letters for ``unknown`` kinds.
+	EmacsLisp used ``u``. Go used ``u``. Julian used ``x``. Lisp used ``u``.
+	Lua used ``X``. and Python used ``x``. They were unified to ``Y`` in
+	the during development of version 5.9.x.
 
 BUGS
 ----

--- a/parsers/go.c
+++ b/parsers/go.c
@@ -146,7 +146,7 @@ static kindDefinition GoKinds[] = {
 	{true, 'm', "member", "struct members"},
 	{true, 'M', "anonMember", "struct anonymous members"},
 	{true, 'n', "methodSpec", "interface method specification"},
-	{true, 'u', "unknown", "unknown",
+	{true, 'Y', "unknown", "unknown",
 	 .referenceOnly = true, ATTACH_ROLES (GoUnknownRoles)},
 	{true, 'P', "packageName", "name for specifying imported package"},
 	{true, 'a', "talias", "type aliases"},

--- a/parsers/julia.c
+++ b/parsers/julia.c
@@ -92,7 +92,7 @@ static kindDefinition JuliaKinds [] = {
       ATTACH_ROLES(JuliaModuleRoles) },
     { true, 's', "struct",   "Structures"   },
     { true, 't', "type",     "Types"        },
-    { true, 'x', "unknown", "name defined in other modules",
+    { true, 'Y', "unknown", "name defined in other modules",
       .referenceOnly = true, ATTACH_ROLES(JuliaUnknownRoles) },
 };
 

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -32,7 +32,7 @@ typedef enum {
 } lispKind;
 
 static kindDefinition LispKinds [] = {
-	{ true, 'u', "unknown", "unknown type of definitions" },
+	{ true, 'Y', "unknown", "unknown type of definitions" },
 	{ true, 'f', "function", "functions" },
 	{ true, 'v', "variable", "variables" },
 	{ true, 'm', "macro", "macros" },
@@ -67,7 +67,7 @@ typedef enum {
  * defvar-mode-local   (=> cadr)
  */
 static kindDefinition EmacsLispKinds [] = {
-	{ true, 'u', "unknown", "unknown type of definitions" },
+	{ true, 'Y', "unknown", "unknown type of definitions" },
 	{ true, 'f', "function", "functions" },
 	{ true, 'v', "variable", "variables" },
 	{ true, 'c', "const", "constants" },

--- a/parsers/lua.c
+++ b/parsers/lua.c
@@ -41,7 +41,7 @@ static kindDefinition LuaKinds [] = {
 	{ true, 'f', "function", "functions" },
 
 	/* `unknown' is a kind just for making FQ tag for functions. */
-	{ false, 'X', "unknown",  "unknown language object",
+	{ false, 'Y', "unknown",  "unknown language object",
 	  .referenceOnly = true, ATTACH_ROLES(LuaUnknownRoles) },
 };
 

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -141,7 +141,7 @@ static kindDefinition PythonKinds[COUNT_KIND] = {
 	{true, 'I', "namespace", "name referring a module defined in other file"},
 	{true, 'i', "module",    "modules",
 	 .referenceOnly = true,  ATTACH_ROLES(PythonModuleRoles)},
-	{true, 'x', "unknown",   "name referring a class/variable/function/module defined in other module",
+	{true, 'Y', "unknown",   "name referring a class/variable/function/module defined in other module",
 	 .referenceOnly = false, ATTACH_ROLES(PythonUnknownRoles)},
 	{false, 'z', "parameter", "function parameters" },
 	{false, 'l', "local",    "local variables" },


### PR DESCRIPTION
Close #3550.

We are thinking about introducing generic reference tags in multiple languages seriously.
For the generic reference tags, "unknown" kind may use.

Making the "unknown" kind consistent will help users.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>