### PR TITLE
GitHub Actions: cleanup code testing-mac.yml

### DIFF
--- a/.github/workflows/testing-mac.yml
+++ b/.github/workflows/testing-mac.yml
@@ -1,4 +1,4 @@
-name: run units target on MacOS
+name: run units target on macOS
 
 on:
   push:
@@ -11,49 +11,31 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-11, macos-12]
-        compiler: [gcc, clang]
+        os: [macos-13, macos-12, macos-11]
 
     runs-on: ${{ matrix.os }}
-
-    env:
-      CC: ${{ matrix.compiler }}
-      BUILDDIR: ${{ matrix.os }}-${{ matrix.compiler }}
 
     steps:
     - uses: actions/checkout@v4
 
     # temporarily disabled, because it always fails these days.
-    #- name: update package information
-    #  run: brew update
+    #- run: brew update
 
-    - name: install tools and libraries
-      run: |
-        # See https://github.com/actions/runner-images/issues/6817.
-        brew install --overwrite python@3.10 python@3.11
-        brew install automake pkg-config bash libxml2 jansson libyaml gdb docutils pcre2
-    - name: autogen.sh
-      run: ./autogen.sh
-    - name: report the version of cc
-      run: ${{ matrix.compiler }} --version
-    - name: report the version of make
-      run: make --version
-    - name: configure
-      run: |
-        mkdir -p ${{ matrix.os }}-"$CC"
-        (
-          cd $BUILDDIR
-          ../configure --enable-debugging --enable-iconv
-        )
-    - name: make
-      run: make -C $BUILDDIR -j2
-    - name: report features
-      run: |
-        (
-          cd $BUILDDIR
-          ./ctags --list-features
-        )
-    - name: make check
-      run: make -C $BUILDDIR check
-    - name: make roundtrip
-      run: make -C $BUILDDIR roundtrip
+    # https://github.com/actions/runner-images/issues/6817
+    - run: brew install --overwrite python@3.10 python@3.11
+    - run: brew install automake pkg-config jansson libyaml docutils pcre2
+
+    - run: cc --version
+    - run: make --version
+
+    - run: ./autogen.sh
+    - run: ./configure --enable-debugging --enable-iconv
+    - run: make -j2
+
+    - run: ./ctags --version
+    - run: ./ctags --list-features
+
+    - run: make check
+    - run: make roundtrip
+    - run: make tmain
+    - run: make units


### PR DESCRIPTION
`/usr/bin/cc` `/usr/bin/gcc` `/usr/bin/clang` are actually the same.

`libxml2` is a keg_only package, which means it was not linked into `/usr/local`. I removed it, because it was pre-installed on macOS.