### PR TITLE
build-sys: change shell command [] to test, because [] was recognized as quote delimiters by autoconf/m4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -295,7 +295,7 @@ if test "$cross_compiling" = "yes"; then
 
     BUILD_OBJEXT='o'
 
-    if [ -f "$TEMP_DIR_FOR_CHECKING/test.exe" ] ; then
+    if test -f "$TEMP_DIR_FOR_CHECKING/test.exe" ; then
         BUILD_EXEEXT='.exe'
     fi
 else


### PR DESCRIPTION
I happened to see the log `/home/leleliu008/.ndk-pkg/run/3382264/uctags/src/configure: line 7427: -f: command not found`  just now. I realized that I shouldn't use  `[]` as `test` in configure.ac