### PR TITLE
Markdown: add hashtags functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /Makefile
 /packcc
 /packcc.exe
+.cache
 .deps
 .dirstamp
 .DS_Store
@@ -30,6 +31,7 @@ autom4te.cache
 badinput
 commit-stamp
 compile
+compile_commands.json
 config.cache
 config.guess
 config.h

--- a/Units/parser-markdown.r/hashtags-utf8.d/args.ctags
+++ b/Units/parser-markdown.r/hashtags-utf8.d/args.ctags
@@ -1,0 +1,4 @@
+--sort=no
+--fields=+e
+--fields-Markdown=+{sectionMarker}
+--extras=+g

--- a/Units/parser-markdown.r/hashtags-utf8.d/expected.tags
+++ b/Units/parser-markdown.r/hashtags-utf8.d/expected.tags
@@ -1,0 +1,26 @@
+标签	input.md	/^#标签 #태그 #وسم   $/;"	h
+태그	input.md	/^#标签 #태그 #وسم   $/;"	h
+وسم	input.md	/^#标签 #태그 #وسم   $/;"	h
+t1	input.md	/^#t1 #t2#invalid#invalid2$/;"	h
+t2	input.md	/^#t1 #t2#invalid#invalid2$/;"	h
+ta	input.md	/^#ta #123$/;"	h
+9_	input.md	/^#9_$/;"	h
+-_-	input.md	/^#-_-$/;"	h
+t/s1	input.md	/^#t\/s1 #t\/s2$/;"	h
+t/s2	input.md	/^#t\/s1 #t\/s2$/;"	h
+t4-5-6	input.md	/^#t4-5-6+excluded  #t7;excluded    #t8#excluded#excluded$/;"	h
+t7	input.md	/^#t4-5-6+excluded  #t7;excluded    #t8#excluded#excluded$/;"	h
+t8	input.md	/^#t4-5-6+excluded  #t7;excluded    #t8#excluded#excluded$/;"	h
+hashtag	input.md	/^text#text #hashtag text#text$/;"	h
+included	input.md	/^#included$/;"	h
+included	input.md	/^   #included$/;"	h
+タブ1/タブ2	input.md	/^ excluded #タブ1\/タブ2 excluded$/;"	h
+T_in_quote	input.md	/^> #T_in_quote$/;"	h
+T_in_quote	input.md	/^>> #T_in_quote$/;"	h
+Title	input.md	/^# Title #$/;"	c	end:22	sectionMarker:##
+t3	input.md	/^# Title2 #t3$/;"	h	chapter:Title
+Title2 #t3	input.md	/^# Title2 #t3$/;"	c	end:39	sectionMarker:#
+t4	input.md	/^#t4$/;"	h	chapter:Title2 #t3
+tag-in-list	input.md	/^- #tag-in-list$/;"	h	chapter:Title2 #t3
+/	input.md	/^#\/$/;"	h	chapter:Title2 #t3
+//////	input.md	/^#\/\/\/\/\/\/$/;"	h	chapter:Title2 #t3

--- a/Units/parser-markdown.r/hashtags-utf8.d/input.md
+++ b/Units/parser-markdown.r/hashtags-utf8.d/input.md
@@ -1,0 +1,39 @@
+#标签 #태그 #وسم   
+#t1 #t2#invalid#invalid2
+
+123 and 4 are invalid
+#ta #123
+#4
+
+#9_
+#-_-
+#t/s1 #t/s2
+#t4-5-6+excluded  #t7;excluded    #t8#excluded#excluded
+text#text #hashtag text#text
+#included
+    #excluded1
+	#excluded2
+   #included
+ excluded #タブ1/タブ2 excluded
+
+>#invalid
+> #T_in_quote
+>> #T_in_quote
+# Title #
+# Title2 #t3
+标签
+
+            #invalid3
+
+
+#t4
+===
+
+- #tag-in-list
+- item 2
+
+##invalid
+##invalid#invalid
+
+#/
+#//////

--- a/Units/parser-markdown.r/section-prefixed-with-spaces.d/expected.tags
+++ b/Units/parser-markdown.r/section-prefixed-with-spaces.d/expected.tags
@@ -1,6 +1,10 @@
+should	input.md	/^  #should NOT be included0 as a chapter$/;"	h
 should be included0 as a chapter	input.md	/^  # should be included0 as a chapter$/;"	c
+should	input.md	/^ #should NOT be included1 as a chapter$/;"	h	chapter:should be included0 as a chapter
 should be included1 as a chapter	input.md	/^ # should be included1 as a chapter$/;"	c
+should	input.md	/^#should NOT be included2 as a chapter$/;"	h	chapter:should be included1 as a chapter
 should be included2 as a chapter	input.md	/^# should be included2 as a chapter$/;"	c
+not-title-1	input.md	/^   #not-title-1$/;"	h	chapter:should be included2 as a chapter
 title 1	input.md	/^   # title 1$/;"	c
 title 2	input.md	/^ ## title 2$/;"	s	chapter:title 1
 title 3	input.md	/^   # title 3$/;"	c

--- a/main/utf8_str.c
+++ b/main/utf8_str.c
@@ -1,0 +1,83 @@
+/*
+*
+*   Copyright (c) 2023, Yinzuo Jiang
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   Defines functions for UTF-8 string manipulation.
+*   utf8_strlen is derived from parsers/rst.c
+*/
+
+#include "general.h"
+
+#include "utf8_str.h"
+
+/* computes the length of an UTF-8 string
+ * if the string doesn't look like UTF-8, return -1
+ * FIXME consider East_Asian_Width Unicode property */
+int utf8_strlen (const char *buf, int buf_len)
+{
+	int len = 0;
+	const char *end = buf + buf_len;
+
+	for (len = 0; buf < end; len++)
+	{
+		/* perform quick and naive validation (no sub-byte checking) */
+		if (!(*buf & 0x80))
+			buf++;
+		else if ((*buf & 0xe0) == 0xc0)
+			buf += 2;
+		else if ((*buf & 0xf0) == 0xe0)
+			buf += 3;
+		else if ((*buf & 0xf8) == 0xf0)
+			buf += 4;
+		else	/* not a valid leading UTF-8 byte, abort */
+			return -1;
+
+		if (buf > end)	/* incomplete last byte */
+			return -1;
+	}
+
+	return len;
+}
+
+/* computes the raw buf length of an UTF-8 (ascii excluded) string
+ * if the string doesn't look like UTF-8, return -1 */
+int utf8_raw_strlen (const char *buf, int buf_len)
+{
+	int raw_len = 0;
+	const char *end = buf + buf_len;
+
+	while (buf < end)
+	{
+		/* perform quick and naive validation (no sub-byte checking) */
+		if (!(*buf & 0x80))
+		{
+			/* stop at ascii character */
+			return raw_len;
+		}
+		else if ((*buf & 0xe0) == 0xc0)
+		{
+			buf += 2;
+			raw_len += 2;
+		}
+		else if ((*buf & 0xf0) == 0xe0)
+		{
+			buf += 3;
+			raw_len += 3;
+		}
+		else if ((*buf & 0xf8) == 0xf0)
+		{
+			buf += 4;
+			raw_len += 4;
+		}
+		else	/* not a valid leading UTF-8 byte, abort */
+			return -1;
+
+		if (buf > end)	/* incomplete last byte */
+			return -1;
+	}
+
+	return raw_len;
+}

--- a/main/utf8_str.h
+++ b/main/utf8_str.h
@@ -1,0 +1,22 @@
+/*
+*
+*   Copyright (c) 2023, Yinzuo Jiang
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   Defines functions for UTF-8 string manipulation.
+*   utf8_strlen is derived from parsers/rst.c
+*/
+
+#ifndef CTAGS_MAIN_UTF8_STR_H
+#define CTAGS_MAIN_UTF8_STR_H
+
+/*
+*   FUNCTION PROTOTYPES
+*/
+
+extern int utf8_strlen (const char *buf, int buf_len);
+extern int utf8_raw_strlen (const char *buf, int buf_len);
+
+#endif /* CTAGS_MAIN_UTF8_STR_H */

--- a/parsers/asciidoc.c
+++ b/parsers/asciidoc.c
@@ -28,6 +28,7 @@
 #include "parse.h"
 #include "read.h"
 #include "vstring.h"
+#include "utf8_str.h"
 #include "nestlevel.h"
 #include "routines.h"
 
@@ -275,37 +276,6 @@ static void process_name(vString *const name, const int kind,
 	if (start <= end)
 		vStringNCatS(name, (const char*)(&(line[start])), end - start + 1);
 }
-
-
-/* computes the length of an UTF-8 string
- * if the string doesn't look like UTF-8, return -1
- * FIXME consider East_Asian_Width Unicode property */
-static int utf8_strlen(const char *buf, int buf_len)
-{
-	int len = 0;
-	const char *end = buf + buf_len;
-
-	for (len = 0; buf < end; len ++)
-	{
-		/* perform quick and naive validation (no sub-byte checking) */
-		if (! (*buf & 0x80))
-			buf ++;
-		else if ((*buf & 0xe0) == 0xc0)
-			buf += 2;
-		else if ((*buf & 0xf0) == 0xe0)
-			buf += 3;
-		else if ((*buf & 0xf8) == 0xf0)
-			buf += 4;
-		else /* not a valid leading UTF-8 byte, abort */
-			return -1;
-
-		if (buf > end) /* incomplete last byte */
-			return -1;
-	}
-
-	return len;
-}
-
 
 static void findAsciidocTags(void)
 {

--- a/parsers/markdown.c
+++ b/parsers/markdown.c
@@ -28,6 +28,7 @@
 #include "parse.h"
 #include "read.h"
 #include "vstring.h"
+#include "utf8_str.h"
 #include "nestlevel.h"
 #include "routines.h"
 #include "promise.h"
@@ -47,6 +48,7 @@ typedef enum {
 	K_LEVEL5SECTION,
 	K_SECTION_COUNT,
 	K_FOOTNOTE = K_SECTION_COUNT,
+	K_HASHTAG,
 } markdownKind;
 
 static kindDefinition MarkdownKinds[] = {
@@ -57,6 +59,7 @@ static kindDefinition MarkdownKinds[] = {
 	{ true, 'T', "l4subsection",  "level 4 sections" },
 	{ true, 'u', "l5subsection",  "level 5 sections" },
 	{ true, 'n', "footnote",      "footnotes" },
+	{ true, 'h', "hashtag",       "hashtags"},
 };
 
 static fieldDefinition MarkdownFields [] = {
@@ -259,6 +262,93 @@ static void notifyEndOfCodeBlock (markdownSubparser *m)
 	}
 }
 
+typedef enum {
+	HTAG_SPACE_FOUND,
+	HTAG_HASHTAG_FOUND,
+	HTAG_TEXT,
+} hashtagState;
+
+/*
+   State machine to find all hashtags in a line.
+ */
+static void getAllHashTagsInLineMaybe (const unsigned char *line, int pos,
+	int lineLen, hashtagState state)
+{
+	while (pos < lineLen)
+	{
+		switch (state)
+		{
+		case HTAG_SPACE_FOUND:
+			if (line[pos] == '#')
+			{
+				state = HTAG_HASHTAG_FOUND;
+			}
+			else if (!isspace (line[pos]))
+				state = HTAG_TEXT;
+			pos++;
+			break;
+		case HTAG_HASHTAG_FOUND:
+		{
+			/* `#123` is invalid */
+			bool hasNonNumericalChar = false;
+
+			const int hashtag_start = pos;
+			while (pos < lineLen)
+			{
+				int utf8_len;
+				if (isalpha (line[pos])
+					|| line[pos] == '_' || line[pos] == '-' || line[pos] == '/')
+				{
+					hasNonNumericalChar = true;
+					pos++;
+				}
+				else if (isdigit (line[pos]))
+				{
+					pos++;
+				}
+				else if ((utf8_len =
+						utf8_raw_strlen ((const char *) &line[pos],
+							lineLen - pos)) > 0)
+				{
+					hasNonNumericalChar = true;
+					pos += utf8_len;
+					Assert (pos <= lineLen);
+				}
+				else
+				{
+					break;
+				}
+			}
+
+			int hashtag_length = pos - hashtag_start;
+			if (hasNonNumericalChar && hashtag_length > 0)
+			{
+				vString *tag =
+					vStringNewNInit ((const char *) (&(line[hashtag_start])), hashtag_length);
+				makeMarkdownTag (tag, K_HASHTAG, false);
+				vStringDelete (tag);
+			}
+
+			if (pos < lineLen)
+			{
+				if (isspace (line[pos]))
+					state = HTAG_SPACE_FOUND;
+				else
+					state = HTAG_TEXT;
+			}
+		}
+			break;
+		case HTAG_TEXT:
+			while (pos < lineLen && !isspace (line[pos]))
+				pos++;
+			state = HTAG_SPACE_FOUND;
+			break;
+		default:
+			break;
+		}
+	}
+}
+
 static void findMarkdownTags (void)
 {
 	vString *prevLine = vStringNew ();
@@ -378,6 +468,8 @@ static void findMarkdownTags (void)
 		/* if it's a title underline, or a delimited block marking character */
 		else if (line[pos] == '=' || line[pos] == '-' || line[pos] == '#' || line[pos] == '>')
 		{
+			/* hashtags may follow the title or quote */
+			getAllHashTagsInLineMaybe(line, pos, lineLen, line[pos] == '#' ? HTAG_SPACE_FOUND :HTAG_TEXT);
 			int nSame;
 			for (nSame = 1; line[pos + nSame] == line[pos]; ++nSame);
 
@@ -422,6 +514,7 @@ static void findMarkdownTags (void)
 		vStringClear (prevLine);
 		if (!lineProcessed)
 		{
+			getAllHashTagsInLineMaybe(line, pos, lineLen, HTAG_SPACE_FOUND);
 			getFootnoteMaybe ((const char *)line);
 			vStringCatS (prevLine, (const char*) line);
 		}

--- a/parsers/rst.c
+++ b/parsers/rst.c
@@ -24,6 +24,7 @@
 #include "parse.h"
 #include "read.h"
 #include "vstring.h"
+#include "utf8_str.h"
 #include "nestlevel.h"
 #include "entry.h"
 #include "routines.h"
@@ -215,36 +216,6 @@ static int get_kind(char c, bool overline, struct sectionTracker tracker[])
 	}
 	return -1;
 }
-
-
-/* computes the length of an UTF-8 string
- * if the string doesn't look like UTF-8, return -1 */
-static int utf8_strlen(const char *buf, int buf_len)
-{
-	int len = 0;
-	const char *end = buf + buf_len;
-
-	for (len = 0; buf < end; len ++)
-	{
-		/* perform quick and naive validation (no sub-byte checking) */
-		if (! (*buf & 0x80))
-			buf ++;
-		else if ((*buf & 0xe0) == 0xc0)
-			buf += 2;
-		else if ((*buf & 0xf0) == 0xe0)
-			buf += 3;
-		else if ((*buf & 0xf8) == 0xf0)
-			buf += 4;
-		else /* not a valid leading UTF-8 byte, abort */
-			return -1;
-
-		if (buf > end) /* incomplete last byte */
-			return -1;
-	}
-
-	return len;
-}
-
 
 static const unsigned char *is_markup_line (const unsigned char *line, char reftype)
 {

--- a/source.mak
+++ b/source.mak
@@ -128,6 +128,7 @@ LIB_PRIVATE_HEADS =		\
 	main/stats_p.h		\
 	main/subparser_p.h	\
 	main/trashbox_p.h	\
+	main/utf8_str.h		\
 	main/writer_p.h		\
 	main/xtag_p.h		\
 	\
@@ -182,6 +183,7 @@ LIB_SRCS =			\
 	main/trace.c			\
 	main/tokeninfo.c		\
 	main/unwindi.c			\
+	main/utf8_str.c			\
 	main/writer.c			\
 	main/writer-etags.c		\
 	main/writer-ctags.c		\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -224,6 +224,7 @@
     <ClCompile Include="..\main\tokeninfo.c" />
     <ClCompile Include="..\main\trashbox.c" />
     <ClCompile Include="..\main\unwindi.c" />
+    <ClCompile Include="..\main\utf8_str.c" />
     <ClCompile Include="..\main\vstring.c" />
     <ClCompile Include="..\main\writer-ctags.c" />
     <ClCompile Include="..\main\writer-etags.c" />
@@ -440,6 +441,7 @@
     <ClInclude Include="..\main\trashbox_p.h" />
     <ClInclude Include="..\main\types.h" />
     <ClInclude Include="..\main\unwindi.h" />
+    <ClInclude Include="..\main\utf8_str.h" />
     <ClInclude Include="..\main\vstring.h" />
     <ClInclude Include="..\main\writer_p.h" />
     <ClInclude Include="..\main\xtag.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -195,6 +195,9 @@
     <ClCompile Include="..\main\unwindi.c">
       <Filter>Source Files\main</Filter>
     </ClCompile>
+    <ClCompile Include="..\main\utf8_str.c">
+      <Filter>Source Files\main</Filter>
+    </ClCompile>
     <ClCompile Include="..\main\vstring.c">
       <Filter>Source Files\main</Filter>
     </ClCompile>
@@ -837,6 +840,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\unwindi.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\main\utf8_str.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\main\vstring.h">


### PR DESCRIPTION
Some markdown editors or plugins, such as [Obsidian](https://help.obsidian.md/Editing+and+formatting/Tags) and [VSCode markdown-hashtags](https://github.com/vanadium23/markdown-hashtags), support parsing #hashtags and navigation. I have modified the markdown parser to support hashtag syntax parsing.