### PR TITLE
using %zu for printing size_t values

### DIFF
--- a/peg/peg_common.h
+++ b/peg/peg_common.h
@@ -130,7 +130,7 @@ static void baseDebug(struct parserBaseCtx *auxil, int event, const char *rule, 
 	if (!baseIsDebugRule(auxil, rule))
 		return;
 
-	fprintf(stderr, "<level:%2lu, len:%4lu>[%7s] %10s: ",
+	fprintf(stderr, "<level:%2zu, len:%4zu>[%7s] %10s: ",
 			level, len,
 			event == 0 /*PCC_DBG_EVALUATE*/ ? "eval" :
 			event == 1 /*PCC_DBG_MATCH*/    ? "match":


### PR DESCRIPTION
References:

https://man7.org/linux/man-pages/man3/ssize_t.3type.html

https://learn.microsoft.com/en-us/cpp/c-runtime-library/format-specification-syntax-printf-and-wprintf-functions?view=msvc-160#size-prefixes-for-printf-and-wprintf-format-type-specifiers