### PR TITLE
vstring: Avoid int -> char truncation warnings

### DIFF
--- a/dsl/optscript.c
+++ b/dsl/optscript.c
@@ -4184,7 +4184,7 @@ op__put_str (OptVM *vm, EsObject *name,
 		for (size_t i = 0; i < d; i++)
 			vStringPut (vstr, ' ');
 		if (c != 0)
-			vStringPut (vstr, (char)c);
+			vStringPut (vstr, c);
 	}
 
 	ptrArrayDeleteLastInBatch (vm->ostack, 3);

--- a/main/field.c
+++ b/main/field.c
@@ -863,13 +863,12 @@ extern bool  doesFieldHaveTabOrNewlineChar (fieldType type, const tagEntryInfo *
 static const char* renderCompactInputLine (vString *b,  const char *const line)
 {
 	bool lineStarted = false;
-	const char *p;
-	int c;
 
 	/*  Write everything up to, but not including, the newline.
 	 */
-	for (p = line, c = *p  ;  c != NEWLINE  &&  c != '\0'  ;  c = *++p)
+	for (const char *p = line; *p != NEWLINE && *p != '\0'; ++p)
 	{
+		int c = (unsigned char) *p;
 		if (lineStarted  || ! isspace (c))  /* ignore leading spaces */
 		{
 			lineStarted = true;

--- a/main/options.c
+++ b/main/options.c
@@ -1286,7 +1286,7 @@ static void processExtraTagsOption (
 
 	longName = vStringNewOrClearWithAutoRelease (longName);
 
-	while ((c = *p++) != '\0')
+	while ((c = (unsigned char) *p++) != '\0')
 	{
 		switch (c)
 		{
@@ -1374,7 +1374,7 @@ static void processFieldsOption (
 	else if (*p != '+'  &&  *p != '-')
 		resetFieldsOption (LANG_IGNORE, false);
 
-	while ((c = *p++) != '\0') switch (c)
+	while ((c = (unsigned char) *p++) != '\0') switch (c)
 	{
 		case '+':
 			if (inLongName)
@@ -3084,7 +3084,7 @@ static bool processLangSpecificFieldsOption (const char *const option,
 		error (WARNING, "Wrong per language field specification: %s", p);
 
 	longName = vStringNewOrClearWithAutoRelease (longName);
-	while ((c = *p++) != '\0')
+	while ((c = (unsigned char) *p++) != '\0')
 	{
 		switch (c)
 		{
@@ -3185,7 +3185,7 @@ static bool processLangSpecificExtraOption (const char *const option,
 		error (WARNING, "Wrong per language extra specification: %s", p);
 
 	longName = vStringNewOrClearWithAutoRelease (longName);
-	while ((c = *p++) != '\0')
+	while ((c = (unsigned char) *p++) != '\0')
 	{
 		switch (c)
 		{

--- a/main/parse.c
+++ b/main/parse.c
@@ -751,7 +751,7 @@ static vString* determineInterpreter (const char* const cmd)
 		for ( ;  isspace ((int) *p)  ;  ++p)
 			;  /* no-op */
 		for ( ;  *p != '\0'  &&  ! isspace ((int) *p)  ;  ++p)
-			vStringPut (interpreter, (int) *p);
+			vStringPut (interpreter, *p);
 	} while (strcmp (vStringValue (interpreter), "env") == 0);
 	return interpreter;
 }
@@ -823,7 +823,7 @@ static vString* determineEmacsModeAtFirstLine (const char* const line)
 		for ( ;  isspace ((int) *p)  ;  ++p)
 			;  /* no-op */
 		for ( ;  *p != '\0'  &&  isLanguageNameChar ((int) *p)  ;  ++p)
-			vStringPut (mode, (int) *p);
+			vStringPut (mode, *p);
 
 		if ((strcmp(vStringValue (mode), "sh") == 0
 			 || strcmp(vStringValue (mode), "shell-script") == 0)
@@ -839,7 +839,7 @@ static vString* determineEmacsModeAtFirstLine (const char* const line)
 			goto out;
 
 		for ( ;  p < end &&  isLanguageNameChar ((int) *p)  ;  ++p)
-			vStringPut (mode, (int) *p);
+			vStringPut (mode, *p);
 
 		for ( ;  isspace ((int) *p)  ;  ++p)
 			;  /* no-op */
@@ -891,7 +891,7 @@ static vString* determineEmacsModeAtEOF (MIO* const fp)
 			for ( ;  isspace ((int) *p)  ;  ++p)
 				;  /* no-op */
 			for ( ;  *p != '\0'  &&  isLanguageNameChar ((int) *p)  ;  ++p)
-				vStringPut (mode, (int) *p);
+				vStringPut (mode, *p);
 
 			is_shell_mode = ((strcasecmp (vStringValue (mode), "sh") == 0
 								 || strcasecmp (vStringValue (mode), "shell-script") == 0));
@@ -955,7 +955,7 @@ static vString* determineVimFileType (const char *const modeline)
 
 		p += strlen(filetype_prefix[i]);
 		for ( ;  *p != '\0'  &&  isalnum ((int) *p)  ;  ++p)
-			vStringPut (filetype, (int) *p);
+			vStringPut (filetype, *p);
 		break;
 	}
 	return filetype;
@@ -2542,7 +2542,7 @@ static void processLangKindDefinition (
 
 	longName = vStringNewOrClearWithAutoRelease (longName);
 
-	while ((c = *p++) != '\0')
+	while ((c = (unsigned char) *p++) != '\0')
 	{
 		switch (c)
 		{

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -244,11 +244,7 @@ extern void vStringCopyToLower (vString *const dest, const vString *const src)
 		vStringResize (dest, src->size);
 	d = dest->buffer;
 	for (i = 0  ;  i < length  ;  ++i)
-	{
-		int c = s [i];
-
-		d [i] = tolower (c);
-	}
+		d [i] = (char) tolower (s [i]);
 	d [i] = '\0';
 }
 
@@ -294,7 +290,7 @@ extern char    *vStringStrdup (const vString *const string)
 	return str;
 }
 
-static char valueToXDigit (int v)
+static int valueToXDigit (int v)
 {
 	Assert (v >= 0 && v <= 0xF);
 

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -304,7 +304,7 @@ extern void vStringCatSWithEscaping (vString* b, const char *s)
 {
 	for(; *s; s++)
 	{
-		int c = *s;
+		unsigned char c = (unsigned char) *s;
 
 		/* escape control characters (incl. \t) */
 		if ((c > 0x00 && c <= 0x1F) || c == 0x7F || c == '\\')

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -102,7 +102,7 @@ CTAGS_INLINE void vStringPutNewlinAgainUnsafe (vString *const string)
 	string->buffer [string->length++] = '\n';
 }
 
-CTAGS_INLINE void vStringPut (vString *const string, const int c)
+CTAGS_INLINE void vStringPutImpl (vString *const string, const int c)
 {
 	/* verify the given character is an unsigned char value */
 	Assert (c >= 0 && c <= 0xff);
@@ -115,8 +115,12 @@ CTAGS_INLINE void vStringPut (vString *const string, const int c)
 		string->buffer [++string->length] = '\0';
 }
 
-CTAGS_INLINE bool vStringPutWithLimit (vString *const string, const int c,
-									   unsigned int maxlen)
+#define vStringPut(s, c) (sizeof(c) == sizeof(char) \
+						  ? vStringPutImpl((s), (unsigned char) (c)) \
+						  : vStringPutImpl((s), (c)))
+
+CTAGS_INLINE bool vStringPutWithLimitImpl (vString *const string, const int c,
+										   unsigned int maxlen)
 {
 	if (vStringLength (string) < maxlen || maxlen == 0)
 	{
@@ -125,5 +129,10 @@ CTAGS_INLINE bool vStringPutWithLimit (vString *const string, const int c,
 	}
 	return false;
 }
+
+#define vStringPutWithLimit(s, c, l) \
+	(sizeof(c) == sizeof(char) \
+	 ? vStringPutWithLimitImpl((s), (unsigned char) (c), (l)) \
+	 : vStringPutWithLimitImpl((s), (c), (l)))
 
 #endif  /* CTAGS_MAIN_VSTRING_H */

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 
+#include "debug.h"
 #include "inline.h"
 
 /*
@@ -103,6 +104,9 @@ CTAGS_INLINE void vStringPutNewlinAgainUnsafe (vString *const string)
 
 CTAGS_INLINE void vStringPut (vString *const string, const int c)
 {
+	/* verify the given character is an unsigned char value */
+	Assert (c >= 0 && c <= 0xff);
+
 	if (string->length + 1 == string->size)  /*  check for buffer overflow */
 		vStringResize (string, string->size * 2);
 

--- a/main/vstring.h
+++ b/main/vstring.h
@@ -106,7 +106,7 @@ CTAGS_INLINE void vStringPut (vString *const string, const int c)
 	if (string->length + 1 == string->size)  /*  check for buffer overflow */
 		vStringResize (string, string->size * 2);
 
-	string->buffer [string->length] = c;
+	string->buffer [string->length] = (char) c;
 	if (c != '\0')
 		string->buffer [++string->length] = '\0';
 }

--- a/old-docs/EXTENDING.html
+++ b/old-docs/EXTENDING.html
@@ -239,7 +239,7 @@ static void findSwineTags (void)
                 ++cp;
             while (isalnum ((int) *cp)  ||  *cp == '_')
             {
-                vStringPut (name, (int) *cp);
+                vStringPut (name, *cp);
                 ++cp;
             }
             makeSimpleTag (name, SwineKinds, K_DEFINE);

--- a/parsers/abaqus.c
+++ b/parsers/abaqus.c
@@ -70,7 +70,7 @@ static void createTag(AbaqusKind kind, const char *buf)
 
 	do
 	{
-		vStringPut(name, (int) *buf);
+		vStringPut(name, *buf);
 		++buf;
 	} while ((*buf != '\0') && (*buf != ','));
 	makeSimpleTag(name, kind);

--- a/parsers/asp.c
+++ b/parsers/asp.c
@@ -127,7 +127,7 @@ static void findAspTags (void)
 						    ++cp;
 					    while (isalnum ((int) *cp)  ||  *cp == '_')
 					    {
-						    vStringPut (name, (int) *cp);
+						    vStringPut (name, *cp);
 						    ++cp;
 					    }
 					    makeSimpleTag (name, K_FUNCTION);
@@ -140,7 +140,7 @@ static void findAspTags (void)
 						    ++cp;
 					    while (isalnum ((int) *cp)  ||  *cp == '_')
 					    {
-						    vStringPut (name, (int) *cp);
+						    vStringPut (name, *cp);
 						    ++cp;
 					    }
 					    makeSimpleTag (name, K_SUB);
@@ -149,7 +149,7 @@ static void findAspTags (void)
 					else {
 					    while (isalnum ((int) *cp)  ||  *cp == '_')
 					    {
-						    vStringPut (name, (int) *cp);
+						    vStringPut (name, *cp);
 						    ++cp;
 					    }
 					    makeSimpleTag (name, K_DIM);
@@ -171,7 +171,7 @@ static void findAspTags (void)
 						    ++cp;
 					    while (isalnum ((int) *cp)  ||  *cp == '_')
 					    {
-						    vStringPut (name, (int) *cp);
+						    vStringPut (name, *cp);
 						    ++cp;
 					    }
 					    makeSimpleTag (name, K_FUNCTION);
@@ -184,7 +184,7 @@ static void findAspTags (void)
 						    ++cp;
 					    while (isalnum ((int) *cp)  ||  *cp == '_')
 					    {
-						    vStringPut (name, (int) *cp);
+						    vStringPut (name, *cp);
 						    ++cp;
 					    }
 					    makeSimpleTag (name, K_SUB);
@@ -193,7 +193,7 @@ static void findAspTags (void)
 					else {
 					    while (isalnum ((int) *cp)  ||  *cp == '_')
 					    {
-						    vStringPut (name, (int) *cp);
+						    vStringPut (name, *cp);
 						    ++cp;
 					    }
 					    makeSimpleTag (name, K_DIM);
@@ -213,7 +213,7 @@ static void findAspTags (void)
 						++cp;
 					while (isalnum ((int) *cp)  ||  *cp == '_')
 					{
-						vStringPut (name, (int) *cp);
+						vStringPut (name, *cp);
 						++cp;
 					}
 					makeSimpleTag (name, K_FUNCTION);
@@ -231,7 +231,7 @@ static void findAspTags (void)
 						++cp;
 					while (isalnum ((int) *cp)  ||  *cp == '_')
 					{
-						vStringPut (name, (int) *cp);
+						vStringPut (name, *cp);
 						++cp;
 					}
 					makeSimpleTag (name, K_SUB);
@@ -249,7 +249,7 @@ static void findAspTags (void)
 						++cp;
 					while (isalnum ((int) *cp)  ||  *cp == '_')
 					{
-						vStringPut (name, (int) *cp);
+						vStringPut (name, *cp);
 						++cp;
 					}
 					makeSimpleTag (name, K_DIM);
@@ -267,7 +267,7 @@ static void findAspTags (void)
 						++cp;
 					while (isalnum ((int) *cp)  ||  *cp == '_')
 					{
-						vStringPut (name, (int) *cp);
+						vStringPut (name, *cp);
 						++cp;
 					}
 					makeSimpleTag (name, K_CLASS);
@@ -285,7 +285,7 @@ static void findAspTags (void)
 						++cp;
 					while (isalnum ((int) *cp)  ||  *cp == '_')
 					{
-						vStringPut (name, (int) *cp);
+						vStringPut (name, *cp);
 						++cp;
 					}
 					makeSimpleTag (name, K_CONST);

--- a/parsers/autoit.c
+++ b/parsers/autoit.c
@@ -145,7 +145,7 @@ static int parseFunc (const unsigned char *p, NestingLevels *nls)
 	skipSpaces (&p);
 	while (isIdentChar ((int) *p))
 	{
-		vStringPut (name, (int) *p);
+		vStringPut (name, *p);
 		++p;
 	}
 	skipSpaces (&p);
@@ -154,7 +154,7 @@ static int parseFunc (const unsigned char *p, NestingLevels *nls)
 		vString *signature = vStringNew ();
 
 		do
-			vStringPut (signature, (int) *p);
+			vStringPut (signature, *p);
 		while (*p != ')' && *p++);
 
 		k = makeAutoItTag (nls, name, K_FUNCTION, signature);
@@ -218,7 +218,7 @@ static void findAutoItTags (void)
 					++p;
 					while (*p != '\0' && *p != '>' && *p != '"')
 					{
-						vStringPut (name, (int) *p);
+						vStringPut (name, *p);
 						++p;
 					}
 					if (vStringLength(name) > 0)
@@ -284,7 +284,7 @@ static void findAutoItTags (void)
 					p++;
 					while (isIdentChar ((int) *p))
 					{
-						vStringPut (name, (int) *p);
+						vStringPut (name, *p);
 						++p;
 					}
 					if (vStringLength(name) > 0)

--- a/parsers/awk.c
+++ b/parsers/awk.c
@@ -53,7 +53,7 @@ static void findAwkTags (void)
 				++cp;
 			while (isalnum ((int) *cp)  ||  *cp == '_')
 			{
-				vStringPut (name, (int) *cp);
+				vStringPut (name, *cp);
 				++cp;
 			}
 			while (isspace ((int) *cp))

--- a/parsers/c-based.c
+++ b/parsers/c-based.c
@@ -1486,7 +1486,22 @@ static void skipToMatch (const char *const pair)
 	while (matchLevel > 0  &&  (c = skipToNonWhite ()) != EOF)
 	{
 		if (CollectingSignature)
-			vStringPut (Signature, c);
+		{
+			if (c <= 0xff)
+				vStringPut (Signature, c);
+			else
+			{
+				switch (c)
+				{
+					case CHAR_SYMBOL:
+					case STRING_SYMBOL:
+						vStringCat (Signature, cppGetLastCharOrStringContents ());
+						break;
+					default:
+						AssertNotReached();
+				}
+			}
+		}
 		if (c == begin)
 		{
 			++matchLevel;

--- a/parsers/css.c
+++ b/parsers/css.c
@@ -58,7 +58,7 @@ static void parseSelector (vString *const string, const int firstChar)
 	int c = firstChar;
 	do
 	{
-		vStringPut (string, (char) c);
+		vStringPut (string, c);
 		c = getcFromInputFile ();
 	} while (isSelectorChar (c));
 	ungetcToInputFile (c);

--- a/parsers/erlang.c
+++ b/parsers/erlang.c
@@ -66,7 +66,7 @@ static const unsigned char *parseIdentifier (
 	vStringClear (identifier);
 	while (isIdentifierCharacter ((int) *cp))
 	{
-		vStringPut (identifier, (int) *cp);
+		vStringPut (identifier, *cp);
 		++cp;
 	}
 	return cp;

--- a/parsers/falcon.c
+++ b/parsers/falcon.c
@@ -83,7 +83,7 @@ static void findFalconTags (void)
 
             while (isIdentifierChar ((int) *cp))
             {
-                vStringPut (name, (int) *cp);
+                vStringPut (name, *cp);
                 ++cp;
             }
             makeSimpleTag (name, K_FUNCTION);
@@ -96,7 +96,7 @@ static void findFalconTags (void)
 
             while (isIdentifierChar ((int) *cp))
             {
-                vStringPut (name, (int) *cp);
+                vStringPut (name, *cp);
                 ++cp;
             }
             makeSimpleTag (name, K_CLASS);
@@ -109,7 +109,7 @@ static void findFalconTags (void)
 
             while (isIdentifierChar ((int) *cp))
             {
-                vStringPut (name, (int) *cp);
+                vStringPut (name, *cp);
                 ++cp;
             }
             makeSimpleTag (name, K_NAMESPACE);
@@ -122,7 +122,7 @@ static void findFalconTags (void)
 
             while (isIdentifierChar ((int) *cp))
             {
-                vStringPut (name, (int) *cp);
+                vStringPut (name, *cp);
                 ++cp;
             }
             makeSimpleTag (name, K_NAMESPACE);

--- a/parsers/haxe.c
+++ b/parsers/haxe.c
@@ -88,7 +88,7 @@ another:
 			vStringClear (name);
 			while (isalnum ((int) *cp)  ||  *cp == '_')
 			{
-				vStringPut (name, (int) *cp);
+				vStringPut (name, *cp);
 				++cp;
 			}
 			makeSimpleTag (name, HXTAG_VARIABLE);
@@ -106,7 +106,7 @@ another:
 			vStringClear (name);
 			while (isalnum ((int) *cp)  ||  *cp == '_')
 			{
-				vStringPut (name, (int) *cp);
+				vStringPut (name, *cp);
 				++cp;
 			}
 			makeSimpleTag (name, HXTAG_METHODS);
@@ -123,7 +123,7 @@ another:
 			vStringClear (name);
 			while (isalnum ((int) *cp)  ||  *cp == '_')
 			{
-				vStringPut (name, (int) *cp);
+				vStringPut (name, *cp);
 				++cp;
 			}
 			makeSimpleTag (name, HXTAG_CLASS);
@@ -140,7 +140,7 @@ another:
 			vStringClear (name);
 			while (isalnum ((int) *cp)  ||  *cp == '_')
 			{
-				vStringPut (name, (int) *cp);
+				vStringPut (name, *cp);
 				++cp;
 			}
 			makeSimpleTag (name, HXTAG_ENUM);
@@ -169,7 +169,7 @@ another:
 				++cp;
 			vStringClear (name);
 			while (isalnum ((int) *cp)  ||  *cp == '_') {
-				vStringPut (name, (int) *cp);
+				vStringPut (name, *cp);
 				++cp;
 			}
 			makeSimpleTag (name, HXTAG_INTERFACE);
@@ -181,7 +181,7 @@ another:
 				++cp;
 			vStringClear (name);
 			while (isalnum ((int) *cp)  ||  *cp == '_') {
-				vStringPut (name, (int) *cp);
+				vStringPut (name, *cp);
 				++cp;
 			}
 			makeSimpleTag (name, HXTAG_TYPEDEF);

--- a/parsers/iniconf.c
+++ b/parsers/iniconf.c
@@ -134,7 +134,7 @@ static void findIniconfTags (void)
 			++cp;
 			while (*cp != '\0' && *cp != ']')
 			{
-				vStringPut (name, (int) *cp);
+				vStringPut (name, *cp);
 				++cp;
 			}
 
@@ -164,7 +164,7 @@ static void findIniconfTags (void)
 			{
 				while (isIdentifier ((int) *cp))
 				{
-					vStringPut (name, (int) *cp);
+					vStringPut (name, *cp);
 					++cp;
 				}
 				vStringStripTrailing (name);
@@ -178,7 +178,7 @@ static void findIniconfTags (void)
 						++cp;
 					while (isValue ((int) *cp))
 					{
-						vStringPut (val, (int) *cp);
+						vStringPut (val, *cp);
 						++cp;
 					}
 					vStringStripTrailing (val);

--- a/parsers/julia.c
+++ b/parsers/julia.c
@@ -235,7 +235,7 @@ static void advanceAndStoreChar (lexerState *lexer)
 {
     if (vStringLength(lexer->token_str) < MAX_STRING_LENGTH)
     {
-        vStringPut(lexer->token_str, (char) lexer->cur_c);
+        vStringPut(lexer->token_str, lexer->cur_c);
     }
     advanceChar(lexer);
 }

--- a/parsers/lua.c
+++ b/parsers/lua.c
@@ -131,7 +131,7 @@ static void extract_next_token (const char *begin, const char *end_sentinel, vSt
 			vStringClear (name);
 		}
 		else if (isLuaIdentifier (*c))
-			vStringPut (name, (int) *c);
+			vStringPut (name, *c);
 		else
 		{
 			/* An unexpected character is found

--- a/parsers/nsis.c
+++ b/parsers/nsis.c
@@ -110,7 +110,7 @@ static int makeSimpleTagWithScope(vString *name, int kindIndex, int parentCorkIn
 #define fillName(NAME,CP,CONDITION)				\
 	while (CONDITION)							\
 	{											\
-		vStringPut ((NAME), (int) *(CP));		\
+		vStringPut ((NAME), *(CP));				\
 		++(CP);									\
 	}											\
 	do {} while (0)
@@ -149,7 +149,7 @@ static const unsigned char* parseSection (const unsigned char* cp, vString *name
 			int in_escape = 0;
 			do
 			{
-				vStringPut (name, (int) *cp);
+				vStringPut (name, *cp);
 				++cp;
 
 				if (*cp == '\0')
@@ -186,7 +186,7 @@ static const unsigned char* parseSection (const unsigned char* cp, vString *name
 			   || *cp == '_' || *cp == '-' || *cp == '.' || *cp == '!'
 			   || *cp == '$' || *cp == '{' || *cp == '}' || *cp == '(' || *cp == ')')
 		{
-			vStringPut (name, (int) *cp);
+			vStringPut (name, *cp);
 			++cp;
 		}
 	}

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -222,7 +222,7 @@ static void readCString (lexingState * st)
 		else
 		{
 			lastIsBackSlash = *c == '\\';
-			vStringPut (st->name, (int) *c);
+			vStringPut (st->name, *c);
 		}
 
 		c++;
@@ -271,11 +271,11 @@ static void readIdentifier (lexingState * st)
 
 	/* first char is a simple letter */
 	if (isAlpha (*st->cp) || *st->cp == '_')
-		vStringPut (st->name, (int) *st->cp);
+		vStringPut (st->name, *st->cp);
 
 	/* Go till you get identifier chars */
 	for (p = st->cp + 1; isIdent (*p); p++)
-		vStringPut (st->name, (int) *p);
+		vStringPut (st->name, *p);
 
 	st->cp = p;
 }
@@ -288,11 +288,11 @@ static void readIdentifierObjcDirective (lexingState * st)
 
 	/* first char is a simple letter */
 	if (*st->cp == '@')
-		vStringPut (st->name, (int) *st->cp);
+		vStringPut (st->name, *st->cp);
 
 	/* Go till you get identifier chars */
 	for (p = st->cp + 1; isIdent (*p); p++)
-		vStringPut (st->name, (int) *p);
+		vStringPut (st->name, *p);
 
 	st->cp = p;
 }

--- a/parsers/ocaml.c
+++ b/parsers/ocaml.c
@@ -337,11 +337,11 @@ static void readIdentifier (lexingState * st)
 
 	/* first char is a simple letter */
 	if (isAlpha (*st->cp) || *st->cp == '_')
-		vStringPut (st->name, (int) *st->cp);
+		vStringPut (st->name, *st->cp);
 
 	/* Go till you get identifier chars */
 	for (p = st->cp + 1; isIdent (*p); p++)
-		vStringPut (st->name, (int) *p);
+		vStringPut (st->name, *p);
 
 	st->cp = p;
 }

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -876,7 +876,7 @@ static void findPerlTags (void)
 			const unsigned char *const first = cp;
 			while (*cp && (int) *cp != ';'  &&  !isspace ((int) *cp))
 			{
-				vStringPut (package, (int) *cp);
+				vStringPut (package, *cp);
 				cp++;
 			}
 			vStringCatS (package, "::");
@@ -929,7 +929,7 @@ static void findPerlTags (void)
 
 			while (isIdentifier (*cp) || (KIND_PERL_PACKAGE == kind && ':' == *cp))
 			{
-				vStringPut (name, (int) *cp);
+				vStringPut (name, *cp);
 				cp++;
 			}
 

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -633,11 +633,11 @@ static void parseString (vString *const string, const int delimiter)
 		int c = getcFromInputFile ();
 
 		if (c == '\\' && (c = getcFromInputFile ()) != EOF)
-			vStringPut (string, (char) c);
+			vStringPut (string, c);
 		else if (c == EOF || c == delimiter)
 			break;
 		else
-			vStringPut (string, (char) c);
+			vStringPut (string, c);
 	}
 }
 
@@ -747,7 +747,7 @@ static void parseHeredoc (vString *const string)
 	{
 		c = getcFromInputFile ();
 
-		vStringPut (string, (char) c);
+		vStringPut (string, c);
 		if (c == '\r' || c == '\n')
 		{
 			/* new line, check for a delimiter right after.  No need to handle
@@ -758,7 +758,7 @@ static void parseHeredoc (vString *const string)
 			c = getcFromInputFile ();
 			while (c == ' ' || c == '\t')
 			{
-				vStringPut (string, (char) c);
+				vStringPut (string, c);
 				c = getcFromInputFile ();
 				indent_len++;
 			}
@@ -799,7 +799,7 @@ static void parseIdentifier (vString *const string, const int firstChar)
 	int c = firstChar;
 	do
 	{
-		vStringPut (string, (char) c);
+		vStringPut (string, c);
 		c = getcFromInputFile ();
 	} while (isIdentChar (c));
 	ungetcToInputFile (c);

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -465,7 +465,7 @@ static void readIdentifier (vString *const string, const int firstChar)
 	int c = firstChar;
 	do
 	{
-		vStringPut (string, (char) c);
+		vStringPut (string, c);
 		c = getcFromInputFile ();
 	}
 	while (isIdentifierChar (c));

--- a/parsers/rust.c
+++ b/parsers/rust.c
@@ -133,7 +133,7 @@ static void writeCurTokenToStr (lexerState *lexer, vString *out_str)
 			vStringCatS(out_str, "->");
 			break;
 		default:
-			vStringPut(out_str, (char) lexer->cur_token);
+			vStringPut(out_str, lexer->cur_token);
 	}
 }
 
@@ -156,7 +156,7 @@ static void advanceNChar (lexerState *lexer, int n)
 static void advanceAndStoreChar (lexerState *lexer)
 {
 	if (vStringLength(lexer->token_str) < MAX_STRING_LENGTH)
-		vStringPut(lexer->token_str, (char) lexer->cur_c);
+		vStringPut(lexer->token_str, lexer->cur_c);
 	advanceChar(lexer);
 }
 

--- a/parsers/scheme.c
+++ b/parsers/scheme.c
@@ -49,7 +49,7 @@ static void readIdentifier (vString *const name, const unsigned char *cp)
 	vStringClear (name);
 	/* Go till you get to white space or a syntactic break */
 	for (p = cp; *p != '\0' && *p != '(' && *p != ')' && !isspace (*p); p++)
-		vStringPut (name, (int) *p);
+		vStringPut (name, *p);
 }
 
 static void findSchemeTags (void)

--- a/parsers/sh.c
+++ b/parsers/sh.c
@@ -213,7 +213,7 @@ static int readDestfileName (const unsigned char *cp, vString *destfile)
 
 	vStringClear(destfile);
 	do {
-		vStringPut (destfile, (int) *cp);
+		vStringPut (destfile, *cp);
 		++cp;
 	} while (isFileChar ((int) *cp));
 
@@ -645,7 +645,7 @@ static void findShTagsCommon (size_t (* keyword_handler) (int,
 
 				while (check_char ((int) *cp))
 				{
-					vStringPut (name, (int) *cp);
+					vStringPut (name, *cp);
 					++cp;
 				}
 			}

--- a/parsers/sml.c
+++ b/parsers/sml.c
@@ -130,7 +130,7 @@ static const unsigned char *parseIdentifier (
 
 	while (isIdentifier ((int) *cp))
 	{
-		vStringPut (identifier, (int) *cp);
+		vStringPut (identifier, *cp);
 		cp++;
 	}
 	return cp;

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -299,7 +299,7 @@ static void parseFunction (const unsigned char *line)
 
 				do
 				{
-					vStringPut (name, (int) *cp);
+					vStringPut (name, *cp);
 					++cp;
 				} while (isalnum ((int) *cp) || *cp == '_' || *cp == '.' || *cp == '#');
 				index = makeSimpleTag (name, K_FUNCTION);
@@ -484,7 +484,7 @@ static bool parseCommand (const unsigned char *line)
 
 	do
 	{
-		vStringPut (name, (int) *cp);
+		vStringPut (name, *cp);
 		++cp;
 	} while (isalnum ((int) *cp) || *cp == '_');
 
@@ -544,7 +544,7 @@ static void parseVariableOrConstant (const unsigned char *line, int infunction, 
 			if (!*cp)
 				break;
 
-			vStringPut (name, (int) *cp);
+			vStringPut (name, *cp);
 			++cp;
 		} while (isalnum ((int) *cp) || *cp == '_' || *cp == '#' || *cp == ':' || *cp == '$');
 		makeSimpleTag (name, kindIndex);
@@ -622,7 +622,7 @@ static bool parseMap (const unsigned char *line)
 
 	do
 	{
-		vStringPut (name, (int) *cp);
+		vStringPut (name, *cp);
 		++cp;
 	} while (*cp && *cp != ' ');
 
@@ -722,7 +722,7 @@ static void parseVimBallFile (const unsigned char *line)
 			cp = line;
 			do
 			{
-				vStringPut (fname, (int) *cp);
+				vStringPut (fname, *cp);
 				++cp;
 			} while (isalnum ((int) *cp) || *cp == '.' || *cp == '/' || *cp == '\\');
 			makeSimpleTag (fname, K_FILENAME);

--- a/parsers/windres.c
+++ b/parsers/windres.c
@@ -68,7 +68,7 @@ static ResParserState parseResDefinition(const unsigned char *line)
 	name = vStringNew();
 	while (*line && !isspace((int) *line))
 	{
-		vStringPut(name, (int) *line);
+		vStringPut(name, *line);
 		line++;
 	}
 
@@ -78,7 +78,7 @@ static ResParserState parseResDefinition(const unsigned char *line)
 	type = vStringNew();
 	while (*line && !isspace((int) *line))
 	{
-		vStringPut(type, (int) *line);
+		vStringPut(type, *line);
 		line++;
 	}
 


### PR DESCRIPTION
Either avoid or silence expected casts from int to char.

I'm not entirely sure whether vStringPut() shouldn't actually take a char argument instead of an int, as it will cast it in all cases. It is however slightly more convenient as the APIs to retrieve characters uses int only for edge cases (e.g. EOF), so the common case is a safe cast and it's more convenient not to explicit it everywhere.