### PR TITLE
 Make: fix wrong end fields for targets having macros on the same line 

### DIFF
--- a/Units/parser-make.r/same-line.d/args.ctags
+++ b/Units/parser-make.r/same-line.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--fields=+ne

--- a/Units/parser-make.r/same-line.d/expected.tags
+++ b/Units/parser-make.r/same-line.d/expected.tags
@@ -1,0 +1,2 @@
+target	input.mak	/^target: macro = 1$/;"	t	line:2	end:2
+macro	input.mak	/^target: macro = 1$/;"	m	line:2

--- a/Units/parser-make.r/same-line.d/input.mak
+++ b/Units/parser-make.r/same-line.d/input.mak
@@ -1,0 +1,2 @@
+#
+target: macro = 1

--- a/main/entry.c
+++ b/main/entry.c
@@ -1625,7 +1625,7 @@ extern void setTagEndLine(tagEntryInfo *tag, unsigned long endLine)
 	{
 		error (WARNING,
 			   "given end line (%lu) for the tag (%s) in the file (%s) is smaller than its start line: %lu",
-			   tag->lineNumber,
+			   endLine,
 			   tag->name,
 			   tag->inputFileName,
 			   tag->lineNumber);

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -221,6 +221,20 @@ static void endTargets (intArray *targets, unsigned long lnum)
 	intArrayClear (targets);
 }
 
+static bool isTheLastTargetOnTheSameLine (intArray *current_targets,
+										  unsigned long line)
+{
+	if (!intArrayIsEmpty (current_targets))
+	{
+		int r = intArrayLast (current_targets);
+		tagEntryInfo *e = getEntryInCorkQueue (r);
+		if (e && e->lineNumber == line)
+			return true;
+	}
+
+	return false;
+}
+
 static void findMakeTags (void)
 {
 	stringList *identifiers = stringListNew ();
@@ -300,7 +314,10 @@ static void findMakeTags (void)
 			newMacro (stringListItem (identifiers, 0), false, appending);
 
 			in_value = true;
-			endTargets (current_targets, getInputLineNumber () - 1);
+			unsigned long curline = getInputLineNumber ();
+			unsigned long adj = isTheLastTargetOnTheSameLine (current_targets,
+															  curline)? 0: 1;
+			endTargets (current_targets, curline - adj);
 			appending = false;
 		}
 		else if (variable_possible && isIdentifier (c))


### PR DESCRIPTION
For the input:

  #
  y: x = 1

ctags with the original code warns:

  ctags: Warning: given end line (1) for the tag (y) in the file (Makefile) is smaller than its start line: 2