### PR TITLE
main,refactor: delete 'inCorkQueue' parameter from attachParserField()

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -979,11 +979,11 @@ static void attachParserFieldGeneric (tagEntryInfo *const tag, fieldType ftype, 
 	}
 }
 
-extern void attachParserField (tagEntryInfo *const tag, bool inCorkQueue, fieldType ftype, const char * value)
+extern void attachParserField (tagEntryInfo *const tag, fieldType ftype, const char * value)
 {
 	Assert (tag != NULL);
 
-	if (inCorkQueue)
+	if (tag->inCorkQueue)
 	{
 		const char * v;
 		v = eStrdup (value);
@@ -1003,7 +1003,7 @@ extern void attachParserFieldToCorkEntry (int index,
 {
 	tagEntryInfo * tag = getEntryInCorkQueue (index);
 	if (tag)
-		attachParserField (tag, true, ftype, value);
+		attachParserField (tag, ftype, value);
 }
 
 extern const tagField* getParserFieldForIndex (const tagEntryInfo * tag, int index)

--- a/main/entry.h
+++ b/main/entry.h
@@ -245,13 +245,7 @@ extern bool isTagExtra (const tagEntryInfo *const tag);
  *
  * If your parser uses the Cork API, and your parser called
  * makeTagEntry () already, you can use both
- * attachParserFieldToCorkEntry () and attachParserField ().  Your
- * parser has the cork index returned from makeTagEntry ().  With the
- * cork index, your parser can call attachParserFieldToCorkEntry ().
- * If your parser already call getEntryInCorkQueue () to get the tag
- * entry for the cork index, your parser can call attachParserField ()
- * with passing true for `inCorkQueue' parameter. attachParserField ()
- * is a bit faster than attachParserFieldToCorkEntry ().
+ * attachParserFieldToCorkEntry () and attachParserField ().
  *
  * attachParserField () and attachParserFieldToCorkEntry () duplicates
  * the memory object specified with `value' and stores the duplicated
@@ -264,9 +258,7 @@ extern bool isTagExtra (const tagEntryInfo *const tag);
  * Case B:
  *
  * If your parser called one of initTagEntry () family but didn't call
- * makeTagEntry () for a tagEntry yet, use attachParserField () with
- * false for `inCorkQueue' whether your parser uses the Cork API or
- * not.
+ * makeTagEntry () for a tagEntry yet, use attachParserField ().
  *
  * The parser (== caller) keeps the memory object specified with `value'
  * till calling makeTagEntry (). The parser must free the memory object
@@ -293,7 +285,7 @@ extern bool isTagExtra (const tagEntryInfo *const tag);
  * The other data type and the combination of types are not implemented yet.
  *
  */
-extern void attachParserField (tagEntryInfo *const tag, bool inCorkQueue, fieldType ftype, const char* value);
+extern void attachParserField (tagEntryInfo *const tag, fieldType ftype, const char* value);
 extern void attachParserFieldToCorkEntry (int index, fieldType ftype, const char* value);
 extern const char* getParserFieldValueForType (tagEntryInfo *const tag, fieldType ftype);
 

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -1754,7 +1754,7 @@ static void matchTagPattern (struct lregexControlBlock *lcb,
 				{
 					vString * const value = substitute (line, fp->template,
 														BACK_REFERENCE_COUNT, pmatch);
-					attachParserField (&e, false, fp->ftype, vStringValue (value));
+					attachParserField (&e, fp->ftype, vStringValue (value));
 					trashBoxPut (field_trashbox, value,
 								 (TrashBoxDestroyItemProc)vStringDelete);
 				}

--- a/main/parse.c
+++ b/main/parse.c
@@ -5756,7 +5756,7 @@ static void createCTSTTags (void)
 
 						name [0] = c++;
 						initTagEntry (&e, name, i);
-						attachParserField (&e, false,
+						attachParserField (&e,
 										   CTSTFields[F_BOOLEAN_FIELD].ftype, "");
 						makeTagEntry (&e);
 
@@ -5766,13 +5766,13 @@ static void createCTSTTags (void)
 
 						name [0] = c++;
 						initTagEntry (&e, name, i);
-						attachParserField (&e, false,
+						attachParserField (&e,
 										   CTSTFields[F_BOOLEAN_AND_STRING_FIELD].ftype, "val");
 						makeTagEntry (&e);
 
 						name [0] = c++;
 						initTagEntry (&e, name, i);
-						attachParserField (&e, false,
+						attachParserField (&e,
 										   CTSTFields[F_BOOLEAN_AND_STRING_FIELD].ftype, "");
 						makeTagEntry (&e);
 

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -602,7 +602,7 @@ static void  readMacroParameters (int index, tagEntryInfo *e, const unsigned cha
 			{
 				cp += 3;
 				if (e)
-					attachParserField (e, true, AsmFields[F_PROPERTIES].ftype,
+					attachParserField (e, AsmFields[F_PROPERTIES].ftype,
 									   "req");
 				vStringCatS (signature, ":req");
 			}
@@ -610,7 +610,7 @@ static void  readMacroParameters (int index, tagEntryInfo *e, const unsigned cha
 			{
 				cp += 6;
 				if (e)
-					attachParserField (e, true, AsmFields[F_PROPERTIES].ftype,
+					attachParserField (e, AsmFields[F_PROPERTIES].ftype,
 									   "vararg");
 				vStringCatS (signature, ":vararg");
 			}

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -605,7 +605,7 @@ void cxxTagSetField(unsigned int uField,const char * szValue,bool bCopyValue)
 	/* If we make a copy for the value, the copy must be freed after
 	 * calling cxxTagCommit() for g_oCXXTag. The parser trash box
 	 * allows us to delay freeing the copy. */
-	attachParserField(&g_oCXXTag,false,g_cxx.pFieldOptions[uField].ftype,
+	attachParserField(&g_oCXXTag,g_cxx.pFieldOptions[uField].ftype,
 					  bCopyValue?parserTrashBoxPut(eStrdup(szValue),eFree):szValue);
 }
 

--- a/parsers/gdscript.c
+++ b/parsers/gdscript.c
@@ -286,7 +286,7 @@ static int makeFunctionTag (const tokenInfo *const token,
 		if (decorators && stringListCount (decorators) > 0)
 		{
 			vstr = makeDecoratorString (decorators);
-			attachParserField (&e, false, GDScriptFields[F_ANNOTATIONS].ftype,
+			attachParserField (&e, GDScriptFields[F_ANNOTATIONS].ftype,
 							   vStringValue (vstr));
 		}
 
@@ -1172,7 +1172,7 @@ static bool parseVariable (tokenInfo *const token, const gdscriptKind kind,
 	if (e && decorators && stringListCount (decorators) > 0)
 	{
 		vString *vstr = makeDecoratorString (decorators);
-		attachParserField (e, true, GDScriptFields[F_ANNOTATIONS].ftype,
+		attachParserField (e, GDScriptFields[F_ANNOTATIONS].ftype,
 						   vStringValue (vstr));
 		vStringDelete (vstr);
 	}

--- a/parsers/ldscript.c
+++ b/parsers/ldscript.c
@@ -224,7 +224,7 @@ static int makeLdScriptTagMaybe (tagEntryInfo *const e, tokenInfo *const token,
 		}
 
 		if (assignment)
-			attachParserField (e, false, LdScriptFields[F_ASSIGNMENT].ftype,
+			attachParserField (e, LdScriptFields[F_ASSIGNMENT].ftype,
 							   assignment);
 	}
 

--- a/parsers/maven2.c
+++ b/parsers/maven2.c
@@ -177,7 +177,7 @@ static char* attachVersionIfExisting (struct sTagEntryInfo *tag, xmlNode *node)
 		}
 	}
 	if (version)
-		attachParserField (tag, false, Maven2Fields [F_VERSION].ftype, version);
+		attachParserField (tag, Maven2Fields [F_VERSION].ftype, version);
 	return version;
 }
 

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -297,7 +297,7 @@ static int makeClassTag (const tokenInfo *const token,
 		e.extensionFields.inheritance = inheritance ? vStringValue (inheritance) : "";
 		if (decorators && vStringLength (decorators) > 0)
 		{
-			attachParserField (&e, false, PythonFields[F_DECORATORS].ftype,
+			attachParserField (&e, PythonFields[F_DECORATORS].ftype,
 			                   vStringValue (decorators));
 		}
 
@@ -321,7 +321,7 @@ static int makeFunctionTag (const tokenInfo *const token,
 			e.extensionFields.signature = vStringValue (arglist);
 		if (decorators && vStringLength (decorators) > 0)
 		{
-			attachParserField (&e, false, PythonFields[F_DECORATORS].ftype,
+			attachParserField (&e, PythonFields[F_DECORATORS].ftype,
 			                   vStringValue (decorators));
 		}
 
@@ -1579,7 +1579,7 @@ static bool parseVariable (tokenInfo *const token, const pythonKind kind)
 						vString *nameref = vStringNewInit (PythonKinds [K_FUNCTION].name);
 						vStringPut (nameref, ':');
 						vStringCat (nameref, anon->string);
-						attachParserField (ve, true, PythonFields[F_NAMEREF].ftype,
+						attachParserField (ve, PythonFields[F_NAMEREF].ftype,
 										   vStringValue (nameref));
 						vStringDelete (nameref);
 					}

--- a/parsers/r.c
+++ b/parsers/r.c
@@ -366,7 +366,7 @@ static int makeSimpleRTagR (tokenInfo *const token, int parent, int kind,
 		if (assignmentOp)
 		{
 			if (strlen (assignmentOp) > 0)
-				attachParserField (tag, true,
+				attachParserField (tag,
 								   RFields [F_ASSIGNMENT_OPERATOR].ftype,
 								   assignmentOp);
 			else
@@ -409,7 +409,7 @@ static int makeSimpleRTag (tokenInfo *const token, int parent, bool in_func, int
 	{
 		tagEntryInfo *e = getEntryInCorkQueue (r);
 		if (e)
-			attachParserField (e, true,
+			attachParserField (e,
 							   RFields [F_CONSTRUCTOR].ftype,
 							   ctor);
 	}

--- a/parsers/rst.c
+++ b/parsers/rst.c
@@ -164,10 +164,10 @@ static void makeSectionRstTag(const vString* const name, const int kind, const M
 			e.extensionFields.scopeIndex = nl->corkIndex;
 
 		m[0] = marker;
-		attachParserField (&e, false, RstFields [F_SECTION_MARKER].ftype, m);
+		attachParserField (&e, RstFields [F_SECTION_MARKER].ftype, m);
 
 		if (overline)
-			attachParserField (&e, false, RstFields [F_SECTION_OVERLINE].ftype, "");
+			attachParserField (&e, RstFields [F_SECTION_OVERLINE].ftype, "");
 
 		r = makeTagEntry (&e);
 	}

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1026,7 +1026,7 @@ static void createTagFull (tokenInfo *const token, verilogKind kind, int role, t
 	}
 
 	if (token->parameter)
-		attachParserField (&tag, false, fieldTable [F_PARAMETER].ftype, "");
+		attachParserField (&tag, fieldTable [F_PARAMETER].ftype, "");
 
 	makeTagEntry (&tag);
 

--- a/parsers/xml.c
+++ b/parsers/xml.c
@@ -147,7 +147,7 @@ static int makeNsPrefixTag (const char *name, xmlNode *node, xmlNsPtr ns)
 	tag.filePosition = getInputFilePositionForLine (tag.lineNumber);
 	char *p = (char *)xmlGetNodePath (node);
 	if (ns->href && *ns->href)
-		attachParserField (&tag, false, XmlFields [F_NS_URI].ftype, (char *)ns->href);
+		attachParserField (&tag, XmlFields [F_NS_URI].ftype, (char *)ns->href);
 
 	n = makeTagWithNotificationCommon (&tag, node);
 	if (p)


### PR DESCRIPTION
Even without the parameter, attachParserField() can know whether a given tag entry is in the cork queue or not with 'inCorkQueue' member of the tag entry.