### PR TITLE
GitHub Actions: update testing-mac.yml

### DIFF
--- a/.github/workflows/testing-mac.yml
+++ b/.github/workflows/testing-mac.yml
@@ -24,7 +24,7 @@ jobs:
     # NOTE: DO NOT try to install python3 package via brew, it has already been included in macos-xx runner images
     # https://github.com/actions/runner-images/blob/macos-13/20231002.1/images/macos/macos-13-Readme.md#python
 
-    - run: brew install automake pkg-config jansson libyaml pcre2
+    - run: brew install automake pkg-config jansson libyaml libxml2 pcre2
 
     - run: pip3 install docutils
 


### PR DESCRIPTION
I have forgotten why leave the libxml2 package not installed. maybe because libxml2 depends on python@3.10, python@3.11, python@3.12 at the same time. It may break the environment.

https://github.com/Homebrew/homebrew-core/blob/master/Formula/lib/libxml2.rb