### PR TITLE
xmlLineNumbersDefault and xmlParseMemory functions are declared in libxml/parser.h, which in turn was not included in main/lxpath.c, adding it to prevent compiler warnings and errors.

### DIFF
--- a/main/lxpath.c
+++ b/main/lxpath.c
@@ -20,6 +20,7 @@
 #include "xtag.h"
 
 #ifdef HAVE_LIBXML
+#include <libxml/parser.h>
 #include <libxml/xpath.h>
 #include <libxml/tree.h>
 


### PR DESCRIPTION
https://github.com/universal-ctags/ctags/issues/3851