### PR TITLE
lex: add support for implementation blocks of conditions

### DIFF
--- a/Units/parser-lex.r/simple-lex.d/expected.tags
+++ b/Units/parser-lex.r/simple-lex.d/expected.tags
@@ -39,6 +39,7 @@ swap_spec	input.l	/^swap_spec em$/;"	r	language:LEX
 font_spec	input.l	/^font_spec (rm|bf|{italic_spec}|tt|{swap_spec}|mediumseries|{normal_spec})$/;"	r	language:LEX
 primitive	input.l	/^primitive \\\\(above|advance|catcode|chardef|closein|closeout|copy|count|countdef|cr|crcr|csname/;"	r	language:LEX
 symbol	input.l	/^symbol ("$"("\\\\"{atoz}+|.)"$"|"\\\\#"|"\\\\$"|"\\\\%"|"\\\\ref")$/;"	r	language:LEX
+B_ENVIRONMENT	input.l	/^<B_ENVIRONMENT> {$/;"	g	language:LEX
 YY_SKIP_YYWRAP	input.l	/^#define YY_SKIP_YYWRAP$/;"	d	language:C	file:
 yywrap	input.l	/^int yywrap() { return 1; }$/;"	f	language:C	typeref:typename:int
 GROUP_STACK_SIZE	input.l	/^#define GROUP_STACK_SIZE /;"	d	language:C	file:

--- a/Units/parser-lex.r/simple-lex.d/input.l
+++ b/Units/parser-lex.r/simple-lex.d/input.l
@@ -497,8 +497,9 @@ symbol ("$"("\\"{atoz}+|.)"$"|"\\#"|"\\$"|"\\%"|"\\ref")
     ++warn_count;
  }}
 
-<B_ENVIRONMENT>[^\}\n]+ { 
- {
+<B_ENVIRONMENT> {
+
+[^\}\n]+ {
     if (strcmp( yytext, "verbatim" ) == 0 )
 	{
 	 input();

--- a/optlib/lex.c
+++ b/optlib/lex.c
@@ -56,11 +56,14 @@ static void initializeLEXParser (const langType language)
 	                               "^.",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "rulesec",
-	                               "^[^%]+",
+	                               "^[^%<]+",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "rulesec",
 	                               "^%%",
 	                               "", "", "{tjump=usercode}{_guest=C,0end,}", NULL);
+	addLanguageTagMultiTableRegex (language, "rulesec",
+	                               "^<([_a-zA-Z][_a-zA-Z0-9]*)>[ \t]*\\{[ \t]*\n",
+	                               "\\1", "g", "", NULL);
 	addLanguageTagMultiTableRegex (language, "rulesec",
 	                               "^.",
 	                               "", "", "", NULL);
@@ -99,7 +102,10 @@ extern parserDefinition* LEXParser (void)
 		  true, 'r', "regex", "named regular expression",
 		},
 		{
-		  true, 'c', "cond", "start or exclusive condition",
+		  true, 'c', "cond", "definition of start or exclusive condition",
+		},
+		{
+		  true, 'g', "group", "grouping of start or exclusive condition rules",
 		},
 	};
 	static selectLanguage selectors[] = { selectLispOrLEXByLEXMarker, NULL };

--- a/optlib/lex.ctags
+++ b/optlib/lex.ctags
@@ -43,7 +43,8 @@
 #
 
 --kinddef-LEX=r,regex,named regular expression
---kinddef-LEX=c,cond,start or exclusive condition
+--kinddef-LEX=c,cond,definition of start or exclusive condition
+--kinddef-LEX=g,group,grouping of start or exclusive condition rules
 
 #
 # Table declarations
@@ -67,8 +68,9 @@
 --_mtable-regex-LEX=codeblock/%\}//{tleave}{_guest=,,0start}
 --_mtable-regex-LEX=codeblock/.//
 
---_mtable-regex-LEX=rulesec/[^%]+//
+--_mtable-regex-LEX=rulesec/[^%<]+//
 --_mtable-regex-LEX=rulesec/%%//{tjump=usercode}{_guest=C,0end,}
+--_mtable-regex-LEX=rulesec/<([_a-zA-Z][_a-zA-Z0-9]*)>[ \t]*\{[ \t]*\n/\1/g/
 --_mtable-regex-LEX=rulesec/.//
 
 --_mtable-regex-LEX=usercode/.+//{_guest=,,0end}


### PR DESCRIPTION
In some lexers, all the rules for a condition are grouped together as: <COND>{
...
}

It is useful to be able to jump to these blocks.