### PR TITLE
erlang: Fix crash parsing directives longer than 31 characters

### DIFF
--- a/Units/parser-erlang.r/crash1.d/input.erl
+++ b/Units/parser-erlang.r/crash1.d/input.erl
@@ -1,0 +1,5 @@
+% long directives used to possibly crash the parser
+% (and always make Valgrind angry)
+-some_extremely_loooong_directive
+-even_longer_might_crash_more_often_than_not_but_anyway_valgrind_would_not_be_hayyp_either_way
+

--- a/parsers/erlang.c
+++ b/parsers/erlang.c
@@ -131,12 +131,12 @@ static void parseDirective (const unsigned char *cp, vString *const module)
 	 * Record definitions are handled separately
 	 */
 	vString *const directive = vStringNew ();
-	const char *const drtv = vStringValue (directive);
 	cp = parseIdentifier (cp, directive);
 	cp = skipSpace (cp);
 	if (*cp == '(')
 		++cp;
 
+	const char *const drtv = vStringValue (directive);
 	if (strcmp (drtv, "record") == 0)
 		parseSimpleTag (cp, K_RECORD);
 	else if (strcmp (drtv, "define") == 0)


### PR DESCRIPTION
Even if they might not exist, fix the code not to crash on them.

The issue was that the pointer to the vString buffer holding the directive name was cached at its value right after the vString creation, yet that buffer might get realloc()ated if it grows past the initial length of 32, possibly making the initial pointer invalid.

Fix this by simply getting the pointer to the value later on.