### PR TITLE
lregex: optimize substitute()

### DIFF
--- a/main/lregex.c
+++ b/main/lregex.c
@@ -1605,7 +1605,7 @@ static vString* substitute (
 			if (0 < dig  &&  dig < nmatch  &&  pmatch [dig].rm_so != -1)
 			{
 				const int diglen = pmatch [dig].rm_eo - pmatch [dig].rm_so;
-				vStringNCatS (result, in + pmatch [dig].rm_so, diglen);
+				vStringNCatSUnsafe (result, in + pmatch [dig].rm_so, diglen);
 			}
 		}
 		else if (*p != '\n'  &&  *p != '\r')


### PR DESCRIPTION
substitute was one of the bottle neck.
It called strlen before memcpy.
We can remove the strlen invocation safely.

The original code:
  $ xargs cat <  /tmp/list > /dev/null; time ./ctags -L - < /tmp/list
  ./ctags -L - < /tmp/list  97.39s user 4.72s system 97% cpu 1:45.09 total

With this change:
  $ xargs cat <  /tmp/list > /dev/null; time ./ctags -L - < /tmp/list
  ./ctags -L - < /tmp/list  87.24s user 4.68s system 97% cpu 1:34.28 total

About 10% faster!