### PR TITLE
C,C++: fix properties field for object defined or declared with structure definitions

### DIFF
--- a/Tmain/extras-field.d/run.sh
+++ b/Tmain/extras-field.d/run.sh
@@ -3,5 +3,5 @@
 
 CTAGS=$1
 
-${CTAGS} --quiet --options=NONE --fields=+Ere-T --extras=+qrf -o - input.cpp \
+${CTAGS} --quiet --options=NONE --kinds-C++=+x --fields=+Ere-T --extras=+qrf -o - input.cpp \
     | sed -e 's|[^	]*\(input.cpp\)|\1|'

--- a/Tmain/extras-field.d/stdout-expected.txt
+++ b/Tmain/extras-field.d/stdout-expected.txt
@@ -1,10 +1,10 @@
 X	input.cpp	/^namespace X {$/;"	n	file:	roles:def	extras:fileScope	end:6
 X::Y	input.cpp	/^  extern class Y {$/;"	c	namespace:X	file:	roles:def	extras:fileScope,qualified	end:5
 X::Y::m	input.cpp	/^    int m;$/;"	m	class:X::Y	typeref:typename:int	file:	roles:def	extras:fileScope,qualified	end:4
-X::v	input.cpp	/^  } v;$/;"	v	namespace:X	typeref:class:X::Y	roles:def	extras:qualified	end:5
+X::v	input.cpp	/^  } v;$/;"	x	namespace:X	typeref:class:X::Y	roles:def	extras:qualified	end:5
 Y	input.cpp	/^  extern class Y {$/;"	c	namespace:X	file:	roles:def	extras:fileScope	end:5
 Z	input.cpp	/^#define Z$/;"	d	file:	roles:def	extras:fileScope	end:1
 Z	input.cpp	/^#undef Z$/;"	d	file:	roles:undef	extras:fileScope,reference
 input.cpp	input.cpp	1;"	F	roles:def	extras:inputFile	end:7
 m	input.cpp	/^    int m;$/;"	m	class:X::Y	typeref:typename:int	file:	roles:def	extras:fileScope	end:4
-v	input.cpp	/^  } v;$/;"	v	namespace:X	typeref:class:X::Y	roles:def	end:5
+v	input.cpp	/^  } v;$/;"	x	namespace:X	typeref:class:X::Y	roles:def	end:5

--- a/Units/parser-c.r/properties.c.d/args.ctags
+++ b/Units/parser-c.r/properties.c.d/args.ctags
@@ -1,0 +1,4 @@
+--sort=no
+--kinds-c=*
+--fields=+x
+--fields-c=+{properties}

--- a/Units/parser-c.r/properties.c.d/expected.tags
+++ b/Units/parser-c.r/properties.c.d/expected.tags
@@ -1,0 +1,5 @@
+T	input.c	/^static struct T {int t;} f1(int i)$/;"	s	file:
+t	input.c	/^static struct T {int t;} f1(int i)$/;"	m	struct:T	typeref:typename:int	file:
+f1	input.c	/^static struct T {int t;} f1(int i)$/;"	f	typeref:struct:T	file:	properties:static
+i	input.c	/^static struct T {int t;} f1(int i)$/;"	z	function:f1	typeref:typename:int	file:
+r	input.c	/^  struct T r = {.t = i};$/;"	l	function:f1	typeref:struct:T	file:

--- a/Units/parser-c.r/properties.c.d/input.c
+++ b/Units/parser-c.r/properties.c.d/input.c
@@ -1,0 +1,9 @@
+// See #3943.
+// static struct S {int s;} fS1(int i);
+
+/* This is invalid input as C++ code. */
+static struct T {int t;} f1(int i)
+{
+  struct T r = {.t = i};
+  return r;
+}

--- a/Units/parser-cxx.r/properties.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/properties.cpp.d/expected.tags
@@ -20,3 +20,8 @@ p01	input.cpp	/^static void p01();$/;"	p	typeref:typename:void	file:	properties:
 p02	input.cpp	/^extern void p02();$/;"	p	typeref:typename:void	file:	properties:extern
 f01	input.cpp	/^static void f01()$/;"	f	typeref:typename:void	file:	properties:static
 f02	input.cpp	/^static inline void f02()$/;"	f	typeref:typename:void	file:	properties:inline,static
+point	input.cpp	/^static struct point { float x, y; } p0, p1;$/;"	s	file:
+x	input.cpp	/^static struct point { float x, y; } p0, p1;$/;"	m	struct:point	typeref:typename:float	file:
+y	input.cpp	/^static struct point { float x, y; } p0, p1;$/;"	m	struct:point	typeref:typename:float	file:
+p0	input.cpp	/^static struct point { float x, y; } p0, p1;$/;"	v	typeref:struct:point	file:	properties:static
+p1	input.cpp	/^static struct point { float x, y; } p0, p1;$/;"	v	typeref:struct:point	file:	properties:static

--- a/Units/parser-cxx.r/properties.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/properties.cpp.d/input.cpp
@@ -42,3 +42,5 @@ static void f01()
 static inline void f02()
 {
 }
+
+static struct point { float x, y; } p0, p1;

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -574,7 +574,26 @@ static bool cxxParserParseEnumStructClassOrUnionFullDeclarationTrailer(
 	if(uKeywordState & CXXParserKeywordStateSeenTypedef)
 		cxxParserExtractTypedef(g_cxx.pTokenChain,true,false);
 	else
+	{
+		// Revert keyword states.
+		// Here we assume the following kind of input:
+		//
+		//   static struct S {...} s;
+		//
+		// To fill properties: field of s with "static", g_cxx.uKeywordState
+		// must be set here.
+		g_cxx.uKeywordState |= uKeywordState & (0
+			| CXXParserKeywordStateSeenStatic
+			| CXXParserKeywordStateSeenExtern
+			| CXXParserKeywordStateSeenMutable
+			| CXXParserKeywordStateSeenInline
+			| CXXParserKeywordStateSeenAttributeDeprecated
+			| CXXParserKeywordStateSeenConstexpr
+			| CXXParserKeywordStateSeenConstinit
+			| CXXParserKeywordStateSeenThreadLocal
+			);
 		cxxParserExtractVariableDeclarations(g_cxx.pTokenChain,0);
+	}
 
 	CXX_DEBUG_LEAVE();
 	return true;

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -550,6 +550,25 @@ static bool cxxParserParseEnumStructClassOrUnionFullDeclarationTrailer(
 	if(cxxTokenTypeIs(g_cxx.pToken,CXXTokenTypeOpeningBracket))
 	{
 		CXX_DEBUG_PRINT("Found opening bracket: possibly a function declaration?");
+
+		// Revert keyword states.
+		// Here we assume the following kind of input:
+		//
+		//   static struct S {...} fn (...) { ... }
+		//
+		// To fill properties: field of fn with "static", g_cxx.uKeywordState
+		// must be set here.
+		//
+		// See cxxParserEmitFunctionTags.
+		//
+		// NOTE: C++ doesn't accept such kind of input. So we propagate
+		// the state only meaningful in C languages.
+		g_cxx.uKeywordState |= uKeywordState & (0
+			| CXXParserKeywordStateSeenStatic
+			| CXXParserKeywordStateSeenInline
+			| CXXParserKeywordStateSeenExtern
+			| CXXParserKeywordStateSeenAttributeDeprecated
+			);
 		if(!cxxParserParseBlockHandleOpeningBracket())
 		{
 			CXX_DEBUG_LEAVE_TEXT("Failed to handle the opening bracket");


### PR DESCRIPTION
With this pull request, ctags can fill properties: field of `svar` and `fn` in the input like:
```
static struct S { ... } svar;
static struct T { ... } fn(...) { ... }
```

The declaration like:
``` 
static struct T { ... } fn(...);
```
is not in the scope of this pull request because of the bug reported in #3943.
