### PR TITLE
C++: accept prototypes starting from :: operator

### DIFF
--- a/Units/parser-cxx.r/prototype-starting-from-scope-op.d/args.ctags
+++ b/Units/parser-cxx.r/prototype-starting-from-scope-op.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--C++-kinds=+p

--- a/Units/parser-cxx.r/prototype-starting-from-scope-op.d/expected.tags
+++ b/Units/parser-cxx.r/prototype-starting-from-scope-op.d/expected.tags
@@ -1,0 +1,2 @@
+bar	input.cpp	/^::std::string bar();$/;"	p	typeref:typename:::std::string	file:
+baz	input.cpp	/^::std::string baz() { return "not a prototype"; }$/;"	f	typeref:typename:::std::string

--- a/Units/parser-cxx.r/prototype-starting-from-scope-op.d/input.cpp
+++ b/Units/parser-cxx.r/prototype-starting-from-scope-op.d/input.cpp
@@ -1,0 +1,5 @@
+// Taken from #3693 submitted by @b4n
+#include <string>
+
+::std::string bar();
+::std::string baz() { return "not a prototype"; }

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -1497,7 +1497,8 @@ void cxxParserAnalyzeOtherStatement(void)
 
 	CXXToken * t = cxxTokenChainFirst(g_cxx.pTokenChain);
 
-	if(!cxxTokenTypeIsOneOf(t,CXXTokenTypeIdentifier | CXXTokenTypeKeyword))
+	if(!cxxTokenTypeIsOneOf(t,CXXTokenTypeIdentifier | CXXTokenTypeKeyword
+							| CXXTokenTypeMultipleColons))
 	{
 		CXX_DEBUG_LEAVE_TEXT("Statement does not start with an identifier or keyword");
 		return;


### PR DESCRIPTION
Close #3693.

The original code could not extract "bar" in
```
  ::std::string bar();
```