### PR TITLE
nestlevel: Fix user data alignment

### DIFF
--- a/main/nestlevel.h
+++ b/main/nestlevel.h
@@ -26,7 +26,8 @@ typedef struct NestingLevels NestingLevels;
 struct NestingLevel
 {
 	int corkIndex;
-	char userData [];
+	/* user data is allocated at the end of this struct (possibly with some
+	 * offset for alignment), get it with nestingLevelGetUserData() */
 };
 
 struct NestingLevels


### PR DESCRIPTION
We need to align the user data properly not to trigger undefined behavior, which even apparently crashes on SPARC.

As `NestingLevels::levels` is actually a single allocation for all levels and their user data mapped as `[NL0|UD0|NL1|UD1|...]` (where NL is a NestingLevel, and UD a user data), we need to align twice, as we need every `NL*` and every `UD*` to align properly.

Here we align everything to `2*sizeof(size_t)`, which is a logic borrowed from GLib, which seems to have borrowed the value from glibc. This is pretty conservative in our case, because actually `NL*`s only need aligning to `int`'s requirements currently, which on some architectures is 4, not 16; but it's trickier to implement (and actually impossible with the current API) as we'd need to compute the actual alignment for each level taking into account it's position in the overall memory region to still align `UD*`s to a conservative value.
Also, having all NL+UD group at the same size makes things a bit simpler for debugging, I guess.

We make sure to only add alignment padding manually for cases where there's actually some user data, not to waste memory needlessly for the common case where `sizeof(UD)` is 0, and thus where we can merely align to `sizeof(NL)` -- which C does for us already.

Note that currently only the Ruby parser is affected, as it's the only current consumer of nesting level user data.

Fixes #3881.