### PR TITLE
Various warnings fixes

### DIFF
--- a/dsl/dsl.c
+++ b/dsl/dsl.c
@@ -36,6 +36,9 @@ typedef struct sDSLEngine DSLEngine;
  * MACROS
  */
 
+/* dummy definition to allow/require an extra semicolon */
+#define END_DEF(sfx) typedef int ctags_dummy_int_type_ignore_me_##sfx
+
 #define DECLARE_VALUE_FN(N)									\
 static EsObject* value_##N (EsObject *args, DSLEnv *env)
 
@@ -43,7 +46,7 @@ static EsObject* value_##N (EsObject *args, DSLEnv *env)
 static EsObject* value_##N (EsObject *args, DSLEnv *env)	\
 {															\
 	return dsl_entry_##N (env->entry);						\
-}
+} END_DEF(value_##N)
 
 /*
  * FUNCTION DECLARATIONS
@@ -698,7 +701,7 @@ static EsObject* builtin_not  (EsObject *args, DSLEnv *env)
 			return es_true;					\
 		else							\
 			return es_false;				\
-	}
+	} END_DEF(builtin_##N)
 
 static EsObject* builtin_eq  (EsObject *args, DSLEnv *env)
 {
@@ -712,10 +715,10 @@ static EsObject* builtin_eq  (EsObject *args, DSLEnv *env)
 		return es_false;
 }
 
-DEFINE_OP_WITH_CHECK(lt, es_number_get (a) < es_number_get (b), es_number_p,  NUMBER_REQUIRED, es_symbol_intern ("<"))
-DEFINE_OP_WITH_CHECK(gt, es_number_get (a) > es_number_get (b), es_number_p,  NUMBER_REQUIRED, es_symbol_intern (">"))
-DEFINE_OP_WITH_CHECK(le, es_number_get (a) <= es_number_get (b), es_number_p, NUMBER_REQUIRED, es_symbol_intern ("<="))
-DEFINE_OP_WITH_CHECK(ge, es_number_get (a) >= es_number_get (b), es_number_p, NUMBER_REQUIRED, es_symbol_intern (">="))
+DEFINE_OP_WITH_CHECK(lt, es_number_get (a) < es_number_get (b), es_number_p,  NUMBER_REQUIRED, es_symbol_intern ("<"));
+DEFINE_OP_WITH_CHECK(gt, es_number_get (a) > es_number_get (b), es_number_p,  NUMBER_REQUIRED, es_symbol_intern (">"));
+DEFINE_OP_WITH_CHECK(le, es_number_get (a) <= es_number_get (b), es_number_p, NUMBER_REQUIRED, es_symbol_intern ("<="));
+DEFINE_OP_WITH_CHECK(ge, es_number_get (a) >= es_number_get (b), es_number_p, NUMBER_REQUIRED, es_symbol_intern (">="));
 
 static EsObject* builtin_prefix (EsObject* args, DSLEnv *env)
 {
@@ -895,29 +898,29 @@ static EsObject* bulitin_debug_print (EsObject *args, DSLEnv *env)
 /*
  * Value functions
  */
-DEFINE_VALUE_FN(name)
-DEFINE_VALUE_FN(input)
-DEFINE_VALUE_FN(pattern)
-DEFINE_VALUE_FN(line)
+DEFINE_VALUE_FN(name);
+DEFINE_VALUE_FN(input);
+DEFINE_VALUE_FN(pattern);
+DEFINE_VALUE_FN(line);
 
-DEFINE_VALUE_FN(access)
-DEFINE_VALUE_FN(end)
-DEFINE_VALUE_FN(extras)
-DEFINE_VALUE_FN(file)
-DEFINE_VALUE_FN(inherits)
-DEFINE_VALUE_FN(implementation)
-DEFINE_VALUE_FN(kind)
-DEFINE_VALUE_FN(language)
-DEFINE_VALUE_FN(nth)
-DEFINE_VALUE_FN(scope)
-DEFINE_VALUE_FN(scope_kind)
-DEFINE_VALUE_FN(scope_name)
-DEFINE_VALUE_FN(signature)
-DEFINE_VALUE_FN(typeref)
-DEFINE_VALUE_FN(typeref_kind)
-DEFINE_VALUE_FN(typeref_name)
-DEFINE_VALUE_FN(roles)
-DEFINE_VALUE_FN(xpath)
+DEFINE_VALUE_FN(access);
+DEFINE_VALUE_FN(end);
+DEFINE_VALUE_FN(extras);
+DEFINE_VALUE_FN(file);
+DEFINE_VALUE_FN(inherits);
+DEFINE_VALUE_FN(implementation);
+DEFINE_VALUE_FN(kind);
+DEFINE_VALUE_FN(language);
+DEFINE_VALUE_FN(nth);
+DEFINE_VALUE_FN(scope);
+DEFINE_VALUE_FN(scope_kind);
+DEFINE_VALUE_FN(scope_name);
+DEFINE_VALUE_FN(signature);
+DEFINE_VALUE_FN(typeref);
+DEFINE_VALUE_FN(typeref_kind);
+DEFINE_VALUE_FN(typeref_name);
+DEFINE_VALUE_FN(roles);
+DEFINE_VALUE_FN(xpath);
 
 static const char*entry_xget (const tagEntry *entry, const char* name)
 {

--- a/dsl/dsl.c
+++ b/dsl/dsl.c
@@ -712,10 +712,10 @@ static EsObject* builtin_eq  (EsObject *args, DSLEnv *env)
 		return es_false;
 }
 
-DEFINE_OP_WITH_CHECK(lt, es_number_get (a) < es_number_get (b), es_number_p,  NUMBER_REQUIRED, es_symbol_intern ("<"));
-DEFINE_OP_WITH_CHECK(gt, es_number_get (a) > es_number_get (b), es_number_p,  NUMBER_REQUIRED, es_symbol_intern (">"));
-DEFINE_OP_WITH_CHECK(le, es_number_get (a) <= es_number_get (b), es_number_p, NUMBER_REQUIRED, es_symbol_intern ("<="));
-DEFINE_OP_WITH_CHECK(ge, es_number_get (a) >= es_number_get (b), es_number_p, NUMBER_REQUIRED, es_symbol_intern (">="));
+DEFINE_OP_WITH_CHECK(lt, es_number_get (a) < es_number_get (b), es_number_p,  NUMBER_REQUIRED, es_symbol_intern ("<"))
+DEFINE_OP_WITH_CHECK(gt, es_number_get (a) > es_number_get (b), es_number_p,  NUMBER_REQUIRED, es_symbol_intern (">"))
+DEFINE_OP_WITH_CHECK(le, es_number_get (a) <= es_number_get (b), es_number_p, NUMBER_REQUIRED, es_symbol_intern ("<="))
+DEFINE_OP_WITH_CHECK(ge, es_number_get (a) >= es_number_get (b), es_number_p, NUMBER_REQUIRED, es_symbol_intern (">="))
 
 static EsObject* builtin_prefix (EsObject* args, DSLEnv *env)
 {

--- a/dsl/sorter.c
+++ b/dsl/sorter.c
@@ -145,29 +145,29 @@ static DSLProcBind pbinds [] = {
 /*
  * Value functions
  */
-DEFINE_ALT_VALUE_FN(name);
-DEFINE_ALT_VALUE_FN(input);
-DEFINE_ALT_VALUE_FN(pattern);
-DEFINE_ALT_VALUE_FN(line);
+DEFINE_ALT_VALUE_FN(name)
+DEFINE_ALT_VALUE_FN(input)
+DEFINE_ALT_VALUE_FN(pattern)
+DEFINE_ALT_VALUE_FN(line)
 
-DEFINE_ALT_VALUE_FN(access);
-DEFINE_ALT_VALUE_FN(end);
-DEFINE_ALT_VALUE_FN(extras);
-DEFINE_ALT_VALUE_FN(file);
-DEFINE_ALT_VALUE_FN(inherits);
-DEFINE_ALT_VALUE_FN(implementation);
-DEFINE_ALT_VALUE_FN(kind);
-DEFINE_ALT_VALUE_FN(language);
-DEFINE_ALT_VALUE_FN(nth);
-DEFINE_ALT_VALUE_FN(scope);
-DEFINE_ALT_VALUE_FN(scope_kind);
-DEFINE_ALT_VALUE_FN(scope_name);
-DEFINE_ALT_VALUE_FN(signature);
-DEFINE_ALT_VALUE_FN(typeref);
-DEFINE_ALT_VALUE_FN(typeref_kind);
-DEFINE_ALT_VALUE_FN(typeref_name);
-DEFINE_ALT_VALUE_FN(roles);
-DEFINE_ALT_VALUE_FN(xpath);
+DEFINE_ALT_VALUE_FN(access)
+DEFINE_ALT_VALUE_FN(end)
+DEFINE_ALT_VALUE_FN(extras)
+DEFINE_ALT_VALUE_FN(file)
+DEFINE_ALT_VALUE_FN(inherits)
+DEFINE_ALT_VALUE_FN(implementation)
+DEFINE_ALT_VALUE_FN(kind)
+DEFINE_ALT_VALUE_FN(language)
+DEFINE_ALT_VALUE_FN(nth)
+DEFINE_ALT_VALUE_FN(scope)
+DEFINE_ALT_VALUE_FN(scope_kind)
+DEFINE_ALT_VALUE_FN(scope_name)
+DEFINE_ALT_VALUE_FN(signature)
+DEFINE_ALT_VALUE_FN(typeref)
+DEFINE_ALT_VALUE_FN(typeref_kind)
+DEFINE_ALT_VALUE_FN(typeref_name)
+DEFINE_ALT_VALUE_FN(roles)
+DEFINE_ALT_VALUE_FN(xpath)
 
 /*
  * Special form(s)

--- a/dsl/sorter.c
+++ b/dsl/sorter.c
@@ -22,6 +22,9 @@
  * MACROS
  */
 
+/* dummy definition to allow/require an extra semicolon */
+#define END_DEF(sfx) typedef int ctags_dummy_int_type_ignore_me_##sfx
+
 #define DECLARE_ALT_VALUE_FN(N)									\
 static EsObject* alt_value_##N (EsObject *args, DSLEnv *env)
 
@@ -31,7 +34,7 @@ static EsObject* alt_value_##N (EsObject *args, DSLEnv *env)			\
 	if (!env->alt_entry)												\
 		dsl_throw (NO_ALT_ENTRY, es_symbol_intern ("&" #N)); 			\
 	return dsl_entry_##N (env->alt_entry);								\
-}
+} END_DEF(alt_value_##N)
 
 
 /*
@@ -145,29 +148,29 @@ static DSLProcBind pbinds [] = {
 /*
  * Value functions
  */
-DEFINE_ALT_VALUE_FN(name)
-DEFINE_ALT_VALUE_FN(input)
-DEFINE_ALT_VALUE_FN(pattern)
-DEFINE_ALT_VALUE_FN(line)
+DEFINE_ALT_VALUE_FN(name);
+DEFINE_ALT_VALUE_FN(input);
+DEFINE_ALT_VALUE_FN(pattern);
+DEFINE_ALT_VALUE_FN(line);
 
-DEFINE_ALT_VALUE_FN(access)
-DEFINE_ALT_VALUE_FN(end)
-DEFINE_ALT_VALUE_FN(extras)
-DEFINE_ALT_VALUE_FN(file)
-DEFINE_ALT_VALUE_FN(inherits)
-DEFINE_ALT_VALUE_FN(implementation)
-DEFINE_ALT_VALUE_FN(kind)
-DEFINE_ALT_VALUE_FN(language)
-DEFINE_ALT_VALUE_FN(nth)
-DEFINE_ALT_VALUE_FN(scope)
-DEFINE_ALT_VALUE_FN(scope_kind)
-DEFINE_ALT_VALUE_FN(scope_name)
-DEFINE_ALT_VALUE_FN(signature)
-DEFINE_ALT_VALUE_FN(typeref)
-DEFINE_ALT_VALUE_FN(typeref_kind)
-DEFINE_ALT_VALUE_FN(typeref_name)
-DEFINE_ALT_VALUE_FN(roles)
-DEFINE_ALT_VALUE_FN(xpath)
+DEFINE_ALT_VALUE_FN(access);
+DEFINE_ALT_VALUE_FN(end);
+DEFINE_ALT_VALUE_FN(extras);
+DEFINE_ALT_VALUE_FN(file);
+DEFINE_ALT_VALUE_FN(inherits);
+DEFINE_ALT_VALUE_FN(implementation);
+DEFINE_ALT_VALUE_FN(kind);
+DEFINE_ALT_VALUE_FN(language);
+DEFINE_ALT_VALUE_FN(nth);
+DEFINE_ALT_VALUE_FN(scope);
+DEFINE_ALT_VALUE_FN(scope_kind);
+DEFINE_ALT_VALUE_FN(scope_name);
+DEFINE_ALT_VALUE_FN(signature);
+DEFINE_ALT_VALUE_FN(typeref);
+DEFINE_ALT_VALUE_FN(typeref_kind);
+DEFINE_ALT_VALUE_FN(typeref_name);
+DEFINE_ALT_VALUE_FN(roles);
+DEFINE_ALT_VALUE_FN(xpath);
 
 /*
  * Special form(s)

--- a/extra-cmds/optscript-repl.c
+++ b/extra-cmds/optscript-repl.c
@@ -38,7 +38,7 @@ op_renew (OptVM *vm, EsObject *name)
 	return OPT_ERR_QUIT;
 }
 
-int
+static int
 optscript_run (OptVM *vm, char *prompt, void *app_data)
 {
 	int r = 0;

--- a/extra-cmds/readtags-cmd.c
+++ b/extra-cmds/readtags-cmd.c
@@ -152,7 +152,7 @@ struct tagEntryArray {
 	struct tagEntryHolder *a;
 };
 
-struct tagEntryArray *tagEntryArrayNew (void)
+static struct tagEntryArray *tagEntryArrayNew (void)
 {
 	struct tagEntryArray * a = eMalloc (sizeof (struct tagEntryArray));
 
@@ -163,7 +163,7 @@ struct tagEntryArray *tagEntryArrayNew (void)
 	return a;
 }
 
-void tagEntryArrayPush (struct tagEntryArray *a, tagEntry *e)
+static void tagEntryArrayPush (struct tagEntryArray *a, tagEntry *e)
 {
 	if (a->count + 1 == a->length)
 	{
@@ -180,7 +180,7 @@ void tagEntryArrayPush (struct tagEntryArray *a, tagEntry *e)
 	a->a[a->count++].e = e;
 }
 
-void tagEntryArrayFree (struct tagEntryArray *a, int freeTags)
+static void tagEntryArrayFree (struct tagEntryArray *a, int freeTags)
 {
 	if (freeTags)
 	{

--- a/extra-cmds/readtags-stub.c
+++ b/extra-cmds/readtags-stub.c
@@ -40,9 +40,9 @@ extern void debugAssert (const char *assertion, const char *file, unsigned int l
 #define selected(var,feature)	(((int)(var) & (int)(feature)) == (int)feature)
 
 CTAGS_ATTR_PRINTF (2, 0)
-extern bool stderrDefaultErrorPrinter (const errorSelection selection,
-					  const char *const format,
-					  va_list ap, void *data CTAGS_ATTR_UNUSED)
+static bool stderrDefaultErrorPrinter (const errorSelection selection,
+				       const char *const format,
+				       va_list ap, void *data CTAGS_ATTR_UNUSED)
 {
 	fprintf (stderr, "%s: %s", getExecutableName (),
 		 selected (selection, WARNING) ? "Warning: " :

--- a/extra-cmds/readtags-stub.c
+++ b/extra-cmds/readtags-stub.c
@@ -39,6 +39,7 @@ extern void debugAssert (const char *assertion, const char *file, unsigned int l
 
 #define selected(var,feature)	(((int)(var) & (int)(feature)) == (int)feature)
 
+CTAGS_ATTR_PRINTF (2, 0)
 extern bool stderrDefaultErrorPrinter (const errorSelection selection,
 					  const char *const format,
 					  va_list ap, void *data CTAGS_ATTR_UNUSED)

--- a/main/error_p.h
+++ b/main/error_p.h
@@ -16,11 +16,11 @@
 #include "routines.h"
 
 typedef bool (* errorPrintFunc) (const errorSelection selection, const char *const format,
-				    va_list ap, void *data);
+				    va_list ap, void *data) CTAGS_ATTR_PRINTF (2, 0);
 
 extern void setErrorPrinter (errorPrintFunc printer, void *data);
 
 extern bool stderrDefaultErrorPrinter (const errorSelection selection, const char *const format, va_list ap,
-					  void *data);
+					  void *data) CTAGS_ATTR_PRINTF (2, 0);
 
 #endif

--- a/main/lxpath.c
+++ b/main/lxpath.c
@@ -11,6 +11,7 @@
 #include "general.h"  /* must always come first */
 #include "debug.h"
 #include "entry.h"
+#include "lxpath_p.h"
 #include "options.h"
 #include "parse_p.h"
 #include "read.h"

--- a/main/lxpath_p.h
+++ b/main/lxpath_p.h
@@ -16,6 +16,7 @@
 
 #include "general.h"  /* must always come first */
 #include "types.h"
+#include "lxpath.h"
 
 
 /*

--- a/main/mbcs.c
+++ b/main/mbcs.c
@@ -53,7 +53,7 @@ extern bool openConverter (const char* inputEncoding, const char* outputEncoding
 	return true;
 }
 
-extern bool isConverting ()
+extern bool isConverting (void)
 {
 	return iconv_fd != (iconv_t) -1;
 }
@@ -101,7 +101,7 @@ retry:
 	return true;
 }
 
-extern void closeConverter ()
+extern void closeConverter (void)
 {
 	if (iconv_fd != (iconv_t) -1)
 	{

--- a/main/mini-geany.c
+++ b/main/mini-geany.c
@@ -44,6 +44,7 @@ tagWriter customWriter = {
 
 
 /* we need to be able to provide an error printer which doesn't crash Geany on error */
+CTAGS_ATTR_PRINTF(2, 0)
 static bool nofatalErrorPrinter (const errorSelection selection,
 					  const char *const format,
 					  va_list ap, void *data CTAGS_ATTR_UNUSED)

--- a/main/mini-geany.c
+++ b/main/mini-geany.c
@@ -75,7 +75,7 @@ static void enableRoles(unsigned int lang, unsigned int kind)
 
 
 /* we need to be able to enable all kinds and roles for all languages (some are disabled by default) */
-static void enableKindsAndRoles()
+static void enableKindsAndRoles(void)
 {
 	unsigned int lang;
 

--- a/main/mini-geany.c
+++ b/main/mini-geany.c
@@ -182,7 +182,7 @@ static unsigned int ctagsGetLangCount(void)
 }
 
 
-void addIgnoreSymbol(const char *value)
+static void addIgnoreSymbol(const char *value)
 {
 	langType lang = getNamedLanguage ("CPreProcessor", 0);
 	/*

--- a/main/options.c
+++ b/main/options.c
@@ -34,6 +34,7 @@
 #include "routines_p.h"
 #include "xtag_p.h"
 #include "param_p.h"
+#include "param.h"
 #include "error_p.h"
 #include "interactive_p.h"
 #include "writer_p.h"

--- a/main/options.c
+++ b/main/options.c
@@ -2217,6 +2217,7 @@ static void processListKinddefFlagsOptions (
 	exit (0);
 }
 
+attr__noreturn
 static void processListRolesOptions (const char *const option CTAGS_ATTR_UNUSED,
 				     const char *const parameter)
 {

--- a/main/read.c
+++ b/main/read.c
@@ -456,7 +456,7 @@ static void resetLangOnStack (inputLangInfo *langInfo, langType lang)
 	langStackPush (& (langInfo->stack), lang);
 }
 
-extern langType baseLangOnStack (inputLangInfo *langInfo)
+static langType baseLangOnStack (inputLangInfo *langInfo)
 {
 	Assert (langInfo->stack.count > 0);
 	return langStackBotom (& (langInfo->stack));

--- a/main/trashbox.c
+++ b/main/trashbox.c
@@ -13,6 +13,7 @@
 #include "debug.h"
 #include "routines.h"
 #include "trashbox.h"
+#include "trashbox_p.h"
 
 typedef TrashBoxDestroyItemProc TrashDestroyItemProc;
 typedef struct sTrash {

--- a/main/unwindi.c
+++ b/main/unwindi.c
@@ -165,7 +165,7 @@ CTAGS_INLINE void uugcInjectC (int chr)
 	uugcUngetC (c);
 }
 
-CTAGS_INLINE long uugcGetLineNumber ()
+CTAGS_INLINE long uugcGetLineNumber (void)
 {
 	Assert (uugcInputFile);
 
@@ -248,7 +248,7 @@ extern void uwiDeactivate (struct sUwiStats *statsToBeUpdated)
 	uugcDeactive();
 }
 
-extern int uwiGetC ()
+extern int uwiGetC (void)
 {
 	int c;
 	uugcChar *chr = uugciGetC ();
@@ -337,7 +337,7 @@ extern void uwiClearMarker (const int upto, const bool revertChars)
 	}
 }
 
-extern void uwiDropMaker ()
+extern void uwiDropMaker (void)
 {
 	uwiPopMarker (0, false);
 }

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -760,8 +760,8 @@ static void initialize (const langType language)
 		return true;													\
 	}
 
-defineCommentCharSetter(At, BOL);
-defineCommentCharSetter(In, MOL);
+defineCommentCharSetter(At, BOL)
+defineCommentCharSetter(In, MOL)
 
 static bool asmSetExtraLinesepChars(const langType language CTAGS_ATTR_UNUSED,
 									const char *optname CTAGS_ATTR_UNUSED, const char *arg)

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -746,6 +746,9 @@ static void initialize (const langType language)
 	Lang_asm = language;
 }
 
+/* dummy definition to allow/require an extra semicolon */
+#define END_DEF(sfx) typedef int ctags_dummy_int_type_ignore_me_##sfx
+
 #define defineCommentCharSetter(PREPOS, POS)							\
 	static bool asmSetCommentChars##PREPOS##POS (const langType language CTAGS_ATTR_UNUSED, \
 												 const char *optname CTAGS_ATTR_UNUSED, const char *arg) \
@@ -758,10 +761,10 @@ static void initialize (const langType language)
 		else															\
 			commentChars##PREPOS##POS = defaultCommentChar##PREPOS##POS; \
 		return true;													\
-	}
+	} END_DEF(asmSetCommentChars##PREPOS##POS)
 
-defineCommentCharSetter(At, BOL)
-defineCommentCharSetter(In, MOL)
+defineCommentCharSetter(At, BOL);
+defineCommentCharSetter(In, MOL);
 
 static bool asmSetExtraLinesepChars(const langType language CTAGS_ATTR_UNUSED,
 									const char *optname CTAGS_ATTR_UNUSED, const char *arg)

--- a/parsers/automake.c
+++ b/parsers/automake.c
@@ -166,7 +166,7 @@ static const char *skipPrefix(const char *name)
 	size_t prefix_len;
 
 	/* Drop "dist_" in "dist_data_DATA" */
-	const static struct sPrefix obj_prefixlist [] = {
+	static const struct sPrefix obj_prefixlist [] = {
 		{ "dist_",    5 },
 		{ "nodist_",  7 },
 		{ "nobase_",  7 },

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -2009,7 +2009,7 @@ static bool buildMacroInfoFromTagEntry (int corkIndex,
 	return true;
 }
 
-extern cppMacroInfo * cppFindMacroFromSymtab (const char *const name)
+static cppMacroInfo * cppFindMacroFromSymtab (const char *const name)
 {
 	cppMacroInfo *info = NULL;
 	foreachEntriesInScope (CORK_NIL, name, buildMacroInfoFromTagEntry, &info);

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -512,7 +512,7 @@ extern void cppUngetc (const int c)
 	Cpp.ungetDataSize++;
 }
 
-int cppUngetBufferSize()
+int cppUngetBufferSize(void)
 {
 	return Cpp.ungetBufferSize;
 }
@@ -1426,7 +1426,7 @@ static int skipToEndOfCxxRawLiteralString (void)
  *  special character to symbolically represent a generic character.
  *  Also detects Vera numbers that include a base specifier (ie. 'b1010).
  */
-static int skipToEndOfChar ()
+static int skipToEndOfChar (void)
 {
 	int c;
 	int count = 0, veraBase = '\0';

--- a/parsers/cpreprocessor.h
+++ b/parsers/cpreprocessor.h
@@ -95,7 +95,7 @@ extern void cppTerminate (void);
 extern void cppBeginStatement (void);
 extern void cppEndStatement (void);
 extern void cppUngetc (const int c);
-extern int cppUngetBufferSize();
+extern int cppUngetBufferSize(void);
 extern void cppUngetString(const char * string,int len);
 extern int cppGetc (void);
 extern const vString * cppGetLastCharOrStringContents (void);

--- a/parsers/cxx/cxx_debug.c
+++ b/parsers/cxx/cxx_debug.c
@@ -123,11 +123,11 @@ typedef void (* cxxDebugDumpCommonFunc)(void *,
 										struct circularRefChecker *,
 										struct circularRefChecker *,
 										bool);
-void cxxDebugDumpCommon (void *data,
-						 void (* func)(void *,
-									   struct circularRefChecker *,
-									   struct circularRefChecker *,
-									   bool))
+static void cxxDebugDumpCommon (void *data,
+								void (* func)(void *,
+											  struct circularRefChecker *,
+											  struct circularRefChecker *,
+											  bool))
 {
 	static struct circularRefChecker *pTokenChecker;
 	static struct circularRefChecker *pChainChecker;

--- a/parsers/cxx/cxx_tag.h
+++ b/parsers/cxx/cxx_tag.h
@@ -188,7 +188,7 @@ void cxxTagSetCorkQueueField(
 	);
 
 // Handle the template-related parts of the tag (class, function, variable)
-void cxxTagHandleTemplateFields();
+void cxxTagHandleTemplateFields(void);
 
 // Commit the composed tag. Must follow a successful cxxTagBegin() call.
 // Returns the index of the tag in the cork queue.

--- a/parsers/gdscript.c
+++ b/parsers/gdscript.c
@@ -139,7 +139,7 @@ static const keywordTable GDScriptKeywordTable[] = {
 
 };
 
-const static struct keywordGroup modifierKeywords = {
+static const struct keywordGroup modifierKeywords = {
 	.value = KEYWORD_modifier,
 	.addingUnlessExisting = false,
 	.keywords = {

--- a/parsers/perl.c
+++ b/parsers/perl.c
@@ -73,7 +73,7 @@ struct hereDocMarkerManager {
 *   FUNCTION DEFINITIONS
 */
 
-static void notifyEnteringPod ()
+static void notifyEnteringPod (void)
 {
 	subparser *sub;
 
@@ -89,7 +89,7 @@ static void notifyEnteringPod ()
 	}
 }
 
-static void notifyLeavingPod ()
+static void notifyLeavingPod (void)
 {
 	subparser *sub;
 

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -166,7 +166,7 @@ static const keywordTable PythonKeywordTable[] = {
 };
 
 /* Taken from https://docs.python.org/3/reference/lexical_analysis.html#keywords */
-const static struct keywordGroup PythonRestKeywords = {
+static const struct keywordGroup PythonRestKeywords = {
 	.value = KEYWORD_REST,
 	.addingUnlessExisting = true,
 	.keywords = {

--- a/parsers/sql.c
+++ b/parsers/sql.c
@@ -365,7 +365,7 @@ static const keywordTable SqlKeywordTable [] = {
 	{ "without",						KEYWORD_without			      },
 };
 
-const static struct keywordGroup predefinedInquiryDirective = {
+static const struct keywordGroup predefinedInquiryDirective = {
 	.value = KEYWORD_inquiry_directive,
 	.addingUnlessExisting = false,
 	.keywords = {

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -302,7 +302,7 @@ static ptrArray *tagContents;
 static fieldDefinition *fieldTable = NULL;
 
 // IEEE Std 1364-2005 LRM, Appendix B "List of Keywords"
-const static struct keywordGroup verilogKeywords = {
+static const struct keywordGroup verilogKeywords = {
 	.value = K_IGNORE,
 	.addingUnlessExisting = true,
 	.keywords = {
@@ -329,7 +329,7 @@ const static struct keywordGroup verilogKeywords = {
 	},
 };
 // IEEE Std 1800-2017 LRM, Annex B "Keywords"
-const static struct keywordGroup systemVerilogKeywords = {
+static const struct keywordGroup systemVerilogKeywords = {
 	.value = K_IGNORE,
 	.addingUnlessExisting = true,
 	.keywords = {
@@ -379,7 +379,7 @@ const static struct keywordGroup systemVerilogKeywords = {
 };
 
 // IEEE Std 1364-2005 LRM, "19. Compiler directives"
-const static struct keywordGroup verilogDirectives = {
+static const struct keywordGroup verilogDirectives = {
 	.value = K_DIRECTIVE,
 	.addingUnlessExisting = true,
 	.keywords = {
@@ -392,7 +392,7 @@ const static struct keywordGroup verilogDirectives = {
 };
 
 // IEEE Std 1800-2017 LRM, "22. Compiler directives"
-const static struct keywordGroup systemVerilogDirectives = {
+static const struct keywordGroup systemVerilogDirectives = {
 	.value = K_DIRECTIVE,
 	.addingUnlessExisting = true,
 	.keywords = {

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -940,7 +940,7 @@ static void createContext (verilogKind kind, vString* const name)
 	}
 }
 
-static void dropContext ()
+static void dropContext (void)
 {
 	verbose ("Dropping context %s\n", vStringValue (currentContext->name));
 	currentContext = popToken (currentContext);

--- a/parsers/yaml.c
+++ b/parsers/yaml.c
@@ -358,7 +358,7 @@ extern void ypathHandleToken (yamlSubparser *yaml, yaml_token_t *token, int stat
 }
 
 #ifdef DO_TRACING
-extern void ypathPrintTypeStack0(struct ypathTypeStack *stack)
+static void ypathPrintTypeStack0(struct ypathTypeStack *stack)
 {
 	if (!stack)
 	{


### PR DESCRIPTION
This fixes various mostly harmless warnings from GCC.  This is not everything yet, and most of it is trivial, but it still gets rid of some and helps tidy code a little.