### PR TITLE
Verilog: all text macro map to new kindDefinition:define 

### DIFF
--- a/Units/parser-verilog.r/systemverilog-basic.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-basic.d/expected.tags
@@ -1,6 +1,6 @@
-DEFINE	input.sv	/^`define DEFINE$/;"	c
-DEF_WITH_EQ	input.sv	/^`define DEF_WITH_EQ = 1'd100$/;"	c
-DEF_VALUE	input.sv	/^`define DEF_VALUE   1'd100$/;"	c
+DEFINE	input.sv	/^`define DEFINE$/;"	d
+DEF_WITH_EQ	input.sv	/^`define DEF_WITH_EQ = 1'd100$/;"	d
+DEF_VALUE	input.sv	/^`define DEF_VALUE   1'd100$/;"	d
 test	input.sv	/^class test;$/;"	C
 a	input.sv	/^    reg a;$/;"	r	class:test
 test.a	input.sv	/^    reg a;$/;"	r	class:test

--- a/Units/parser-verilog.r/systemverilog-class.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-class.d/expected.tags
@@ -1,6 +1,6 @@
-DEFINE	input.sv	/^`define DEFINE$/;"	c
-DEF_WITH_EQ	input.sv	/^`define DEF_WITH_EQ = 1'd100$/;"	c
-DEF_VALUE	input.sv	/^`define DEF_VALUE   1'd100$/;"	c
+DEFINE	input.sv	/^`define DEFINE$/;"	d
+DEF_WITH_EQ	input.sv	/^`define DEF_WITH_EQ = 1'd100$/;"	d
+DEF_VALUE	input.sv	/^`define DEF_VALUE   1'd100$/;"	d
 test	input.sv	/^class test;$/;"	C
 a	input.sv	/^    reg a;$/;"	r	class:test
 test.a	input.sv	/^    reg a;$/;"	r	class:test

--- a/Units/parser-verilog.r/systemverilog-directive.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-directive.d/expected.tags
@@ -1,21 +1,21 @@
 directive	input.sv	/^module directive;$/;"	m
-D	input.sv	/^`define D(x,y) initial $display("start", x , y, "end");$/;"	c	module:directive
-MACRO1	input.sv	/^`define MACRO1(a=5,b="B",c) $display(a,,b,,c);$/;"	c	module:directive
-MACRO2	input.sv	/^`define MACRO2(a=5, b, c="C") $display(a,,b,,c);$/;"	c	module:directive
-MACRO3	input.sv	/^`define MACRO3(a=5, b=0, c="C") $display(a,,b,,c);$/;"	c	module:directive
-wordsize	input.sv	/^`define wordsize 8$/;"	c	module:directive
+D	input.sv	/^`define D(x,y) initial $display("start", x , y, "end");$/;"	d	module:directive
+MACRO1	input.sv	/^`define MACRO1(a=5,b="B",c) $display(a,,b,,c);$/;"	d	module:directive
+MACRO2	input.sv	/^`define MACRO2(a=5, b, c="C") $display(a,,b,,c);$/;"	d	module:directive
+MACRO3	input.sv	/^`define MACRO3(a=5, b=0, c="C") $display(a,,b,,c);$/;"	d	module:directive
+wordsize	input.sv	/^`define wordsize 8$/;"	d	module:directive
 data	input.sv	/^logic [1:`wordsize] data;$/;"	r	module:directive
-var_nand	input.sv	/^`define var_nand(dly) nand #dly$/;"	c	module:directive
-max	input.sv	/^`define max(a,b)((a) > (b) ? (a) : (b))$/;"	c	module:directive
-TOP	input.sv	/^`define TOP(a,b) a + b$/;"	c	module:directive
+var_nand	input.sv	/^`define var_nand(dly) nand #dly$/;"	d	module:directive
+max	input.sv	/^`define max(a,b)((a) > (b) ? (a) : (b))$/;"	d	module:directive
+TOP	input.sv	/^`define TOP(a,b) a + b$/;"	d	module:directive
 main	input.sv	/^module main;$/;"	m
-HI	input.sv	/^`define HI Hello$/;"	c	module:main
-LO	input.sv	/^`define LO "`HI, world"$/;"	c	module:main
-H	input.sv	/^`define H(x) "Hello, x"$/;"	c	module:main
+HI	input.sv	/^`define HI Hello$/;"	d	module:main
+LO	input.sv	/^`define LO "`HI, world"$/;"	d	module:main
+H	input.sv	/^`define H(x) "Hello, x"$/;"	d	module:main
 directive2	input.sv	/^module directive2;$/;"	m
-msg	input.sv	/^`define msg(x,y) `"x: `\\`"y`\\`"`"$/;"	c	module:directive2
-append	input.sv	/^`define append(f) f``_master$/;"	c	module:directive2
-home	input.sv	/^`define home(filename) `"\/home\/mydir\/filename`"$/;"	c	module:directive2
+msg	input.sv	/^`define msg(x,y) `"x: `\\`"y`\\`"`"$/;"	d	module:directive2
+append	input.sv	/^`define append(f) f``_master$/;"	d	module:directive2
+home	input.sv	/^`define home(filename) `"\/home\/mydir\/filename`"$/;"	d	module:directive2
 and_op	input.sv	/^module and_op (a, b, c);$/;"	m
 a	input.sv	/^    output a;$/;"	p	module:and_op
 b	input.sv	/^    input b, c;$/;"	p	module:and_op
@@ -23,10 +23,10 @@ c	input.sv	/^    input b, c;$/;"	p	module:and_op
 a	input.sv	/^        wire a = b & c;$/;"	n	module:and_op
 test	input.sv	/^module test(out);$/;"	m
 out	input.sv	/^    output out;$/;"	p	module:test
-wow	input.sv	/^    `define wow$/;"	c	module:test
-nest_one	input.sv	/^    `define nest_one$/;"	c	module:test
-second_nest	input.sv	/^    `define second_nest$/;"	c	module:test
-nest_two	input.sv	/^    `define nest_two$/;"	c	module:test
+wow	input.sv	/^    `define wow$/;"	d	module:test
+nest_one	input.sv	/^    `define nest_one$/;"	d	module:test
+second_nest	input.sv	/^    `define second_nest$/;"	d	module:test
+nest_two	input.sv	/^    `define nest_two$/;"	d	module:test
 test	input.sv	/^module test;$/;"	m
 ifdef_in_port	input.sv	/^module ifdef_in_port ($/;"	m
 a	input.sv	/^    input logic a,$/;"	p	module:ifdef_in_port
@@ -37,9 +37,9 @@ c	input.sv	/^    input logic c$/;"	p	module:ifdef_in_port
 user_t	input.sv	/^typedef logic user_t;$/;"	T
 define_in_port	input.sv	/^module define_in_port ($/;"	m
 a	input.sv	/^    input user_t a,$/;"	p	module:define_in_port
-FOO	input.sv	/^`define FOO$/;"	c	module:define_in_port
+FOO	input.sv	/^`define FOO$/;"	d	module:define_in_port
 b	input.sv	/^    input user_t b,$/;"	p	module:define_in_port
-BAR	input.sv	/^`define BAR$/;"	c	module:define_in_port
+BAR	input.sv	/^`define BAR$/;"	d	module:define_in_port
 c1	input.sv	/^        input user_t c1,$/;"	p	module:define_in_port
 c2	input.sv	/^        input user_t c2,$/;"	p	module:define_in_port
 c3	input.sv	/^        input user_t c3,c4,$/;"	p	module:define_in_port
@@ -47,9 +47,9 @@ c4	input.sv	/^        input user_t c3,c4,$/;"	p	module:define_in_port
 d1	input.sv	/^        output user_t d1 ,$/;"	p	module:define_in_port
 d2	input.sv	/^        output user_t d2$/;"	p	module:define_in_port
 define_in_port_messy	input.sv	/^module define_in_port_messy ($/;"	m
-FOO	input.sv	/^`define FOO$/;"	c	module:define_in_port_messy
+FOO	input.sv	/^`define FOO$/;"	d	module:define_in_port_messy
 a	input.sv	/^    input user_t a$/;"	p	module:define_in_port_messy
-BAR	input.sv	/^`define BAR$/;"	c	module:define_in_port_messy
+BAR	input.sv	/^`define BAR$/;"	d	module:define_in_port_messy
 b	input.sv	/^    ,input user_t b$/;"	p	module:define_in_port_messy
 c1	input.sv	/^        ,input user_t c1$/;"	p	module:define_in_port_messy
 c2	input.sv	/^        ,input user_t c2$/;"	p	module:define_in_port_messy
@@ -57,7 +57,7 @@ c3	input.sv	/^        ,input user_t c3 , c4$/;"	p	module:define_in_port_messy
 c4	input.sv	/^        ,input user_t c3 , c4$/;"	p	module:define_in_port_messy
 d1	input.sv	/^        , output user_t d1$/;"	p	module:define_in_port_messy
 d2	input.sv	/^        , output user_t d2$/;"	p	module:define_in_port_messy
-MY_DEFINE	input.sv	/^`define MY_DEFINE$/;"	c
-assert_clk	input.sv	/^`define assert_clk(arg, __clk=clk, __rst_n=rst_n) \\$/;"	c
+MY_DEFINE	input.sv	/^`define MY_DEFINE$/;"	d
+assert_clk	input.sv	/^`define assert_clk(arg, __clk=clk, __rst_n=rst_n) \\$/;"	d
 forSkipMacro	input.sv	/^module forSkipMacro;$/;"	m
-add_t	input.sv	/^`define add_t(f) f``_t$/;"	c	module:forSkipMacro
+add_t	input.sv	/^`define add_t(f) f``_t$/;"	d	module:forSkipMacro

--- a/Units/parser-verilog.r/systemverilog-nocontext.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-nocontext.d/expected.tags
@@ -1,6 +1,6 @@
-DEFINE	input.sv	/^`define DEFINE$/;"	c
-DEF_WITH_EQ	input.sv	/^`define DEF_WITH_EQ = 1'd100$/;"	c
-DEF_VALUE	input.sv	/^`define DEF_VALUE   1'd100$/;"	c
+DEFINE	input.sv	/^`define DEFINE$/;"	d
+DEF_WITH_EQ	input.sv	/^`define DEF_WITH_EQ = 1'd100$/;"	d
+DEF_VALUE	input.sv	/^`define DEF_VALUE   1'd100$/;"	d
 PARAM	input.sv	/^parameter PARAM = 1;$/;"	c
 LOCALPARAM	input.sv	/^localparam LOCALPARAM = 2**2;$/;"	c
 STATE1	input.sv	/^localparam STATE1 = 4'h0,$/;"	c

--- a/Units/parser-verilog.r/verilog-2001.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-2001.d/expected.tags
@@ -1,6 +1,6 @@
-DEFINE	input.v	/^`define DEFINE$/;"	c
-DEF_WITH_EQ	input.v	/^`define DEF_WITH_EQ = 1'd100$/;"	c
-DEF_VALUE	input.v	/^`define DEF_VALUE   1'd100$/;"	c
+DEFINE	input.v	/^`define DEFINE$/;"	d
+DEF_WITH_EQ	input.v	/^`define DEF_WITH_EQ = 1'd100$/;"	d
+DEF_VALUE	input.v	/^`define DEF_VALUE   1'd100$/;"	d
 mod	input.v	/^module mod#($/;"	m
 PARAM1	input.v	/^    parameter PARAM1 = 10,$/;"	c	module:mod
 mod.PARAM1	input.v	/^    parameter PARAM1 = 10,$/;"	c	module:mod

--- a/Units/parser-verilog.r/verilog-basic.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-basic.d/expected.tags
@@ -1,6 +1,6 @@
-DEFINE	input.v	/^`define DEFINE$/;"	c
-DEF_WITH_EQ	input.v	/^`define DEF_WITH_EQ = 1'd100$/;"	c
-DEF_VALUE	input.v	/^`define DEF_VALUE   1'd100$/;"	c
+DEFINE	input.v	/^`define DEFINE$/;"	d
+DEF_WITH_EQ	input.v	/^`define DEF_WITH_EQ = 1'd100$/;"	d
+DEF_VALUE	input.v	/^`define DEF_VALUE   1'd100$/;"	d
 mod	input.v	/^module mod ($/;"	m
 PARAM	input.v	/^parameter PARAM = 1;$/;"	c	module:mod
 mod.PARAM	input.v	/^parameter PARAM = 1;$/;"	c	module:mod

--- a/Units/parser-verilog.r/verilog-memleak.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-memleak.d/expected.tags
@@ -1,4 +1,4 @@
-DEFINE	input.v	/^`define DEFINE$/;"	c
+DEFINE	input.v	/^`define DEFINE$/;"	d
 mod	input.v	/^module mod ($/;"	m
 PARAM	input.v	/^parameter PARAM = 1;$/;"	c	module:mod
 a	input.v	/^input a,b, c, d ;$/;"	p	module:mod

--- a/Units/parser-verilog.r/verilog-multiline-macro.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-multiline-macro.d/expected.tags
@@ -1,2 +1,2 @@
-defvar_with_comment	input.sv	/^`define defvar_with_comment \\$/;"	c
-defvar_without_comment	input.sv	/^`define defvar_without_comment \\$/;"	c
+defvar_with_comment	input.sv	/^`define defvar_with_comment \\$/;"	d
+defvar_without_comment	input.sv	/^`define defvar_without_comment \\$/;"	d

--- a/Units/parser-verilog.r/verilog-nocontext.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-nocontext.d/expected.tags
@@ -1,6 +1,6 @@
-DEFINE	input.v	/^`define DEFINE$/;"	c
-DEF_WITH_EQ	input.v	/^`define DEF_WITH_EQ = 1'd100$/;"	c
-DEF_VALUE	input.v	/^`define DEF_VALUE   1'd100$/;"	c
+DEFINE	input.v	/^`define DEFINE$/;"	d
+DEF_WITH_EQ	input.v	/^`define DEF_WITH_EQ = 1'd100$/;"	d
+DEF_VALUE	input.v	/^`define DEF_VALUE   1'd100$/;"	d
 PARAM	input.v	/^parameter PARAM = 1;$/;"	c
 LOCALPARAM	input.v	/^localparam LOCALPARAM = 2**2;$/;"	c
 STATE1	input.v	/^localparam STATE1 = 4'h0,$/;"	c

--- a/Units/parser-verilog.r/verilog-sf_bug98.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-sf_bug98.d/expected.tags
@@ -2,5 +2,5 @@ pass_task_1	input.v	/^task pass_task_1;$/;"	t
 fail_task_2	input.v	/^task fail_task_2;$/;"	t
 pass_func_1	input.v	/^function pass_func_1;$/;"	f
 fail_func_2	input.v	/^function fail_func_2;$/;"	f
-pass_define_1	input.v	/^`define pass_define_1 1'b1;$/;"	c
-fail_define_2	input.v	/^`define fail_define_2 1'b1;$/;"	c
+pass_define_1	input.v	/^`define pass_define_1 1'b1;$/;"	d
+fail_define_2	input.v	/^`define fail_define_2 1'b1;$/;"	d

--- a/Units/parser-verilog.r/verilog-sf_bug99.d/expected.tags
+++ b/Units/parser-verilog.r/verilog-sf_bug99.d/expected.tags
@@ -1,8 +1,8 @@
-HOSTA	input.v	/^`define HOSTA$/;"	c
-HOSTB	input.v	/^`define HOSTB$/;"	c
-HOSTC	input.v	/^`define HOSTC$/;"	c
-HOSTD	input.v	/^`define HOSTD$/;"	c
-GUESTA	input.v	/^`define GUESTA 1$/;"	c
-GUESTB	input.v	/^`define GUESTB 2$/;"	c
-GUESTC	input.v	/^`define GUESTC 3$/;"	c
-GUESTD	input.v	/^`define GUESTD 4$/;"	c
+HOSTA	input.v	/^`define HOSTA$/;"	d
+HOSTB	input.v	/^`define HOSTB$/;"	d
+HOSTC	input.v	/^`define HOSTC$/;"	d
+HOSTD	input.v	/^`define HOSTD$/;"	d
+GUESTA	input.v	/^`define GUESTA 1$/;"	d
+GUESTB	input.v	/^`define GUESTB 2$/;"	d
+GUESTC	input.v	/^`define GUESTC 3$/;"	d
+GUESTD	input.v	/^`define GUESTD 4$/;"	d

--- a/man/ctags-lang-verilog.7.rst.in
+++ b/man/ctags-lang-verilog.7.rst.in
@@ -54,7 +54,8 @@ Supported Kinds
 	T       typedef    yes     no      0      NONE   type declarations
 	V       covergroup yes     no      0      NONE   covergroups
 	b       block      yes     no      0      NONE   blocks (begin, fork)
-	c       constant   yes     no      0      NONE   constants (define, parameter, specparam, enum values)
+	c       constant   yes     no      0      NONE   constants (parameter, specparam, enum values)
+	d       define     yes     no      0      NONE   text macros
 	e       event      yes     no      0      NONE   events
 	f       function   yes     no      0      NONE   functions
 	i       instance   yes     no      0      NONE   instances of module or interface
@@ -74,7 +75,8 @@ Note that ``prototype`` (``Q``) is disabled by default.
 	$ ctags --list-kinds-full=Verilog
 	#LETTER NAME     ENABLED REFONLY NROLES MASTER DESCRIPTION
 	b       block    yes     no      0      NONE   blocks (begin, fork)
-	c       constant yes     no      0      NONE   constants (define, parameter, specparam)
+	c       constant yes     no      0      NONE   constants (parameter, specparam)
+	d       define   yes     no      0      NONE   text macros
 	e       event    yes     no      0      NONE   events
 	f       function yes     no      0      NONE   functions
 	i       instance yes     no      0      NONE   instances of module

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -65,7 +65,6 @@
 typedef enum {
 	/* parser private items */
 	K_IGNORE = -16,	/* Verilog/SystemVerilog keywords to be ignored */
-	K_DEFINE,
 	K_DIRECTIVE,
 	K_END,
 	K_END_DE,	/* End of Design Elements */
@@ -78,6 +77,7 @@ typedef enum {
 	K_UNDEFINED = KEYWORD_NONE,
 	/* the followings items are also used as indices for VerilogKinds[] and SystemVerilogKinds[] */
 	K_CONSTANT= 0,
+	K_DEFINE,
 	K_EVENT,
 	K_FUNCTION,
 	K_MODULE,
@@ -154,7 +154,8 @@ static roleDefinition SystemVerilogModuleRoles [] = {
 };
 
 static kindDefinition VerilogKinds [] = {
- { true, 'c', "constant",  "constants (define, parameter, specparam)" },
+ { true, 'c', "constant",  "constants (parameter, specparam)" },
+ { true, 'd', "define",    "text macros" },
  { true, 'e', "event",     "events" },
  { true, 'f', "function",  "functions" },
  { true, 'm', "module",    "modules",
@@ -168,7 +169,8 @@ static kindDefinition VerilogKinds [] = {
 };
 
 static kindDefinition SystemVerilogKinds [] = {
- { true, 'c', "constant",  "constants (define, parameter, specparam, enum values)" },
+ { true, 'c', "constant",  "constants (parameter, specparam, enum values)" },
+ { true, 'd', "define",    "text macros" },
  { true, 'e', "event",     "events" },
  { true, 'f', "function",  "functions" },
  { true, 'm', "module",    "modules",
@@ -1412,7 +1414,7 @@ static int processDefine (tokenInfo *const token, int c)
 	if (isWordToken (c))
 	{
 		c = readWordTokenNoSkip (token, c);
-		createTag (token, K_CONSTANT);
+		createTag (token, K_DEFINE);
 	}
 	c = skipToNewLine (c);
 	c = skipWhite (c);
@@ -2086,6 +2088,8 @@ extern parserDefinition* VerilogParser (void)
 {
 	static const char *const extensions [] = { "v", NULL };
 	parserDefinition* def = parserNew ("Verilog");
+	def->versionCurrent = 1;
+	def->versionAge = 1;
 	def->kindTable  = VerilogKinds;
 	def->kindCount  = ARRAY_SIZE (VerilogKinds);
 	def->fieldTable = VerilogFields;
@@ -2100,6 +2104,8 @@ extern parserDefinition* SystemVerilogParser (void)
 {
 	static const char *const extensions [] = { "sv", "svh", "svi", NULL };
 	parserDefinition* def = parserNew ("SystemVerilog");
+	def->versionCurrent = 1;
+	def->versionAge = 1;
 	def->kindTable  = SystemVerilogKinds;
 	def->kindCount  = ARRAY_SIZE (SystemVerilogKinds);
 	def->fieldTable = SystemVerilogFields;


### PR DESCRIPTION
In some case,  readtags return different kind of text macro(define) and parameter is better for me.
