### PR TITLE
LEX: make reference tags for the conditions used for making groups

### DIFF
--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -71,6 +71,7 @@ Julia          n/module          imported           on      loaded by "import"
 Julia          n/module          namespace          on      only some symbols in it are imported
 Julia          n/module          used               on      loaded by "using"
 Kconfig        k/kconfig         source             on      kconfig file loaded with source directive
+LEX            c/cond            grouping           on       conditions used for grouping of start or exclusive condition rules
 LdScript       i/inputSection    destination        on      specified as the destination of code and data
 LdScript       i/inputSection    discarded          on      discarded when linking
 LdScript       i/inputSection    mapped             on      mapped to output section
@@ -208,6 +209,7 @@ Julia          n/module          imported           on      loaded by "import"
 Julia          n/module          namespace          on      only some symbols in it are imported
 Julia          n/module          used               on      loaded by "using"
 Kconfig        k/kconfig         source             on      kconfig file loaded with source directive
+LEX            c/cond            grouping           on       conditions used for grouping of start or exclusive condition rules
 LdScript       i/inputSection    destination        on      specified as the destination of code and data
 LdScript       i/inputSection    discarded          on      discarded when linking
 LdScript       i/inputSection    mapped             on      mapped to output section

--- a/Units/parser-lex.r/simple-lex.d/args.ctags
+++ b/Units/parser-lex.r/simple-lex.d/args.ctags
@@ -1,3 +1,3 @@
 --sort=no
---fields=+l
---extras=+g
+--fields=+lr
+--extras=+gr

--- a/Units/parser-lex.r/simple-lex.d/expected.tags
+++ b/Units/parser-lex.r/simple-lex.d/expected.tags
@@ -1,88 +1,92 @@
-B_ENVIRONMENT	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX
-E_ENVIRONMENT	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX
-VERBATIM	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX
-INCLUDE	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX
-MATH	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX
-COMMENT	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX
-VERB	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX
-DEF	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX
-AFTER_DISPLAY	input.l	/^%x AFTER_DISPLAY ENV_DEF ICOR GETICOR$/;"	c	language:LEX
-ENV_DEF	input.l	/^%x AFTER_DISPLAY ENV_DEF ICOR GETICOR$/;"	c	language:LEX
-ICOR	input.l	/^%x AFTER_DISPLAY ENV_DEF ICOR GETICOR$/;"	c	language:LEX
-GETICOR	input.l	/^%x AFTER_DISPLAY ENV_DEF ICOR GETICOR$/;"	c	language:LEX
-START	input.l	/^%s START$/;"	c	language:LEX
-b_group	input.l	/^b_group ("{"|\\\\bgroup)$/;"	r	language:LEX
-e_group	input.l	/^e_group ("}"|\\\\egroup)$/;"	r	language:LEX
-b_math	input.l	/^b_math \\\\\\($/;"	r	language:LEX
-e_math	input.l	/^e_math \\\\\\)$/;"	r	language:LEX
-math	input.l	/^math \\\$$/;"	r	language:LEX
-b_display	input.l	/^b_display \\\\\\[$/;"	r	language:LEX
-e_display	input.l	/^e_display \\\\\\]$/;"	r	language:LEX
-display	input.l	/^display \\$\\\$$/;"	r	language:LEX
-par	input.l	/^par ([ \\t]*\\n[ \\t]*\\n[ \\t\\n]*)$/;"	r	language:LEX
-non_par_ws	input.l	/^non_par_ws ([ \\t]+\\n?[ \\t]*|[ \\t]*\\n[ \\t]*|[ \\t]*\\n?[ \\t]+)$/;"	r	language:LEX
-ws	input.l	/^ws [ \\n\\t](%[^\\n]\\n)*$/;"	r	language:LEX
-space	input.l	/^space ({ws}|\\~|\\\\space)$/;"	r	language:LEX
-hard_space	input.l	/^hard_space (\\~|\\\\space)$/;"	r	language:LEX
-u_letter	input.l	/^u_letter [A-ZÆØÅ] $/;"	r	language:LEX
-l_letter	input.l	/^l_letter [a-zæøå] $/;"	r	language:LEX
-punct	input.l	/^punct [\\!\\.\\?]$/;"	r	language:LEX
-atoz	input.l	/^atoz [a-zA-Z]$/;"	r	language:LEX
-letter	input.l	/^letter [A-ZÆØÅa-zæøå]$/;"	r	language:LEX
-c_bin	input.l	/^c_bin ("-"|"+"|"\\\\cdot"|"\\\\oplus"|"\\\\otimes"|"\\\\times")$/;"	r	language:LEX
-l_bin	input.l	/^l_bin (",")$/;"	r	language:LEX
-general_abbrev	input.l	/^general_abbrev {letter}+{punct}$/;"	r	language:LEX
-non_abbrev	input.l	/^non_abbrev {u_letter}{u_letter}+{punct}$/;"	r	language:LEX
-italic_spec	input.l	/^italic_spec (sl|it)$/;"	r	language:LEX
-normal_spec	input.l	/^normal_spec normalshape$/;"	r	language:LEX
-swap_spec	input.l	/^swap_spec em$/;"	r	language:LEX
-font_spec	input.l	/^font_spec (rm|bf|{italic_spec}|tt|{swap_spec}|mediumseries|{normal_spec})$/;"	r	language:LEX
-primitive	input.l	/^primitive \\\\(above|advance|catcode|chardef|closein|closeout|copy|count|countdef|cr|crcr|csname/;"	r	language:LEX
-symbol	input.l	/^symbol ("$"("\\\\"{atoz}+|.)"$"|"\\\\#"|"\\\\$"|"\\\\%"|"\\\\ref")$/;"	r	language:LEX
-YY_SKIP_YYWRAP	input.l	/^#define YY_SKIP_YYWRAP$/;"	d	language:C	file:
-yywrap	input.l	/^int yywrap() { return 1; }$/;"	f	language:C	typeref:typename:int
-GROUP_STACK_SIZE	input.l	/^#define GROUP_STACK_SIZE /;"	d	language:C	file:
-INPUT_STACK_SIZE	input.l	/^#define INPUT_STACK_SIZE /;"	d	language:C	file:
-PROGNAME	input.l	/^#define PROGNAME /;"	d	language:C	file:
-CG_NAME	input.l	/^#define CG_NAME /;"	d	language:C	file:
-CG_TYPE	input.l	/^#define CG_TYPE /;"	d	language:C	file:
-CG_LINE	input.l	/^#define CG_LINE /;"	d	language:C	file:
-CG_ITALIC	input.l	/^#define CG_ITALIC /;"	d	language:C	file:
-CG_FILE	input.l	/^#define CG_FILE /;"	d	language:C	file:
-returnval	input.l	/^char returnval[100];$/;"	v	language:C	typeref:typename:char[100]
-line_count	input.l	/^int line_count = 1;$/;"	v	language:C	typeref:typename:int
-warn_count	input.l	/^int warn_count = 0;$/;"	v	language:C	typeref:typename:int
-file_name	input.l	/^char *file_name;$/;"	v	language:C	typeref:typename:char *
-verb_char	input.l	/^char verb_char;$/;"	v	language:C	typeref:typename:char
-tex_group	input.l	/^typedef struct tex_group $/;"	s	language:C	file:
-s_name	input.l	/^    unsigned char *s_name;$/;"	m	language:C	struct:tex_group	typeref:typename:unsigned char *	file:
-s_type	input.l	/^    int s_type;$/;"	m	language:C	struct:tex_group	typeref:typename:int	file:
-s_line	input.l	/^    int s_line;$/;"	m	language:C	struct:tex_group	typeref:typename:int	file:
-italic	input.l	/^    int italic;$/;"	m	language:C	struct:tex_group	typeref:typename:int	file:
-s_file	input.l	/^    char *s_file; $/;"	m	language:C	struct:tex_group	typeref:typename:char *	file:
-tex_group	input.l	/^ } tex_group;$/;"	t	language:C	typeref:struct:tex_group	file:
-gstack	input.l	/^tex_group *gstack;$/;"	v	language:C	typeref:typename:tex_group *
-gstack_size	input.l	/^int gstack_size = GROUP_STACK_SIZE;$/;"	v	language:C	typeref:typename:int
-gstackp	input.l	/^int gstackp = 0;$/;"	v	language:C	typeref:typename:int
-input_	input.l	/^typedef struct input_ $/;"	s	language:C	file:
-stream	input.l	/^    YY_BUFFER_STATE stream;$/;"	m	language:C	struct:input_	typeref:typename:YY_BUFFER_STATE	file:
-name	input.l	/^    char *name;$/;"	m	language:C	struct:input_	typeref:typename:char *	file:
-linenum	input.l	/^    int linenum;$/;"	m	language:C	struct:input_	typeref:typename:int	file:
-input_	input.l	/^ } input_;$/;"	t	language:C	typeref:struct:input_	file:
-istack	input.l	/^input_ *istack;$/;"	v	language:C	typeref:typename:input_ *
-istack_size	input.l	/^int istack_size = INPUT_STACK_SIZE;$/;"	v	language:C	typeref:typename:int
-istackp	input.l	/^int istackp = 0;$/;"	v	language:C	typeref:typename:int
-def_count	input.l	/^int def_count = 0;$/;"	v	language:C	typeref:typename:int
-main	input.l	/^int main( argc, argv )$/;"	f	language:C
-strstr	input.l	/^strstr(string, substring)$/;"	f	language:C
-push	input.l	/^void push(p_name, p_type, p_line)$/;"	f	language:C
-input_file	input.l	/^void input_file(file_nam)$/;"	f	language:C
-pop	input.l	/^void pop()$/;"	f	language:C	typeref:typename:void
-bg_command	input.l	/^char *bg_command(name)$/;"	f	language:C
-eg_command	input.l	/^char *eg_command(name,type)$/;"	f	language:C
-g_checkend	input.l	/^void g_checkend(n)$/;"	f	language:C
-e_checkend	input.l	/^void e_checkend(n, name)$/;"	f	language:C
-f_checkend	input.l	/^void f_checkend(name)$/;"	f	language:C
-print_bad_match	input.l	/^void print_bad_match(end_command,type)$/;"	f	language:C
-check_top_level_end	input.l	/^int check_top_level_end(end_command,type)$/;"	f	language:C
-linecount	input.l	/^void linecount()$/;"	f	language:C	typeref:typename:void
+B_ENVIRONMENT	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX	roles:def
+E_ENVIRONMENT	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX	roles:def
+VERBATIM	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX	roles:def
+INCLUDE	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX	roles:def
+MATH	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX	roles:def
+COMMENT	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX	roles:def
+VERB	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX	roles:def
+DEF	input.l	/^%x B_ENVIRONMENT E_ENVIRONMENT VERBATIM INCLUDE MATH COMMENT VERB DEF$/;"	c	language:LEX	roles:def
+AFTER_DISPLAY	input.l	/^%x AFTER_DISPLAY ENV_DEF ICOR GETICOR$/;"	c	language:LEX	roles:def
+ENV_DEF	input.l	/^%x AFTER_DISPLAY ENV_DEF ICOR GETICOR$/;"	c	language:LEX	roles:def
+ICOR	input.l	/^%x AFTER_DISPLAY ENV_DEF ICOR GETICOR$/;"	c	language:LEX	roles:def
+GETICOR	input.l	/^%x AFTER_DISPLAY ENV_DEF ICOR GETICOR$/;"	c	language:LEX	roles:def
+START	input.l	/^%s START$/;"	c	language:LEX	roles:def
+b_group	input.l	/^b_group ("{"|\\\\bgroup)$/;"	r	language:LEX	roles:def
+e_group	input.l	/^e_group ("}"|\\\\egroup)$/;"	r	language:LEX	roles:def
+b_math	input.l	/^b_math \\\\\\($/;"	r	language:LEX	roles:def
+e_math	input.l	/^e_math \\\\\\)$/;"	r	language:LEX	roles:def
+math	input.l	/^math \\\$$/;"	r	language:LEX	roles:def
+b_display	input.l	/^b_display \\\\\\[$/;"	r	language:LEX	roles:def
+e_display	input.l	/^e_display \\\\\\]$/;"	r	language:LEX	roles:def
+display	input.l	/^display \\$\\\$$/;"	r	language:LEX	roles:def
+par	input.l	/^par ([ \\t]*\\n[ \\t]*\\n[ \\t\\n]*)$/;"	r	language:LEX	roles:def
+non_par_ws	input.l	/^non_par_ws ([ \\t]+\\n?[ \\t]*|[ \\t]*\\n[ \\t]*|[ \\t]*\\n?[ \\t]+)$/;"	r	language:LEX	roles:def
+ws	input.l	/^ws [ \\n\\t](%[^\\n]\\n)*$/;"	r	language:LEX	roles:def
+space	input.l	/^space ({ws}|\\~|\\\\space)$/;"	r	language:LEX	roles:def
+hard_space	input.l	/^hard_space (\\~|\\\\space)$/;"	r	language:LEX	roles:def
+u_letter	input.l	/^u_letter [A-ZÆØÅ] $/;"	r	language:LEX	roles:def
+l_letter	input.l	/^l_letter [a-zæøå] $/;"	r	language:LEX	roles:def
+punct	input.l	/^punct [\\!\\.\\?]$/;"	r	language:LEX	roles:def
+atoz	input.l	/^atoz [a-zA-Z]$/;"	r	language:LEX	roles:def
+letter	input.l	/^letter [A-ZÆØÅa-zæøå]$/;"	r	language:LEX	roles:def
+c_bin	input.l	/^c_bin ("-"|"+"|"\\\\cdot"|"\\\\oplus"|"\\\\otimes"|"\\\\times")$/;"	r	language:LEX	roles:def
+l_bin	input.l	/^l_bin (",")$/;"	r	language:LEX	roles:def
+general_abbrev	input.l	/^general_abbrev {letter}+{punct}$/;"	r	language:LEX	roles:def
+non_abbrev	input.l	/^non_abbrev {u_letter}{u_letter}+{punct}$/;"	r	language:LEX	roles:def
+italic_spec	input.l	/^italic_spec (sl|it)$/;"	r	language:LEX	roles:def
+normal_spec	input.l	/^normal_spec normalshape$/;"	r	language:LEX	roles:def
+swap_spec	input.l	/^swap_spec em$/;"	r	language:LEX	roles:def
+font_spec	input.l	/^font_spec (rm|bf|{italic_spec}|tt|{swap_spec}|mediumseries|{normal_spec})$/;"	r	language:LEX	roles:def
+primitive	input.l	/^primitive \\\\(above|advance|catcode|chardef|closein|closeout|copy|count|countdef|cr|crcr|csname/;"	r	language:LEX	roles:def
+symbol	input.l	/^symbol ("$"("\\\\"{atoz}+|.)"$"|"\\\\#"|"\\\\$"|"\\\\%"|"\\\\ref")$/;"	r	language:LEX	roles:def
+B_ENVIRONMENT	input.l	/^<B_ENVIRONMENT> {$/;"	c	language:LEX	roles:grouping
+stdio.h	input.l	/^#include <stdio.h>/;"	h	language:C	roles:system
+string.h	input.l	/^#include <string.h>/;"	h	language:C	roles:system
+win32lib.h	input.l	/^#include <win32lib.h>/;"	h	language:C	roles:system
+YY_SKIP_YYWRAP	input.l	/^#define YY_SKIP_YYWRAP$/;"	d	language:C	file:	roles:def
+yywrap	input.l	/^int yywrap() { return 1; }$/;"	f	language:C	typeref:typename:int	roles:def
+GROUP_STACK_SIZE	input.l	/^#define GROUP_STACK_SIZE /;"	d	language:C	file:	roles:def
+INPUT_STACK_SIZE	input.l	/^#define INPUT_STACK_SIZE /;"	d	language:C	file:	roles:def
+PROGNAME	input.l	/^#define PROGNAME /;"	d	language:C	file:	roles:def
+CG_NAME	input.l	/^#define CG_NAME /;"	d	language:C	file:	roles:def
+CG_TYPE	input.l	/^#define CG_TYPE /;"	d	language:C	file:	roles:def
+CG_LINE	input.l	/^#define CG_LINE /;"	d	language:C	file:	roles:def
+CG_ITALIC	input.l	/^#define CG_ITALIC /;"	d	language:C	file:	roles:def
+CG_FILE	input.l	/^#define CG_FILE /;"	d	language:C	file:	roles:def
+returnval	input.l	/^char returnval[100];$/;"	v	language:C	typeref:typename:char[100]	roles:def
+line_count	input.l	/^int line_count = 1;$/;"	v	language:C	typeref:typename:int	roles:def
+warn_count	input.l	/^int warn_count = 0;$/;"	v	language:C	typeref:typename:int	roles:def
+file_name	input.l	/^char *file_name;$/;"	v	language:C	typeref:typename:char *	roles:def
+verb_char	input.l	/^char verb_char;$/;"	v	language:C	typeref:typename:char	roles:def
+tex_group	input.l	/^typedef struct tex_group $/;"	s	language:C	file:	roles:def
+s_name	input.l	/^    unsigned char *s_name;$/;"	m	language:C	struct:tex_group	typeref:typename:unsigned char *	file:	roles:def
+s_type	input.l	/^    int s_type;$/;"	m	language:C	struct:tex_group	typeref:typename:int	file:	roles:def
+s_line	input.l	/^    int s_line;$/;"	m	language:C	struct:tex_group	typeref:typename:int	file:	roles:def
+italic	input.l	/^    int italic;$/;"	m	language:C	struct:tex_group	typeref:typename:int	file:	roles:def
+s_file	input.l	/^    char *s_file; $/;"	m	language:C	struct:tex_group	typeref:typename:char *	file:	roles:def
+tex_group	input.l	/^ } tex_group;$/;"	t	language:C	typeref:struct:tex_group	file:	roles:def
+gstack	input.l	/^tex_group *gstack;$/;"	v	language:C	typeref:typename:tex_group *	roles:def
+gstack_size	input.l	/^int gstack_size = GROUP_STACK_SIZE;$/;"	v	language:C	typeref:typename:int	roles:def
+gstackp	input.l	/^int gstackp = 0;$/;"	v	language:C	typeref:typename:int	roles:def
+input_	input.l	/^typedef struct input_ $/;"	s	language:C	file:	roles:def
+stream	input.l	/^    YY_BUFFER_STATE stream;$/;"	m	language:C	struct:input_	typeref:typename:YY_BUFFER_STATE	file:	roles:def
+name	input.l	/^    char *name;$/;"	m	language:C	struct:input_	typeref:typename:char *	file:	roles:def
+linenum	input.l	/^    int linenum;$/;"	m	language:C	struct:input_	typeref:typename:int	file:	roles:def
+input_	input.l	/^ } input_;$/;"	t	language:C	typeref:struct:input_	file:	roles:def
+istack	input.l	/^input_ *istack;$/;"	v	language:C	typeref:typename:input_ *	roles:def
+istack_size	input.l	/^int istack_size = INPUT_STACK_SIZE;$/;"	v	language:C	typeref:typename:int	roles:def
+istackp	input.l	/^int istackp = 0;$/;"	v	language:C	typeref:typename:int	roles:def
+def_count	input.l	/^int def_count = 0;$/;"	v	language:C	typeref:typename:int	roles:def
+main	input.l	/^int main( argc, argv )$/;"	f	language:C	roles:def
+strstr	input.l	/^strstr(string, substring)$/;"	f	language:C	roles:def
+push	input.l	/^void push(p_name, p_type, p_line)$/;"	f	language:C	roles:def
+input_file	input.l	/^void input_file(file_nam)$/;"	f	language:C	roles:def
+pop	input.l	/^void pop()$/;"	f	language:C	typeref:typename:void	roles:def
+bg_command	input.l	/^char *bg_command(name)$/;"	f	language:C	roles:def
+eg_command	input.l	/^char *eg_command(name,type)$/;"	f	language:C	roles:def
+g_checkend	input.l	/^void g_checkend(n)$/;"	f	language:C	roles:def
+e_checkend	input.l	/^void e_checkend(n, name)$/;"	f	language:C	roles:def
+f_checkend	input.l	/^void f_checkend(name)$/;"	f	language:C	roles:def
+print_bad_match	input.l	/^void print_bad_match(end_command,type)$/;"	f	language:C	roles:def
+check_top_level_end	input.l	/^int check_top_level_end(end_command,type)$/;"	f	language:C	roles:def
+linecount	input.l	/^void linecount()$/;"	f	language:C	typeref:typename:void	roles:def

--- a/Units/parser-lex.r/simple-lex.d/input.l
+++ b/Units/parser-lex.r/simple-lex.d/input.l
@@ -497,8 +497,9 @@ symbol ("$"("\\"{atoz}+|.)"$"|"\\#"|"\\$"|"\\%"|"\\ref")
     ++warn_count;
  }}
 
-<B_ENVIRONMENT>[^\}\n]+ { 
- {
+<B_ENVIRONMENT> {
+
+[^\}\n]+ {
     if (strcmp( yytext, "verbatim" ) == 0 )
 	{
 	 input();

--- a/docs/man-pages.rst
+++ b/docs/man-pages.rst
@@ -32,6 +32,7 @@ Man pages
 	ctags-lang-julia(7) <man/ctags-lang-julia.7.rst>
 	ctags-lang-kconfig(7) <man/ctags-lang-kconfig.7.rst>
 	ctags-lang-ldscript(7) <man/ctags-lang-ldscript.7.rst>
+	ctags-lang-lex(7) <man/ctags-lang-lex.7.rst>
 	ctags-lang-markdown(7) <man/ctags-lang-markdown.7.rst>
 	ctags-lang-python(7) <man/ctags-lang-python.7.rst>
 	ctags-lang-r(7) <man/ctags-lang-r.7.rst>

--- a/docs/man/ctags-lang-lex.7.rst
+++ b/docs/man/ctags-lang-lex.7.rst
@@ -1,0 +1,33 @@
+.. _ctags-lang-lex(7):
+
+==============================================================
+ctags-lang-lex
+==============================================================
+
+Random notes about tagging Lex source code with Universal Ctags
+
+:Version: 6.1.0
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**ctags** ... --languages=+LEX ...
+|	**ctags** ... --language-force=LEX ...
+|	**ctags** ... --map-Lex=+.l ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging LEX source code.
+
+VERSIONS
+--------
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* New role ``grouping`` for ``cond`` kind
+
+SEE ALSO
+--------
+:ref:`ctags(1) <ctags(1)>`

--- a/man/GNUmakefile.am
+++ b/man/GNUmakefile.am
@@ -43,6 +43,7 @@ GEN_IN_MAN_FILES = \
 	ctags-lang-julia.7 \
 	ctags-lang-kconfig.7 \
 	ctags-lang-ldscript.7 \
+	ctags-lang-lex.7 \
 	ctags-lang-markdown.7 \
 	ctags-lang-python.7 \
 	ctags-lang-r.7 \

--- a/man/ctags-lang-lex.7.rst.in
+++ b/man/ctags-lang-lex.7.rst.in
@@ -1,0 +1,33 @@
+.. _ctags-lang-lex(7):
+
+==============================================================
+ctags-lang-lex
+==============================================================
+---------------------------------------------------------------------
+Random notes about tagging Lex source code with Universal Ctags
+---------------------------------------------------------------------
+:Version: @VERSION@
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**@CTAGS_NAME_EXECUTABLE@** ... --languages=+LEX ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --language-force=LEX ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Lex=+.l ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging LEX source code.
+
+VERSIONS
+--------
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* New role ``grouping`` for ``cond`` kind
+
+SEE ALSO
+--------
+ctags(1)

--- a/optlib/lex.c
+++ b/optlib/lex.c
@@ -56,11 +56,14 @@ static void initializeLEXParser (const langType language)
 	                               "^.",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "rulesec",
-	                               "^[^%]+",
+	                               "^[^%<]+",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "rulesec",
 	                               "^%%",
 	                               "", "", "{tjump=usercode}{_guest=C,0end,}", NULL);
+	addLanguageTagMultiTableRegex (language, "rulesec",
+	                               "^<([_a-zA-Z][_a-zA-Z0-9]*)>[ \t]*\\{[ \t]*\n",
+	                               "\\1", "c", "{_role=grouping}", NULL);
 	addLanguageTagMultiTableRegex (language, "rulesec",
 	                               "^.",
 	                               "", "", "", NULL);
@@ -94,20 +97,24 @@ extern parserDefinition* LEXParser (void)
 		NULL
 	};
 
+	static roleDefinition LEXCondRoleTable [] = {
+		{ true, "grouping", " conditions used for grouping of start or exclusive condition rules" },
+	};
 	static kindDefinition LEXKindTable [] = {
 		{
 		  true, 'r', "regex", "named regular expression",
 		},
 		{
-		  true, 'c', "cond", "start or exclusive condition",
+		  true, 'c', "cond", "definition of start or exclusive condition",
+		  ATTACH_ROLES(LEXCondRoleTable),
 		},
 	};
 	static selectLanguage selectors[] = { selectLispOrLEXByLEXMarker, NULL };
 
 	parserDefinition* const def = parserNew ("LEX");
 
-	def->versionCurrent= 0;
-	def->versionAge    = 0;
+	def->versionCurrent= 1;
+	def->versionAge    = 1;
 	def->enabled       = true;
 	def->extensions    = extensions;
 	def->patterns      = patterns;

--- a/optlib/lex.ctags
+++ b/optlib/lex.ctags
@@ -26,7 +26,7 @@
 # - https://github.com/westes/flex/blob/master/doc/flex.texi
 #
 
---langdef=LEX
+--langdef=LEX{version=1.1}
 
 #
 # Map definitions
@@ -43,7 +43,8 @@
 #
 
 --kinddef-LEX=r,regex,named regular expression
---kinddef-LEX=c,cond,start or exclusive condition
+--kinddef-LEX=c,cond,definition of start or exclusive condition
+--_roledef-LEX.{cond}=grouping, conditions used for grouping of start or exclusive condition rules
 
 #
 # Table declarations
@@ -67,8 +68,9 @@
 --_mtable-regex-LEX=codeblock/%\}//{tleave}{_guest=,,0start}
 --_mtable-regex-LEX=codeblock/.//
 
---_mtable-regex-LEX=rulesec/[^%]+//
+--_mtable-regex-LEX=rulesec/[^%<]+//
 --_mtable-regex-LEX=rulesec/%%//{tjump=usercode}{_guest=C,0end,}
+--_mtable-regex-LEX=rulesec/<([_a-zA-Z][_a-zA-Z0-9]*)>[ \t]*\{[ \t]*\n/\1/c/{_role=grouping}
 --_mtable-regex-LEX=rulesec/.//
 
 --_mtable-regex-LEX=usercode/.+//{_guest=,,0end}


### PR DESCRIPTION
In some lexers, all the rules for a condition are grouped together as: 
```
<COND>{
...
}
```
It is useful to be able to jump to these blocks.

Conditions used for grouping are tagged as reference tags having "grouping" role of "cond" kind. So you must add --extras=+r to your ctags cmdline for enabling this support.

Update the parser version to 1.1.

This is derrived from #3937.