### PR TITLE
Update matlab.c

### DIFF
--- a/parsers/matlab.c
+++ b/parsers/matlab.c
@@ -19,13 +19,13 @@
 
 static tagRegexTable matlabTagRegexTable [] = {
 	/* function [x,y,z] = asdf */
-	{ "^[ \t]*function[ \t]*\\[.*\\][ \t]*=[ \t]*([a-zA-Z0-9_]+)",
+	{ "^[ \t]*function[ \t]*\\[.*\\][ \t]*=[ \t]*([.a-zA-Z0-9_]+)",
 	  "\\1", "f,function", NULL},
 	/* function x = asdf */
-	{"^[ \t]*function[ \t]*[a-zA-Z0-9_]+[ \t]*=[ \t]*([a-zA-Z0-9_]+)",
+	{"^[ \t]*function[ \t]*[a-zA-Z0-9_]+[ \t]*=[ \t]*([.a-zA-Z0-9_]+)",
 	 "\\1", "f,function", NULL},
 	/* function asdf */
-	{"^[ \t]*function[ \t]*([a-zA-Z0-9_]+)[^=]*$", "\\1",
+	{"^[ \t]*function[ \t]*([.a-zA-Z0-9_]+)[^=]*$", "\\1",
 	 "f,function", NULL},
 	/* variables */
 	{"^[ \t]*([a-zA-Z0-9_]+)[ \t]*=[ \t]", "\\1",


### PR DESCRIPTION
Update function regexps for 'get\.*' and 'set\.*' methods. For example:
     function get.myproperty(obj)
     ...
Otherwise function tag returned is just 'get' instead of 'get.myproperty'.