### PR TITLE
D: remove `overload`, not a keyword

### DIFF
--- a/Units/parser-d.r/simple.d.d/expected.tags
+++ b/Units/parser-d.r/simple.d.d/expected.tags
@@ -29,6 +29,7 @@ quxx	input.d	/^		bool quxx;$/;"	m	union:Struct.Union	file:
 test.simple	input.d	/^module test.simple;$/;"	M
 tfun	input.d	/^	auto tfun(T)(T v)$/;"	f	class:Class
 this	input.d	/^	public this(AliasInt x)$/;"	f	class:Class
+toString	input.d	/^	override string toString() { return ""; }$/;"	f	class:Class
 type_con	input.d	/^const(int)* type_con;$/;"	v
 type_imm	input.d	/^immutable(int)* type_imm;$/;"	v
 type_shar	input.d	/^shared(int)[] type_shar;$/;"	v

--- a/Units/parser-d.r/simple.d.d/input.d
+++ b/Units/parser-d.r/simple.d.d/input.d
@@ -33,6 +33,8 @@ class Class : Interface
 		this._bar = x;
 	}
 
+	override string toString() { return ""; }
+
 	public AliasInt bar()
 	{
 		return this._bar;

--- a/parsers/c-based.c
+++ b/parsers/c-based.c
@@ -76,7 +76,7 @@ enum eKeywordId {
 	KEYWORD_LONG,
 	KEYWORD_MUTABLE,
 	KEYWORD_NAMESPACE, KEYWORD_NEW, KEYWORD_NATIVE,
-	KEYWORD_OPERATOR, KEYWORD_OVERLOAD, KEYWORD_OVERRIDE,
+	KEYWORD_OPERATOR, KEYWORD_OVERRIDE,
 	KEYWORD_PACKAGE, KEYWORD_PRIVATE,
 	KEYWORD_PROTECTED, KEYWORD_PUBLIC,
 	KEYWORD_REGISTER, KEYWORD_RETURN, KEYWORD_SHARED,
@@ -443,7 +443,6 @@ static const keywordDesc KeywordTable [] = {
      { "null",            KEYWORD_NULL,            { 0, 1, 0 } },
      { "operator",        KEYWORD_OPERATOR,        { 1, 1, 0 } },
      { "out",             KEYWORD_OUT,             { 0, 1, 0 } },
-     { "overload",        KEYWORD_OVERLOAD,        { 0, 1, 0 } },
      { "override",        KEYWORD_OVERRIDE,        { 1, 1, 0 } },
      { "package",         KEYWORD_PACKAGE,         { 0, 1, 1 } },
      { "pragma",          KEYWORD_PRAGMA,          { 0, 1, 0 } },
@@ -2115,7 +2114,7 @@ static bool skipPostArgumentStuff (
 				case KEYWORD_NAMESPACE:
 				case KEYWORD_NEW:
 				case KEYWORD_OPERATOR:
-				case KEYWORD_OVERLOAD:
+				case KEYWORD_OVERRIDE:
 				case KEYWORD_PRIVATE:
 				case KEYWORD_PROTECTED:
 				case KEYWORD_PUBLIC:


### PR DESCRIPTION
Presumably this was mistakenly added instead of `override` (which is also there).
https://dlang.org/spec/lex.html#keywords

`override` only appears before a function declaration. 
https://dlang.org/spec/function.html#virtual-functions