### PR TITLE
Perl: skip string literals when collecting heredoc markers

### DIFF
--- a/Units/parser-perl.r/no-heredoc.d/args.ctags
+++ b/Units/parser-perl.r/no-heredoc.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--kinds-Perl=+{heredoc}

--- a/Units/parser-perl.r/no-heredoc.d/expected.tags
+++ b/Units/parser-perl.r/no-heredoc.d/expected.tags
@@ -13,3 +13,7 @@ heredoc4tag	input.pl	/^print "abc" . <<heredoc3tag . 'efg' . << "heredoc4tag" . 
 f7tag	input.pl	/^sub f7tag() {}$/;"	s
 f8tag	input.pl	/^sub f8tag() {}$/;"	s
 f9tag	input.pl	/^sub f9tag() {}$/;"	s
+five_sub	input-0.pl	/^sub five_sub() {$/;"	s
+five_mark0	input-0.pl	/^print 3 + 2 . <<five_mark0;$/;"	h
+five_mark1	input-0.pl	/^print 3 + 2 . <<~five_mark1;$/;"	h
+five_mark2	input-0.pl	/^print 3 + 2 . << "five_mark2";$/;"	h

--- a/Units/parser-perl.r/no-heredoc.d/expected.tags
+++ b/Units/parser-perl.r/no-heredoc.d/expected.tags
@@ -1,0 +1,15 @@
+f0tag	input.pl	/^sub f0tag() {}$/;"	s
+f1tag	input.pl	/^sub f1tag() {}$/;"	s
+f2tag	input.pl	/^sub f2tag() {}$/;"	s
+f3tag	input.pl	/^sub f3tag() {}$/;"	s
+hereodc0tag	input.pl	/^print 'cat <<<heredoct0notag' . <<hereodc0tag;$/;"	h
+f4tag	input.pl	/^sub f4tag() {}$/;"	s
+hereodc1tag	input.pl	/^print "cat <<<heredoct1notag" . <<hereodc1tag;$/;"	h
+f5tag	input.pl	/^sub f5tag() {}$/;"	s
+hereodc2tag	input.pl	/^print `cat <<<heredoct1notag` . <<hereodc2tag;$/;"	h
+f6tag	input.pl	/^sub f6tag() {}$/;"	s
+heredoc3tag	input.pl	/^print "abc" . <<heredoc3tag . 'efg' . << "heredoc4tag" . `ls` . '<<hereodc5notag';$/;"	h
+heredoc4tag	input.pl	/^print "abc" . <<heredoc3tag . 'efg' . << "heredoc4tag" . `ls` . '<<hereodc5notag';$/;"	h
+f7tag	input.pl	/^sub f7tag() {}$/;"	s
+f8tag	input.pl	/^sub f8tag() {}$/;"	s
+f9tag	input.pl	/^sub f9tag() {}$/;"	s

--- a/Units/parser-perl.r/no-heredoc.d/input-0.pl
+++ b/Units/parser-perl.r/no-heredoc.d/input-0.pl
@@ -1,0 +1,31 @@
+print 3 + 2 <<5;
+5
+    ;
+
+sub five_sub() {
+    return 5
+}
+print 3 + 2 << five_sub;
+five
+    ;
+
+print 3 + 2 . <<five_mark0;
+a
+five_mark0
+
+print 3 + 2 . <<~five_mark1;
+a
+five_mark1
+
+print 3 + 2 << ~five_sub;
+five_sub;
+
+print 3 + 2 . << "five_mark2";
+	ox
+five_mark2
+
+
+
+
+
+

--- a/Units/parser-perl.r/no-heredoc.d/input.pl
+++ b/Units/parser-perl.r/no-heredoc.d/input.pl
@@ -1,0 +1,47 @@
+# Derrived from #3588 submitted by @petdance
+
+sub f0tag() {}
+
+my $x = '<<NOT_A_HEREDOC0';
+
+sub f1tag() {}
+
+print "<<NOT_A_HEREDOC0\n";
+
+sub f2tag() {}
+
+print `cat <<<BASH_HERE_STRING`;
+
+sub f3tag() {}
+
+print 'cat <<<heredoct0notag' . <<hereodc0tag;
+sub f0notag() {}
+hereodc0tag
+
+sub f4tag() {}
+
+print "cat <<<heredoct1notag" . <<hereodc1tag;
+sub f1notag() {}
+hereodc1tag
+
+sub f5tag() {}
+
+print `cat <<<heredoct1notag` . <<hereodc2tag;
+sub f2notag() {}
+hereodc2tag
+
+sub f6tag() {}
+
+print "abc" . <<heredoc3tag . 'efg' . << "heredoc4tag" . `ls` . '<<hereodc5notag';
+sub f3notag() {}
+heredoc3tag
+sub f4notag() {}
+heredoc4tag
+sub f7tag() {}
+
+sub f8tag() {}
+
+my $i = 1;
+print "a" . 3 << $i;
+
+sub f9tag() {}

--- a/Units/parser-perl.r/perl-module.d/expected.tags
+++ b/Units/parser-perl.r/perl-module.d/expected.tags
@@ -10,3 +10,5 @@ sort	input.pl	/^use sort     qw(stable _quicksort _mergesort);$/;"	M	line:10	rol
 integer	input.pl	/^no integer;$/;"	M	line:12	roles:unused	extras:reference
 strict	input.pl	/^no strict 'refs';$/;"	M	line:13	roles:unused	extras:reference
 warnings	input.pl	/^no warnings;$/;"	M	line:14	roles:unused	extras:reference
+5.006_001	input.pl	/^use 5.006_001;$/;"	M	line:16	roles:used	extras:reference
+5.006_001	input.pl	/^no 5.006_001;$/;"	M	line:17	roles:unused	extras:reference

--- a/Units/parser-perl.r/perl-module.d/input.pl
+++ b/Units/parser-perl.r/perl-module.d/input.pl
@@ -12,3 +12,6 @@ use sort     qw(stable _quicksort _mergesort);
 no integer;
 no strict 'refs';
 no warnings;
+
+use 5.006_001;
+no 5.006_001;

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -22,11 +22,9 @@
 #include "routines.h"
 #include "selectors.h"
 #include "subparser.h"
+#include "trace.h"
 #include "vstring.h"
 #include "xtag.h"
-
-#define TRACE_PERL_C 0
-#define TRACE if (TRACE_PERL_C) printf("perl.c:%d: ", __LINE__), printf
 
 /*
 *   DATA DEFINITIONS
@@ -665,7 +663,7 @@ static void findPerlTags (void)
 
 		if (strncmp((const char*) cp, "sub", (size_t) 3) == 0)
 		{
-			TRACE("this looks like a sub\n");
+			TRACE_PRINT("this looks like a sub");
 			cp += 3;
 			kind = KIND_PERL_SUBROUTINE;
 			spaceRequired = true;
@@ -814,11 +812,11 @@ static void findPerlTags (void)
 		}
 		if (kind != KIND_PERL_NONE)
 		{
-			TRACE("cp0: %s\n", (const char *) cp);
+			TRACE_PRINT("cp0: %s", (const char *) cp);
 			if (spaceRequired && *cp && !isspace (*cp))
 				continue;
 
-			TRACE("cp1: %s\n", (const char *) cp);
+			TRACE_PRINT("cp1: %s", (const char *) cp);
 			while (isspace (*cp))
 				cp++;
 
@@ -846,7 +844,7 @@ static void findPerlTags (void)
 				vStringCatS (name, "STDOUT");
 			}
 
-			TRACE("name: %s\n", vStringValue (name));
+			TRACE_PRINT("name: %s", vStringValue (name));
 
 			if (0 == vStringLength(name)) {
 				vStringClear(name);

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -659,8 +659,6 @@ static void findPerlTags (void)
 		while (isspace (*cp))
 			cp++;
 
-		collectHereDocMarkers (&hdoc_mgr, cp);
-
 		if (strncmp((const char*) cp, "sub", (size_t) 3) == 0)
 		{
 			TRACE_PRINT("this looks like a sub");
@@ -809,6 +807,9 @@ static void findPerlTags (void)
 				if ((int) *p == ':' && (int) *(p + 1) != ':')
 					kind = KIND_PERL_LABEL;
 			}
+
+			if (kind != KIND_PERL_LABEL)
+				collectHereDocMarkers (&hdoc_mgr, cp);
 		}
 		if (kind != KIND_PERL_NONE)
 		{

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -693,7 +693,7 @@ static void findPerlTags (void)
 			}
 
 			vString *module = NULL;
-			while (isalnum(*cp) || *cp == ':' || *cp == '.') {
+			while (isalnum(*cp) || *cp == ':' || *cp == '.' || *cp == '_') {
 				if (!module)
 					module = vStringNew();
 				vStringPut(module, *cp);
@@ -753,7 +753,7 @@ static void findPerlTags (void)
 			while (isspace (*cp))
 				cp++;
 			vString *module = NULL;
-			while (isalnum(*cp) || *cp == ':' || *cp == '.') {
+			while (isalnum(*cp) || *cp == ':' || *cp == '.' || *cp == '_') {
 				if (!module)
 					module = vStringNew();
 				vStringPut(module, *cp);

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -526,6 +526,7 @@ static const unsigned char *collectHereDocMarker (struct hereDocMarkerManager *m
 	unsigned char *cp = NULL;
 	bool indented = false;
 	unsigned char quote_char = 0;
+	bool space_seen = false;
 
 	if (starter == NULL)
 		return NULL;
@@ -536,7 +537,12 @@ static const unsigned char *collectHereDocMarker (struct hereDocMarkerManager *m
 
 	cp = starter + 2;
 	while (isspace (*cp))
+	{
+		/* To avoid confusing with a shift operator, we track
+		 * spaces after the starter (<<). */
+		space_seen = true;
 		cp++;
+	}
 
 	if (*cp == '\0')
 		return NULL;
@@ -547,6 +553,8 @@ static const unsigned char *collectHereDocMarker (struct hereDocMarkerManager *m
 		return cp + 1;
 
 	if (*cp == '~') {
+		if (space_seen)
+			return cp + 1;
 		indented = true;
 		cp++;
 		if (*cp == '\0')
@@ -570,6 +578,8 @@ static const unsigned char *collectHereDocMarker (struct hereDocMarkerManager *m
 			return NULL;
 		break;
 	default:
+		if (space_seen)
+			return cp;
 		break;
 	}
 

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -547,11 +547,6 @@ static const unsigned char *collectHereDocMarker (struct hereDocMarkerManager *m
 	if (*cp == '\0')
 		return NULL;
 
-	/* Is shift operator? */
-	if (isdigit (*cp))
-		/* Scan the rest of the string. */
-		return cp + 1;
-
 	if (*cp == '~') {
 		if (space_seen)
 			return cp + 1;
@@ -578,6 +573,8 @@ static const unsigned char *collectHereDocMarker (struct hereDocMarkerManager *m
 			return NULL;
 		break;
 	default:
+		if (!isIdentifier1(*cp))
+			return cp;
 		if (space_seen)
 			return cp;
 		break;

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -512,7 +512,9 @@ static void collectHereDocMarkers (struct hereDocMarkerManager *mgr,
 								   const unsigned char *line)
 {
 	const unsigned char *cp = line;
-	while ((cp = collectHereDocMarker(mgr, cp)) != NULL);
+	const unsigned char *last = cp;
+	while ((cp = collectHereDocMarker(mgr, cp)) != NULL)
+		Assert(last < cp);
 }
 
 static bool isInHereDoc (struct hereDocMarkerManager *mgr,


### PR DESCRIPTION
Close #3588.

`q/...<<MARKER.../` is not handled in this pull request.