### PR TITLE
GitHub Actions: disable tagging temporarily

### DIFF
--- a/misc/git-tag-maybe.sh
+++ b/misc/git-tag-maybe.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+echo tagging is disabled temporary
+exit 0
+
 ##################################### util #######################################
 
 COLOR_RED='\033[0;31m'          # Red


### PR DESCRIPTION
For preparing ctags 6.0.0, disable weekly tagging temporarily.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>