### PR TITLE
GitHub Actions: testing-mac.yml: do not run brew update, as an immediate workaround.

### DIFF
--- a/.github/workflows/testing-mac.yml
+++ b/.github/workflows/testing-mac.yml
@@ -22,8 +22,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: update package information
-      run: brew update
+
+    # temporarily disabled, because it always fails these days.
+    #- name: update package information
+    #  run: brew update
+
     - name: install tools and libraries
       run: |
         # See https://github.com/actions/runner-images/issues/6817.


### PR DESCRIPTION
I have been paying attention to the issue of `brew update`. There is no perfect solution as far as I known till now. so , I think just do not run `brew update` as an immediate workaround.

folks keep reporting this issue to GitHub Actions Team and Homebrew Team:

https://github.com/actions/runner/issues/2677
https://github.com/Homebrew/brew/issues/15621