### PR TITLE
xmlLineNumbersDefault and xmlParseMemory functions are declared in libxml/parser.h, which in turn was not included in main/selectors.c, adding it to prevent compiler warnings and errors.

### DIFF
--- a/main/selectors.c
+++ b/main/selectors.c
@@ -358,7 +358,7 @@ selectFortranOrForthByForthMarker (MIO *input,
 }
 
 #ifdef HAVE_LIBXML
-
+#include <libxml/parser.h>
 #include <libxml/xpath.h>
 #include <libxml/tree.h>
 


### PR DESCRIPTION
https://github.com/universal-ctags/ctags/issues/3851