### PR TITLE
Org:  optimize

### DIFF
--- a/optlib/org.c
+++ b/optlib/org.c
@@ -32,6 +32,9 @@ static void initializeOrgParser (const langType language)
 	                               "^#\\+begin_src[ ]+([a-zA-Z0-9][-#+a-zA-Z0-9]*)",
 	                               "", "", "{tenter=srcblock}{_guest=\\1,0end,}", NULL);
 	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^#\\+(NAME|name):[[:blank:]]+([[:graph:][:blank:]]+)([\n])?",
+	                               "\\2", "d", "", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
 	                               "^(\\*{1,7})[ \t]+([[:graph:][:blank:]]+)([\n])?",
 	                               "", "", ""
 		"{{\n"
@@ -40,9 +43,6 @@ static void initializeOrgParser (const langType language)
 	addLanguageTagMultiTableRegex (language, "toplevel",
 	                               "^<<([^>]+)>>",
 	                               "\\1", "d", "", NULL);
-	addLanguageTagMultiTableRegex (language, "toplevel",
-	                               "^#\\+(NAME|name):[[:blank:]]+([[:graph:][:blank:]]+)([\n])?",
-	                               "\\2", "d", "", NULL);
 	addLanguageTagMultiTableRegex (language, "toplevel",
 	                               "^.",
 	                               "", "", "", NULL);

--- a/optlib/org.c
+++ b/optlib/org.c
@@ -15,7 +15,10 @@ static void initializeOrgParser (const langType language)
 	addLanguageRegexTable (language, "srcblock");
 
 	addLanguageTagMultiTableRegex (language, "toplevel",
-	                               "^[:blank:]*#\\+begin_src[ ]+([a-zA-Z0-9][-#+a-zA-Z0-9]*)",
+	                               "^[^#*<]+",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^#\\+begin_src[ ]+([a-zA-Z0-9][-#+a-zA-Z0-9]*)",
 	                               "", "", "{tenter=srcblock}{_guest=\\1,0end,}", NULL);
 	addLanguageTagMultiTableRegex (language, "toplevel",
 	                               "^\\*\\*\\*\\*\\*\\*\\*[ \t]+([[:graph:][:blank:]]+)([\n])?",

--- a/optlib/org.c
+++ b/optlib/org.c
@@ -35,6 +35,9 @@ static void initializeOrgParser (const langType language)
 	                               "^#\\+(NAME|name):[[:blank:]]+([[:graph:][:blank:]]+)([\n])?",
 	                               "\\2", "d", "", NULL);
 	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^#[^\n]*\n",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
 	                               "^(\\*{1,7})[ \t]+([[:graph:][:blank:]]+)([\n])?",
 	                               "", "", ""
 		"{{\n"

--- a/optlib/org.c
+++ b/optlib/org.c
@@ -47,7 +47,10 @@ static void initializeOrgParser (const langType language)
 	                               "^.",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "srcblock",
-	                               "^[:blank:]*#\\+end_src",
+	                               "^[^#]+",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "srcblock",
+	                               "^#\\+end_src",
 	                               "", "", "{tleave}{_guest=,,0end}", NULL);
 	addLanguageTagMultiTableRegex (language, "srcblock",
 	                               "^.",

--- a/optlib/org.c
+++ b/optlib/org.c
@@ -10,6 +10,17 @@
 
 static void initializeOrgParser (const langType language)
 {
+	addLanguageOptscriptToHook (language, SCRIPT_HOOK_PRELUDE,
+		"{{    /kindTable [\n"
+		"        /part\n"
+		"        /chapter\n"
+		"        /section\n"
+		"        /subsection\n"
+		"        /subsubsection\n"
+		"        /paragraph\n"
+		"        /subparagraph\n"
+		"    ] def\n"
+		"}}");
 
 	addLanguageRegexTable (language, "toplevel");
 	addLanguageRegexTable (language, "srcblock");
@@ -21,26 +32,11 @@ static void initializeOrgParser (const langType language)
 	                               "^#\\+begin_src[ ]+([a-zA-Z0-9][-#+a-zA-Z0-9]*)",
 	                               "", "", "{tenter=srcblock}{_guest=\\1,0end,}", NULL);
 	addLanguageTagMultiTableRegex (language, "toplevel",
-	                               "^\\*\\*\\*\\*\\*\\*\\*[ \t]+([[:graph:][:blank:]]+)([\n])?",
-	                               "\\1", "G", "", NULL);
-	addLanguageTagMultiTableRegex (language, "toplevel",
-	                               "^\\*\\*\\*\\*\\*\\*[ \t]+([[:graph:][:blank:]]+)([\n])?",
-	                               "\\1", "P", "", NULL);
-	addLanguageTagMultiTableRegex (language, "toplevel",
-	                               "^\\*\\*\\*\\*\\*[ \t]+([[:graph:][:blank:]]+)([\n])?",
-	                               "\\1", "b", "", NULL);
-	addLanguageTagMultiTableRegex (language, "toplevel",
-	                               "^\\*\\*\\*\\*[ \t]+([[:graph:][:blank:]]+)([\n])?",
-	                               "\\1", "u", "", NULL);
-	addLanguageTagMultiTableRegex (language, "toplevel",
-	                               "^\\*\\*\\*[ \t]+([[:graph:][:blank:]]+)([\n])?",
-	                               "\\1", "s", "", NULL);
-	addLanguageTagMultiTableRegex (language, "toplevel",
-	                               "^\\*\\*[ \t]+([[:graph:][:blank:]]+)([\n])?",
-	                               "\\1", "c", "", NULL);
-	addLanguageTagMultiTableRegex (language, "toplevel",
-	                               "^\\*[ \t]+([[:graph:][:blank:]]+)([\n])?",
-	                               "\\1", "p", "", NULL);
+	                               "^(\\*{1,7})[ \t]+([[:graph:][:blank:]]+)([\n])?",
+	                               "", "", ""
+		"{{\n"
+		"    \\2 kindTable \\1 length 1 sub get @2 _tag _commit pop\n"
+		"}}", NULL);
 	addLanguageTagMultiTableRegex (language, "toplevel",
 	                               "^<<([^>]+)>>",
 	                               "\\1", "d", "", NULL);
@@ -109,6 +105,7 @@ extern parserDefinition* OrgParser (void)
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
+	def->useCork       = CORK_QUEUE;
 	def->kindTable     = OrgKindTable;
 	def->kindCount     = ARRAY_SIZE(OrgKindTable);
 	def->initialize    = initializeOrgParser;

--- a/optlib/org.ctags
+++ b/optlib/org.ctags
@@ -57,6 +57,8 @@
 --_mtable-regex-Org=toplevel/#\+begin_src[ ]+([a-zA-Z0-9][-#+a-zA-Z0-9]*)//{tenter=srcblock}{_guest=\1,0end,}
 # labels
 --_mtable-regex-Org=toplevel/#\+(NAME|name):[[:blank:]]+([[:graph:][:blank:]]+)([\n])?/\2/d/
+# skip #...
+--_mtable-regex-Org=toplevel/#[^\n]*\n//
 # sections stuff
 --_mtable-regex-Org=toplevel/(\*{1,7})[ \t]+([[:graph:][:blank:]]+)([\n])?//{{
     \2 kindTable \1 length 1 sub get @2 _tag _commit pop

--- a/optlib/org.ctags
+++ b/optlib/org.ctags
@@ -39,8 +39,9 @@
 ################################
 # beginning of toplevel
 ################################
+--_mtable-regex-Org=toplevel/[^#*<]+//
 # if encounter a src block do language identify languge and defer
---_mtable-regex-Org=toplevel/[:blank:]*#\+begin_src[ ]+([a-zA-Z0-9][-#+a-zA-Z0-9]*)//{tenter=srcblock}{_guest=\1,0end,}
+--_mtable-regex-Org=toplevel/#\+begin_src[ ]+([a-zA-Z0-9][-#+a-zA-Z0-9]*)//{tenter=srcblock}{_guest=\1,0end,}
 # sections stuff
 --_mtable-regex-Org=toplevel/\*\*\*\*\*\*\*[ \t]+([[:graph:][:blank:]]+)([\n])?/\1/G/
 --_mtable-regex-Org=toplevel/\*\*\*\*\*\*[ \t]+([[:graph:][:blank:]]+)([\n])?/\1/P/

--- a/optlib/org.ctags
+++ b/optlib/org.ctags
@@ -55,13 +55,14 @@
 --_mtable-regex-Org=toplevel/[^#*<]+//
 # if encounter a src block do language identify languge and defer
 --_mtable-regex-Org=toplevel/#\+begin_src[ ]+([a-zA-Z0-9][-#+a-zA-Z0-9]*)//{tenter=srcblock}{_guest=\1,0end,}
+# labels
+--_mtable-regex-Org=toplevel/#\+(NAME|name):[[:blank:]]+([[:graph:][:blank:]]+)([\n])?/\2/d/
 # sections stuff
 --_mtable-regex-Org=toplevel/(\*{1,7})[ \t]+([[:graph:][:blank:]]+)([\n])?//{{
     \2 kindTable \1 length 1 sub get @2 _tag _commit pop
 }}
 # labels
 --_mtable-regex-Org=toplevel/<<([^>]+)>>/\1/d/
---_mtable-regex-Org=toplevel/#\+(NAME|name):[[:blank:]]+([[:graph:][:blank:]]+)([\n])?/\2/d/
 ## else do nothing (end of toplevel)
 --_mtable-regex-Org=toplevel/.//
 

--- a/optlib/org.ctags
+++ b/optlib/org.ctags
@@ -36,6 +36,19 @@
 # definition of levels
 --_tabledef-Org=toplevel
 --_tabledef-Org=srcblock
+
+--_prelude-Org={{
+    /kindTable [
+        /part
+        /chapter
+        /section
+        /subsection
+        /subsubsection
+        /paragraph
+        /subparagraph
+    ] def
+}}
+
 ################################
 # beginning of toplevel
 ################################
@@ -43,13 +56,9 @@
 # if encounter a src block do language identify languge and defer
 --_mtable-regex-Org=toplevel/#\+begin_src[ ]+([a-zA-Z0-9][-#+a-zA-Z0-9]*)//{tenter=srcblock}{_guest=\1,0end,}
 # sections stuff
---_mtable-regex-Org=toplevel/\*\*\*\*\*\*\*[ \t]+([[:graph:][:blank:]]+)([\n])?/\1/G/
---_mtable-regex-Org=toplevel/\*\*\*\*\*\*[ \t]+([[:graph:][:blank:]]+)([\n])?/\1/P/
---_mtable-regex-Org=toplevel/\*\*\*\*\*[ \t]+([[:graph:][:blank:]]+)([\n])?/\1/b/
---_mtable-regex-Org=toplevel/\*\*\*\*[ \t]+([[:graph:][:blank:]]+)([\n])?/\1/u/
---_mtable-regex-Org=toplevel/\*\*\*[ \t]+([[:graph:][:blank:]]+)([\n])?/\1/s/
---_mtable-regex-Org=toplevel/\*\*[ \t]+([[:graph:][:blank:]]+)([\n])?/\1/c/
---_mtable-regex-Org=toplevel/\*[ \t]+([[:graph:][:blank:]]+)([\n])?/\1/p/
+--_mtable-regex-Org=toplevel/(\*{1,7})[ \t]+([[:graph:][:blank:]]+)([\n])?//{{
+    \2 kindTable \1 length 1 sub get @2 _tag _commit pop
+}}
 # labels
 --_mtable-regex-Org=toplevel/<<([^>]+)>>/\1/d/
 --_mtable-regex-Org=toplevel/#\+(NAME|name):[[:blank:]]+([[:graph:][:blank:]]+)([\n])?/\2/d/

--- a/optlib/org.ctags
+++ b/optlib/org.ctags
@@ -69,6 +69,7 @@
 # beginning of src block
 ################################
 # if end of src block exit
---_mtable-regex-Org=srcblock/[:blank:]*#\+end_src//{tleave}{_guest=,,0end}
+--_mtable-regex-Org=srcblock/[^#]+//
+--_mtable-regex-Org=srcblock/#\+end_src//{tleave}{_guest=,,0end}
 # else do nothing
 --_mtable-regex-Org=srcblock/.//


### PR DESCRIPTION
The Org parser is incredibly slow.

The original:
```
[yamato@dev64]~/var/ctags-github% ./ctags --totals /home/yamato/var/emacs/doc/misc/org.org
1 file, 22606 lines (802 kB) scanned in 98.8 seconds (8 kB/s)
625 tags added to tag file
625 tags sorted in 0.00 seconds
longest tag line = 127
```

With this pull request:
```
[yamato@dev64]~/var/ctags-github% ./ctags --totals /home/yamato/var/emacs/doc/misc/org.org
1 file, 22606 lines (802 kB) scanned in 0.6 seconds (1291 kB/s)
624 tags added to tag file
624 tags sorted in 0.00 seconds
longest tag line = 127
```

It becomes 150% faster with this pull request.

BTW, this parser doesn't fill scope fields.