### PR TITLE
HTML: introduce a specialized tokenizer for script areas

### DIFF
--- a/Units/parser-html.r/comment-starter-in-script.d/args.ctags
+++ b/Units/parser-html.r/comment-starter-in-script.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+g
+--fields=+Kl

--- a/Units/parser-html.r/comment-starter-in-script.d/expected.tags
+++ b/Units/parser-html.r/comment-starter-in-script.d/expected.tags
@@ -1,0 +1,3 @@
+Foo	input.html	/^<h1>Foo<\/h1>$/;"	heading1	language:HTML
+BAR	input.html	/^<h1>BAR<\/h1>$/;"	heading1	language:HTML
+x	input.html	/^  var x/;"	variable	language:JavaScript

--- a/Units/parser-html.r/comment-starter-in-script.d/input.html
+++ b/Units/parser-html.r/comment-starter-in-script.d/input.html
@@ -1,0 +1,6 @@
+<h1>Foo</h1>
+<script>
+  // <!--
+  var x
+</script>
+<h1>BAR</h1>

--- a/Units/parser-html.r/string-in-script.d/args.ctags
+++ b/Units/parser-html.r/string-in-script.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+g
+--fields=+Kl

--- a/Units/parser-html.r/string-in-script.d/expected.tags
+++ b/Units/parser-html.r/string-in-script.d/expected.tags
@@ -1,0 +1,6 @@
+Foo	input.html	/^<h1>Foo<\/h1>$/;"	heading1	language:HTML
+BAR	input.html	/^<h1>BAR<\/h1>$/;"	heading1	language:HTML
+bar	input.html	/^	const bar = 123$/;"	constant	language:JavaScript
+baz	input.html	/^	function baz () {$/;"	function	language:JavaScript
+bar2	input.html	/^	const bar2 = 123$/;"	constant	language:JavaScript
+baz2	input.html	/^	function baz2 () {$/;"	function	language:JavaScript

--- a/Units/parser-html.r/string-in-script.d/input.html
+++ b/Units/parser-html.r/string-in-script.d/input.html
@@ -1,0 +1,24 @@
+<!-- Taken from #3581 submitted by @polyscone -->
+<h1>Foo</h1>
+
+<script>
+	const bar = 123
+
+	// I don't know why, but an apostrophe breaks
+	// the JavaScript guest language
+	function baz () {
+		return 'abc'
+	}
+</script>
+
+<script>
+	const bar2 = 123
+
+	// I don"t know why, but an apostrophe breaks
+	// the JavaScript guest language
+	function baz2 () {
+		return 'abc'
+	}
+</script>
+
+<h1>BAR</h1>


### PR DESCRIPTION
The original code used a html-aware tokenizer for reading tokens in <script>...</script> areas.

As reported in #3581 and #3597, this original code could not recognize <script>...</script> areas in some cases.

This change introduces a tokenizer specialized to script areas in addition to the original html-aware tokenizer.

Close #3581.
Close #3597.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>