### PR TITLE
Quarto: new parser

### DIFF
--- a/Tmain/list-subparsers-all.d/stdout-expected.txt
+++ b/Tmain/list-subparsers-all.d/stdout-expected.txt
@@ -16,6 +16,7 @@ OpenAPI              Yaml       base <> sub {bidirectional}
 PlistXML             XML        base <> sub {bidirectional}
 PythonLoggingConfig  Iniconf    base <> sub {bidirectional}
 QtMoc                C++        base <> sub {bidirectional}
+Quarto               Markdown   base <= sub {dedicated}
 R6Class              R          base <> sub {bidirectional}
 RMarkdown            Markdown   base <= sub {dedicated}
 RSpec                Ruby       base => sub {shared}

--- a/Units/parser-quarto.r/simple.d/args.ctags
+++ b/Units/parser-quarto.r/simple.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+{guest}
+--fields=+{end}{line}{language}

--- a/Units/parser-quarto.r/simple.d/expected.tags
+++ b/Units/parser-quarto.r/simple.d/expected.tags
@@ -1,0 +1,2 @@
+defun	input.qmd	/^#| label: defun$/;"	l	line:2	language:Quarto	end:6
+f	input.qmd	/^def f():$/;"	f	line:4	language:Python	end:5

--- a/Units/parser-quarto.r/simple.d/input.qmd
+++ b/Units/parser-quarto.r/simple.d/input.qmd
@@ -1,0 +1,7 @@
+```{python}
+#| label: defun
+#| fig-cap: "Define a function"
+def f():
+    pass
+```
+

--- a/Units/parser-quarto.r/unexecuted-block.d/args.ctags
+++ b/Units/parser-quarto.r/unexecuted-block.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+{guest}
+--fields=+{end}{line}{language}

--- a/Units/parser-quarto.r/unexecuted-block.d/expected.tags
+++ b/Units/parser-quarto.r/unexecuted-block.d/expected.tags
@@ -1,0 +1,4 @@
+__anon53b260bc0100	input.qmd	/^```{python}$/;"	l	line:1	language:Quarto	end:4
+__anon53b260bc0200	input.qmd	/^```{{python}}$/;"	l	line:6	language:Quarto	end:9
+f	input.qmd	/^def f():$/;"	f	line:2	language:Python	end:3
+g	input.qmd	/^def g():$/;"	f	line:7	language:Python	end:8

--- a/Units/parser-quarto.r/unexecuted-block.d/input.qmd
+++ b/Units/parser-quarto.r/unexecuted-block.d/input.qmd
@@ -1,0 +1,9 @@
+```{python}
+def f():
+    pass
+```
+
+```{{python}}
+def g():
+    pass
+```

--- a/Units/parser-rmarkdown.r/frontmatter.d/expected.tags
+++ b/Units/parser-rmarkdown.r/frontmatter.d/expected.tags
@@ -1,8 +1,8 @@
 S1	input.rmd	/^# S1$/;"	chapter	line:4	language:Markdown	end:17
-xyX	input.rmd	/^```{r xyX}$/;"	chunklabel	line:6	language:RMarkdown	extras:subparser
+xyX	input.rmd	/^```{r xyX}$/;"	chunklabel	line:6	language:RMarkdown	extras:subparser	end:16
 S2	input.rmd	/^# S2$/;"	chapter	line:18	language:Markdown	end:28
-__anon9d4e183a0100	input.rmd	/^```{r, cache = TRUE, dependson = "xyX"}$/;"	chunklabel	line:20	language:RMarkdown	extras:subparser,anonymous
-__anon9d4e183a0200	input.rmd	/^```{python}$/;"	chunklabel	line:24	language:RMarkdown	extras:subparser,anonymous
+__anon9d4e183a0100	input.rmd	/^```{r, cache = TRUE, dependson = "xyX"}$/;"	chunklabel	line:20	language:RMarkdown	extras:subparser,anonymous	end:22
+__anon9d4e183a0200	input.rmd	/^```{python}$/;"	chunklabel	line:24	language:RMarkdown	extras:subparser,anonymous	end:28
 S3	input.rmd	/^# S3$/;"	chapter	line:29	language:Markdown	end:30
 x	input.rmd	/^x <- 1$/;"	globalVar	line:8	language:R	extras:guest	end:8
 foo	input.rmd	/^foo <- function () {$/;"	function	line:9	language:R	extras:guest	end:12

--- a/Units/parser-rmarkdown.r/simple-rmarkdown.d/expected.tags
+++ b/Units/parser-rmarkdown.r/simple-rmarkdown.d/expected.tags
@@ -1,8 +1,8 @@
 S1	input.rmd	/^# S1$/;"	chapter	line:1	language:Markdown	end:14
-xyX	input.rmd	/^```{r xyX}$/;"	chunklabel	line:3	language:RMarkdown	extras:subparser
+xyX	input.rmd	/^```{r xyX}$/;"	chunklabel	line:3	language:RMarkdown	extras:subparser	end:13
 S2	input.rmd	/^# S2$/;"	chapter	line:15	language:Markdown	end:25
-__anon4a45a9700100	input.rmd	/^```{r, cache = TRUE, dependson = "xyX"}$/;"	chunklabel	line:17	language:RMarkdown	extras:subparser,anonymous
-__anon4a45a9700200	input.rmd	/^```{python}$/;"	chunklabel	line:21	language:RMarkdown	extras:subparser,anonymous
+__anon4a45a9700100	input.rmd	/^```{r, cache = TRUE, dependson = "xyX"}$/;"	chunklabel	line:17	language:RMarkdown	extras:subparser,anonymous	end:19
+__anon4a45a9700200	input.rmd	/^```{python}$/;"	chunklabel	line:21	language:RMarkdown	extras:subparser,anonymous	end:25
 S3	input.rmd	/^# S3$/;"	chapter	line:26	language:Markdown	end:27
 x	input.rmd	/^x <- 1$/;"	globalVar	line:5	language:R	extras:guest	end:5
 foo	input.rmd	/^foo <- function () {$/;"	function	line:6	language:R	extras:guest	end:9

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -454,6 +454,7 @@ The following parsers have been added:
 * PythonLoggingConfig
 * QemuHX *optlib*
 * QtMoc
+* Quarto *Markdown based subparser*
 * R
 * R6Class *R based subparser*
 * Rake *Ruby based subparser*

--- a/main/parsers_p.h
+++ b/main/parsers_p.h
@@ -148,6 +148,7 @@
 	PythonLoggingConfigParser, \
 	QemuHXParser, \
 	QtMocParser, \
+	QuartoParser, \
 	RMarkdownParser, \
 	RParser, \
 	RakeParser, \

--- a/parsers/markdown.h
+++ b/parsers/markdown.h
@@ -21,9 +21,46 @@ typedef struct sMarkdownSubparser markdownSubparser;
 
 struct sMarkdownSubparser {
 	subparser subparser;
+	/* ```something
+	   ---^ The rest of string is passed as LANGMARKER.
+
+	   A sub parser analyses LANGMARKER.
+	   If the sub parser can extract a name of language from LANGMARKER,
+	   the parser puts the name to LANGNAME, and returns true.
+	   If not, return false.
+
+	   e.g.
+
+	   ```{python}
+
+	   Fot this input, ctags pases "{python}" as LANGMARKER. */
 	bool (* extractLanguageForCodeBlock) (markdownSubparser *s,
 										  const char *langMarker,
 										  vString *langName);
+
+	/* ```something
+	   ...
+	   <code block>
+	   ...
+	   ```
+
+	   ctags passes each LINE in the code block to the sub parser
+	   that returns true when ctags calls extractLanguageForCodeBlock()
+	   with the sub parser. */
+	void (* notifyCodeBlockLine) (markdownSubparser *s,
+								  const unsigned char *line);
+
+	/* ```something
+	   ...
+	   codeblock
+	   ...
+	   ```
+	   ^ The end of code block.
+
+	   ctags notifies the sub parser that the end of code block
+	   is found.
+	*/
+	void (* notifyEndOfCodeBlock) (markdownSubparser *s);
 };
 
 #endif

--- a/parsers/quarto.c
+++ b/parsers/quarto.c
@@ -1,0 +1,224 @@
+/*
+ *
+ *  Copyright (c) 2023, Masatake YAMATO
+ *
+ *   This source code is released for free distribution under the terms of the
+ *   GNU General Public License version 2 or (at your option) any later version.
+ *
+ * This module contains functions for generating tags for Quarto files.
+ * https://quarto.org/docs/guide/
+ * https://quarto.org/docs/reference/
+ * https://www.jaysong.net/RBook/quarto.html#sec-quarto-howtouse <Japanese>
+ *
+ */
+
+/*
+ *   INCLUDE FILES
+ */
+#include "general.h"	/* must always come first */
+#include "markdown.h"
+
+#include "entry.h"
+#include "parse.h"
+#include "read.h"
+
+#include <ctype.h>
+#include <string.h>
+
+/*
+ *   DATA DEFINITIONS
+ */
+typedef enum {
+	K_CHUNK_LABEL = 0,
+} quartoKind;
+
+static kindDefinition QuartoKinds[] = {
+	{ true, 'l', "chunklabel",       "chunk labels"},
+};
+
+struct sQuartoSubparser {
+	markdownSubparser markdown;
+	int lastChunkLabel;
+};
+
+/*
+*   FUNCTION DEFINITIONS
+*/
+
+static void findQuartoTags (void)
+{
+	scheduleRunningBaseparser (0);
+}
+
+#define skip_space(CP) 	while (*CP == ' ' || *CP == '\t') CP++;
+
+static int makeQuartoTag (vString *name, int kindIndex, bool anonymous)
+{
+	tagEntryInfo e;
+	initTagEntry (&e, vStringValue (name), kindIndex);
+	if (anonymous)
+		markTagExtraBit (&e, XTAG_ANONYMOUS);
+	return makeTagEntry (&e);
+}
+
+static bool extractLanguageForCodeBlock (markdownSubparser *s,
+										 const char *langMarker,
+										 vString *langName)
+{
+	struct sQuartoSubparser *quarto = (struct sQuartoSubparser *)s;
+	const char *cp = langMarker;
+	bool unexecutedBlock = false;
+
+	if (*cp != '{')
+		return false;
+	cp++;
+
+	/* Handle unexecuted blocks like ```{{python}} */
+	if (*cp == '{') {
+		unexecutedBlock = true;
+		cp++;
+	}
+
+	const char *end = strpbrk(cp, " \t,}");
+	if (!end)
+		return false;
+
+	if (end - cp == 0)
+		return false;
+
+	vStringNCatS (langName, cp, end - cp);
+
+	if (unexecutedBlock) {
+		end = strpbrk(cp, " \t,}");
+		if (!end)
+		{
+			vStringClear (langName);
+			return false;
+		}
+	}
+
+	cp = end;
+	if (*cp == ',' || *cp == '}')
+	{
+		vString *name = anonGenerateNew("__anon", K_CHUNK_LABEL);
+		quarto->lastChunkLabel = makeQuartoTag (name,
+												K_CHUNK_LABEL,
+												true);
+		vStringDelete (name);
+		return true;
+	}
+
+	skip_space(cp);
+
+	vString *chunk_label  = vStringNew ();
+	bool anonymous = false;
+	while (isalnum((unsigned char)*cp) || *cp == '-')
+		vStringPut (chunk_label, *cp++);
+
+	if (vStringLength (chunk_label) == 0)
+	{
+		anonGenerate (chunk_label, "__anon", K_CHUNK_LABEL);
+		anonymous = true;
+	}
+
+	skip_space(cp);
+	if (*cp == ',' || *cp == '}')
+		quarto->lastChunkLabel = makeQuartoTag (chunk_label,
+												K_CHUNK_LABEL,
+												anonymous);
+
+	vStringDelete (chunk_label);
+	return true;
+}
+
+static void notifyCodeBlockLine (markdownSubparser *s,
+								 const unsigned char *line)
+{
+	struct sQuartoSubparser *quarto = (struct sQuartoSubparser *)s;
+
+	if (strncmp ((const char *)line, "#| ", 3))
+		return;
+
+	line += 3;
+	skip_space (line);
+
+	if (strncmp ((const char *)line, "label:", 6))
+		return;
+
+	line += 6;
+	skip_space (line);
+
+	if (!*line)
+		return;
+
+	vString *label = vStringNewInit ((const char *)line);
+	vStringStripTrailing (label);
+	if (!vStringIsEmpty (label))
+	{
+		/* If an anonymous tag is made for the label of this code chunk,
+		 * it becomes unnecessary; the real one can be made from
+		 * "#! label: ..." */
+		if (quarto->lastChunkLabel != CORK_NIL)
+		{
+			tagEntryInfo *e = getEntryInCorkQueue (quarto->lastChunkLabel);
+			if (e && isTagExtraBitMarked (e, XTAG_ANONYMOUS))
+				markTagAsPlaceholder (e, true);
+		}
+
+		quarto->lastChunkLabel = makeQuartoTag (label,
+												K_CHUNK_LABEL,
+												false);
+	}
+	vStringDelete (label);
+}
+
+static void notifyEndOfCodeBlock (markdownSubparser *s)
+{
+	struct sQuartoSubparser *quarto = (struct sQuartoSubparser *)s;
+
+	if (quarto->lastChunkLabel == CORK_NIL)
+		return;
+
+	tagEntryInfo *e = getEntryInCorkQueue (quarto->lastChunkLabel);
+	if (e)
+		e->extensionFields.endLine = getInputLineNumber ();
+
+	quarto->lastChunkLabel = CORK_NIL;
+}
+
+static void inputStart (subparser *s)
+{
+	struct sQuartoSubparser *quatro = (struct sQuartoSubparser*)s;
+
+	quatro->lastChunkLabel = CORK_NIL;
+}
+
+extern parserDefinition* QuartoParser (void)
+{
+	static const char *const extensions [] = { "qmd", NULL };
+	static struct sQuartoSubparser quartoSubparser = {
+		.markdown = {
+			.subparser = {
+				.direction = SUBPARSER_SUB_RUNS_BASE,
+				.inputStart = inputStart,
+			},
+			.extractLanguageForCodeBlock = extractLanguageForCodeBlock,
+			.notifyCodeBlockLine = notifyCodeBlockLine,
+			.notifyEndOfCodeBlock = notifyEndOfCodeBlock,
+		},
+	};
+	static parserDependency dependencies [] = {
+		[0] = { DEPTYPE_SUBPARSER, "Markdown", &quartoSubparser },
+	};
+
+	parserDefinition* const def = parserNew ("Quarto");
+
+
+	def->dependencies = dependencies;
+	def->dependencyCount = ARRAY_SIZE(dependencies);
+	def->kindTable      = QuartoKinds;
+	def->kindCount  = ARRAY_SIZE (QuartoKinds);
+	def->extensions = extensions;
+	def->parser     = findQuartoTags;
+	return def;
+}

--- a/source.mak
+++ b/source.mak
@@ -382,6 +382,7 @@ PARSER_SRCS =				\
 	parsers/protobuf.c		\
 	parsers/python.c		\
 	parsers/pythonloggingconfig.c	\
+	parsers/quarto.c		\
 	parsers/r-r6class.c		\
 	parsers/r-s4class.c		\
 	parsers/r.c			\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -337,6 +337,7 @@
     <ClCompile Include="..\parsers\protobuf.c" />
     <ClCompile Include="..\parsers\python.c" />
     <ClCompile Include="..\parsers\pythonloggingconfig.c" />
+    <ClCompile Include="..\parsers\quarto.c" />
     <ClCompile Include="..\parsers\r-r6class.c" />
     <ClCompile Include="..\parsers\r-s4class.c" />
     <ClCompile Include="..\parsers\r.c" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -534,6 +534,9 @@
     <ClCompile Include="..\parsers\pythonloggingconfig.c">
       <Filter>Source Files\parsers</Filter>
     </ClCompile>
+    <ClCompile Include="..\parsers\quarto.c">
+      <Filter>Source Files\parsers</Filter>
+    </ClCompile>
     <ClCompile Include="..\parsers\r-r6class.c">
       <Filter>Source Files\parsers</Filter>
     </ClCompile>


### PR DESCRIPTION
This parser is based on the RMarkdown parser.

The way of extracting chunk labels is enhanced for Quarto.

A. recognizing unexecuted blocks like

       ```{{python}}
       ...
       ```
   Quarto makes an anonymous tag for the code block.

B. recognizing " label: " in code blocks like

       ```{python}
       #| label: optimization-techniques
       ...
       ```
   Quarto extracts "optimization-techniques" as a tag.

