### PR TITLE
GitHub Actions: use Android NDK r25c instead of Android NDK r26-rc

### DIFF
--- a/.github/workflows/cross-compile-android-ndk-on-mac.yml
+++ b/.github/workflows/cross-compile-android-ndk-on-mac.yml
@@ -24,12 +24,6 @@ jobs:
 
       - name: Run ./configure ...
         run: |
-          # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#environment-variables-3
-          [ -n "$ANDROID_NDK_LATEST_HOME" ] && {
-            export ANDROID_NDK_HOME="$ANDROID_NDK_LATEST_HOME"
-            export ANDROID_NDK_ROOT="$ANDROID_NDK_LATEST_HOME"
-          }
-
           BUILD_MACHINE_OS_TYPE=$(uname | tr A-Z a-z)
           BUILD_MACHINE_OS_ARCH=$(uname -m)
 

--- a/.github/workflows/cross-compile-android-ndk-on-ubuntu.yml
+++ b/.github/workflows/cross-compile-android-ndk-on-ubuntu.yml
@@ -25,12 +25,6 @@ jobs:
 
       - name: Run ./configure ...
         run: |
-          # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md#environment-variables-3
-          [ -n "$ANDROID_NDK_LATEST_HOME" ] && {
-            export ANDROID_NDK_HOME="$ANDROID_NDK_LATEST_HOME"
-            export ANDROID_NDK_ROOT="$ANDROID_NDK_LATEST_HOME"
-          }
-
           BUILD_MACHINE_OS_TYPE=$(uname | tr A-Z a-z)
           BUILD_MACHINE_OS_ARCH=$(uname -m)
 


### PR DESCRIPTION
Android NDK r25c is stable release.

Android NDK r26-rc is not stable.

Reference:
https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#environment-variables-2 https://developer.android.com/ndk/downloads