### PR TITLE
Revert "main,tlib: fix wording"

### DIFF
--- a/main/mini-geany.c
+++ b/main/mini-geany.c
@@ -345,7 +345,7 @@ extern int main (int argc, char **argv)
 		/* set to something else */
 		addIgnoreSymbol("FOO");
 
-		printf("The total number of parsers is: %d\n", ctagsGetLangCount());
+		printf("Number of all parsers is: %d\n", ctagsGetLangCount());
 		printf("We are parsing %s which provides the following kinds:\n",
 			ctagsGetLangName(lang));
 		for (i = 0; kinds[i] != '\0'; i++)

--- a/misc/tlib
+++ b/misc/tlib
@@ -32,11 +32,11 @@ fi
 ${VALGRIND} ${MINI_GEANY} > ${actual}
 echo "${VALGRIND} ${MINI_GEANY} output:"
 cat ${actual}
-N=$(sed -n -e 's/^The total number of parsers is: \([0-9]*\)$/\1/p' ${actual})
+N=$(sed -n -e 's/^Number of all parsers is: \([0-9]*\)$/\1/p' ${actual})
 
 test "$N" -gt 0
 
-sed -i -e '/^The total number of parsers is: [0-9]*$/d' ${actual}
+sed -i -e '/^Number of all parsers is: [0-9]*$/d' ${actual}
 
 echo "comparing with expected output:"
 diff -uN --strip-trailing-cr ${expected} ${actual} && rm ${actual}


### PR DESCRIPTION
Reverts universal-ctags/ctags#3834

The log of the original commit wrong needs to be revised.