### PR TITLE
Powershell: fix string escape issue

### DIFF
--- a/Units/parser-powershell.r/simple-powershell.d/expected.tags
+++ b/Units/parser-powershell.r/simple-powershell.d/expected.tags
@@ -2,6 +2,9 @@ ErrorActionPreference	input.ps1	/^$ErrorActionPreference = "Stop"$/;"	v
 Settings	input.ps1	/^$Global:Settings = $null$/;"	v
 ALocalVar	input.ps1	/^$Local:ALocalVar = $null$/;"	v
 BasePath	input.ps1	/^$BasePath = split-path -parent $Global:MyInvocation.InvocationName$/;"	v
+cDrive	input.ps1	/^$cDrive="C:\\"$/;"	v
+nextLine	input.ps1	/^$nextLine="`n"$/;"	v
+backtick	input.ps1	/^$backtick='`'$/;"	v
 Read-Configuration-File	input.ps1	/^FUNCTION Read-Configuration-File() {$/;"	f	signature:()
 LogMessageOK	input.ps1	/^Function LogMessageOK()$/;"	f	signature:()
 LogMessage	input.ps1	/^function LogMessage() {$/;"	f	signature:()

--- a/Units/parser-powershell.r/simple-powershell.d/input.ps1
+++ b/Units/parser-powershell.r/simple-powershell.d/input.ps1
@@ -25,6 +25,10 @@ $Local:ALocalVar = $null
 # a usual variable
 $BasePath = split-path -parent $Global:MyInvocation.InvocationName
 
+# different type of escape in string
+$cDrive="C:\"
+$nextLine="`n"
+$backtick='`'
 
 FUNCTION Read-Configuration-File() {
     $Hostname = [System.Environment]::MachineName

--- a/parsers/powershell.c
+++ b/parsers/powershell.c
@@ -248,7 +248,7 @@ static void parseString (vString *const string, const int delimiter)
 	{
 		int c = getcFromInputFile ();
 
-		if (c == '\\' && (c = getcFromInputFile ()) != EOF)
+		if (delimiter == '"' && c == '`' && (c = getcFromInputFile ()) != EOF)
 			vStringPut (string, c);
 		else if (c == EOF || c == delimiter)
 			break;


### PR DESCRIPTION
According to [official doc](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_special_characters?view=powershell-7.3), powershell use ` to escape string and it only works in ".