### PR TITLE
Fix typo in conditional in C++ parser

### DIFF
--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -314,7 +314,7 @@ tagEntryInfo * cxxTagBegin(unsigned int uKind,CXXToken * pToken)
 		if (g_oCXXTag.extensionFields.scopeIndex != CORK_NIL)
 		{
 			if (uKind == CXXTagKindMEMBER || uKind == CXXTagKindENUMERATOR
-				|| uKind == CXXTagKindPARAMETER || CXXTagCPPKindTEMPLATEPARAM)
+				|| uKind == CXXTagKindPARAMETER || uKind == CXXTagCPPKindTEMPLATEPARAM)
 				g_oCXXTag.extensionFields.nth =
 					(short) countEntriesInScope(g_oCXXTag.extensionFields.scopeIndex,
 												true,


### PR DESCRIPTION
Introduced in b9249a8fc960f751bbae0430ac711f21af771eb0