### PR TITLE
Fix many calls to ctype functions

### DIFF
--- a/Units/simple-diff.d/input.diff
+++ b/Units/simple-diff.d/input.diff
@@ -106,7 +106,7 @@ index 0000000..a1bf5f3
 +		if (strncmp ((const char*) cp, DiffDelims[delim], 4u) == 0)
 +		{
 +			cp += 4;
-+			if (isspace ((int) *cp)) continue;
++			if (isspace (*cp)) continue;
 +			/* when original filename is /dev/null use the new one instead */
 +			if (delim == DIFF_DELIM_MINUS &&
 +				strncmp ((const char*) cp, "/dev/null", 9u) == 0 &&

--- a/dsl/dsl.c
+++ b/dsl/dsl.c
@@ -803,7 +803,7 @@ static EsObject* caseop (EsObject *o, int (*op)(int))
 		char *r = strdup (s);
 
 		for (char *tmp = r; *tmp != '\0'; tmp++)
-			*tmp = op (*tmp);
+			*tmp = op ((unsigned char) *tmp);
 
 		EsObject *q = es_object_autounref (es_string_new (r));
 		free (r);

--- a/dsl/optscript.c
+++ b/dsl/optscript.c
@@ -1160,7 +1160,7 @@ name_or_number_new (const char* s, void *data)
 	const char *t = s;
 	while (*t)
 	{
-		if (!isdigit ((int)*t))
+		if (!isdigit ((unsigned char) *t))
 		{
 			number = false;
 			break;

--- a/main/args.c
+++ b/main/args.c
@@ -31,7 +31,7 @@ static char *nextStringArg (const char** const next)
 	const char* start;
 
 	Assert (*next != NULL);
-	for (start = *next  ;  isspace ((int) *start)  ;  ++start)
+	for (start = *next  ;  isspace ((unsigned char) *start)  ;  ++start)
 		;
 	if (*start == '\0')
 		*next = start;
@@ -40,7 +40,7 @@ static char *nextStringArg (const char** const next)
 		size_t length;
 		const char* end;
 
-		for (end = start ;  *end != '\0'  &&  ! isspace ((int) *end)  ;  ++end)
+		for (end = start; *end != '\0' && ! isspace ((unsigned char) *end); ++end)
 			;
 		length = end - start;
 		Assert (length > 0);
@@ -156,7 +156,7 @@ static char* nextFileLine (FILE* const fp)
 
 static bool isCommentLine (char* line)
 {
-	while (isspace(*line))
+	while (isspace((unsigned char) *line))
 		++line;
 	return (*line == '#');
 }

--- a/main/field.c
+++ b/main/field.c
@@ -878,7 +878,7 @@ static const char* renderCompactInputLine (vString *b,  const char *const line)
 
 				/*  Consume repeating white space.
 				 */
-				while (next = *(p+1) , isspace (next)  &&  next != NEWLINE)
+				while (next = (unsigned char) *(p+1), isspace (next) && next != NEWLINE)
 					++p;
 				c = ' ';  /* force space character for any white space */
 			}
@@ -1328,7 +1328,7 @@ extern int defineField (fieldDefinition *def, langType language)
 	Assert (def->name);
 	for (i = 0; i < strlen (def->name); i++)
 	{
-		Assert ( isalpha (def->name [i]) );
+		Assert ( isalpha ((unsigned char) def->name [i]) );
 	}
 	def->letter = NUL_FIELD_LETTER;
 

--- a/main/keyword.c
+++ b/main/keyword.c
@@ -74,17 +74,17 @@ static hashEntry *getHashTableEntry (unsigned long hashedValue)
 static unsigned int hashValue (const char *const string, langType language,
 	unsigned int maxLen, bool *maxLenReached)
 {
-	const signed char *p;
+	const char *p;
 	unsigned int h = 5381;
 
 	Assert (string != NULL);
 
 	/* "djb" hash as used in g_str_hash() in glib */
-	for (p = (const signed char *)string; *p != '\0'; p++)
+	for (p = string; *p != '\0'; p++)
 	{
-		h = (h << 5) + h + tolower (*p);
+		h = (h << 5) + h + (signed char) tolower ((unsigned char) *p);
 
-		if (p > (const signed char *)string + maxLen)
+		if (p > string + maxLen)
 		{
 			*maxLenReached = true;
 			return 0;

--- a/main/kind.c
+++ b/main/kind.c
@@ -91,7 +91,7 @@ static void initRoleObject (roleObject *robj, roleDefinition *rdef, freeRoleDefF
 #ifdef DEBUG
 	size_t len = strlen (rdef->name);
 	for (int i = 0; i < len; i++)
-		Assert (isalnum (rdef->name [i]));
+		Assert (isalnum ((unsigned char) rdef->name [i]));
 #endif
 	robj->def = rdef;
 	robj->free = freefunc;

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -824,7 +824,7 @@ static void pre_ptrn_flag_guest_long (const char* const s, const char* const v, 
 	{
 		const char *n_tmp = v + 1;
 		const char *n = n_tmp;
-		for (; isdigit (*n_tmp); n_tmp++);
+		for (; isdigit ((unsigned char) *n_tmp); n_tmp++);
 		char c = *n_tmp;
 		*(char *)n_tmp = '\0';
 		if (!strToInt (n, 10, &(guest->lang.spec.patternGroup)))
@@ -886,7 +886,7 @@ static void pre_ptrn_flag_guest_long (const char* const s, const char* const v, 
 		{
 			char *n = tmp;
 
-			for (; isdigit (*tmp); tmp++);
+			for (; isdigit ((unsigned char) *tmp); tmp++);
 			char c = *tmp;
 			*tmp = '\0';
 			if (!strToInt (n, 10, &(current->patternGroup)))
@@ -1599,7 +1599,7 @@ static vString* substitute (
 	const char* p;
 	for (p = out  ;  *p != '\0'  ;  p++)
 	{
-		if (*p == '\\'  &&  isdigit ((int) *++p))
+		if (*p == '\\'  &&  isdigit ((unsigned char) *++p))
 		{
 			const int dig = *p - '0';
 			if (0 < dig  &&  dig < nmatch  &&  pmatch [dig].rm_so != -1)
@@ -2294,7 +2294,7 @@ static regexPattern *addTagRegexInternal (struct lregexControlBlock *lcb,
 	{
 		if (p == kindName)
 		{
-			if (!isalpha(*p))
+			if (!isalpha((unsigned char) *p))
 				error (FATAL,
 					   "A kind name doesn't start with an alphabetical character: "
 					   "'%s' in \"--%s-%s\" option",
@@ -2310,7 +2310,7 @@ static regexPattern *addTagRegexInternal (struct lregexControlBlock *lcb,
 			 * in which Exuberant-ctags users define kind names with whitespaces.
 			 * "FATAL" error breaks the compatibility.
 			 */
-			if (!isalnum(*p))
+			if (!isalnum((unsigned char) *p))
 				error (/* regptype == REG_PARSER_SINGLE_LINE? WARNING: */ FATAL,
 					   "Non-alphanumeric char is used in kind name: "
 					   "'%s' in \"--%s-%s\" option",
@@ -2433,7 +2433,7 @@ static void addTagRegexOption (struct lregexControlBlock *lcb,
 		const char *c;
 		for (c = pattern; *c; c++)
 		{
-			if (! (isalnum(*c) || *c == '_'))
+			if (! (isalnum((unsigned char) *c) || *c == '_'))
 			{
 				if (*c &&  (*(c + 1) != '^'))
 				{
@@ -2652,7 +2652,7 @@ extern void addRegexTable (struct lregexControlBlock *lcb, const char *name)
 {
 	const char *c;
 	for (c = name; *c; c++)
-		if (! (isalnum(*c) || *c == '_'))
+		if (! (isalnum((unsigned char) *c) || *c == '_'))
 			error (FATAL, "`%c' in \"%s\" is not acceptable as part of table name", *c, name);
 
 	if (getTableIndexForName(lcb, name) >= 0)

--- a/main/options.c
+++ b/main/options.c
@@ -2604,7 +2604,7 @@ static void processIgnoreOption (const char *const list, int IgnoreOrDefine)
 		addIgnoreListFromFile (lang, fileName);
 	}
 #if defined (WIN32)
-	else if (isalpha (list [0])  &&  list [1] == ':')
+	else if (isalpha ((unsigned char) list [0])  &&  list [1] == ':')
 		addIgnoreListFromFile (lang, list);
 #endif
 	else if (strcmp (list, "-") == 0)

--- a/main/parse.c
+++ b/main/parse.c
@@ -573,7 +573,7 @@ static bool processLangDefineScopesep(const langType language,
 		error (FATAL,
 			   "the kind letter `%c' in \"--%s\" option is reserved for \"%s\" kind and no separator can be assigned to",
 			   KIND_FILE_DEFAULT_LETTER, option, KIND_FILE_DEFAULT_NAME);
-	else if (isalpha (parentKletter))
+	else if (isalpha ((unsigned char) parentKletter))
 	{
 		kindDefinition *kdef = getKindForLetter (parser->kindControlBlock, parentKletter);
 		if (kdef == NULL)
@@ -623,7 +623,7 @@ static bool processLangDefineScopesep(const langType language,
 		error (FATAL,
 			   "the kind letter `%c' in \"--%s\" option is reserved for \"%s\" kind and no separator can be assigned to",
 			   KIND_FILE_DEFAULT_LETTER, option, KIND_FILE_DEFAULT_NAME);
-	else if (isalpha (kletter))
+	else if (isalpha ((unsigned char) kletter))
 	{
 		kindDefinition *kdef = getKindForLetter (parser->kindControlBlock, kletter);
 		if (kdef == NULL)
@@ -748,9 +748,9 @@ static vString* determineInterpreter (const char* const cmd)
 	do
 	{
 		vStringClear (interpreter);
-		for ( ;  isspace ((int) *p)  ;  ++p)
+		for ( ;  isspace ((unsigned char) *p)  ;  ++p)
 			;  /* no-op */
-		for ( ;  *p != '\0'  &&  ! isspace ((int) *p)  ;  ++p)
+		for ( ;  *p != '\0'  &&  ! isspace ((unsigned char) *p)  ;  ++p)
 			vStringPut (interpreter, *p);
 	} while (strcmp (vStringValue (interpreter), "env") == 0);
 	return interpreter;
@@ -795,7 +795,7 @@ static bool isShellZsh (const char *p)
 
 	if (*p == ':')
 		p++;
-	while (isspace ((int) *p))
+	while (isspace ((unsigned char) *p))
 		p++;
 
 	if (strncmp (p, "\"zsh\"", 5) == 0
@@ -813,16 +813,16 @@ static vString* determineEmacsModeAtFirstLine (const char* const line)
 		goto out;
 	p += strlen("-*-");
 
-	for ( ;  isspace ((int) *p)  ;  ++p)
+	for ( ;  isspace ((unsigned char) *p)  ;  ++p)
 		;  /* no-op */
 
 	if (strncasecmp(p, "mode:", strlen("mode:")) == 0)
 	{
 		/* -*- mode: MODE; -*- */
 		p += strlen("mode:");
-		for ( ;  isspace ((int) *p)  ;  ++p)
+		for ( ;  isspace ((unsigned char) *p)  ;  ++p)
 			;  /* no-op */
-		for ( ;  *p != '\0'  &&  isLanguageNameChar ((int) *p)  ;  ++p)
+		for ( ;  *p != '\0'  &&  isLanguageNameChar ((unsigned char) *p)  ;  ++p)
 			vStringPut (mode, *p);
 
 		if ((strcmp(vStringValue (mode), "sh") == 0
@@ -838,10 +838,10 @@ static vString* determineEmacsModeAtFirstLine (const char* const line)
 		if (end == NULL)
 			goto out;
 
-		for ( ;  p < end &&  isLanguageNameChar ((int) *p)  ;  ++p)
+		for ( ;  p < end &&  isLanguageNameChar ((unsigned char) *p)  ;  ++p)
 			vStringPut (mode, *p);
 
-		for ( ;  isspace ((int) *p)  ;  ++p)
+		for ( ;  isspace ((unsigned char) *p)  ;  ++p)
 			;  /* no-op */
 		if (strncmp(p, "-*-", strlen("-*-")) != 0)
 			vStringClear (mode);
@@ -888,9 +888,9 @@ static vString* determineEmacsModeAtEOF (MIO* const fp)
 			headerFound = false;
 
 			p += strlen ("mode:");
-			for ( ;  isspace ((int) *p)  ;  ++p)
+			for ( ;  isspace ((unsigned char) *p)  ;  ++p)
 				;  /* no-op */
-			for ( ;  *p != '\0'  &&  isLanguageNameChar ((int) *p)  ;  ++p)
+			for ( ;  *p != '\0'  &&  isLanguageNameChar ((unsigned char) *p)  ;  ++p)
 				vStringPut (mode, *p);
 
 			is_shell_mode = ((strcasecmp (vStringValue (mode), "sh") == 0
@@ -903,7 +903,7 @@ static vString* determineEmacsModeAtEOF (MIO* const fp)
 		else if (is_shell_mode && (p = strstr (line, "sh-set-shell")))
 		{
 			p += strlen("sh-set-shell");
-			while (isspace ((int) *p))
+			while (isspace ((unsigned char) *p))
 				p++;
 			if (strncmp (p, "\"zsh\"", 5) == 0)
 				vStringCopyS (mode, "Zsh");
@@ -954,7 +954,7 @@ static vString* determineVimFileType (const char *const modeline)
 			continue;
 
 		p += strlen(filetype_prefix[i]);
-		for ( ;  *p != '\0'  &&  isalnum ((int) *p)  ;  ++p)
+		for ( ;  *p != '\0'  &&  isalnum ((unsigned char) *p)  ;  ++p)
 			vStringPut (filetype, *p);
 		break;
 	}
@@ -1011,7 +1011,7 @@ static vString* extractVimFileTypeCommon(MIO* input, bool eof)
 			if ((p = strstr (vStringValue (ring[j]), prefix[k])) != NULL)
 			{
 				p += strlen(prefix[k]);
-				for ( ;  isspace ((int) *p)  ;  ++p)
+				for ( ;  isspace ((unsigned char) *p)  ;  ++p)
 					;  /* no-op */
 				filetype = determineVimFileType(p);
 				break;
@@ -1066,9 +1066,11 @@ static vString* determineZshAutoloadTag (const char *const modeline,
 	   #compdef ...
 	   #autoload [ OPTIONS ] */
 
-	if (((strncmp (modeline, "#compdef", 8) == 0) && isspace (*(modeline + 8)))
+	if (((strncmp (modeline, "#compdef", 8) == 0)
+	     && isspace ((unsigned char) *(modeline + 8)))
 	    || ((strncmp (modeline, "#autoload", 9) == 0)
-		&& (isspace (*(modeline + 9)) || *(modeline + 9) == '\0')))
+	        && (isspace ((unsigned char) *(modeline + 9))
+	            || *(modeline + 9) == '\0')))
 		return vStringNewInit ("zsh");
 	else
 		return NULL;
@@ -2701,7 +2703,7 @@ static bool processLangDefineKind(const langType language,
 	{
 		if (p == name_start)
 		{
-			if (!isalpha(*p))
+			if (!isalpha((unsigned char) *p))
 			{
 				char *name_in_msg = eStrndup (name_start, marker_end - name_start);
 				error (FATAL,
@@ -2712,7 +2714,7 @@ static bool processLangDefineKind(const langType language,
 		}
 		else
 		{
-			if (!isalnum (*p))
+			if (!isalnum ((unsigned char) *p))
 			{
 				char *name_in_msg = eStrndup (name_start, marker_end - name_start);
 				error (FATAL,
@@ -2833,7 +2835,7 @@ static bool processLangDefineRole(const langType language,
 	const char * tmp_start = p;
 	while (p != tmp_end)
 	{
-		if (!isalnum (*p))
+		if (!isalnum ((unsigned char) *p))
 			error (FATAL, "unacceptable char as part of role name in \"--%s\" option: %c",
 				   option, *p);
 		p++;
@@ -3518,7 +3520,7 @@ static bool processLangDefineParam (const langType language,
 
 	for (; p < name_end; p++)
 	{
-		if (!isalnum (*p) && *p != '_')
+		if (!isalnum ((unsigned char) *p) && *p != '_')
 			error (FATAL, "unacceptable char as part of extra name in \"--%s\" option",
 				   option);
 	}
@@ -3914,7 +3916,7 @@ static bool processLangDefineExtra (const langType language,
 
 	for (; p < name_end; p++)
 	{
-		if (!isalnum (*p))
+		if (!isalnum ((unsigned char) *p))
 			error (FATAL, "unacceptable char as part of extra name in \"--%s\" option",
 				   option);
 	}
@@ -3983,7 +3985,7 @@ static bool processLangDefineField (const langType language,
 
 	for (; p < name_end; p++)
 	{
-		if (!isalpha (*p))
+		if (!isalpha ((unsigned char) *p))
 			error (FATAL, "unacceptable char as part of field name in \"--%s\" option",
 				   option);
 	}

--- a/main/read.c
+++ b/main/read.c
@@ -529,7 +529,7 @@ static unsigned long readLineNumber (char **str)
 
 	skipWhite (str);
 	s = *str;
-	while (*s != '\0' && isdigit (*s))
+	while (*s != '\0' && isdigit ((unsigned char) *s))
 	{
 		lNum = (lNum * 10) + (*s - '0');
 		s++;
@@ -578,7 +578,7 @@ static bool parseLineDirective (char *s)
 	skipWhite (&s);
 	DebugStatement ( const char* lineStr = ""; )
 
-	if (isdigit (*s))
+	if (isdigit ((unsigned char) *s))
 		result = true;
 	else if (strncmp (s, "line", 4) == 0)
 	{

--- a/main/routines.c
+++ b/main/routines.c
@@ -285,7 +285,7 @@ extern int struppercmp (const char *s1, const char *s2)
 	int result;
 	do
 	{
-		result = toupper ((int) *s1) - toupper ((int) *s2);
+		result = toupper ((unsigned char) *s1) - toupper ((unsigned char) *s2);
 	} while (result == 0  &&  *s1++ != '\0'  &&  *s2++ != '\0');
 	return result;
 }
@@ -295,7 +295,7 @@ extern int strnuppercmp (const char *s1, const char *s2, size_t n)
 	int result;
 	do
 	{
-		result = toupper ((int) *s1) - toupper ((int) *s2);
+		result = toupper ((unsigned char) *s1) - toupper ((unsigned char) *s2);
 	} while (result == 0  &&  --n > 0  &&  *s1++ != '\0'  &&  *s2++ != '\0');
 	return result;
 }
@@ -330,7 +330,7 @@ extern void toLowerString (char* str)
 {
 	while (*str != '\0')
 	{
-		*str = tolower ((int) *str);
+		*str = (char) tolower ((unsigned char) *str);
 		++str;
 	}
 }
@@ -339,7 +339,7 @@ extern void toUpperString (char* str)
 {
 	while (*str != '\0')
 	{
-		*str = toupper ((int) *str);
+		*str = (char) toupper ((unsigned char) *str);
 		++str;
 	}
 }
@@ -351,7 +351,7 @@ extern char* newLowerString (const char* str)
 	char* const result = xMalloc (strlen (str) + 1, char);
 	int i = 0;
 	do
-		result [i] = tolower ((int) str [i]);
+		result [i] = (char) tolower ((unsigned char) str [i]);
 	while (str [i++] != '\0');
 	return result;
 }
@@ -363,7 +363,7 @@ extern char* newUpperString (const char* str)
 	char* const result = xMalloc (strlen (str) + 1, char);
 	int i = 0;
 	do
-		result [i] = toupper ((int) str [i]);
+		result [i] = (char) toupper ((unsigned char) str [i]);
 	while (str [i++] != '\0');
 	return result;
 }
@@ -675,7 +675,7 @@ extern bool isAbsolutePath (const char *const path)
 #if defined (MSDOS_STYLE_PATH)
 	if (isPathSeparator (path [0]))
 		result = true;
-	else if (isalpha (path [0])  &&  path [1] == ':')
+	else if (isalpha ((unsigned char) path [0])  &&  path [1] == ':')
 	{
 		if (isPathSeparator (path [2]))
 			result = true;
@@ -806,8 +806,8 @@ extern char* absoluteFilename (const char *file)
 	{
 #ifdef MSDOS_STYLE_PATH
 		/* Canonicalize drive letter case. */
-		if (res [1] == ':'  &&  islower (res [0]))
-			res [0] = toupper (res [0]);
+		if (res [1] == ':'  &&  islower ((unsigned char) res [0]))
+			res [0] = toupper ((unsigned char) res [0]);
 #endif
 	}
 	canonicalizePath (res);
@@ -849,7 +849,7 @@ extern char* relativeFilename (const char *file, const char *dir)
 	absdir = absoluteFilename (file);
 	fp = absdir;
 	dp = dir;
-	while (fnmChEq (*fp++, *dp++))
+	while (fnmChEq ((unsigned char) *fp++, (unsigned char) *dp++))
 		continue;
 	fp--;
 	dp--;  /* back to the first differing char */

--- a/main/script.c
+++ b/main/script.c
@@ -39,7 +39,7 @@ static void vStringCatToupperS (vString *str, const char *s)
 {
 	for (const char *tmp = s; *tmp != '\0'; tmp++)
 	{
-		int c = toupper (*tmp);
+		int c = toupper ((unsigned char) *tmp);
 		vStringPut (str, c);
 	}
 }

--- a/main/selectors.c
+++ b/main/selectors.c
@@ -57,13 +57,13 @@ static const char *selectByLines (MIO *input,
 static const char *
 tastePerlLine (const char *line, void *data CTAGS_ATTR_UNUSED)
 {
-	while (isspace(*line))
+	while (isspace((unsigned char) *line))
 		++line;
 #define STRLEN(s) (sizeof(s) - 1)
 /* Assume the first character has been checked: */
 #define CHECK_PART(line, s) (								\
 		0 == strncmp((line) + 1, (s) + 1, STRLEN(s) - 1) && \
-		!isalnum((line)[STRLEN(s)]))
+		!isalnum((unsigned char) (line)[STRLEN(s)]))
 	switch (line[0]) {
 	case '#':		/* TODO: taste modeline */
 	case '\0':
@@ -154,7 +154,7 @@ tasteObjectiveCOrMatLabLines (const char *line, void *data CTAGS_ATTR_UNUSED)
 	else {
 		if (startsWith (line, "function ")) {
 			const char *p = line + strlen ("function ");
-			while (isspace(*p))
+			while (isspace((unsigned char) *p))
 				p++;
 			if (*p != '\0' && *p != '(')
 				return TR_MATLAB;

--- a/main/vstring.c
+++ b/main/vstring.c
@@ -175,7 +175,7 @@ extern void vStringStripLeading (vString *const string)
 {
 	size_t n = 0;
 
-	while (n < string->length && isspace ((int) string->buffer [n]))
+	while (n < string->length && isspace ((unsigned char) string->buffer [n]))
 		n++;
 	if (n > 0)
 	{
@@ -189,7 +189,7 @@ extern void vStringStripLeading (vString *const string)
 extern void vStringStripTrailing (vString *const string)
 {
 	while (string->length > 0 &&
-		   isspace ((int) string->buffer [string->length - 1]))
+	       isspace ((unsigned char) string->buffer [string->length - 1]))
 	{
 		string->length--;
 		string->buffer [string->length] = '\0';
@@ -244,7 +244,7 @@ extern void vStringCopyToLower (vString *const dest, const vString *const src)
 		vStringResize (dest, src->size);
 	d = dest->buffer;
 	for (i = 0  ;  i < length  ;  ++i)
-		d [i] = (char) tolower (s [i]);
+		d [i] = (char) tolower ((unsigned char) s [i]);
 	d [i] = '\0';
 }
 

--- a/main/xtag.c
+++ b/main/xtag.c
@@ -355,7 +355,7 @@ extern int defineXtag (xtagDefinition *def, langType language)
 	Assert (def->name);
 	for (i = 0; i < strlen (def->name); i++)
 	{
-		Assert ( isalnum (def->name [i]) );
+		Assert ( isalnum ((unsigned char) def->name [i]) );
 	}
 	def->letter = NUL_XTAG_LETTER;
 

--- a/old-docs/EXTENDING.html
+++ b/old-docs/EXTENDING.html
@@ -232,12 +232,12 @@ static void findSwineTags (void)
     {
         /* Look for a line beginning with "def" followed by name */
         if (strncmp ((const char*) line, "def", (size_t) 3) == 0  &amp;&amp;
-            isspace ((int) line [3]))
+            isspace (line [3]))
         {
             const unsigned char *cp = line + 4;
-            while (isspace ((int) *cp))
+            while (isspace (*cp))
                 ++cp;
-            while (isalnum ((int) *cp)  ||  *cp == '_')
+            while (isalnum (*cp)  ||  *cp == '_')
             {
                 vStringPut (name, *cp);
                 ++cp;

--- a/parsers/abaqus.c
+++ b/parsers/abaqus.c
@@ -44,7 +44,9 @@ static int getWord(const char *ref, const char **ptr)
 {
 	const char *p = *ptr;
 
-	while ((*ref != '\0') && (*p != '\0') && (tolower(*ref) == tolower(*p))) ref++, p++;
+	while ((*ref != '\0') && (*p != '\0') &&
+	       (tolower((unsigned char) *ref) == tolower((unsigned char) *p)))
+		ref++, p++;
 
 	if (*ref) return false;
 

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -205,7 +205,7 @@ static bool isDefineOperator (const vString *const operator)
 		(unsigned char*) vStringValue (operator);
 	const size_t length = vStringLength (operator);
 	const bool result = (bool) (length > 0  &&
-		toupper ((int) *op) == 'D'  &&
+		toupper (*op) == 'D'  &&
 		(length == 2 ||
 		 (length == 4  &&  (int) op [2] == '.') ||
 		 (length == 5  &&  (int) op [3] == '.')));
@@ -291,9 +291,9 @@ static const unsigned char *readSymbol (
 {
 	const unsigned char *cp = start;
 	vStringClear (sym);
-	if (isInitialSymbolCharacter ((int) *cp))
+	if (isInitialSymbolCharacter (*cp))
 	{
-		while (isSymbolCharacter ((int) *cp))
+		while (isSymbolCharacter (*cp))
 		{
 			vStringPut (sym, *cp);
 			++cp;
@@ -308,7 +308,7 @@ static const unsigned char *readOperator (
 {
 	const unsigned char *cp = start;
 	vStringClear (operator);
-	while (*cp != '\0'  &&  ! isspace ((int) *cp) && *cp != ',')
+	while (*cp != '\0'  &&  ! isspace (*cp) && *cp != ',')
 	{
 		vStringPut (operator, *cp);
 		++cp;
@@ -574,7 +574,7 @@ static void  readMacroParameters (int index, tagEntryInfo *e, const unsigned cha
 		const unsigned char *tmp;
 		tagEntryInfo *e = NULL;
 
-		while (isspace ((int) *cp))
+		while (isspace (*cp))
 			++cp;
 
 		tmp = cp;
@@ -632,7 +632,7 @@ static void  readMacroParameters (int index, tagEntryInfo *e, const unsigned cha
 			}
 		}
 
-		while (isspace ((int) *cp))
+		while (isspace (*cp))
 			++cp;
 
 		if (*cp == ',')
@@ -664,7 +664,7 @@ static void findAsmTagsCommon (bool useCpp)
 	 while ((line = asmReadLineFromInputFile (commentCharsInMOL, useCpp)) != NULL)
 	 {
 		const unsigned char *cp = line;
-		bool labelCandidate = (bool) (! isspace ((int) *cp));
+		bool labelCandidate = (bool) (! isspace (*cp));
 		bool nameFollows = false;
 		bool directive = false;
 		const bool isComment = (bool)
@@ -675,7 +675,7 @@ static void findAsmTagsCommon (bool useCpp)
 			continue;
 
 		/* skip white space */
-		while (isspace ((int) *cp))
+		while (isspace (*cp))
 			++cp;
 
 		/* read symbol */
@@ -700,11 +700,11 @@ static void findAsmTagsCommon (bool useCpp)
 				labelCandidate = false;
 		}
 
-		if (! isspace ((int) *cp)  &&  *cp != '\0')
+		if (! isspace (*cp)  &&  *cp != '\0')
 			continue;
 
 		/* skip white space */
-		while (isspace ((int) *cp))
+		while (isspace (*cp))
 			++cp;
 
 		/* skip leading dot */
@@ -718,7 +718,7 @@ static void findAsmTagsCommon (bool useCpp)
 		/* attempt second read of symbol */
 		if (vStringLength (name) == 0)
 		{
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
 			cp = readSymbol (cp, name);
 			nameFollows = true;

--- a/parsers/asp.c
+++ b/parsers/asp.c
@@ -51,7 +51,7 @@ static void findAspTags (void)
 		while (*cp != '\0')
 		{
 			/* jump over whitespace */
-			while (isspace ((int)*cp))
+			while (isspace (*cp))
 				cp++;
 
 			/* jump over strings */
@@ -70,9 +70,9 @@ static void findAspTags (void)
 			else if (strncasecmp ((const char*) cp, "end", (size_t) 3)== 0)
 			{
 				cp += 3;
-				if (isspace ((int)*cp))
+				if (isspace (*cp))
 				{
-					while (isspace ((int)*cp))
+					while (isspace (*cp))
 						++cp;
 
 					if (strncasecmp ((const char*) cp, "function", (size_t) 8) == 0)
@@ -93,9 +93,9 @@ static void findAspTags (void)
 			else if (strncasecmp ((const char*) cp, "exit", (size_t) 4)==0)
 			{
 				cp += 4;
-				if (isspace ((int) *cp))
+				if (isspace (*cp))
 				{
-					while (isspace ((int) *cp))
+					while (isspace (*cp))
 						++cp;
 
 					if (strncasecmp ((const char*) cp, "function", (size_t) 8) == 0)
@@ -116,16 +116,16 @@ static void findAspTags (void)
 			else if (strncasecmp ((const char*) cp, "public", (size_t) 6) == 0)
 			{
 				cp += 6;
-				if (isspace ((int) *cp))
+				if (isspace (*cp))
 				{
-					while (isspace ((int) *cp))
+					while (isspace (*cp))
 						++cp;
 					if (strncasecmp ((const char*) cp, "function", (size_t) 8) == 0)
 					{
 						cp+=8;
-					    while (isspace ((int) *cp))
+					    while (isspace (*cp))
 						    ++cp;
-					    while (isalnum ((int) *cp)  ||  *cp == '_')
+					    while (isalnum (*cp)  ||  *cp == '_')
 					    {
 						    vStringPut (name, *cp);
 						    ++cp;
@@ -136,9 +136,9 @@ static void findAspTags (void)
 					else if (strncasecmp ((const char*) cp, "sub", (size_t) 3) == 0)
 					{
 						cp+=3;
-					    while (isspace ((int) *cp))
+					    while (isspace (*cp))
 						    ++cp;
-					    while (isalnum ((int) *cp)  ||  *cp == '_')
+					    while (isalnum (*cp)  ||  *cp == '_')
 					    {
 						    vStringPut (name, *cp);
 						    ++cp;
@@ -147,7 +147,7 @@ static void findAspTags (void)
 					    vStringClear (name);
 					}
 					else {
-					    while (isalnum ((int) *cp)  ||  *cp == '_')
+					    while (isalnum (*cp)  ||  *cp == '_')
 					    {
 						    vStringPut (name, *cp);
 						    ++cp;
@@ -160,16 +160,16 @@ static void findAspTags (void)
 			else if (strncasecmp ((const char*) cp, "private", (size_t) 7) == 0)
 			{
 				cp += 7;
-				if (isspace ((int) *cp))
+				if (isspace (*cp))
 				{
-					while (isspace ((int) *cp))
+					while (isspace (*cp))
 						++cp;
 					if (strncasecmp ((const char*) cp, "function", (size_t) 8) == 0)
 					{
 						cp+=8;
-					    while (isspace ((int) *cp))
+					    while (isspace (*cp))
 						    ++cp;
-					    while (isalnum ((int) *cp)  ||  *cp == '_')
+					    while (isalnum (*cp)  ||  *cp == '_')
 					    {
 						    vStringPut (name, *cp);
 						    ++cp;
@@ -180,9 +180,9 @@ static void findAspTags (void)
 					else if (strncasecmp ((const char*) cp, "sub", (size_t) 3) == 0)
 					{
 						cp+=3;
-					    while (isspace ((int) *cp))
+					    while (isspace (*cp))
 						    ++cp;
-					    while (isalnum ((int) *cp)  ||  *cp == '_')
+					    while (isalnum (*cp)  ||  *cp == '_')
 					    {
 						    vStringPut (name, *cp);
 						    ++cp;
@@ -191,7 +191,7 @@ static void findAspTags (void)
 					    vStringClear (name);
 					}
 					else {
-					    while (isalnum ((int) *cp)  ||  *cp == '_')
+					    while (isalnum (*cp)  ||  *cp == '_')
 					    {
 						    vStringPut (name, *cp);
 						    ++cp;
@@ -207,11 +207,11 @@ static void findAspTags (void)
 			{
 				cp += 8;
 
-				if (isspace ((int) *cp))
+				if (isspace (*cp))
 				{
-					while (isspace ((int) *cp))
+					while (isspace (*cp))
 						++cp;
-					while (isalnum ((int) *cp)  ||  *cp == '_')
+					while (isalnum (*cp)  ||  *cp == '_')
 					{
 						vStringPut (name, *cp);
 						++cp;
@@ -225,11 +225,11 @@ static void findAspTags (void)
 			else if (strncasecmp ((const char*) cp, "sub", (size_t) 3) == 0)
 			{
 				cp += 3;
-				if (isspace ((int) *cp))
+				if (isspace (*cp))
 				{
-					while (isspace ((int) *cp))
+					while (isspace (*cp))
 						++cp;
-					while (isalnum ((int) *cp)  ||  *cp == '_')
+					while (isalnum (*cp)  ||  *cp == '_')
 					{
 						vStringPut (name, *cp);
 						++cp;
@@ -243,11 +243,11 @@ static void findAspTags (void)
 			else if (strncasecmp ((const char*) cp, "dim", (size_t) 3) == 0)
 			{
 				cp += 3;
-				if (isspace ((int) *cp))
+				if (isspace (*cp))
 				{
-					while (isspace ((int) *cp))
+					while (isspace (*cp))
 						++cp;
-					while (isalnum ((int) *cp)  ||  *cp == '_')
+					while (isalnum (*cp)  ||  *cp == '_')
 					{
 						vStringPut (name, *cp);
 						++cp;
@@ -261,11 +261,11 @@ static void findAspTags (void)
 			else if (strncasecmp ((const char*) cp, "class", (size_t) 5) == 0)
 			{
 				cp += 5;
-				if (isspace ((int) *cp))
+				if (isspace (*cp))
 				{
-					while (isspace ((int) *cp))
+					while (isspace (*cp))
 						++cp;
-					while (isalnum ((int) *cp)  ||  *cp == '_')
+					while (isalnum (*cp)  ||  *cp == '_')
 					{
 						vStringPut (name, *cp);
 						++cp;
@@ -279,11 +279,11 @@ static void findAspTags (void)
 			else if (strncasecmp ((const char*) cp, "const", (size_t) 5) == 0)
 			{
 				cp += 5;
-				if (isspace ((int) *cp))
+				if (isspace (*cp))
 				{
-					while (isspace ((int) *cp))
+					while (isspace (*cp))
 						++cp;
-					while (isalnum ((int) *cp)  ||  *cp == '_')
+					while (isalnum (*cp)  ||  *cp == '_')
 					{
 						vStringPut (name, *cp);
 						++cp;

--- a/parsers/autoit.c
+++ b/parsers/autoit.c
@@ -132,7 +132,7 @@ static void setEndLine (const NestingLevels *const nls)
 
 static void skipSpaces (const unsigned char **p)
 {
-	while (isspace ((int) **p))
+	while (isspace (**p))
 		++(*p);
 }
 
@@ -143,7 +143,7 @@ static int parseFunc (const unsigned char *p, NestingLevels *nls)
 	vString *name = vStringNew ();
 
 	skipSpaces (&p);
-	while (isIdentChar ((int) *p))
+	while (isIdentChar (*p))
 	{
 		vStringPut (name, *p);
 		++p;
@@ -282,7 +282,7 @@ static void findAutoItTags (void)
 				if (*p == '$')
 				{
 					p++;
-					while (isIdentChar ((int) *p))
+					while (isIdentChar (*p))
 					{
 						vStringPut (name, *p);
 						++p;

--- a/parsers/awk.c
+++ b/parsers/awk.c
@@ -41,22 +41,22 @@ static void findAwkTags (void)
 
 	while ((line = readLineFromInputFile ()) != NULL)
 	{
-		while (isspace ((int) *line))
+		while (isspace (*line))
 			++line;
 
 		if (strncmp ((const char *) line, "function", (size_t) 8) == 0  &&
-			isspace ((int) line [8]))
+			isspace (line [8]))
 		{
 			const unsigned char *cp = line + 8;
 
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
-			while (isalnum ((int) *cp)  ||  *cp == '_')
+			while (isalnum (*cp)  ||  *cp == '_')
 			{
 				vStringPut (name, *cp);
 				++cp;
 			}
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
 			if (*cp == '(')
 				makeSimpleTag (name, K_FUNCTION);

--- a/parsers/basic.c
+++ b/parsers/basic.c
@@ -224,7 +224,7 @@ static const char *nextPos (const char *pos)
 	return pos;
 }
 
-static bool isIdentChar (char c)
+static bool isIdentChar (int c)
 {
 	return c && !isspace (c) && c != '(' && c != ',' && c != '=';
 }
@@ -251,7 +251,7 @@ static void extract_dim (char const *pos, BasicKind kind)
 	if (strncasecmp (pos, "shared", 6) == 0)
 		pos += 6; /* skip keyword "shared" */
 
-	while (isspace (*pos))
+	while (isspace ((unsigned char) *pos))
 		pos++;
 
 	/* capture "dim as String str" */
@@ -259,30 +259,31 @@ static void extract_dim (char const *pos, BasicKind kind)
 	{
 			pos += 2; /* skip keyword "as" */
 
-		while (isspace (*pos))
+		while (isspace ((unsigned char) *pos))
 			pos++;
-		while (!isspace (*pos) && *pos) /* skip next part which is a type */
+		while (!isspace ((unsigned char) *pos) && *pos) /* skip next part which is a type */
 			pos++;
-		while (isspace (*pos))
+		while (isspace ((unsigned char) *pos))
 			pos++;
 		/* now we are at the name */
 	}
 	/* capture "dim as foo ptr bar" */
-	if (strncasecmp (pos, "ptr", 3) == 0 && isspace(*(pos+3)))
+	if (strncasecmp (pos, "ptr", 3) == 0 && isspace((unsigned char) *(pos+3)))
 	{
 		pos += 3; /* skip keyword "ptr" */
-		while (isspace (*pos))
+		while (isspace ((unsigned char) *pos))
 			pos++;
 	}
 	/*	capture "dim as string * 4096 chunk" */
 	if (strncmp (pos, "*", 1) == 0)
 	{
 		pos += 1; /* skip "*" */
-		while (isspace (*pos) || isdigit(*pos) || ispunct(*pos))
+		while (isspace ((unsigned char) *pos) || isdigit((unsigned char) *pos) ||
+		       ispunct((unsigned char) *pos))
 			pos++;
 	}
 
-	for (; isIdentChar (*pos); pos++)
+	for (; isIdentChar ((unsigned char) *pos); pos++)
 		vStringPut (name, *pos);
 	makeBasicTag (name, kind);
 
@@ -296,14 +297,14 @@ static void extract_dim (char const *pos, BasicKind kind)
 		if (*pos == '\'')
 			break; /* break if we are in a comment */
 
-		while (isspace (*pos) || *pos == ',')
+		while (isspace ((unsigned char) *pos) || *pos == ',')
 			pos++;
 
 		if (*pos == '\'')
 			break; /* break if we are in a comment */
 
 		vStringClear (name);
-		for (; isIdentChar (*pos); pos++)
+		for (; isIdentChar ((unsigned char) *pos); pos++)
 			vStringPut (name, *pos);
 		makeBasicTag (name, kind);
 	}
@@ -316,7 +317,7 @@ static int extract_name (char const *pos, BasicKind kind, struct matchState *sta
 {
 	int r = CORK_NIL;
 	vString *name = vStringNew ();
-	for (; isIdentChar (*pos); pos++)
+	for (; isIdentChar ((unsigned char) *pos); pos++)
 		vStringPut (name, *pos);
 	if (state && state->declaration)
 	{
@@ -358,7 +359,7 @@ static bool match_keyword (const char **cp, vString *buf,
 		return false;
 
 	const char *old_p = p;
-	while (isspace (*p))
+	while (isspace ((unsigned char) *p))
 		p++;
 
 	if (kw == KEYWORD_ACCESS)
@@ -403,7 +404,7 @@ static bool match_keyword (const char **cp, vString *buf,
 static void match_colon_label (char const *p)
 {
 	char const *end = p + strlen (p) - 1;
-	while (isspace (*end))
+	while (isspace ((unsigned char) *end))
 		end--;
 	if (*end == ':')
 	{
@@ -430,7 +431,7 @@ static void findBasicTags (void)
 	{
 		const char *p = line;
 
-		while (isspace (*p))
+		while (isspace ((unsigned char) *p))
 			p++;
 
 		/* Empty line? */
@@ -439,7 +440,7 @@ static void findBasicTags (void)
 
 		/* REM comment? */
 		if (strncasecmp (p, "REM", 3) == 0  &&
-			(isspace (*(p + 3)) || *(p + 3) == '\0'))
+			(isspace ((unsigned char) *(p + 3)) || *(p + 3) == '\0'))
 			continue;
 
 		/* Single-quote comment? */

--- a/parsers/beta.c
+++ b/parsers/beta.c
@@ -99,8 +99,11 @@ static void findBetaTags (void)
 		last = vStringLength (line) - 1;
 		first = 0;
 		/* skip white space at start and end of line */
-		while (last > 0 && isspace ((int) vStringChar (line, last))) last--;
-		while (first < last && isspace ((int) vStringChar (line, first))) first++;
+		while (last > 0 && isspace ((unsigned char) vStringChar (line, last)))
+			last--;
+		while (first < last &&
+		       isspace ((unsigned char) vStringChar (line, first)))
+			first++;
 		/* if line still has a reasonable length and ... */
 		if (last - first > 4 &&
 			(vStringChar (line, first)     == '-' &&
@@ -118,9 +121,11 @@ static void findBetaTags (void)
 				last -= 2;
 				first += 2;
 				while (last && vStringChar (line, last) != ':') last--;
-				while (last && (isspace ((int) vStringChar (line, last-1)))) last--;
+				while (last &&
+				       (isspace ((unsigned char) vStringChar (line, last-1))))
+					last--;
 				while (first < last &&
-					   (isspace ((int) vStringChar (line, first)) ||
+					   (isspace ((unsigned char) vStringChar (line, first)) ||
 						vStringChar (line, first) == '-'))
 					first++;
 				/* If there's anything left it is a fragment title */
@@ -178,21 +183,23 @@ static void findBetaTags (void)
 					char c2;
 					pos += 2; /* skip past << */
 					/* skip past space before SLOT */
-					while (pos < len && isspace ((int) vStringChar (line, pos)))
+					while (pos < len &&
+					       isspace ((unsigned char) vStringChar (line, pos)))
 						pos++;
 					/* skip past SLOT */
 					if (pos+4 <= len &&
 						!strncasecmp (vStringValue(line) + pos, "SLOT", (size_t)4))
 						pos += 4;
 					/* skip past space after SLOT */
-					while (pos < len && isspace ((int) vStringChar (line, pos)))
+					while (pos < len &&
+					       isspace ((unsigned char) vStringChar (line, pos)))
 						pos++;
 					eoname = pos;
 					/* skip to end of name */
 					while (eoname < len &&
 							(c2 = vStringChar (line, eoname)) != '>' &&
 							c2 != ':' &&
-							!isspace ((int) c2))
+							!isspace ((unsigned char) c2))
 						eoname++;
 					if (eoname < len)
 					{
@@ -229,7 +236,8 @@ static void findBetaTags (void)
 					/* Found pattern name, get start and end */
 					int eoname = pos;
 					int soname;
-					while (eoname && isspace ((int) vStringChar (line, eoname-1)))
+					while (eoname &&
+					       isspace ((unsigned char) vStringChar (line, eoname-1)))
 						eoname--;
 				foundanothername:
 					/* terminate right after name */
@@ -245,7 +253,7 @@ static void findBetaTags (void)
 						makeBetaTag (vStringValue (line) + soname, K_PATTERN);
 						/* scan back past white space */
 						while (soname &&
-								isspace ((int) vStringChar (line, soname-1)))
+						       isspace ((unsigned char) vStringChar (line, soname-1)))
 							soname--;
 						if (soname && vStringChar (line, soname-1) == ',')
 						{

--- a/parsers/clojure.c
+++ b/parsers/clojure.c
@@ -29,27 +29,31 @@ static kindDefinition ClojureKinds[] = {
 
 static int isNamespace (const char *strp)
 {
-	return strncmp (++strp, "ns", 2) == 0 && isspace (strp[2]);
+	return strncmp (++strp, "ns", 2) == 0 && isspace ((unsigned char) strp[2]);
 }
 
 static int isCoreNamespace (const char *strp)
 {
-	return strncmp (++strp, "clojure.core/ns", 15) == 0 && isspace (strp[15]);
+	return strncmp (++strp, "clojure.core/ns", 15) == 0 &&
+	       isspace ((unsigned char) strp[15]);
 }
 
 static int isFunction (const char *strp)
 {
-	return (strncmp (++strp, "defn", 4) == 0 && isspace (strp[4]));
+	return (strncmp (++strp, "defn", 4) == 0 &&
+	        isspace ((unsigned char) strp[4]));
 }
 
 static int isCoreFunction (const char *strp)
 {
-	return (strncmp (++strp, "clojure.core/defn", 17) == 0 && isspace (strp[17]));
+	return (strncmp (++strp, "clojure.core/defn", 17) == 0 &&
+	        isspace ((unsigned char) strp[17]));
 }
 
 static int isQuote (const char *strp)
 {
-	return strncmp (++strp, "quote", 5) == 0 && isspace (strp[5]);
+	return strncmp (++strp, "quote", 5) == 0 &&
+	       isspace ((unsigned char) strp[5]);
 }
 
 static void functionName (vString * const name, const char *dbp)
@@ -61,12 +65,12 @@ static void functionName (vString * const name, const char *dbp)
 	else if (*dbp == '(' && isQuote (dbp))
 	{
 		dbp += 7;
-		while (isspace (*dbp))
+		while (isspace ((unsigned char) *dbp))
 			dbp++;
 	}
 
-	for (p = dbp; *p != '\0' && *p != '(' && !isspace ((int) *p) && *p != ')';
-		p++)
+	for (p = dbp; *p != '\0' && *p != '(' && !isspace ((unsigned char) *p)
+		 && *p != ')'; p++)
 		vStringPut (name, *p);
 }
 
@@ -139,9 +143,9 @@ static void makeFunctionTag (vString * const name, const char *dbp, int scope_in
 
 static void skipToSymbol (const char **p)
 {
-	while (**p != '\0' && !isspace ((int) **p))
+	while (**p != '\0' && !isspace ((unsigned char) **p))
 		*p = *p + 1;
-	while (isspace ((int) **p))
+	while (isspace ((unsigned char) **p))
 		*p = *p + 1;
 }
 
@@ -155,7 +159,7 @@ static void findClojureTags (void)
 	{
 		vStringClear (name);
 
-		while (isspace (*p))
+		while (isspace ((unsigned char) *p))
 			p++;
 
 		if (*p == '(')

--- a/parsers/cobol.c
+++ b/parsers/cobol.c
@@ -180,7 +180,7 @@ static void cblppAppendLine (vString *buffer,
 			if (*indicator == '-')
 			{
 				vStringStripTrailing (buffer);
-				while (isspace (*lineStart))
+				while (isspace ((unsigned char) *lineStart))
 					lineStart++;
 			}
 
@@ -328,14 +328,14 @@ static void findCOBOLTags (const CobolFormat format)
 	do { \
 		const char READ_LITERAL__q = isQuote (*line) ? *line++ : 0; \
 		READ_WHILE (word, (READ_LITERAL__q && READ_LITERAL__q != *line) || \
-		                   isIdentifierChar (*line)); \
+		                   isIdentifierChar ((unsigned char) *line)); \
 		if (READ_LITERAL__q && READ_LITERAL__q == *line) \
 			line++; \
 		keyword = lookupCaseKeyword (word, Lang_cobol); \
 	} while (0)
 #define READ_WORD(word, keyword) \
 	do { \
-		READ_WHILE (word, isIdentifierChar (*line)); \
+		READ_WHILE (word, isIdentifierChar ((unsigned char) *line)); \
 		keyword = lookupCaseKeyword (word, Lang_cobol); \
 	} while (0)
 #define READ_KEYWORD(keyword) \
@@ -343,7 +343,8 @@ static void findCOBOLTags (const CobolFormat format)
 		char READ_KEYWORD__word[64]; \
 		READ_WORD (READ_KEYWORD__word, keyword); \
 	} while (0)
-#define SKIP_SPACES() do { while (isspace (*line)) line++; } while (0)
+#define SKIP_SPACES() \
+	do { while (isspace ((unsigned char) *line)) line++; } while (0)
 
 		SKIP_SPACES ();
 		READ_WORD (word, keyword);

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -2194,7 +2194,7 @@ static cppMacroInfo * saveMacro(hashTable *table, const char * macro)
 		return NULL;
 	}
 
-	if(!(isalpha(*c) || (*c == '_' || (*c == '$') )))
+	if(!(isalpha((unsigned char) *c) || (*c == '_' || (*c == '$') )))
 	{
 		CXX_DEBUG_LEAVE_TEXT("Macro does not start with an alphanumeric character");
 		return NULL; // must be a sequence of letters and digits
@@ -2202,7 +2202,7 @@ static cppMacroInfo * saveMacro(hashTable *table, const char * macro)
 
 	const char * identifierBegin = c;
 
-	while(*c && (isalnum(*c) || (*c == '_') || (*c == '$') ))
+	while(*c && (isalnum((unsigned char) *c) || (*c == '_') || (*c == '$') ))
 		c++;
 
 	const char * identifierEnd = c;
@@ -2335,14 +2335,14 @@ static cppMacroInfo * saveMacro(hashTable *table, const char * macro)
 
 		while(*c)
 		{
-			if(isalpha(*c) || (*c == '_'))
+			if(isalpha((unsigned char) *c) || (*c == '_'))
 			{
 				if(c > begin)
 					ADD_CONSTANT_REPLACEMENT(begin,c - begin);
 
 				const char * tokenBegin = c;
 
-				while(*c && (isalnum(*c) || (*c == '_')))
+				while(*c && (isalnum((unsigned char) *c) || (*c == '_')))
 					c++;
 
 				// check if it is a parameter

--- a/parsers/diff.c
+++ b/parsers/diff.c
@@ -149,7 +149,7 @@ static void findDiffTags (void)
 		{
 			scope_index = CORK_NIL;
 			cp += 4;
-			if (isspace ((int) *cp)) continue;
+			if (isspace (*cp)) continue;
 			/* when original filename is /dev/null use the new one instead */
 			if (delim == DIFF_DELIM_MINUS &&
 				strncmp ((const char*) cp, "/dev/null", 9u) == 0 &&
@@ -184,7 +184,7 @@ static void findDiffTags (void)
 			 && (strncmp ((const char*) cp, DiffDelims[1], 4u) == 0))
 		{
 			cp += 4;
-			if (isspace ((int) *cp)) continue;
+			if (isspace (*cp)) continue;
 			/* when modified filename is /dev/null, the original name is deleted. */
 			if (strncmp ((const char*) cp, "/dev/null", 9u) == 0 &&
 			    (cp[9] == 0 || isspace (cp[9])))

--- a/parsers/erlang.c
+++ b/parsers/erlang.c
@@ -55,7 +55,7 @@ static bool isIdentifierCharacter (int c)
 
 static const unsigned char *skipSpace (const unsigned char *cp)
 {
-	while (isspace ((int) *cp))
+	while (isspace (*cp))
 		++cp;
 	return cp;
 }
@@ -64,7 +64,7 @@ static const unsigned char *parseIdentifier (
 		const unsigned char *cp, vString *const identifier)
 {
 	vStringClear (identifier);
-	while (isIdentifierCharacter ((int) *cp))
+	while (isIdentifierCharacter (*cp))
 	{
 		vStringPut (identifier, *cp);
 		++cp;
@@ -171,7 +171,7 @@ static void findErlangTags (void)
 			++cp;  /* Move off of the '-' */
 			parseDirective(cp, module);
 		}
-		else if (isIdentifierFirstCharacter ((int) *cp))
+		else if (isIdentifierFirstCharacter (*cp))
 			parseFunctionTag (cp, module);
 	}
 	vStringDelete (module);

--- a/parsers/falcon.c
+++ b/parsers/falcon.c
@@ -52,7 +52,7 @@ static bool isIdentifierChar (int c)
 
 static const unsigned char *skipSpace (const unsigned char *cp)
 {
-    while (isspace ((int) *cp))
+    while (isspace (*cp))
         ++cp;
 
     return cp;
@@ -81,7 +81,7 @@ static void findFalconTags (void)
             cp += 8;
             cp = skipSpace (cp);
 
-            while (isIdentifierChar ((int) *cp))
+            while (isIdentifierChar (*cp))
             {
                 vStringPut (name, *cp);
                 ++cp;
@@ -94,7 +94,7 @@ static void findFalconTags (void)
             cp += 5;
             cp = skipSpace (cp);
 
-            while (isIdentifierChar ((int) *cp))
+            while (isIdentifierChar (*cp))
             {
                 vStringPut (name, *cp);
                 ++cp;
@@ -107,7 +107,7 @@ static void findFalconTags (void)
             cp += 4;
             cp = skipSpace (cp);
 
-            while (isIdentifierChar ((int) *cp))
+            while (isIdentifierChar (*cp))
             {
                 vStringPut (name, *cp);
                 ++cp;
@@ -120,7 +120,7 @@ static void findFalconTags (void)
             cp += 12;
             cp = skipSpace (cp);
 
-            while (isIdentifierChar ((int) *cp))
+            while (isIdentifierChar (*cp))
             {
                 vStringPut (name, *cp);
                 ++cp;

--- a/parsers/haskell.c
+++ b/parsers/haskell.c
@@ -105,7 +105,7 @@ static void add_tag(const char *token, haskellKind kind, vString *name)
 	vStringClear(name);
 }
 
-static int isident(char c)
+static int isident(int c)
 {
 	return isalnum(c) || c == '_' || c == '\'' || c == '$';
 }

--- a/parsers/haxe.c
+++ b/parsers/haxe.c
@@ -78,15 +78,15 @@ another:
 		vStringCopyS(laccess,priv);
 
 		if (strncmp ((const char*) cp, "var", (size_t) 3) == 0  &&
-			isspace ((int) cp [3]))
+			isspace (cp [3]))
 		{
 			cp += 3;
 
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
 
 			vStringClear (name);
-			while (isalnum ((int) *cp)  ||  *cp == '_')
+			while (isalnum (*cp)  ||  *cp == '_')
 			{
 				vStringPut (name, *cp);
 				++cp;
@@ -96,15 +96,15 @@ another:
 			vStringClear (name);
 		}
 		else if (strncmp ((const char*) cp, "function", (size_t) 8) == 0  &&
-			isspace ((int) cp [8]))
+			isspace (cp [8]))
 		{
 			cp += 8;
 
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
 
 			vStringClear (name);
-			while (isalnum ((int) *cp)  ||  *cp == '_')
+			while (isalnum (*cp)  ||  *cp == '_')
 			{
 				vStringPut (name, *cp);
 				++cp;
@@ -114,14 +114,14 @@ another:
 			vStringClear (name);
 		}
 		else if (strncmp ((const char*) cp, "class", (size_t) 5) == 0 &&
-				 isspace ((int) cp [5]))
+				 isspace (cp [5]))
 		{
 			cp += 5;
 
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
 			vStringClear (name);
-			while (isalnum ((int) *cp)  ||  *cp == '_')
+			while (isalnum (*cp)  ||  *cp == '_')
 			{
 				vStringPut (name, *cp);
 				++cp;
@@ -131,14 +131,14 @@ another:
 			vStringClear (name);
 		}
 		else if (strncmp ((const char*) cp, "enum", (size_t) 4) == 0 &&
-				  isspace ((int) cp [4]))
+				  isspace (cp [4]))
 		{
 			cp += 4;
 
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
 			vStringClear (name);
-			while (isalnum ((int) *cp)  ||  *cp == '_')
+			while (isalnum (*cp)  ||  *cp == '_')
 			{
 				vStringPut (name, *cp);
 				++cp;
@@ -146,41 +146,41 @@ another:
 			makeSimpleTag (name, HXTAG_ENUM);
 			vStringClear (name);
 		} else if (strncmp ((const char*) cp, "public", (size_t) 6) == 0 &&
-				 isspace((int) cp [6]))
+				 isspace(cp [6]))
 		{
 			cp += 6;
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
 			vStringCopyS(laccess,pub);
 			goto another;
 		} else if (strncmp ((const char*) cp, "static", (size_t) 6) == 0 &&
-				 isspace((int) cp [6]))
+				 isspace(cp [6]))
 		{
 			cp += 6;
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
 			goto another;
 		} else if (strncmp ((const char*) cp, "interface", (size_t) 9) == 0 &&
-			isspace((int) cp [9]))
+			isspace(cp [9]))
 		{
 			cp += 9;
 
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
 			vStringClear (name);
-			while (isalnum ((int) *cp)  ||  *cp == '_') {
+			while (isalnum (*cp)  ||  *cp == '_') {
 				vStringPut (name, *cp);
 				++cp;
 			}
 			makeSimpleTag (name, HXTAG_INTERFACE);
 			vStringClear (name);
-		} else if (strncmp ((const char *) cp,"typedef",(size_t) 7) == 0 && isspace(((int) cp[7]))) {
+		} else if (strncmp ((const char *) cp,"typedef",(size_t) 7) == 0 && isspace((cp[7]))) {
 			cp += 7;
 
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
 			vStringClear (name);
-			while (isalnum ((int) *cp)  ||  *cp == '_') {
+			while (isalnum (*cp)  ||  *cp == '_') {
 				vStringPut (name, *cp);
 				++cp;
 			}

--- a/parsers/html.c
+++ b/parsers/html.c
@@ -546,7 +546,7 @@ static void makeClassRefTags (const char *classes)
 
 	do
 	{
-		if (*classes && !isspace (*classes))
+		if (*classes && !isspace ((unsigned char) *classes))
 			vStringPut (klass, *classes);
 		else if (!vStringIsEmpty (klass))
 		{

--- a/parsers/iniconf.c
+++ b/parsers/iniconf.c
@@ -124,7 +124,7 @@ static void findIniconfTags (void)
 		const unsigned char* cp = line;
 		bool possible = true;
 
-		if (isspace ((int) *cp) || *cp == '#' || *cp == ';' || *cp == '\0'
+		if (isspace (*cp) || *cp == '#' || *cp == ';' || *cp == '\0'
 		    || (*cp == '/' && *(cp+1) == '/'))
 			continue;
 
@@ -160,23 +160,23 @@ static void findIniconfTags (void)
 		while (*cp != '\0')
 		{
 			/*  We look for any sequence of identifier characters following a white space */
-			if (possible && isIdentifier ((int) *cp))
+			if (possible && isIdentifier (*cp))
 			{
-				while (isIdentifier ((int) *cp))
+				while (isIdentifier (*cp))
 				{
 					vStringPut (name, *cp);
 					++cp;
 				}
 				vStringStripTrailing (name);
-				while (isspace ((int) *cp))
+				while (isspace (*cp))
 					++cp;
 				if (*cp == '=' || *cp == ':')
 				{
 
 					cp++;
-					while (isspace ((int) *cp))
+					while (isspace (*cp))
 						++cp;
-					while (isValue ((int) *cp))
+					while (isValue (*cp))
 					{
 						vStringPut (val, *cp);
 						++cp;
@@ -211,7 +211,7 @@ static void findIniconfTags (void)
 				vStringClear (name);
 			}
 			else
-				possible = !!(isspace ((int) *cp));
+				possible = !!(isspace (*cp));
 
 			if (*cp != '\0')
 				++cp;

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -725,25 +725,27 @@ static bool readUnicodeEscapeSequenceValue (uint32_t *const value,
 			 * We skip the leading 0s because there can be any number of them
 			 * and they don't change any meaning. */
 			bool has_leading_zero = false;
+			int l;
 
-			while ((cp[cp_len] = (char) getcFromInputFile ()) == '0')
+			while ((cp[cp_len] = (char) (l = getcFromInputFile ())) == '0')
 				has_leading_zero = true;
 
-			while (isxdigit (cp[cp_len]) && ++cp_len < ARRAY_SIZE (cp))
-				cp[cp_len] = (char) getcFromInputFile ();
+			while (isxdigit (l) && ++cp_len < ARRAY_SIZE (cp))
+				cp[cp_len] = (char) (l = getcFromInputFile ());
 			valid = ((cp_len > 0 || has_leading_zero) &&
 					 cp_len < ARRAY_SIZE (cp) && cp[cp_len] == '}' &&
 					 /* also check if it's a valid Unicode code point */
 					 (cp_len < 6 ||
 					  (cp_len == 6 && strncmp (cp, "110000", 6) < 0)));
 			if (! valid) /* put back the last (likely invalid) character */
-				ungetcToInputFile (cp[cp_len]);
+				ungetcToInputFile (l);
 		}
 		else
 		{	/* Handles Unicode escape sequences: \u Hex4Digits */
+			int l;
 			do
-				cp[cp_len] = (char) ((cp_len == 0) ? e : getcFromInputFile ());
-			while (isxdigit (cp[cp_len]) && ++cp_len < 4);
+				cp[cp_len] = (char) (l = ((cp_len == 0) ? e : getcFromInputFile ()));
+			while (isxdigit (l) && ++cp_len < 4);
 			valid = (cp_len == 4);
 		}
 

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -266,7 +266,7 @@ static void L_getit (vString *const name, const unsigned char *dbp,
 		while (isspace (*dbp))
 			dbp++;
 	}
-	for (p=dbp ; *p!='\0' && *p!='(' && !isspace ((int) *p) && *p!=')' ; p++)
+	for (p=dbp ; *p!='\0' && *p!='(' && !isspace (*p) && *p!=')' ; p++)
 		vStringPut (name, *p);
 
 	if (vStringLength (name) > 0)
@@ -296,13 +296,13 @@ static void findLispTagsCommon (bool case_insensitive,
 			if (L_isdef (p, case_insensitive))
 			{
 				vStringClear (kind_hint);
-				while (*p != '\0' && !isspace ((int) *p))
+				while (*p != '\0' && !isspace (*p))
 				{
 					vStringPut (kind_hint,
-								case_insensitive? toupper((int)*p): *p);
+								case_insensitive? toupper(*p): *p);
 					p++;
 				}
-				while (isspace ((int) *p))
+				while (isspace (*p))
 					p++;
 				L_getit (name, p, case_insensitive, hint2kind, kind_hint);
 			}
@@ -310,7 +310,7 @@ static void findLispTagsCommon (bool case_insensitive,
 			{
 				do
 					p++;
-				while (*p != '\0' && !isspace ((int) *p)
+				while (*p != '\0' && !isspace (*p)
 						&& *p != ':' && *p != '(' && *p != ')');
 				if (*p == ':')
 				{
@@ -321,10 +321,10 @@ static void findLispTagsCommon (bool case_insensitive,
 					if (L_isdef (p - 1, case_insensitive))
 					{
 						vStringClear (kind_hint);
-						while (*p != '\0' && !isspace ((int) *p))
+						while (*p != '\0' && !isspace (*p))
 						{
 							vStringPut (kind_hint,
-										case_insensitive? toupper((int)*p): *p);
+										case_insensitive? toupper(*p): *p);
 							p++;
 						}
 						while (isspace (*p))

--- a/parsers/lua.c
+++ b/parsers/lua.c
@@ -61,7 +61,7 @@ static bool is_a_code_line (const unsigned char *line)
 {
 	bool result;
 	const unsigned char *p = line;
-	while (isspace ((int) *p))
+	while (isspace (*p))
 		p++;
 	if (p [0] == '\0')
 		result = false;
@@ -74,8 +74,9 @@ static bool is_a_code_line (const unsigned char *line)
 
 static bool isLuaIdentifier (char c)
 {
-	return (bool) !(isspace(c)  || c == '(' || c == ')' || c == '=' || c == '.' || c == ':'
-					|| c == '{' || c == '}');
+	return (bool) !(isspace((unsigned char) c)  || c == '(' || c == ')'
+					|| c == '=' || c == '.' || c == ':' || c == '{'
+					|| c == '}');
 }
 
 static void set_scope (int child, int parent)
@@ -102,7 +103,7 @@ static void extract_next_token (const char *begin, const char *end_sentinel, vSt
 		return;
 
 	/* Trim prefixed white spaces  */
-	while (isspace ((int) *begin))
+	while (isspace ((unsigned char) *begin))
 		begin++;
 
 	/* Both on '(' */
@@ -112,7 +113,7 @@ static void extract_next_token (const char *begin, const char *end_sentinel, vSt
 	const char *end = end_sentinel - 1;
 
 	/* Trim suffixed white spaces  */
-	while (isspace ((int) *end))
+	while (isspace ((unsigned char) *end))
 		end--;
 
 	Assert (begin <= end);
@@ -156,7 +157,7 @@ static void extract_prev_token (const char *end, const char *begin_sentinel, vSt
 	if (! (begin_sentinel <= end))
 		return;
 
-	while (isspace ((int) *end))
+	while (isspace ((unsigned char) *end))
 	{
 		end--;
 		if (! (begin_sentinel <= end))
@@ -227,7 +228,7 @@ static void findLuaTags (void)
 			p = p + 8;  /* skip the `function' word */
 
 			/* We expect [ \t(] */
-			if (! (*p == '(' || isspace ((int)*p)))
+			if (! (*p == '(' || isspace ((unsigned char) *p)))
 				continue;
 			q = strchr ((const char*) p, '(');
 			if (q)

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -100,7 +100,7 @@ static bool isSpecialTarget (vString *const name)
 	}
 	while (i < vStringLength (name)) {
 		char ch = vStringChar (name, i++);
-		if (ch != '_' && !isupper (ch))
+		if (ch != '_' && !isupper ((unsigned char) ch))
 		{
 			return false;
 		}

--- a/parsers/nsis.c
+++ b/parsers/nsis.c
@@ -76,7 +76,7 @@ static fieldDefinition NsisFields[] = {
 
 static const unsigned char* skipWhitespace (const unsigned char* cp)
 {
-	while (isspace ((int) *cp))
+	while (isspace (*cp))
 		++cp;
 	return cp;
 }
@@ -86,9 +86,9 @@ static const unsigned char* skipFlags (const unsigned char* cp)
 	while (*cp == '/')
 	{
 		++cp;
-		while (! isspace ((int) *cp))
+		while (! isspace (*cp))
 			++cp;
-		while (isspace ((int) *cp))
+		while (isspace (*cp))
 			++cp;
 	}
 	return cp;
@@ -104,8 +104,8 @@ static int makeSimpleTagWithScope(vString *name, int kindIndex, int parentCorkIn
 
 #define lineStartingWith(CP,EXPECTED,EOL)								\
 	(strncasecmp ((const char*) CP, EXPECTED, strlen(EXPECTED)) == 0	\
-		&& (EOL ? (isspace ((int) CP [strlen(EXPECTED)]) || CP [strlen(EXPECTED)] == '\0') \
-			: isspace ((int) CP [strlen(EXPECTED)])))
+		&& (EOL ? (isspace ((unsigned char) CP [strlen(EXPECTED)]) || CP [strlen(EXPECTED)] == '\0') \
+			: isspace ((unsigned char) CP [strlen(EXPECTED)])))
 
 #define fillName(NAME,CP,CONDITION)				\
 	while (CONDITION)							\
@@ -182,7 +182,7 @@ static const unsigned char* parseSection (const unsigned char* cp, vString *name
 	}
 	else
 	{
-		while (isalnum ((int) *cp)
+		while (isalnum (*cp)
 			   || *cp == '_' || *cp == '-' || *cp == '.' || *cp == '!'
 			   || *cp == '$' || *cp == '{' || *cp == '}' || *cp == '(' || *cp == ')')
 		{
@@ -201,7 +201,7 @@ static const unsigned char* parseSection (const unsigned char* cp, vString *name
 		vStringClear (name);
 		cp = skipWhitespace (cp);
 
-		fillName (name, cp, (isalnum ((int) *cp) || *cp == '_'));
+		fillName (name, cp, (isalnum (*cp) || *cp == '_'));
 
 		if (vStringLength (name) > 0)
 		{
@@ -221,7 +221,7 @@ static const unsigned char* parseLangString (const unsigned char* cp, vString *n
 	 * e.g.
 	 * https://github.com/vim/vim/blob/3dabd718f4b2d8e09de9e2ec73832620b91c2f79/nsis/lang/english.nsi
 	 */
-	fillName (name, cp, (isalnum ((int) *cp) || *cp == '_' || *cp == '^'));
+	fillName (name, cp, (isalnum (*cp) || *cp == '_' || *cp == '^'));
 
 	if (vStringLength (name) > 0)
 	{
@@ -231,7 +231,7 @@ static const unsigned char* parseLangString (const unsigned char* cp, vString *n
 		vStringClear (name);
 
 		cp = skipWhitespace (cp);
-		fillName (name, cp, ((*cp != '\0') && (!isspace ((int) *cp))));
+		fillName (name, cp, ((*cp != '\0') && (!isspace (*cp))));
 		if (vStringLength (name) > 0)
 		{
 			attachParserFieldToCorkEntry (r, NsisFields[F_LANGID].ftype,
@@ -266,7 +266,7 @@ static void findNsisTags (void)
 			cp = skipWhitespace (cp);
 
 			fillName (name, cp,
-					  (isalnum ((int) *cp) || *cp == '_' || *cp == '-' || *cp == '.' || *cp == '!'));
+					  (isalnum (*cp) || *cp == '_' || *cp == '-' || *cp == '.' || *cp == '!'));
 
 			makeSimpleTag (name, K_FUNCTION);
 			vStringClear (name);
@@ -278,7 +278,7 @@ static void findNsisTags (void)
 			cp = skipWhitespace (cp);
 			cp = skipFlags (cp);
 
-			fillName (name, cp, (isalnum ((int) *cp) || *cp == '_'));
+			fillName (name, cp, (isalnum (*cp) || *cp == '_'));
 
 			makeSimpleTag (name, K_VARIABLE);
 			vStringClear (name);
@@ -319,7 +319,7 @@ static void findNsisTags (void)
 			cp = skipWhitespace (cp);
 			cp = skipFlags (cp);
 
-			fillName (name, cp, (isalnum ((int) *cp) || *cp == '_'));
+			fillName (name, cp, (isalnum (*cp) || *cp == '_'));
 
 			makeSimpleTag (name, K_DEFINITION);
 			vStringClear (name);
@@ -331,7 +331,7 @@ static void findNsisTags (void)
 			cp = skipWhitespace (cp);
 			cp = skipFlags (cp);
 
-			fillName (name, cp, (isalnum ((int) *cp) || *cp == '_'));
+			fillName (name, cp, (isalnum (*cp) || *cp == '_'));
 
 			int index = makeSimpleTag (name, K_MACRO);
 			if (vStringLength (name) > 0)
@@ -340,7 +340,7 @@ static void findNsisTags (void)
 				{
 					vStringClear (name);
 					cp = skipWhitespace (cp);
-					fillName (name, cp, (isalnum ((int) *cp) || *cp == '_'));
+					fillName (name, cp, (isalnum (*cp) || *cp == '_'));
 					if (vStringLength (name) == 0)
 						break;
 					makeSimpleTagWithScope (name, K_MACRO_PARAM, index);

--- a/parsers/pascal.c
+++ b/parsers/pascal.c
@@ -67,16 +67,16 @@ static void makePascalTag (const tagEntryInfo* const tag)
 
 static const unsigned char* dbp;
 
-#define starttoken(c) (isalpha ((int) c) || (int) c == '_')
-#define intoken(c)    (isalnum ((int) c) || (int) c == '_' || (int) c == '.')
-#define endtoken(c)   (! intoken (c)  &&  ! isdigit ((int) c))
+#define starttoken(c) (isalpha ((unsigned char) c) || (int) c == '_')
+#define intoken(c)    (isalnum ((unsigned char) c) || (int) c == '_' || (int) c == '.')
+#define endtoken(c)   (! intoken (c)  &&  ! isdigit ((unsigned char) c))
 
 static bool tail (const char *cp)
 {
 	bool result = false;
 	register int len = 0;
 
-	while (*cp != '\0' && tolower ((int) *cp) == tolower ((int) dbp [len]))
+	while (*cp != '\0' && tolower ((unsigned char) *cp) == tolower (dbp [len]))
 		cp++, len++;
 	if (*cp == '\0' && !intoken (dbp [len]))
 	{
@@ -121,7 +121,7 @@ static void parseArglist (const char *buf, vString *arglist, vString *vartype)
 		if (NULL != (var = strchr (end, ':')))
 		{
 			var++; /* skip ':' */
-			while (isspace ((int) *var))
+			while (isspace ((unsigned char) *var))
 				++var;
 
 			if (starttoken (*var))
@@ -240,7 +240,7 @@ static void findPascalTags (void)
 			/* check if this is an "extern" declaration */
 			if (*dbp == '\0')
 				continue;
-			if (tolower ((int) *dbp == 'e'))
+			if (tolower (*dbp == 'e'))
 			{
 				if (tail ("extern"))  /* superfluous, really! */
 				{
@@ -248,7 +248,7 @@ static void findPascalTags (void)
 					verify_tag = false;
 				}
 			}
-			else if (tolower ((int) *dbp) == 'f')
+			else if (tolower (*dbp) == 'f')
 			{
 				if (tail ("forward"))  /*  check for forward reference */
 				{
@@ -272,7 +272,7 @@ static void findPascalTags (void)
 				continue;
 
 			/* grab block name */
-			while (isspace ((int) *dbp))
+			while (isspace (*dbp))
 				++dbp;
 			if (!starttoken(*dbp))
 				continue;
@@ -292,7 +292,7 @@ static void findPascalTags (void)
 		}
 		else if (!incomment && !inquote && !found_tag)
 		{
-			switch (tolower ((int) c))
+			switch (tolower (c))
 			{
 				case 'c':
 					if (tail ("onstructor"))

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -252,16 +252,16 @@ static void makeTagFromLeftSide (const char *begin, const char *end,
 	const char *b, *e;
 	if (! PerlKinds[KIND_PERL_CONSTANT].enabled)
 		return;
-	for (e = end - 1; e > begin && isspace(*e); --e)
+	for (e = end - 1; e > begin && isspace((unsigned char) *e); --e)
 		;
 	if (e < begin)
 		return;
-	for (b = e; b >= begin && isIdentifier(*b); --b)
+	for (b = e; b >= begin && isIdentifier((unsigned char) *b); --b)
 		;
 	/* Identifier must be either beginning of line of have some whitespace
 	 * on its left:
 	 */
-	if (b < begin || isspace(*b) || ',' == *b)
+	if (b < begin || isspace((unsigned char) *b) || ',' == *b)
 		++b;
 	else if (b != begin)
 		return;
@@ -874,7 +874,7 @@ static void findPerlTags (void)
 			else
 				vStringClear (package);
 			const unsigned char *const first = cp;
-			while (*cp && (int) *cp != ';'  &&  !isspace ((int) *cp))
+			while (*cp && (int) *cp != ';'  &&  !isspace (*cp))
 			{
 				vStringPut (package, *cp);
 				cp++;

--- a/parsers/perl6.c
+++ b/parsers/perl6.c
@@ -274,7 +274,7 @@ next_line:
         if (!s)
             return 0;                           /* EOF */
     }
-    while (*s && isspace(*s))                   /* Skip whitespace */
+    while (*s && isspace((unsigned char) *s))   /* Skip whitespace */
         ++s;
     if ('#' == *s)
         goto next_line;

--- a/parsers/rpmspec.c
+++ b/parsers/rpmspec.c
@@ -134,7 +134,7 @@ static void scan_configure_options (const char *line)
 			tmp += strlen(prefix->prefix);
 			while (*tmp)
 			{
-				if (isspace (*tmp) || iscntrl (*tmp)
+				if (isspace ((unsigned char) *tmp) || iscntrl ((unsigned char) *tmp)
 					|| *tmp == '=' || *tmp == '\\')
 					break;
 				vStringPut(name, *tmp);
@@ -258,7 +258,7 @@ static bool found_undef_cb (const char *line,
 
 static bool alldigits (const char * str)
 {
-	while (isdigit ((int)*str))
+	while (isdigit ((unsigned char) *str))
 		str++;
 
 	if (*str == '\0')

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -564,7 +564,7 @@ static void parseSignature (const unsigned char** cp, vString* vstr)
 				vStringPut (vstr, b);
 				continue;
 			}
-			else if (isspace (vStringLast (vstr)))
+			else if (isspace ((unsigned char) vStringLast (vstr)))
 			{
 				if (! (isspace (**cp)))
 				{

--- a/parsers/sh.c
+++ b/parsers/sh.c
@@ -194,7 +194,7 @@ static int readDestfileName (const unsigned char *cp, vString *destfile)
 {
 	const unsigned char *origin = cp;
 
-	while (isspace ((int) *cp))
+	while (isspace (*cp))
 		++cp;
 
 	/* >... */
@@ -205,17 +205,17 @@ static int readDestfileName (const unsigned char *cp, vString *destfile)
 	if (*cp == '>')
 		++cp;
 
-	while (isspace ((int) *cp))
+	while (isspace (*cp))
 		++cp;
 
-	if (!isFileChar ((int) *cp))
+	if (!isFileChar (*cp))
 		return 0;
 
 	vStringClear(destfile);
 	do {
 		vStringPut (destfile, *cp);
 		++cp;
-	} while (isFileChar ((int) *cp));
+	} while (isFileChar (*cp));
 
 	if (vStringLength(destfile) > 0)
 		return cp - origin;
@@ -509,7 +509,7 @@ static void findShTagsCommon (size_t (* keyword_handler) (int,
 			int sub_n = 0;
 
 			/* jump over whitespace */
-			while (isspace ((int)*cp))
+			while (isspace (*cp))
 				cp++;
 
 			/* jump over strings */
@@ -556,7 +556,7 @@ static void findShTagsCommon (size_t (* keyword_handler) (int,
 				}
 				else
 				{
-					while (isIdentChar ((int) *cp))
+					while (isIdentChar (*cp))
 						cp++;
 					end = cp;
 				}
@@ -584,7 +584,7 @@ static void findShTagsCommon (size_t (* keyword_handler) (int,
 			check_char = isBashFunctionChar;
 
 			if (cp [0] == '.'
-				    && isspace((int) cp [1]))
+				    && isspace(cp [1]))
 			{
 				found_kind = K_SCRIPT;
 				found_role = R_SCRIPT_LOADED;
@@ -617,7 +617,7 @@ static void findShTagsCommon (size_t (* keyword_handler) (int,
 			}
 
 			if (found_kind != K_NOTHING)
-				while (isspace ((int) *cp))
+				while (isspace (*cp))
 					++cp;
 
 			if (found_kind == K_SUBPARSER)
@@ -629,7 +629,7 @@ static void findShTagsCommon (size_t (* keyword_handler) (int,
 			else
 			{
 				// Get the name of the function, alias or file to be read by source
-				if (! check_char ((int) *cp))
+				if (! check_char (*cp))
 				{
 					found_kind = K_NOTHING;
 					found_role = ROLE_DEFINITION_INDEX;
@@ -643,21 +643,21 @@ static void findShTagsCommon (size_t (* keyword_handler) (int,
 					continue;
 				}
 
-				while (check_char ((int) *cp))
+				while (check_char (*cp))
 				{
 					vStringPut (name, *cp);
 					++cp;
 				}
 			}
 
-			while (isspace ((int) *cp))
+			while (isspace (*cp))
 				++cp;
 
 			if ((found_kind != K_SCRIPT)
 			    && *cp == '(')
 			{
 				++cp;
-				while (isspace ((int) *cp))
+				while (isspace (*cp))
 					++cp;
 				if (*cp == ')')
 				{

--- a/parsers/sml.c
+++ b/parsers/sml.c
@@ -86,7 +86,7 @@ static void makeSmlTag (smlKind type, vString *name)
 
 static const unsigned char *skipSpace (const unsigned char *cp)
 {
-	while (isspace ((int) *cp))
+	while (isspace (*cp))
 		++cp;
 	return cp;
 }
@@ -108,7 +108,7 @@ static const unsigned char *parseIdentifier (
 {
 	bool stringLit = false;
 	vStringClear (identifier);
-	while (*cp != '\0'  &&  (!isIdentifier ((int) *cp) || stringLit))
+	while (*cp != '\0'  &&  (!isIdentifier (*cp) || stringLit))
 	{
 		int oneback = *cp;
 		cp++;
@@ -128,7 +128,7 @@ static const unsigned char *parseIdentifier (
 	if (strcmp ((const char *) cp, "") == 0 || cp == NULL)
 		return cp;
 
-	while (isIdentifier ((int) *cp))
+	while (isIdentifier (*cp))
 	{
 		vStringPut (identifier, *cp);
 		cp++;

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -3010,7 +3010,7 @@ static void parseCCFLAGS (tokenInfo *const token)
 	/* http://web.deu.edu.tr/doc/oracle/B19306_01/server.102/b14237/initparams158.htm#REFRN10261 */
 	while (*s)
 	{
-		if (in_var && isIdentChar1((int)*s))
+		if (in_var && isIdentChar1((unsigned char) *s))
 			vStringPut(ccflag, *s);
 		else if (*s == ':' && !vStringIsEmpty(ccflag))
 		{

--- a/parsers/systemdunit.c
+++ b/parsers/systemdunit.c
@@ -82,7 +82,7 @@ static void makeSystemdReferencedUnit (const char *value, int kind, int role)
 			makeSimpleRefTag (unit, kind, role);
 			vStringClear (unit);
 		}
-		else if (! isspace ((int) *value))
+		else if (! isspace ((unsigned char) *value))
 			vStringPut (unit, *value);
 
 		value++;

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -896,7 +896,7 @@ static bool isIdentifier (tokenInfo* token)
 	{
 		for (int i = 0; i < vStringLength (token->name); i++)
 		{
-			int c = vStringChar (token->name, i);
+			int c = (unsigned char) vStringChar (token->name, i);
 			if (i == 0)
 			{
 				// treat a text-macro as an identifier (#3712)

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -130,7 +130,7 @@ static const unsigned char *skipPrefix (const unsigned char *name, int *scope)
 					break;
 			}
 			++counter;
-		} while (isalnum ((int) name[counter]) ||
+		} while (isalnum (name[counter]) ||
 				name[counter] == '_'           ||
 				name[counter] == '.'           ||
 				name[counter] == '#'
@@ -203,7 +203,7 @@ static const unsigned char *readVimLine (void)
 
 	while ((line = readLineFromInputFile ()) != NULL)
 	{
-		while (isspace ((int) *line))
+		while (isspace (*line))
 			++line;
 
 		if ((int) *line == '"')
@@ -245,7 +245,7 @@ static vString *parseSignature (const unsigned char *cp,
 
 	while (*cp != '\0')
 	{
-		if (isspace ((int) *cp)
+		if (isspace (*cp)
 			&& vStringLast (buf) == ',')
 		{
 			++cp;
@@ -278,15 +278,15 @@ static void parseFunction (const unsigned char *line)
 
 	if (*cp == '!')
 		++cp;
-	if (isspace ((int) *cp))
+	if (isspace (*cp))
 	{
-		while (*cp && isspace ((int) *cp))
+		while (*cp && isspace (*cp))
 			++cp;
 
 		if (*cp)
 		{
 			cp = skipPrefix (cp, &scope);
-			if (isupper ((int) *cp)  ||
+			if (isupper (*cp)  ||
 					scope == 's'  ||  /* script scope */
 					scope == '<'  ||  /* script scope */
 					scope == 'g'  ||  /* global scope */
@@ -301,14 +301,14 @@ static void parseFunction (const unsigned char *line)
 				{
 					vStringPut (name, *cp);
 					++cp;
-				} while (isalnum ((int) *cp) || *cp == '_' || *cp == '.' || *cp == '#');
+				} while (isalnum (*cp) || *cp == '_' || *cp == '.' || *cp == '#');
 				index = makeSimpleTag (name, K_FUNCTION);
 				vStringClear (name);
 
 				e = getEntryInCorkQueue (index);
 				if (e && isFieldEnabled (FIELD_SIGNATURE))
 				{
-					while (*cp && isspace ((int) *cp))
+					while (*cp && isspace (*cp))
 						++cp;
 					if (*cp == '(')
 						signature = parseSignature (cp, e, NULL);
@@ -323,7 +323,7 @@ static void parseFunction (const unsigned char *line)
 		if (signature)
 		{
 			cp = line;
-			while (*cp && isspace ((int) *cp))
+			while (*cp && isspace (*cp))
 				++cp;
 			/* A backslash at the start of a line stands for a line continuation.
 			 * https://vimhelp.org/repeat.txt.html#line-continuation */
@@ -351,9 +351,9 @@ static void parseAutogroup (const unsigned char *line)
 
 	/* Found Autocommand Group (augroup) */
 	const unsigned char *cp = line;
-	if (isspace ((int) *cp))
+	if (isspace (*cp))
 	{
-		while (*cp && isspace ((int) *cp))
+		while (*cp && isspace (*cp))
 			++cp;
 
 		if (*cp)
@@ -406,7 +406,7 @@ static bool parseCommand (const unsigned char *line)
 		if (*cp == '\\')
 			++cp;
 
-		while (*cp && isspace ((int) *cp))
+		while (*cp && isspace (*cp))
 			++cp;
 	}
 	else if (line && wordMatchLen (cp, "command", 3))
@@ -427,7 +427,7 @@ static bool parseCommand (const unsigned char *line)
 			goto cleanUp;
 		}
 
-		while (*cp && isspace ((int) *cp))
+		while (*cp && isspace (*cp))
 			++cp;
 	}
 	else
@@ -447,7 +447,7 @@ static bool parseCommand (const unsigned char *line)
 	 */
 	do
 	{
-		if (isspace ((int) *cp))
+		if (isspace (*cp))
 		{
 			++cp;
 		}
@@ -456,10 +456,10 @@ static bool parseCommand (const unsigned char *line)
 			/*
 			 * Read until the next space which separates options or the name
 			 */
-			while (*cp && !isspace ((int) *cp))
+			while (*cp && !isspace (*cp))
 				++cp;
 		}
-		else if (!isalnum ((int) *cp))
+		else if (!isalnum (*cp))
 		{
 			/*
 			 * Broken syntax: throw away this line
@@ -467,7 +467,7 @@ static bool parseCommand (const unsigned char *line)
 			cmdProcessed = true;
 			goto cleanUp;
 		}
-	} while (*cp &&  !isalnum ((int) *cp));
+	} while (*cp &&  !isalnum (*cp));
 
 	if (!*cp)
 	{
@@ -486,7 +486,7 @@ static bool parseCommand (const unsigned char *line)
 	{
 		vStringPut (name, *cp);
 		++cp;
-	} while (isalnum ((int) *cp) || *cp == '_');
+	} while (isalnum (*cp) || *cp == '_');
 
 	makeSimpleTag (name, K_COMMAND);
 	vStringClear (name);
@@ -504,9 +504,9 @@ static void parseVariableOrConstant (const unsigned char *line, int infunction, 
 	const unsigned char *cp = line;
 	const unsigned char *np = line;
 	/* get the name */
-	if (isspace ((int) *cp))
+	if (isspace (*cp))
 	{
-		while (*cp && isspace ((int) *cp))
+		while (*cp && isspace (*cp))
 			++cp;
 
 		/*
@@ -532,7 +532,7 @@ static void parseVariableOrConstant (const unsigned char *line, int infunction, 
 			goto cleanUp;
 
 		/* deal with spaces, $, @ and & */
-		while (*cp && *cp != '$' && !isalnum ((int) *cp))
+		while (*cp && *cp != '$' && !isalnum (*cp))
 			++cp;
 
 		if (!*cp)
@@ -546,7 +546,7 @@ static void parseVariableOrConstant (const unsigned char *line, int infunction, 
 
 			vStringPut (name, *cp);
 			++cp;
-		} while (isalnum ((int) *cp) || *cp == '_' || *cp == '#' || *cp == ':' || *cp == '$');
+		} while (isalnum (*cp) || *cp == '_' || *cp == '#' || *cp == ':' || *cp == '$');
 		makeSimpleTag (name, kindIndex);
 		vStringClear (name);
 	}
@@ -587,7 +587,7 @@ static bool parseMap (const unsigned char *line)
 
 	do
 	{
-		while (*cp && isspace ((int) *cp))
+		while (*cp && isspace (*cp))
 			++cp;
 
 		if (strncmp ((const char *) cp, "<Leader>", (size_t) 8) == 0)
@@ -724,7 +724,7 @@ static void parseVimBallFile (const unsigned char *line)
 			{
 				vStringPut (fname, *cp);
 				++cp;
-			} while (isalnum ((int) *cp) || *cp == '.' || *cp == '/' || *cp == '\\');
+			} while (isalnum (*cp) || *cp == '.' || *cp == '/' || *cp == '\\');
 			makeSimpleTag (fname, K_FILENAME);
 			vStringClear (fname);
 		}

--- a/parsers/windres.c
+++ b/parsers/windres.c
@@ -66,17 +66,17 @@ static ResParserState parseResDefinition(const unsigned char *line)
 	vString *name, *type;
 
 	name = vStringNew();
-	while (*line && !isspace((int) *line))
+	while (*line && !isspace(*line))
 	{
 		vStringPut(name, *line);
 		line++;
 	}
 
-	while (*line && isspace((int) *line))
+	while (*line && isspace(*line))
 		line++;
 
 	type = vStringNew();
-	while (*line && !isspace((int) *line))
+	while (*line && !isspace(*line))
 	{
 		vStringPut(type, *line);
 		line++;
@@ -133,7 +133,7 @@ static ResParserState parseResLine(const unsigned char *line, ResParserState sta
 {
 	while (*line != '\0')	/* readLineFromInputFile returns NULL terminated strings */
 	{
-		while (isspace((int) *line))
+		while (isspace(*line))
 			line++;
 
 		switch (state)
@@ -155,7 +155,7 @@ static ResParserState parseResLine(const unsigned char *line, ResParserState sta
 				{
 					state = P_STATE_IN_COMMENT;
 				}
-				else if (isalnum((int) *line))
+				else if (isalnum(*line))
 				{
 					return parseResDefinition(line);
 				}


### PR DESCRIPTION
All ctype functions like `isspace()`, `tolower()` and alike expect a character as an `unsigned char` or EOF, anything else has undefined behavior.

This commit should fix all calls to the various ctype functions either:

* adding `unsigned char` cast where appropriate;
* removing useless `int` casts that are more confusing than useful.

Some instances required slightly more involved changes though, but the fix itself is the same.

---

That one was long, boring and a bit tricky. I *think* I didn't miss any calls (used some grepping and went through it all), but I could have let one slip somehow I guess… reviewing will likely be just as tricky, sorry.