### PR TITLE
[WIP] Make isIncludeFile() return TRUE for files with an unknown extension

### DIFF
--- a/main/options.c
+++ b/main/options.c
@@ -131,6 +131,12 @@ static const char *const HeaderExtensions [] = {
 	"h", "H", "hh", "hpp", "hxx", "h++", "inc", "def", NULL
 };
 
+static const char *const SourceExtensions [] = {
+	"c", "c++", "cc", "cp", "cpp", "cxx", "C", "CPP", "CXX", NULL
+};
+
+static stringList* SourceExt;
+
 long ctags_debugLevel = 0L;
 bool ctags_verbose = false;
 
@@ -1142,7 +1148,9 @@ extern bool isIncludeFile (const char *const fileName)
 	const char *const extension = fileExtension (fileName);
 	if (Option.headerExt != NULL)
 		result = stringListExtensionMatched (Option.headerExt, extension);
-	return result;
+	if (result)
+		return true;
+	return !stringListExtensionMatched (SourceExt, extension);
 }
 
 /*
@@ -3856,6 +3864,7 @@ extern void initOptions (void)
 
 	verbose ("Setting option defaults\n");
 	installHeaderListDefaults ();
+	SourceExt = stringListNewFromArgv (SourceExtensions);
 	verbose ("  Installing default language mappings:\n");
 	installLanguageMapDefaults ();
 	verbose ("  Installing default language aliases:\n");
@@ -3935,6 +3944,7 @@ extern void freeOptionResources (void)
 	freeList (&Excluded);
 	freeList (&ExcludedException);
 	freeList (&Option.headerExt);
+	freeList (&SourceExt);
 	freeList (&Option.etagsInclude);
 
 	freeSearchPathList (&OptlibPathList);


### PR DESCRIPTION
This PR is inspired by the problem reported here in Geany:

https://github.com/geany/geany/issues/3454

Basically the problem is that if ctags parses a file with an unknown file extension, the `isIncludeFile()` function returns `false` which makes the code at various places in C/C++ parser like
```
if (isFunctionDeclaration && !isHeader())
    tag->isFileScope = true;
```
set `tag->isFileScope = true`. I think that when we don't know for sure whether a file is a header or source, it would be safer to treat it as a header and not to generate the `fileScope` extras flag for it (see more in https://github.com/geany/geany/pull/3457#issuecomment-1504879986).

I'm posting this as a draft here only for further discussion. The patch makes unit tests fail (I didn't want to spend time on it unless I know this PR is something that is wanted in ctags), misses a unit test and also the documentation of the `-h` command-line option should be changed. Since all files would be treated as headers by default, the only use for `-h` would be to override source files like `*.c` to be treated as headers.