### PR TITLE
buildsys: improve cross-build for freebsd and openbsd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,8 +45,10 @@ case $host in
         fi
         ;;
     *freebsd*|*openbsd*)
-        # https://github.com/universal-ctags/ctags/issues/3338
-        export LDFLAGS="$LDFLAGS -L/usr/local/lib"
+        if test "$cross_compiling" = "no" ; then
+            # https://github.com/universal-ctags/ctags/issues/3338
+            export LDFLAGS="$LDFLAGS -L/usr/local/lib"
+        fi
         ;;
 esac
 


### PR DESCRIPTION
on `FreeBSD` and `OpenBSD`, the most 3rd-party libs are installed in `/usr/local/lib` directory, we need to manully add `-L/usr/local/lib` to `LDFLAGS` only when do native build.