### PR TITLE
Ruby:  handle curly bracket

### DIFF
--- a/Units/parser-ruby.r/ruby-curly-brackets.d/args.ctags
+++ b/Units/parser-ruby.r/ruby-curly-brackets.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--fields=+{end}{signature}

--- a/Units/parser-ruby.r/ruby-curly-brackets.d/expected.tags
+++ b/Units/parser-ruby.r/ruby-curly-brackets.d/expected.tags
@@ -1,0 +1,11 @@
+__anona00f52fc0100	input.rb	/^Class.new {$/;"	c	end:5
+f	input.rb	/^  def f(n)$/;"	S	class:__anona00f52fc0100	signature:(n)	end:4
+x	input.rb	/^def x$/;"	f	signature:()	end:9
+__anone0f8ea590100	input-0.rb	/^Class.new do$/;"	c	end:3
+f0	input-0.rb	/^  def f0(n) n end$/;"	S	class:__anone0f8ea590100	signature:(n)	end:2
+y	input-0.rb	/^def y$/;"	f	signature:()	end:7
+C	input-1.rb	/^class C$/;"	c	end:5
+f1	input-1.rb	/^    def f1(n) n end$/;"	S	class:C	signature:(n)	end:3
+z	input-1.rb	/^def z$/;"	f	signature:()	end:9
+__anone0fa031b0100	input-2.rb	/^Class.new {$/;"	c	end:3
+f2	input-2.rb	/^  def f2() end$/;"	S	class:__anone0fa031b0100	signature:()	end:2

--- a/Units/parser-ruby.r/ruby-curly-brackets.d/input-0.rb
+++ b/Units/parser-ruby.r/ruby-curly-brackets.d/input-0.rb
@@ -1,0 +1,8 @@
+Class.new do
+  def f0(n) n end
+end
+
+def y
+  y
+end
+

--- a/Units/parser-ruby.r/ruby-curly-brackets.d/input-1.rb
+++ b/Units/parser-ruby.r/ruby-curly-brackets.d/input-1.rb
@@ -1,0 +1,10 @@
+class C
+  class << self
+    def f1(n) n end
+  end
+end
+
+def z
+  z
+end
+

--- a/Units/parser-ruby.r/ruby-curly-brackets.d/input-2.rb
+++ b/Units/parser-ruby.r/ruby-curly-brackets.d/input-2.rb
@@ -1,0 +1,3 @@
+Class.new {
+  def f2() end
+}

--- a/Units/parser-ruby.r/ruby-curly-brackets.d/input.rb
+++ b/Units/parser-ruby.r/ruby-curly-brackets.d/input.rb
@@ -1,0 +1,9 @@
+Class.new {
+  def f(n)
+    n
+  end
+}
+
+def x
+  x
+end

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -917,7 +917,18 @@ static int readAndEmitDef (const unsigned char **cp)
 	 *   end
 	 * end
 	 */
-	if (e_scope && e_scope->kindIndex == K_CLASS && *(e_scope->name) == '\0')
+	if (e_scope && e_scope->kindIndex == K_CLASS
+		&& (
+			/* Class.new do
+			   ... in this case, an anonymous class is created and
+			   ... pushed. */
+			isTagExtraBitMarked (e_scope, XTAG_ANONYMOUS)
+			||
+			/* class <<
+			   ... in this case, a placeholder tag having an empty
+			   ... name is created and pushed. */
+			*(e_scope->name) == '\0'
+			))
 		kind = K_SINGLETON;
 	int corkIndex = readAndEmitTag (cp, kind);
 	tagEntryInfo *e = getEntryInCorkQueue (corkIndex);
@@ -1060,7 +1071,10 @@ static void findRubyTags (void)
 
 			int r;
 			if (*(cp - 1) != 's')
+			{
 				r = emitRubyTagFull(NULL, K_CLASS, true, false);
+				expect_separator = true;
+			}
 			else
 				r = readAndEmitTag (&cp, K_CLASS); /* "class" */
 
@@ -1183,8 +1197,11 @@ static void findRubyTags (void)
 			{
 				enterUnnamedScope ();
 			}
-			else if (canMatchKeyword (&cp, "do"))
+			else if (canMatchKeyword (&cp, "do") || (*cp == '{'))
 			{
+				if (*cp == '{')
+					++cp;
+
 				if (! expect_separator)
 				{
 					enterUnnamedScope ();
@@ -1194,8 +1211,11 @@ static void findRubyTags (void)
 				else
 					expect_separator = false;
 			}
-			else if (canMatchKeyword (&cp, "end") && nesting->n > 0)
+			else if ((canMatchKeyword (&cp, "end") || (*cp == '}')) && nesting->n > 0)
 			{
+				if (*cp == '}')
+					++cp;
+
 				/* Leave the most recent scope. */
 				nestingLevelsPop (nesting);
 			}

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -117,7 +117,7 @@ static vString* nestingLevelsToScope (const NestingLevels* nls)
 	{
 	    NestingLevel *nl = nestingLevelsGetNthFromRoot (nls, i);
 	    tagEntryInfo *e = getEntryOfNestingLevel (nl);
-	    if (e && strlen (e->name) > 0 && (!e->placeholder))
+	    if (e && (*e->name != '\0') && (!e->placeholder))
 	    {
 	        if (chunks_output++ > 0)
 	            vStringPut (result, SCOPE_SEPARATOR);
@@ -917,7 +917,7 @@ static int readAndEmitDef (const unsigned char **cp)
 	 *   end
 	 * end
 	 */
-	if (e_scope && e_scope->kindIndex == K_CLASS && strlen (e_scope->name) == 0)
+	if (e_scope && e_scope->kindIndex == K_CLASS && *(e_scope->name) == '\0')
 		kind = K_SINGLETON;
 	int corkIndex = readAndEmitTag (cp, kind);
 	tagEntryInfo *e = getEntryInCorkQueue (corkIndex);


### PR DESCRIPTION
```
Class.new {
  def f2() end
}
```

With this change, ctags extracts `f2`.