### PR TITLE
main: reserve errno in external sorting

### DIFF
--- a/main/sort.c
+++ b/main/sort.c
@@ -123,7 +123,7 @@ extern void externalSortTags (const bool toStdout, MIO *tagFile)
 		vStringCatS (cmd, sortCommand);
 		if (! toStdout)
 		{
-			vStringCats (cmd, " -o ");
+			vStringCatS (cmd, " -o ");
 			appendCstringWithQuotes (cmd, tagFileName ());
 			vStringPut (cmd, ' ');
 			appendCstringWithQuotes (cmd, tagFileName ());

--- a/main/sort.c
+++ b/main/sort.c
@@ -109,19 +109,12 @@ extern void externalSortTags (const bool toStdout, MIO *tagFile)
 		putenv (sortOrder1);
 		putenv (sortOrder2);
 # endif
-		vStringCatS (cmd, sortCommand);
-		if (! toStdout)
-		{
-			vStringCatS (cmd, " -o ");
-			appendCstringWithQuotes (cmd, tagFileName ());
-			vStringPut (cmd, ' ');
-			appendCstringWithQuotes (cmd, tagFileName ());
-		}
 #else
 		vStringCatS (cmd, sortOrder1);
 		vStringPut (cmd, ' ');
 		vStringCatS (cmd, sortOrder2);
 		vStringPut (cmd, ' ');
+#endif
 		vStringCatS (cmd, sortCommand);
 		if (! toStdout)
 		{
@@ -130,7 +123,6 @@ extern void externalSortTags (const bool toStdout, MIO *tagFile)
 			vStringPut (cmd, ' ');
 			appendCstringWithQuotes (cmd, tagFileName ());
 		}
-#endif
 		verbose ("system (\"%s\")\n", vStringValue (cmd));
 		if (toStdout)
 		{


### PR DESCRIPTION
This change fixes that ctags reports the following strange error message:
    
      $ /usr/bin/ctags --quiet --options=NONE -o - main/*.c | no-such-command
      zsh: no-such-command: command not found...
      ctags: cannot sort tag file : Success

Success?
    
With this change, ctags reports:
    
      ./ctags --quiet --options=NONE -o - main/*.c | no-such-command
      zsh: no-such-command: command not found...
      ctags: cannot sort tag file
