### PR TITLE
input-validate: add CATEGORIES make variable

### DIFF
--- a/docs/testing-parser.rst
+++ b/docs/testing-parser.rst
@@ -477,7 +477,7 @@ Here is an example validating an input file for JSON.
 
   $ make validate-input VALIDATORS=jq
   ...
-  Category: ROOT
+  Category: parser-json.r
   ------------------------------------------------------------
   simple-json.d/input.json with jq                                 valid
 
@@ -547,6 +547,9 @@ directory has its specific *validator* file.
 If a *Unit* test case doesn't have *expected.tags* file, the make
 target doesn't run the validator on the file even if a default
 validator is given in its category directory.
+
+If a *Unit* test case specifies NONE in its *validator* file,
+the make target doesn't run the validator, either.
 
 If a *Unit* test case specifies KNOWN-INVALIDATION in its *validator*
 file, the make target just increments "#skipped (known invalidation)"

--- a/docs/testing-parser.rst
+++ b/docs/testing-parser.rst
@@ -506,6 +506,15 @@ two cases, the target skips validating input files:
 
     A command for a validator is not available.
 
+*validate-input* make target supports the CATEGORIES variable as *units* make target does.
+
+.. code-block:: console
+
+  $ make validate-input units CATEGORIES=parser-json.r
+  ...
+
+This example shows validating input files and running units test on *parser-json.r* category.
+
 *validator* file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/makefiles/testing.mak
+++ b/makefiles/testing.mak
@@ -169,8 +169,10 @@ validate-input:
 	if test -n "$(VALIDATORS)"; then	\
 		VALIDATORS="--validators=$(VALIDATORS)"; \
 	fi; \
-	c="$(srcdir)/misc/units validate-input $${VALIDATORS}"; \
-		$(SHELL) $${c} $(srcdir)/Units $(srcdir)/misc/validators
+	c="$(srcdir)/misc/units validate-input \
+		--categories=$(CATEGORIES) \
+		$${VALIDATORS}"; \
+	$(SHELL) $${c} $(srcdir)/Units $(srcdir)/misc/validators
 #
 # Test main part, not parsers
 #

--- a/misc/units
+++ b/misc/units
@@ -2522,6 +2522,7 @@ $0 validate-input [OPTIONS] UNITS-DIR VALIDATORS-DIR
 		--validators=validator[,...]: Validate test cases specifying
 					    given validators.
 		--colorized-output: yes|no: print the result in color.
+		--categories CATEGORY1[,CATEGORY2,...]: run only CATEGORY* related cases.
 EOF
 }
 
@@ -2843,6 +2844,16 @@ validate_category ()
     local d
     local default_validator=${_NOOP_VALIDATOR}
 
+    #
+    # Filtered by CATEGORIES
+    #
+    if [ -n "$CATEGORIES" ] && ! member_p "${category}" $CATEGORIES; then
+	return 1
+    fi
+    echo
+    echo "Category: ${category}"
+    line
+
     if [ -r "${base_dir}/validator" ]; then
 	default_validator=$(cat "${base_dir}/validator" | grep -v '#')
 	if [ -z "${default_validator}" ]; then
@@ -2938,6 +2949,27 @@ action_validate_input ()
 		COLORIZED_OUTPUT=${1#--colorized-output=}
 		shift
 		;;
+	    --categories)
+		shift
+		for c in $(echo "$1" | tr ',' ' '); do
+		    if [ "$c" = "ROOT" ]; then
+			CATEGORIES="$CATEGORIES ROOT"
+		    else
+			CATEGORIES="$CATEGORIES ${c%.r}.r"
+		    fi
+		done
+		shift
+		;;
+	    --categories=*)
+		for c in $(echo "${1#--categories=}" | tr ',' ' '); do
+		    if [ "$c" = "ROOT" ]; then
+			CATEGORIES="$CATEGORIES ROOT"
+		    else
+			CATEGORIES="$CATEGORIES ${c%.r}.r"
+		    fi
+		done
+		shift
+		;;
 	    -*)
 		ERROR 1 "unknown option \"${1}\" for ${action} action"
 		;;
@@ -2979,9 +3011,6 @@ action_validate_input ()
     for d in ${units_dir}/*.r; do
 	[ -d "$d" ] || continue
 	category=${d##*/}
-	echo
-	echo "Category: ${category}"
-	line
 	validate_category "${category}" "$d" "${validators_dir}"
     done
 


### PR DESCRIPTION
This PR lets *validate-input* make target support the CATEGORIES variable as *units* make target does.

Some minor fixes  of input validation are also included.

