### PR TITLE
D: parse user-defined attributes

### DIFF
--- a/Units/parser-d.r/simple.d.d/expected.tags
+++ b/Units/parser-d.r/simple.d.d/expected.tags
@@ -11,6 +11,8 @@ TemplateAlias	input.d	/^	alias TemplateAlias = a!T;$/;"	a	file:
 UT	input.d	/^union UT(T){}$/;"	u	file:
 Union	input.d	/^	union Union$/;"	u	struct:Struct	file:
 _bar	input.d	/^	private AliasInt _bar;$/;"	m	class:Class	file:
+attr_anon	input.d	/^@(obj) T attr_anon;$/;"	v
+attr_decl	input.d	/^@attr(i) int attr_decl = 1;$/;"	v
 bar	input.d	/^	bar,$/;"	e	enum:Enum	file:
 bar	input.d	/^	public AliasInt bar()$/;"	f	class:Class
 conditional	input.d	/^	T conditional;$/;"	v	file:

--- a/Units/parser-d.r/simple.d.d/input.d
+++ b/Units/parser-d.r/simple.d.d/input.d
@@ -78,6 +78,11 @@ int i;
 int error;
  +/
 
+@attr(i) int attr_decl = 1;
+@attr(i) attr_decl_infer = 1; // FIXME
+@(obj) T attr_anon;
+void attr_post() @attr(obj); // FIXME
+
 static if (is(typeof(__traits(getMember, a, name)) == function))
 	T conditional;
 

--- a/parsers/c-based.c
+++ b/parsers/c-based.c
@@ -494,6 +494,7 @@ static const keywordDesc KeywordTable [] = {
 *   FUNCTION PROTOTYPES
 */
 static void createTags (const unsigned int nestLevel, statementInfo *const parent);
+static void parseAtMarkStyleAnnotation (statementInfo *const st);
 
 /*
 *   FUNCTION DEFINITIONS
@@ -2213,7 +2214,7 @@ static void processAngleBracket (void)
 	}
 }
 
-static void parseJavaAnnotation (statementInfo *const st)
+static void parseAtMarkStyleAnnotation (statementInfo *const st)
 {
 	/*
 	 * @Override
@@ -2348,7 +2349,7 @@ static int parseParens (statementInfo *const st, parenInfo *const info)
 			default:
 				if (c == '@' && isInputLanguage (Lang_java))
 				{
-					parseJavaAnnotation(st);
+					parseAtMarkStyleAnnotation (st);
 				}
 				else if (cppIsident1 (c))
 				{
@@ -2639,7 +2640,7 @@ static void parseGeneralToken (statementInfo *const st, const int c)
 	}
 	else if (c == '@' && isInputLanguage (Lang_java))
 	{
-		parseJavaAnnotation (st);
+		parseAtMarkStyleAnnotation (st);
 	}
 	else if (c == STRING_SYMBOL) {
 		setToken(st, TOKEN_NONE);

--- a/parsers/c-based.c
+++ b/parsers/c-based.c
@@ -2123,6 +2123,10 @@ static bool skipPostArgumentStuff (
 					break;
 				}
 			}
+			else if (isInputLanguage (Lang_d) && c == '@')
+			{
+				parseAtMarkStyleAnnotation (st);
+			}
 		}
 		if (! end)
 		{
@@ -2226,7 +2230,11 @@ static void parseAtMarkStyleAnnotation (statementInfo *const st)
 	tokenInfo *const token = activeToken (st);
 
 	int c = skipToNonWhite ();
-	readIdentifier (token, c);
+	if (cppIsident1 (c))
+		readIdentifier (token, c);
+	else
+		cppUngetc (c); // D allows: @ ( ArgumentList )
+
 	if (token->keyword == KEYWORD_INTERFACE)
 	{
 		/* Oops. This was actually "@interface" defining a new annotation. */
@@ -2347,7 +2355,7 @@ static int parseParens (statementInfo *const st, parenInfo *const info)
 				break;
 
 			default:
-				if (c == '@' && isInputLanguage (Lang_java))
+				if (c == '@' && (isInputLanguage (Lang_d) || isInputLanguage (Lang_java)))
 				{
 					parseAtMarkStyleAnnotation (st);
 				}
@@ -2638,7 +2646,7 @@ static void parseGeneralToken (statementInfo *const st, const int c)
 		if (c2 != '=')
 			cppUngetc (c2);
 	}
-	else if (c == '@' && isInputLanguage (Lang_java))
+	else if (c == '@' && (isInputLanguage (Lang_d) || isInputLanguage (Lang_java)))
 	{
 		parseAtMarkStyleAnnotation (st);
 	}


### PR DESCRIPTION
Hi,
I'm working on porting the remaining Geany D parser changes to ctags.

UDAs can precede a declaration or come after a function parameter list.
https://dlang.org/spec/attribute.html#uda

* I'm not sure if all the lines in expected.tags starting with `!_TAG_` should be there. Please let me know if there's a switch I should be using.
* I'm not sure if I add a changelog entry somewhere, please let me know.
