### PR TITLE
GitHub Actions: cleanup code

### DIFF
--- a/.github/workflows/testing-nmake.yml
+++ b/.github/workflows/testing-nmake.yml
@@ -33,15 +33,9 @@ jobs:
             set "XX="
           )
 
-          if "${{ matrix.arch }}" == "x64" (
-            set "TARGET_ARCH=amd64"
-          ) else (
-            set "TARGET_ARCH=x86"
-          )
-
           @echo on
 
-          echo call "C:\Program Files%XX%\Microsoft Visual Studio\${{ matrix.version }}\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %TARGET_ARCH% > nmake-setup.cmd
+          echo call "C:\Program Files%XX%\Microsoft Visual Studio\${{ matrix.version }}\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.arch }} > nmake-setup.cmd
           type nmake-setup.cmd
 
       - name: build libiconv


### PR DESCRIPTION
Reference: https://learn.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160#vcvarsall-syntax

the first argument of vcvarsall.bat can be either amd64 or x64