### PR TITLE
autoit: Drop $ from variable names

### DIFF
--- a/Units/parser-autoit.r/simple-au3.d/expected.tags
+++ b/Units/parser-autoit.r/simple-au3.d/expected.tags
@@ -1,8 +1,3 @@
-$iDoubled	input.au3	/^Local $iDoubled = 0$/;"	l	roles:def
-$iFirst	input.au3	/^    LOCAL STATIC $iFirst = 0$/;"	l	func:All functions.MyDummy	roles:def	properties:static
-$iNumber	input.au3	/^Local $iNumber = 10$/;"	l	roles:def
-$iSecond	input.au3	/^    STATIC LOCAL $iSecond = 1$/;"	l	func:All functions.MyDummy	roles:def	properties:static
-$iSomething	input.au3	/^    Local $iSomething = 42$/;"	l	func:All functions.MyDouble0	roles:def
 All functions	input.au3	/^#Region All functions$/;"	r	roles:def	end:54
 Constants.au3	input.au3	/^#include <Constants.au3>$/;"	S	roles:system
 GUIConstantsEx.au3	input.au3	/^#include<GUIConstantsEx.au3>$/;"	S	roles:system
@@ -12,3 +7,8 @@ MyDouble1	input.au3	/^    	FUNC MyDouble1($iValue)$/;"	f	region:All functions	si
 MyDummy	input.au3	/^FUNC MyDummy($iValue)$/;"	f	region:All functions	signature:($iValue)	roles:def	end:53
 MyVolatileDouble	input.au3	/^Volatile Func MyVolatileDouble ($iValue)$/;"	f	region:All functions	signature:($iValue)	roles:def	end:47	properties:volatile
 WindowsConstants.au3	input.au3	/^#include "WindowsConstants.au3"$/;"	S	roles:local
+iDoubled	input.au3	/^Local $iDoubled = 0$/;"	l	roles:def
+iFirst	input.au3	/^    LOCAL STATIC $iFirst = 0$/;"	l	func:All functions.MyDummy	roles:def	properties:static
+iNumber	input.au3	/^Local $iNumber = 10$/;"	l	roles:def
+iSecond	input.au3	/^    STATIC LOCAL $iSecond = 1$/;"	l	func:All functions.MyDummy	roles:def	properties:static
+iSomething	input.au3	/^    Local $iSomething = 42$/;"	l	func:All functions.MyDouble0	roles:def

--- a/docs/man-pages.rst
+++ b/docs/man-pages.rst
@@ -17,6 +17,7 @@ Man pages
 	ctags-faq(7) <man/ctags-faq.7.rst>
 
 	ctags-lang-asm(7) <man/ctags-lang-asm.7.rst>
+	ctags-lang-autoit(7) <man/ctags-lang-autoit.7.rst>
 	ctags-lang-elm(7) <man/ctags-lang-elm.7.rst>
 	ctags-lang-fortran(7) <man/ctags-lang-fortran.7.rst>
 	ctags-lang-gdscript(7) <man/ctags-lang-gdscript.7.rst>

--- a/docs/man/ctags-lang-autoit.7.rst
+++ b/docs/man/ctags-lang-autoit.7.rst
@@ -1,0 +1,33 @@
+.. _ctags-lang-autoit(7):
+
+==============================================================
+ctags-lang-autoit
+==============================================================
+
+Random notes about tagging AutoIt source code with Universal Ctags
+
+:Version: 6.0.0
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**ctags** ... --languages=+AutoIt ...
+|	**ctags** ... --language-force=AutoIt ...
+|	**ctags** ... --map-AutoIt=+.au3 ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging AutoIt source code.
+
+VERSIONS
+--------
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* Drop ``$`` from tags for variables names.
+
+SEE ALSO
+--------
+:ref:`ctags(1) <ctags(1)>`

--- a/man/GNUmakefile.am
+++ b/man/GNUmakefile.am
@@ -28,6 +28,7 @@ GEN_IN_MAN_FILES = \
 	ctags-faq.7 \
 	\
 	ctags-lang-asm.7 \
+	ctags-lang-autoit.7 \
 	ctags-lang-elm.7 \
 	ctags-lang-fortran.7 \
 	ctags-lang-gdscript.7 \

--- a/man/ctags-lang-autoit.7.rst.in
+++ b/man/ctags-lang-autoit.7.rst.in
@@ -1,0 +1,33 @@
+.. _ctags-lang-autoit(7):
+
+==============================================================
+ctags-lang-autoit
+==============================================================
+---------------------------------------------------------------------
+Random notes about tagging AutoIt source code with Universal Ctags
+---------------------------------------------------------------------
+:Version: @VERSION@
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**@CTAGS_NAME_EXECUTABLE@** ... --languages=+AutoIt ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --language-force=AutoIt ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-AutoIt=+.au3 ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging AutoIt source code.
+
+VERSIONS
+--------
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* Drop ``$`` from tags for variables names.
+
+SEE ALSO
+--------
+ctags(1)

--- a/parsers/autoit.c
+++ b/parsers/autoit.c
@@ -313,5 +313,7 @@ parserDefinition *AutoItParser (void)
 	def->extensions = extensions;
 	def->parser     = findAutoItTags;
 	def->useCork    = CORK_QUEUE;
+	def->versionCurrent = 1;
+	def->versionAge = 0;
 	return def;
 }

--- a/parsers/autoit.c
+++ b/parsers/autoit.c
@@ -281,7 +281,7 @@ static void findAutoItTags (void)
 					skipSpaces (&p);
 				if (*p == '$')
 				{
-					vStringPut (name, (int) *p++);
+					p++;
 					while (isIdentChar ((int) *p))
 					{
 						vStringPut (name, (int) *p);


### PR DESCRIPTION
At least PHP, which also declares variables using `$`, such as
```
$x = 5;
```
outputs pure variable name without the `$` prefix and this patch unifies this behavior.