### PR TITLE
SQL: Skip PL/SQL selection directives and add sanity check for inquiry directive size

### DIFF
--- a/Units/parser-sql.r/sql-plsql-selection-directive.d/args.ctags
+++ b/Units/parser-sql.r/sql-plsql-selection-directive.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+q
+--kinds-SQL=+d

--- a/Units/parser-sql.r/sql-plsql-selection-directive.d/expected.tags
+++ b/Units/parser-sql.r/sql-plsql-selection-directive.d/expected.tags
@@ -1,0 +1,7 @@
+demo_pkg	input.sql	/^create or replace package body demo_pkg is$/;"	P
+demo_pkg.test_func1	input.sql	/^function test_func1 return INTEGER$/;"	f	package:demo_pkg
+test_func1	input.sql	/^function test_func1 return INTEGER$/;"	f	package:demo_pkg
+demo_pkg.test_func2	input.sql	/^function test_func2 return INTEGER$/;"	f	package:demo_pkg
+test_func2	input.sql	/^function test_func2 return INTEGER$/;"	f	package:demo_pkg
+demo_pkg.test_func5	input.sql	/^function test_func5 return INTEGER$/;"	f	package:demo_pkg
+test_func5	input.sql	/^function test_func5 return INTEGER$/;"	f	package:demo_pkg

--- a/Units/parser-sql.r/sql-plsql-selection-directive.d/input.sql
+++ b/Units/parser-sql.r/sql-plsql-selection-directive.d/input.sql
@@ -1,0 +1,42 @@
+create or replace package body demo_pkg is
+
+function test_func1 return INTEGER
+as
+begin
+    return 1;
+end;
+
+$IF $$MY_VERSION_CODE > 3 $THEN
+
+function test_func2 return INTEGER
+as
+begin
+    return 3;
+end;
+
+$ELSIF $$MY_VERSION_CODE > 5 $THEN
+
+function test_func3 return INTEGER
+as
+begin
+    return 5;
+end;
+
+$ELSE
+
+function test_func4 return INTEGER
+as
+begin
+    return 7;
+end;
+
+$END
+
+function test_func5 return INTEGER
+as
+begin
+    return 9;
+end;
+
+end demo_pkg;
+


### PR DESCRIPTION
PLSQL selection directives are of the form
```
$IF boolean_static_expression $THEN
   text
[ $ELSIF boolean_static_expression $THEN
   text
]...
[ $ELSE
   text
]
$END
```
In addition, boolean_static_expression conditions like
```
$$MY_CUSTOM_VAR > 3
```
can appear which confuses the current parser because it
thinks `$$` is the start of dollar-quoted string and drops
the rest of the code. In addition, as the double-quoted
string is getting bigger and bigger and tested against
inquiry directives by
```
lookupCaseKeyword (vStringValue (string), Lang_sql)
```
it takes huge amount of time to perform the repeated
lookups in the hash table.

This patch skips all the code between `$IF` and `$END` because
we can't know which of the branches to take and this is the
easiest way to avoid invalid code. In addition, this patch
also drops `$` from all identifiers starting with `$$` between
`$IF` and `$END` as these may be conditional variables in the
`$IF` block.

---

Another issue is that
`$$` typed anywhere in the code, e.g. by accident, makes the rest of the
code appear to the parser as a dollar-quoted string which can be thousands
of bytes long. In this case `lookupCaseKeyword()` is called repeatedly on
this ever increasing string which consumes a lot of time and makes the
parser appear completely unresponsive for large files.

This patch adds a sanity check to perform `lookupCaseKeyword()` only for
strings of length smaller than 30 (currently the longest inquiry directive
keyword is 21 characters long so there should be some safe extra margin
even for longer keywords if added in the future).

Fixes #3647.