### PR TITLE
Ruby:  optimize the parser by reducing the numbers of calling strlen

### DIFF
--- a/main/read.c
+++ b/main/read.c
@@ -1075,16 +1075,23 @@ extern int skipToCharacterInInputFile2 (int c0, int c1)
  *  the terminating newline. A NULL return value means that all lines in the
  *  file have been read and we are at the end of file.
  */
-extern const unsigned char *readLineFromInputFile (void)
+extern const unsigned char *readLineFromInputFileWithLength (size_t *length)
 {
 	vString* const line = iFileGetLine (true);
 	const unsigned char* result = NULL;
 	if (line != NULL)
 	{
 		result = (const unsigned char*) vStringValue (line);
+		*length = vStringLength (line);
 		DebugStatement ( debugPrintf (DEBUG_READ, "%s\n", result); )
 	}
 	return result;
+}
+
+extern const unsigned char *readLineFromInputFile (void)
+{
+	size_t dummy;
+	return readLineFromInputFileWithLength(&dummy);
 }
 
 /*

--- a/main/read.h
+++ b/main/read.h
@@ -54,6 +54,7 @@ extern int skipToCharacterInInputFile (int c);
 extern int skipToCharacterInInputFile2 (int c0, int c1);
 extern void ungetcToInputFile (int c);
 extern const unsigned char *readLineFromInputFile (void);
+extern const unsigned char *readLineFromInputFileWithLength (size_t *length);
 
 extern unsigned long getSourceLineNumber (void);
 

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -208,7 +208,7 @@ extern bool rubyCanMatchKeyword (const unsigned char** s, const char* literal)
  */
 #define vStringTruncateMaybe(VS,LEN) if (VS) vStringTruncate ((VS), (LEN))
 
-extern bool canMatchKeywordWithAssignFull (const unsigned char** s, const char* literal, vString *assignee)
+static bool canMatchKeywordWithAssignFull (const unsigned char** s, const char* literal, vString *assignee)
 {
 	const unsigned char* original_pos = *s;
 	size_t original_len;


### PR DESCRIPTION
About 20% faster with this change.
Eventually, we have to switch to a token-based parser.
This is just a way to extend the life of the current parser.

Without this change:

```
[yamato@dev64]~/var/codebase% for x in Ruby ; do ./codebase ctags --ctags ~/var/ctags-github/ctags $x; done
version: e3439eb0
features: +wildcards +regex +iconv +option-directory +xpath +json +interactive +sandbox +yaml +packcc +optscript +pcre2
log: results/e3439eb0,Ruby................,..........,time......,default...,2024-01-13-07:37:44.log
tagsoutput: /dev/null
cmdline: + /home/yamato/var/ctags-github/ctags --quiet --options=NONE --sort=no --options=profile.d/maps --totals=yes --languages=Ruby -o - -R code/katello code/metasploit-framework code/puppet code/rails code/redmine code/rspec-core code/ruby code/theforeman-puppet code/vagrant
20744 files, 2852961 lines (88272 kB) scanned in 4.0 seconds (22230 kB/s)
185632 tags added to tag file

real	0m4.171s
user	0m3.849s
sys	0m0.298s
+ set +x
```
With this change:

```
[yamato@dev64]~/var/codebase% for x in Ruby ; do ./codebase ctags --ctags ~/var/ctags-github/ctags $x; done
version: daa583dd
features: +wildcards +regex +iconv +option-directory +xpath +json +interactive +sandbox +yaml +packcc +optscript +pcre2
log: results/daa583dd,Ruby................,..........,time......,default...,2024-01-13-07:38:23.log
tagsoutput: /dev/null
cmdline: + /home/yamato/var/ctags-github/ctags --quiet --options=NONE --sort=no --options=profile.d/maps --totals=yes --languages=Ruby -o - -R code/katello code/metasploit-framework code/puppet code/rails code/redmine code/rspec-core code/ruby code/theforeman-puppet code/vagrant
20744 files, 2852961 lines (88272 kB) scanned in 3.3 seconds (26730 kB/s)
185632 tags added to tag file

real	0m3.492s
user	0m3.141s
sys	0m0.330s
+ set +x
```