### PR TITLE
main: report the guessed reason if system("sort") is failed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -601,7 +601,7 @@ if test "$have_mkstemp" != yes -a "$have_tempnam" != yes; then
 fi
 
 AC_CHECK_FUNCS(opendir findfirst _findfirst, break)
-AC_CHECK_FUNCS(strerror)
+AC_CHECK_FUNCS(strerror strsignal)
 
 AC_CHECK_FUNCS(truncate, have_truncate=yes)
 # === Cannot nest AC_CHECK_FUNCS() calls

--- a/configure.ac
+++ b/configure.ac
@@ -573,6 +573,9 @@ PRETTY_ARG_VAR([EXTRA_CFLAGS], [extra C compiler flags],
 PRETTY_ARG_VAR([WARNING_CFLAGS], [C compiler warning flags],
 	       [-Wall])
 
+# Checks for function availability
+# -----------------------------------
+
 # For gnulib.
 #   Place it further down in the file, typically where you normally check for
 #   header files or functions.

--- a/main/sort.c
+++ b/main/sort.c
@@ -96,8 +96,8 @@ extern void externalSortTags (const bool toStdout, MIO *tagFile)
 	int ret = -1;
 	int system_errno = 0;
 
+	vString *cmd = vStringNew ();
 	{
-		vString *cmd = vStringNew ();
 
 		/*  Ensure ASCII value sort order.
 		 */
@@ -147,18 +147,26 @@ extern void externalSortTags (const bool toStdout, MIO *tagFile)
 			ret = system (vStringValue (cmd));
 			system_errno = errno;
 		}
-		vStringDelete (cmd);
 	}
 	if (ret != 0)
 	{
 		errorSelection selection = FATAL;
 		if (ret == -1)
 		{
-			selection |= PERROR;
 			errno = system_errno;
+			error (selection|PERROR, "cannot sort tag file");
 		}
-		error (selection, "cannot sort tag file");
+
+#ifdef HAVE_STRSIGNAL
+		error (selection, "cannot sort tag file: system (\"%s\") exited with %d (%s?)",
+			   vStringValue(cmd), ret, strsignal(ret));
+#else
+		error (selection, "cannot sort tag file: system (\"%s\") exited with %d",
+			   vStringValue(cmd), ret);
+#endif
+
 	}
+	vStringDelete (cmd);
 }
 
 #else


### PR DESCRIPTION
```
$ ~/bin/ctags -o - -R ~/var/ctags-github/main |readtags __NR_read
ctags: cannot sort tag file: system ("sort -u") exited with 13 (Broken pipe?)
```