### PR TITLE
main: Don't strdup the inputFileName when storing a tag to the corkQueue

### DIFF
--- a/main/entry.h
+++ b/main/entry.h
@@ -54,6 +54,8 @@ struct sTagEntryInfo {
 	unsigned int isPseudoTag:1;	/* Used only in xref output.
 								   If a tag is a pseudo, set this. */
 	unsigned int inCorkQueue:1;
+	unsigned int isInputFileNameShared: 1; /* shares the value for inputFileName.
+											* Set in the cork queue; don't touch this.*/
 
 	unsigned long lineNumber;     /* line number of tag */
 	const char* pattern;	      /* pattern for locating input line
@@ -61,7 +63,15 @@ struct sTagEntryInfo {
 	unsigned int boundaryInfo;    /* info about nested input stream */
 	MIOPos      filePosition;     /* file position of line containing tag */
 	langType langType;         /* language of input file */
-	const char *inputFileName;   /* name of input file */
+	const char *inputFileName;   /* name of input file.
+									You cannot modify the contents of buffer pointed
+									by this member of the tagEntryInfo returned from
+									getEntryInCorkQueue(). The buffer may be shared
+									between tag entries in the cork queue.
+
+									Further more, modifying this member of the
+									tagEntryInfo returned from getEntryInCorkQueue()
+									may cause a memory leak. */
 	const char *name;             /* name of the tag */
 	int kindIndex;	      /* kind descriptor */
 	uint8_t extra[ ((XTAG_COUNT) / 8) + 1 ];


### PR DESCRIPTION
When storing a tag entry to the corkQueue, the most of members of the tag entry are duplicated for isolating the the stored tag entry from the original parsing context.

In the most of all cases, we can expect all tag entries in the corkQueue has the same value as inputFileName member. Strdup'ing the value is waste of memory resource especially when the input file name is long.