### PR TITLE
main: make ~/.ctags.d as the default element for the optlib path list

### DIFF
--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -2153,11 +2153,17 @@ ENVIRONMENT VARIABLES
 FILES
 -----
 
+Output files
+~~~~~~~~~~~~
+
 ``tags``
 	The default tag file created by ctags.
 
 ``TAGS``
 	The default tag file created by etags.
+
+Preloading option files
+~~~~~~~~~~~~~~~~~~~~~~~
 
 ``$XDG_CONFIG_HOME/ctags/*.ctags``, or ``$HOME/.config/ctags/*.ctags`` if
 ``$XDG_CONFIG_HOME`` is not defined

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -830,7 +830,7 @@ Option File Options
 
 ``--optlib-dir=[+]<directory>``
 	Add an optlib *<directory>* to or reset the optlib path list.
-	By default, the optlib path list is empty.
+	See "`Default optlib path list`_" about the default elements for optlib path list.
 
 optlib Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2203,6 +2203,19 @@ Preloading option files
 
 	``*.ctags`` files in a directory are loaded in alphabetical order.
 
+Default optlib path list
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``$XDG_CONFIG_HOME/ctags``, or ``$HOME/.config/ctags`` if
+``$XDG_CONFIG_HOME`` is not defined
+(on other than MS Windows)
+
+``$HOME/.ctags.d``
+
+``$HOMEDRIVE$HOMEPATH/ctags.d`` (on MS Windows only)
+
+	These directories are parts of the optlib path list by default.
+	See "`Option File Options`_" about the optlib path list.
 
 SEE ALSO
 --------

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -2217,6 +2217,22 @@ Default optlib path list
 	These directories are parts of the optlib path list by default.
 	See "`Option File Options`_" about the optlib path list.
 
+	If you have a set of options that you want to enable
+	conditionally, make a directory in the path in the optlib path
+	list, and put the options to the files having .ctags as extensions
+	under the directory. ``--options=<the-directory-name>`` is for
+	enabling the options.
+
+	For example, consider you have some options you want to enable
+	only when tagging the Linux kernel source tree.  In that case,
+	make ``$HOME/.ctags.d/linux`` directory, put the options to
+	``$HOME/.ctags.d/linux/my.ctags``. If you have many options, you
+	can split them into multiple files like
+	``$HOME/.ctags.d/linux/device-driver.ctags`` and
+	``$HOME/.ctags.d/linux/network-stack.ctags``. Either way, you can
+	enable the options in the .ctags file(s) under the directory by
+	adding ``--options=linux`` to your ctags command line.
+
 SEE ALSO
 --------
 

--- a/main/options.c
+++ b/main/options.c
@@ -194,8 +194,8 @@ typedef enum eOptionLoadingStage {
 	OptionLoadingStageNone,
 	OptionLoadingStageCustom,
 	OptionLoadingStageXdg,
-	OptionLoadingStageHomeRecursive,
-	OptionLoadingStageCurrentRecursive,
+	OptionLoadingStageHomeDir,
+	OptionLoadingStageCurrentDir,
 	OptionLoadingStageEnvVar,
 	OptionLoadingStageCmdline,
 } OptionLoadingStage;
@@ -613,8 +613,8 @@ static const char *const StageDescription [] = {
 	[OptionLoadingStageNone]   = "not initialized",
 	[OptionLoadingStageCustom] = "custom file",
 	[OptionLoadingStageXdg] = "file(s) under $XDG_CONFIG_HOME and $HOME/.config",
-	[OptionLoadingStageHomeRecursive] = "file(s) under $HOME",
-	[OptionLoadingStageCurrentRecursive] = "file(s) under the current directory",
+	[OptionLoadingStageHomeDir] = "file(s) under $HOME",
+	[OptionLoadingStageCurrentDir] = "file(s) under the current directory",
 	[OptionLoadingStageCmdline] = "command line",
 };
 
@@ -3768,7 +3768,7 @@ static struct preloadPathElt preload_path_list [] = {
 		.isDirectory = true,
 		.makePath = prependEnvvar,
 		.extra = "HOME",
-		.stage = OptionLoadingStageHomeRecursive,
+		.stage = OptionLoadingStageHomeDir,
 	},
 #ifdef WIN32
 	{
@@ -3776,20 +3776,20 @@ static struct preloadPathElt preload_path_list [] = {
 		.isDirectory = true,
 		.makePath = getConfigAtHomeOnWindows,
 		.extra = NULL,
-		.stage = OptionLoadingStageHomeRecursive,
+		.stage = OptionLoadingStageHomeDir,
 	},
 #endif
 	{
 		.path = ".ctags.d",
 		.isDirectory = true,
 		.makePath = NULL,
-		.stage = OptionLoadingStageCurrentRecursive,
+		.stage = OptionLoadingStageCurrentDir,
 	},
 	{
 		.path = "ctags.d",
 		.isDirectory = true,
 		.makePath = NULL,
-		.stage = OptionLoadingStageCurrentRecursive,
+		.stage = OptionLoadingStageCurrentDir,
 	},
 	{
 		.path = NULL,

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -2153,11 +2153,17 @@ ENVIRONMENT VARIABLES
 FILES
 -----
 
+Output files
+~~~~~~~~~~~~
+
 ``tags``
 	The default tag file created by @CTAGS_NAME_EXECUTABLE@.
 
 ``TAGS``
 	The default tag file created by @ETAGS_NAME_EXECUTABLE@.
+
+Preloading option files
+~~~~~~~~~~~~~~~~~~~~~~~
 
 ``$XDG_CONFIG_HOME/ctags/*.ctags``, or ``$HOME/.config/ctags/*.ctags`` if
 ``$XDG_CONFIG_HOME`` is not defined

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -830,7 +830,7 @@ Option File Options
 
 ``--optlib-dir=[+]<directory>``
 	Add an optlib *<directory>* to or reset the optlib path list.
-	By default, the optlib path list is empty.
+	See "`Default optlib path list`_" about the default elements for optlib path list.
 
 optlib Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2203,6 +2203,19 @@ Preloading option files
 
 	``*.ctags`` files in a directory are loaded in alphabetical order.
 
+Default optlib path list
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+``$XDG_CONFIG_HOME/ctags``, or ``$HOME/.config/ctags`` if
+``$XDG_CONFIG_HOME`` is not defined
+(on other than MS Windows)
+
+``$HOME/.ctags.d``
+
+``$HOMEDRIVE$HOMEPATH/ctags.d`` (on MS Windows only)
+
+	These directories are parts of the optlib path list by default.
+	See "`Option File Options`_" about the optlib path list.
 
 SEE ALSO
 --------

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -2217,6 +2217,22 @@ Default optlib path list
 	These directories are parts of the optlib path list by default.
 	See "`Option File Options`_" about the optlib path list.
 
+	If you have a set of options that you want to enable
+	conditionally, make a directory in the path in the optlib path
+	list, and put the options to the files having .ctags as extensions
+	under the directory. ``--options=<the-directory-name>`` is for
+	enabling the options.
+
+	For example, consider you have some options you want to enable
+	only when tagging the Linux kernel source tree.  In that case,
+	make ``$HOME/.ctags.d/linux`` directory, put the options to
+	``$HOME/.ctags.d/linux/my.ctags``. If you have many options, you
+	can split them into multiple files like
+	``$HOME/.ctags.d/linux/device-driver.ctags`` and
+	``$HOME/.ctags.d/linux/network-stack.ctags``. Either way, you can
+	enable the options in the .ctags file(s) under the directory by
+	adding ``--options=linux`` to your ctags command line.
+
 SEE ALSO
 --------
 


### PR DESCRIPTION
Default optlib path list
~~~~~~~~~~~~~~~~~~~~~~~~

``$XDG_CONFIG_HOME/ctags``, or ``$HOME/.config/ctags`` if
``$XDG_CONFIG_HOME`` is not defined
(on other than MS Windows)

``$HOME/.ctags.d``

``$HOMEDRIVE$HOMEPATH/ctags.d`` (on MS Windows only)

        These directories are parts of the optlib path list by default.
        See "`Option File Options`_" about the optlib path list.

        If you have a set of options that you want to enable
        conditionally, make a directory in the path in the optlib path
        list, and put the options to the files having .ctags as extensions
        under the directory. ``--options=<the-directory-name>`` is for
        enabling the options.

        For example, consider you have some options you want to enable
        only when tagging the Linux kernel source tree.  In that case,
        make ``$HOME/.ctags.d/linux`` directory, put the options to
        ``$HOME/.ctags.d/linux/my.ctags``. If you have many options, you
        can split them into multiple files like
        ``$HOME/.ctags.d/linux/device-driver.ctags`` and
        ``$HOME/.ctags.d/linux/network-stack.ctags``. Either way, you can
        enable the options in the .ctags file(s) under the directory by
        adding ``--options=linux`` to your ctags command line.

