### PR TITLE
Markdown: bug fix for tagging a chapter unexpectedly

### DIFF
--- a/Units/parser-markdown.r/chapter-begin-with-whitespaces.d/args.ctags
+++ b/Units/parser-markdown.r/chapter-begin-with-whitespaces.d/args.ctags
@@ -1,0 +1,4 @@
+--sort=no
+--fields=+e
+--fields-Markdown=+{sectionMarker}
+--extras=+g

--- a/Units/parser-markdown.r/chapter-begin-with-whitespaces.d/expected.tags
+++ b/Units/parser-markdown.r/chapter-begin-with-whitespaces.d/expected.tags
@@ -1,0 +1,7 @@
+# title 1	input.md	/^   # title 1$/;"	c	end:5	sectionMarker:#
+# title 2	input.md	/^ ## title 2$/;"	s	chapter:# title 1	end:5	sectionMarker:#
+# title 3	input.md	/^   # title 3$/;"	c	end:19	sectionMarker:#
+# title 4	input.md	/^ ### title 4$/;"	S	chapter:# title 3	end:19	sectionMarker:#
+# title 5	input.md	/^ #### title 5$/;"	t	subsection:# title 3""# title 4	end:19	sectionMarker:#
+# title 6	input.md	/^ ##### title 6$/;"	T	subsubsection:# title 3""# title 4""# title 5	end:19	sectionMarker:#
+# title 7	input.md	/^ ###### title 7$/;"	u	l4subsection:# title 3""# title 4""# title 5""# title 6	end:19	sectionMarker:#

--- a/Units/parser-markdown.r/chapter-begin-with-whitespaces.d/input.md
+++ b/Units/parser-markdown.r/chapter-begin-with-whitespaces.d/input.md
@@ -1,0 +1,19 @@
+   #not-title-1
+
+
+   # title 1
+ ## title 2
+   # title 3
+ ### title 4
+ #### title 5
+ ##### title 6
+ ###### title 7
+
+xxx# not title 2
+xxx## not title 3
+xxx### not title 4
+xxx#### not title 5
+	# not title 6 when starting with tab
+
+..##### not title 7
+ ####### not title 8

--- a/parsers/markdown.c
+++ b/parsers/markdown.c
@@ -406,14 +406,21 @@ static void findMarkdownTags (void)
 					makeSectionMarkdownTag (prevLine, kind, marker);
 			}
 			/* otherwise is it a one line title */
-			else if (line[pos] == '#' && nSame <= K_SECTION_COUNT && isspace (line[nSame]))
+			else if (line[pos] == '#' && isspace (line[nSame]))
 			{
-				int kind = nSame - 1;
-				bool delimited = false;
-				vString *name = getHeading (kind, line, lineLen, &delimited);
-				if (vStringLength (name) > 0)
-					makeSectionMarkdownTag (name, kind, delimited ? "##" : "#");
-				vStringDelete (name);
+				/* recalculate nSame from pos */
+				for (nSame = 1; line[pos + nSame] == line[pos]; ++nSame);
+
+				pos += nSame;
+				if (nSame <= K_SECTION_COUNT && isspace (line[pos]))
+				{
+					int kind = nSame - 1;
+					bool delimited = false;
+					vString *name = getHeading (kind, line, lineLen, &delimited);
+					if (vStringLength (name) > 0)
+						makeSectionMarkdownTag (name, kind, delimited ? "##" : "#");
+					vStringDelete (name);
+				}
 			}
 
 			lineProcessed = true;


### PR DESCRIPTION
The previous commit had an error in handling examples such as
`   # title2`, `  #not-a-title`.

See also: #3748 