### PR TITLE
GitHub Actions: enable BSD workflows

### DIFF
--- a/.github/workflows/testing-freebsd.yml
+++ b/.github/workflows/testing-freebsd.yml
@@ -1,0 +1,46 @@
+name: run units target on FreeBSD
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  testing:
+    runs-on: macos-12
+
+    strategy:
+      fail-fast: false
+      matrix:
+        freebsd-version: [12,13]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/cache@v3
+      with:
+        path: ~/.vagrant.d/boxes
+        key: vagrant-generic-freebsd-${{ matrix.freebsd-version }}
+        restore-keys: |
+          vagrant-generic-freebsd-${{ matrix.freebsd-version }}
+
+    # https://app.vagrantup.com/boxes/search?utf8=%E2%9C%93&sort=downloads&provider=&q=freebsd
+    # https://github.com/leleliu008/github-actions-vagrant
+    - uses: leleliu008/github-actions-vagrant@v2
+      with:
+        mem: 2048
+        box: generic/freebsd${{ matrix.freebsd-version }}
+        log: warn
+        run: |
+          run pkg install -y automake pkgconf gmake python3
+          run freebsd-version
+          run cc --version
+          run ./autogen.sh
+          run ./configure --prefix=/usr
+          run gmake
+          run gmake install
+          run file ctags
+          run ctags --version
+          run gmake check CI=gha+vagrant+freebsd
+          run gmake roundtrip CI=gha+vagrant+freebsd

--- a/.github/workflows/testing-netbsd.yml
+++ b/.github/workflows/testing-netbsd.yml
@@ -1,0 +1,41 @@
+name: run units target on NetBSD
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  testing:
+    runs-on: macos-12
+    
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/cache@v3
+      with:
+        path: ~/.vagrant.d/boxes
+        key: vagrant-generic-netbsd-9
+        restore-keys: |
+          vagrant-generic-netbsd-9
+
+    - uses: leleliu008/github-actions-vagrant@v2
+      with:
+        mem: 2048
+        box: generic/netbsd9
+        log: warn
+        run: |
+          run sudo pkgin -y install mozilla-rootcerts automake autoconf pkg-config gmake
+
+          run cc --version
+
+          run ./autogen.sh
+          run ./configure --prefix=/usr
+          run gmake
+          run sudo gmake install
+          run file /usr/bin/ctags
+          run ctags --version
+          # bugs to fix
+          #run make check CI=gha+vagrant+netbsd
+          run gmake roundtrip CI=gha+vagrant+netbsd

--- a/.github/workflows/testing-openbsd.yml
+++ b/.github/workflows/testing-openbsd.yml
@@ -1,0 +1,50 @@
+name: run units target on OpenBSD
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  testing:
+    runs-on: macos-12
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/cache@v3
+      with:
+        path: ~/.vagrant.d/boxes
+        key: vagrant-generic-openbsd-7
+        restore-keys: |
+          vagrant-generic-openbsd-7
+
+    - uses: leleliu008/github-actions-vagrant@v2
+      with:
+        mem: 2048
+        box: generic/openbsd7
+        log: warn
+        run: |
+          export AUTOCONF_VERSION=2.69
+          export AUTOMAKE_VERSION=1.16
+              
+          export CFLAGS='-I/usr/local/include -L/usr/local/lib'
+              
+          if [ ! -f /usr/local/lib/libiconv.so ] ; then
+            sudo ln -s /usr/local/lib/libiconv.so.* /usr/local/lib/libiconv.so
+          fi
+              
+          run sudo pkg_add automake%1.16 gmake
+
+          run cc --version
+            
+          run ./autogen.sh
+          run ./configure --prefix=/usr
+          run gmake
+          run sudo gmake install
+          run file /usr/bin/ctags
+          run ctags --version
+          # bugs to fix
+          #run make check CI=gha+vagrant+openbsd
+          run gmake roundtrip CI=gha+vagrant+openbsd


### PR DESCRIPTION
We disabled BSD workflows due to the issue
https://github.com/actions/runner-images/issues/8730, which in turn had been fixed, so let's enable these BSD workflows