### PR TITLE
cosmetic: gitignore *.swp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.od
 *.pdf
 *.pyc
+*.swp
 *.c3workspace
 *.c3workspace.user
 *.tar.gz


### PR DESCRIPTION
*.swp is quite common for VIM users while editing code, ignore it.