### PR TITLE
GitHub Actions: change github actions checkout from v2 to v3

### DIFF
--- a/.github/workflows/cross-compile-android-ndk-on-mac.yml
+++ b/.github/workflows/cross-compile-android-ndk-on-mac.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.build-machine-os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: brew install gcc make automake autoconf file
 

--- a/.github/workflows/cross-compile-android-ndk-on-ubuntu.yml
+++ b/.github/workflows/cross-compile-android-ndk-on-ubuntu.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.build-machine-os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: sudo apt-get -y -o APT::Immediate-Configure=false update
       - run: sudo apt-get -y -o APT::Immediate-Configure=false install gcc make automake autoconf file

--- a/.github/workflows/cross-compile-mingw-w64-on-mac.yml
+++ b/.github/workflows/cross-compile-mingw-w64-on-mac.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.build-machine-os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: brew install mingw-w64 gcc make automake autoconf file
 

--- a/.github/workflows/cross-compile-mingw-w64-on-ubuntu.yml
+++ b/.github/workflows/cross-compile-mingw-w64-on-ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.build-machine-os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: sudo apt-get -y -o APT::Immediate-Configure=false update
       - run: sudo apt-get -y -o APT::Immediate-Configure=false install mingw-w64 gcc make automake autoconf file

--- a/.github/workflows/run-citre-tests.yml
+++ b/.github/workflows/run-citre-tests.yml
@@ -21,7 +21,7 @@ jobs:
       READTAGS: '${{ github.workspace }}/readtags'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: update package information
         run: sudo apt-get -y -o APT::Immediate-Configure=false update
       - name: install tools and libraries
@@ -41,7 +41,7 @@ jobs:
       - name: install Emacs
         run: sudo apt-get -y -o APT::Immediate-Configure=false install emacs
       - name: checkout Citre repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: 'universal-ctags/citre'
           path: 'citre'

--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         path: ctags
 

--- a/.github/workflows/testing-alpine.yml
+++ b/.github/workflows/testing-alpine.yml
@@ -23,7 +23,7 @@ jobs:
       # this is to fix https://github.com/actions/checkout/issues/760
       - run: git config --global --add safe.directory /__w/ctags/ctags
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - run: cc --version
 

--- a/.github/workflows/testing-bsds.yml.bak
+++ b/.github/workflows/testing-bsds.yml.bak
@@ -16,7 +16,7 @@ jobs:
         freebsd-version: [12,13]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: actions/cache@v2
       with:
@@ -50,7 +50,7 @@ jobs:
     runs-on: macos-12
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: actions/cache@v2
       with:
@@ -93,7 +93,7 @@ jobs:
     runs-on: macos-12
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/testing-freebsd.yml
+++ b/.github/workflows/testing-freebsd.yml
@@ -16,7 +16,7 @@ jobs:
         freebsd-version: [12,13]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/testing-gnulinux.yml
+++ b/.github/workflows/testing-gnulinux.yml
@@ -27,7 +27,7 @@ jobs:
       DEBIAN_FRONTEND: noninteractive
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: update package information

--- a/.github/workflows/testing-mac.yml
+++ b/.github/workflows/testing-mac.yml
@@ -21,7 +21,7 @@ jobs:
       BUILDDIR: ${{ matrix.os }}-${{ matrix.compiler }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: update package information
       run: brew update
     - name: install tools and libraries

--- a/.github/workflows/testing-msys2.yml
+++ b/.github/workflows/testing-msys2.yml
@@ -39,7 +39,7 @@ jobs:
     
     - run: git config --global core.autocrlf input
       shell: bash
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - run: ./autogen.sh
     - run: ./configure --prefix=/usr

--- a/.github/workflows/testing-netbsd.yml
+++ b/.github/workflows/testing-netbsd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-12
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/testing-openbsd.yml
+++ b/.github/workflows/testing-openbsd.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-12
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/testing-with-vlagrind.yml
+++ b/.github/workflows/testing-with-vlagrind.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: update package information
       run: sudo apt-get update
     - name: install tools and libraries


### PR DESCRIPTION
https://github.com/actions/checkout@v2 use node12 runtime by default 
https://github.com/actions/checkout@v3 use node16 runtime by default

Reference: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/