### PR TITLE
TEMP: build-sys: link libreadtags to ctags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -138,7 +138,7 @@ utiltest_LDADD  =
 utiltest_LDADD += libutil.a
 dist_utiltest_SOURCES = $(UTILTEST_HEADS) $(UTILTEST_SRCS)
 
-libctags_a_CPPFLAGS = -I. -I$(srcdir) -I$(srcdir)/main -I$(srcdir)/dsl -I$(srcdir)/peg -DHAVE_PACKCC
+libctags_a_CPPFLAGS = -I. -I$(srcdir) -I$(srcdir)/main -I$(srcdir)/dsl -I$(srcdir)/libreadtags -I$(srcdir)/peg -DHAVE_PACKCC
 if ENABLE_DEBUGGING
 libctags_a_CPPFLAGS+= $(DEBUG_CPPFLAGS)
 endif

--- a/source.mak
+++ b/source.mak
@@ -485,14 +485,18 @@ READTAGS_DSL_SRCS = \
 	$(NULL)
 READTAGS_DSL_OBJS = $(READTAGS_DSL_SRCS:.c=.$(OBJEXT))
 
+LIBREADTAGS_SRCS  = libreadtags/readtags.c
+LIBREADTAGS_HEADS = libreadtags/readtags.h
+
 READTAGS_SRCS  = \
-	libreadtags/readtags.c      \
+	$(LIBREADTAGS_SRCS)     \
 	extra-cmds/printtags.c  \
 	extra-cmds/readtags-cmd.c  \
 	extra-cmds/readtags-stub.c \
 	\
 	$(NULL)
 READTAGS_HEADS = \
+	$(LIBREADTAGS_HEADS) \
 	libreadtags/readtags.h \
 	extra-cmds/printtags.h  \
 	extra-cmds/readtags-stub.h \
@@ -546,8 +550,8 @@ MINGW_GNULIB_SRCS = \
 ENVIRONMENT_HEADS =
 ENVIRONMENT_SRCS =
 
-ALL_LIB_HEADS = $(LIB_HEADS) $(PARSER_HEADS) $(DEBUG_HEADS) $(DSL_HEADS) $(OPTSCRIPT_DSL_HEADS)
-ALL_LIB_SRCS  = $(LIB_SRCS) $(PARSER_SRCS) $(DEBUG_SRCS) $(DSL_SRCS) $(OPTSCRIPT_DSL_SRCS)
+ALL_LIB_HEADS = $(LIB_HEADS) $(PARSER_HEADS) $(DEBUG_HEADS) $(DSL_HEADS) $(OPTSCRIPT_DSL_HEADS) $(LIBREADTAGS_HEADS)
+ALL_LIB_SRCS  = $(LIB_SRCS) $(PARSER_SRCS) $(DEBUG_SRCS) $(DSL_SRCS) $(OPTSCRIPT_DSL_SRCS) $(LIBREADTAGS_SRCS)
 ALL_LIB_OBJS = \
 	$(ALL_LIB_SRCS:.c=.$(OBJEXT)) \
 	$(LIBOBJS)

--- a/win32/GNUmakefile
+++ b/win32/GNUmakefile
@@ -24,16 +24,16 @@ all: $(VCXPROJ) $(VCXPROJ_FILTERS)
 include $(SOURCE_MAK)
 
 # exclude some files for Win32 and replace a slash (/) to a backslash (\)
-MVC_SRCS = $(MVC_GNULIB_SRCS) $(CMDLINE_SRCS) $(LIB_SRCS) $(OPTLIB2C_SRCS) $(PARSER_SRCS) $(OPTSCRIPT_DSL_SRCS) $(DEBUG_SRCS) $(WIN32_SRCS)
+MVC_SRCS = $(MVC_GNULIB_SRCS) $(CMDLINE_SRCS) $(LIB_SRCS) $(OPTLIB2C_SRCS) $(PARSER_SRCS) $(OPTSCRIPT_DSL_SRCS) $(LIBREADTAGS_SRCS) $(DEBUG_SRCS) $(WIN32_SRCS)
 MVC_SRCS_EXCLUDE = main/mbcs.c main/seccomp.c main/trace.c
 MVC_SRCS_CONV = $(sort $(subst /,\\,$(filter-out $(MVC_SRCS_EXCLUDE),$(MVC_SRCS))))
 
-MVC_HEADS = $(MVC_GNULIB_HEADS) $(CMDLINE_HEADS) $(LIB_HEADS) $(OPTLIB2C_HEADS) $(PARSER_HEADS) $(OPTSCRIPT_DSL_HEADS) $(DEBUG_HEADS)  $(WIN32_HEADS)
+MVC_HEADS = $(MVC_GNULIB_HEADS) $(CMDLINE_HEADS) $(LIB_HEADS) $(OPTLIB2C_HEADS) $(PARSER_HEADS) $(OPTSCRIPT_DSL_HEADS) $(LIBREADTAGS_HEADS) $(DEBUG_HEADS) $(WIN32_HEADS)
 MVC_HEADS_EXCLUDE = main/interactive_p.h main/mbcs.h main/mbcs_p.h main/trace.h
 MVC_HEADS_CONV = $(sort $(subst /,\\,$(filter-out $(MVC_HEADS_EXCLUDE),$(MVC_HEADS))))
 
-MVC_INC_DIRS1 = ..;../main;../gnulib;../parsers;../parsers/cxx;../dsl;
-MVC_INC_DIRS2 = ..;../main;../gnulib;../parsers;../parsers/cxx;
+MVC_INC_DIRS1 = ..;../main;../gnulib;../parsers;../parsers/cxx;../dsl;../libreadtags;
+MVC_INC_DIRS2 = ..;../main;../gnulib;../parsers;../parsers/cxx;../libreadtags;
 
 # a portable 'echo' which disables the interpretation of escape characters like 'echo -E' on bash
 # see https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.70/autoconf.html#Limitations-of-Builtins

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -101,7 +101,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..;../main;../gnulib;../parsers;../parsers/cxx;../dsl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;../main;../gnulib;../parsers;../parsers/cxx;../dsl;../libreadtags;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -121,7 +121,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..;../main;../gnulib;../parsers;../parsers/cxx;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;../main;../gnulib;../parsers;../parsers/cxx;../libreadtags;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -138,7 +138,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..;../main;../gnulib;../parsers;../parsers/cxx;../dsl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;../main;../gnulib;../parsers;../parsers/cxx;../dsl;../libreadtags;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>
@@ -156,7 +156,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>..;../main;../gnulib;../parsers;../parsers/cxx;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;../main;../gnulib;../parsers;../parsers/cxx;../libreadtags;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>
@@ -181,6 +181,7 @@
     <ClCompile Include="..\gnulib\regex.c" />
     <ClCompile Include="..\gnulib\setlocale_null.c" />
     <ClCompile Include="..\gnulib\wmempcpy.c" />
+    <ClCompile Include="..\libreadtags\readtags.c" />
     <ClCompile Include="..\main\CommonPrelude.c" />
     <ClCompile Include="..\main\args.c" />
     <ClCompile Include="..\main\cmd.c" />
@@ -375,6 +376,7 @@
     <ClInclude Include="..\dsl\optscript.h" />
     <ClInclude Include="..\gnulib\fnmatch.h" />
     <ClInclude Include="..\gnulib\regex.h" />
+    <ClInclude Include="..\libreadtags\readtags.h" />
     <ClInclude Include="..\main\args_p.h" />
     <ClInclude Include="..\main\colprint_p.h" />
     <ClInclude Include="..\main\ctags.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="..\gnulib\wmempcpy.c">
       <Filter>Source Files\gnulib</Filter>
     </ClCompile>
+    <ClCompile Include="..\libreadtags\readtags.c">
+      <Filter>Source Files\libreadtags</Filter>
+    </ClCompile>
     <ClCompile Include="..\main\CommonPrelude.c">
       <Filter>Source Files\main</Filter>
     </ClCompile>
@@ -642,6 +645,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\gnulib\regex.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\libreadtags\readtags.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\args_p.h">


### PR DESCRIPTION
This change is preparation for adding features querying existing tags files during parsing.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>