### PR TITLE
D: fix parsing parameter with pointer

### DIFF
--- a/Units/parser-d.r/simple.d.d/expected.tags
+++ b/Units/parser-d.r/simple.d.d/expected.tags
@@ -17,6 +17,7 @@ bar	input.d	/^	bar,$/;"	e	enum:Enum	file:
 bar	input.d	/^	public AliasInt bar()$/;"	f	class:Class
 conditional	input.d	/^	T conditional;$/;"	v	file:
 foo	input.d	/^	foo,$/;"	e	enum:Enum	file:
+g_inout	input.d	/^inout(int)* g_inout(inout(int)* p) { return p; }$/;"	f
 globalVar	input.d	/^__gshared int globalVar;$/;"	v
 i	input.d	/^int i;$/;"	v
 main	input.d	/^void main(string[] args)$/;"	f	file:

--- a/Units/parser-d.r/simple.d.d/input.d
+++ b/Units/parser-d.r/simple.d.d/input.d
@@ -21,7 +21,7 @@ enum Enum : int
 
 interface Interface
 {
-	public AliasInt bar();
+	public AliasInt bar(); // FIXME prototypes
 }
 
 class Class : Interface
@@ -73,7 +73,8 @@ Object obj;
 
 const(int)* type_con;
 immutable(int)* type_imm;
-inout(int)* f_inout(inout Object); // FIXME
+inout(int)* f_inout(inout Object); // FIXME prototypes
+inout(int)* g_inout(inout(int)* p) { return p; }
 shared(int)[] type_shar;
 
 private:
@@ -86,7 +87,7 @@ int error;
 @attr(i) int attr_decl = 1;
 @attr(i) attr_decl_infer = 1; // FIXME
 @(obj) T attr_anon;
-void attr_post() @attr(obj); // FIXME
+void attr_post() @attr(obj); // FIXME prototypes
 
 static if (is(typeof(__traits(getMember, a, name)) == function))
 	T conditional;

--- a/parsers/c-based.c
+++ b/parsers/c-based.c
@@ -2285,7 +2285,6 @@ static void parseAtMarkStyleAnnotation (statementInfo *const st)
 static int parseParens (statementInfo *const st, parenInfo *const info)
 {
 	tokenInfo *const token = activeToken (st);
-	unsigned int identifierCount = 0;
 	unsigned int depth = 1;
 	bool firstChar = true;
 	int nextChar = '\0';
@@ -2307,8 +2306,6 @@ static int parseParens (statementInfo *const st, parenInfo *const info)
 			case '&':
 			case '*':
 				info->isPointer = true;
-				if (identifierCount == 0)
-					info->isParamList = false;
 				initToken (token);
 				break;
 


### PR DESCRIPTION
This just removes the remnants of code for fallback C parsing. `identifierCount` is never changed anywhere.

Now the test for `inout(T)` works.