### PR TITLE
Verilog: fix for continuous assignment delays

### DIFF
--- a/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-net-var.d/expected.tags
@@ -147,13 +147,18 @@ e	input.sv	/^module delay_control #(d, e);$/;"	c	module:delay_control
 rega	input.sv	/^  int rega, regb, regr;$/;"	r	module:delay_control
 regb	input.sv	/^  int rega, regb, regr;$/;"	r	module:delay_control
 regr	input.sv	/^  int rega, regb, regr;$/;"	r	module:delay_control
+cont_a	input.sv	/^module cont_a;$/;"	m
+mynet	input.sv	/^  wire (strong1, pull0) mynet = enable;$/;"	n	module:cont_a
+cont_b	input.sv	/^module cont_b;$/;"	m
+mynet	input.sv	/^  wire mynet;$/;"	n	module:cont_b
 delay_control_wire	input.sv	/^module delay_control_wire #(d, e);$/;"	m
 d	input.sv	/^module delay_control_wire #(d, e);$/;"	c	module:delay_control_wire
 e	input.sv	/^module delay_control_wire #(d, e);$/;"	c	module:delay_control_wire
-wirea	input.sv	/^  wire wirea #10 = wireb;$/;"	n	module:delay_control_wire
-wireb	input.sv	/^  wire wireb #d = wireb;$/;"	n	module:delay_control_wire
-wirec	input.sv	/^  wire wirec #((d+e)\/2) = wireb;$/;"	n	module:delay_control_wire
-wired	input.sv	/^  wire wired #wirer = wirer + 1;$/;"	n	module:delay_control_wire
+wireA	input.sv	/^  wire #10 wireA;$/;"	n	module:delay_control_wire
+wirea	input.sv	/^  wire #10 wirea = wireb;$/;"	n	module:delay_control_wire
+wireb	input.sv	/^  wire #d wireb = wireb;$/;"	n	module:delay_control_wire
+wirec	input.sv	/^  wire #((d+e)\/2) wirec = wireb;$/;"	n	module:delay_control_wire
+wired	input.sv	/^  wire #wirer wired = wirer + 1;$/;"	n	module:delay_control_wire
 w$ire	input.sv	/^  wire w$ire, wire$;  \/\/ '$' included$/;"	n	module:delay_control_wire
 wire$	input.sv	/^  wire w$ire, wire$;  \/\/ '$' included$/;"	n	module:delay_control_wire
 rst	input.sv	/^module rst;$/;"	m

--- a/Units/parser-verilog.r/systemverilog-net-var.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-net-var.d/input.sv
@@ -208,11 +208,23 @@ module delay_control #(d, e);
 endmodule
 
 // 10.3 Continuous assignments
+module cont_a;
+  wire (strong1, pull0) mynet = enable;
+endmodule
+
+module cont_b;
+  wire mynet;
+  assign (strong1, pull0) mynet = enable;
+endmodule
+
+// 10.3.3 Continuous assignment delays
 module delay_control_wire #(d, e);
-  wire wirea #10 = wireb;
-  wire wireb #d = wireb;
-  wire wirec #((d+e)/2) = wireb;
-  wire wired #wirer = wirer + 1;
+  wire #10 wireA;
+  assign wireA = wireB;
+  wire #10 wirea = wireb;
+  wire #d wireb = wireb;
+  wire #((d+e)/2) wirec = wireb;
+  wire #wirer wired = wirer + 1;
   wire w$ire, wire$;  // '$' included
 endmodule
 

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1878,7 +1878,8 @@ static int tagIdsInPort (tokenInfo *const token, int c, verilogKind kind, bool m
 // Tag a list of identifiers in a data declaration
 static int tagIdsInDataDecl (tokenInfo* token, int c, verilogKind kind)
 {
-	c = skipClassType (token, c);
+	if (token->kind != K_NET)
+		c = skipClassType (token, c);
 	if (c == ';')
 		return c;
 


### PR DESCRIPTION
FIx to support the following code.

```
  wire #10 wireA;
  wire #10 wirea = wireb;
```

cf. LRM 10.3.3 Continuous assignment delays