### PR TITLE
refact github/workflows/tagging.yml

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -1,26 +1,19 @@
-name: Create a periodical tag
+name: Create a weekly tag
 
 on:
   schedule:
     - cron:  '0 0 * * 0'
-
-env:
-  # Account for creating a tag
-  USER_NAME: "Universal-ctags CI"
-  USER_EMAIL: "Universal-ctags@users.noreply.github.com"
 
 jobs:
   tag:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        path: ctags
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: create a weekly tag
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        cd ctags
-        misc/git-tag-maybe.sh
+      - run: git config user.name  'Universal-ctags CI'
+      - run: git config user.email 'Universal-ctags@users.noreply.github.com'
+
+      - run: misc/git-tag-maybe.sh


### PR DESCRIPTION
1. use `fetch-depth: 0` with `actions/checkout@v3`, beacuse default is `fetch-depth: 1` which means only one commit is fetched and no tags and branches are fetched.
close #3754
    
2. It looks like someone tries to use `USER_NAME` and `USER_EMAIL` to configure git `user.name` and `user.email`, this didn't take effect. so I add following:
 
```bash
git config user.name  'Universal-ctags CI'
git config user.email 'Universal-ctags@users.noreply.github.com'
```

3. I removed some unsed code in this file.
    
