### PR TITLE
HTML: limit reading string objects when parrsing in a script area

### DIFF
--- a/Units/parser-html.r/string-in-script.d/args.ctags
+++ b/Units/parser-html.r/string-in-script.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+g
+--fields=+Kl

--- a/Units/parser-html.r/string-in-script.d/expected.tags
+++ b/Units/parser-html.r/string-in-script.d/expected.tags
@@ -1,0 +1,6 @@
+Foo	input.html	/^<h1>Foo<\/h1>$/;"	heading1	language:HTML
+BAR	input.html	/^<h1>BAR<\/h1>$/;"	heading1	language:HTML
+bar	input.html	/^	const bar = 123$/;"	constant	language:JavaScript
+baz	input.html	/^	function baz () {$/;"	function	language:JavaScript
+bar2	input.html	/^	const bar2 = 123$/;"	constant	language:JavaScript
+baz2	input.html	/^	function baz2 () {$/;"	function	language:JavaScript

--- a/Units/parser-html.r/string-in-script.d/input.html
+++ b/Units/parser-html.r/string-in-script.d/input.html
@@ -1,0 +1,24 @@
+<!-- Taken from #3581 submitted by @polyscone -->
+<h1>Foo</h1>
+
+<script>
+	const bar = 123
+
+	// I don't know why, but an apostrophe breaks
+	// the JavaScript guest language
+	function baz () {
+		return 'abc'
+	}
+</script>
+
+<script>
+	const bar2 = 123
+
+	// I don"t know why, but an apostrophe breaks
+	// the JavaScript guest language
+	function baz2 () {
+		return 'abc'
+	}
+</script>
+
+<h1>BAR</h1>


### PR DESCRIPTION
Close #3581.

MORE DESCRIPTIONS ARE NEEDED.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>