### PR TITLE
Terraform: fix two known bugs

### DIFF
--- a/Units/parser-terraform.r/local.d/expected.tags
+++ b/Units/parser-terraform.r/local.d/expected.tags
@@ -1,0 +1,1 @@
+this_is_a_local_variable_1	input.tf	/^  this_is_a_local_variable_1 = "this is the value of local variable 1"$/;"	l

--- a/Units/parser-terraform.r/local.d/input.tf
+++ b/Units/parser-terraform.r/local.d/input.tf
@@ -1,0 +1,3 @@
+locals {
+  this_is_a_local_variable_1 = "this is the value of local variable 1"
+}

--- a/Units/parser-terraform.r/simple-terraform.d/expected.tags
+++ b/Units/parser-terraform.r/simple-terraform.d/expected.tags
@@ -4,4 +4,6 @@ example_events_bus	input.tf	/^resource "aws_cloudwatch_event_bus" "example_event
 database	input.tf	/^module "database" {$/;"	m	language:Terraform	roles:def
 example_database_password	input.tf	/^data "aws_ssm_parameter" "example_database_password" {$/;"	d	language:Terraform	roles:def
 password	input.tf	/^output "password" {$/;"	o	language:Terraform	roles:def
+this_is_a_local_variable_1	input.tf	/^  this_is_a_local_variable_1 = "this is the value of local variable 1"$/;"	l	language:Terraform	roles:def
+this_is_a_local_variable_2	input.tf	/^  this_is_a_local_variable_2 = var.events_bus_name == local.this_is_a_local_variable_1 ## var.ev/;"	l	language:Terraform	roles:def
 events_bus_name	input-0.tfvars	/^events_bus_name = "hyper-connector"$/;"	v	language:Terraform	roles:assigned

--- a/Units/parser-terraform.r/simple-terraform.d/input.tf
+++ b/Units/parser-terraform.r/simple-terraform.d/input.tf
@@ -25,3 +25,35 @@ data "aws_ssm_parameter" "example_database_password" {
 output "password" {
   value = data.aws_ssm_parameter.example_database_password.value
 }
+
+locals {
+  this_is_a_local_variable_1 = "this is the value of local variable 1"
+  this_is_a_local_variable_2 = var.events_bus_name == local.this_is_a_local_variable_1 ## var.events_bus_name == shouldn't be picked up as a local
+
+  /* THE DEFINITIONS IN THIS BLOCK SHOULDN'T BE PICKED UP
+variable "no_parse_super_aws_thing" {
+  type = string
+  default = "hello-world"
+}
+resource "aws_cloudwatch_event_bus" "no_parse_example_events_bus_1" {
+  name = var.events_bus_name
+}
+
+module "no_parse_database_1" {
+  source = "../../modules/database"
+}
+
+data "aws_ssm_parameter" "no_parse_example_database_password_1" {
+  name = "example-database-password"
+}
+
+output "no_parse_password_1" {
+  value = data.aws_ssm_parameter.example_database_password.value
+}
+
+locals {
+  no_parse_this_is_a_local_variable_1 = "this is the value of local variable 1"
+
+}
+*/
+}

--- a/docs/man/ctags-lang-terraform.7.rst
+++ b/docs/man/ctags-lang-terraform.7.rst
@@ -34,11 +34,13 @@ to extract variables assigned in variables definitions (`*.tfvars`).
 The TerraformVariables parser extracts variables in `*.tfvars` files
 with ``variable`` kind with ``assigned`` role of ``Terraform`` language.
 
-KNOWN BUGS
-----------
-* The parser doesn't ignore strings inside a block comment (``/* ... */``).
+VERSIONS
+--------
 
-* The parser doesn't extract variables defined with ``locals`` keyword.
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* New kind ``local``
 
 SEE ALSO
 --------

--- a/man/ctags-lang-terraform.7.rst.in
+++ b/man/ctags-lang-terraform.7.rst.in
@@ -34,11 +34,13 @@ to extract variables assigned in variables definitions (`*.tfvars`).
 The TerraformVariables parser extracts variables in `*.tfvars` files
 with ``variable`` kind with ``assigned`` role of ``Terraform`` language.
 
-KNOWN BUGS
-----------
-* The parser doesn't ignore strings inside a block comment (``/* ... */``).
+VERSIONS
+--------
 
-* The parser doesn't extract variables defined with ``locals`` keyword.
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* New kind ``local``
 
 SEE ALSO
 --------

--- a/optlib/terraform.c
+++ b/optlib/terraform.c
@@ -8,8 +8,77 @@
 #include "xtag.h"
 
 
-static void initializeTerraformParser (const langType language CTAGS_ATTR_UNUSED)
+static void initializeTerraformParser (const langType language)
 {
+
+	addLanguageRegexTable (language, "toplevel");
+	addLanguageRegexTable (language, "comment");
+	addLanguageRegexTable (language, "locals");
+	addLanguageRegexTable (language, "multicomment");
+
+	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^(\\#|//)",
+	                               "", "", "{tenter=comment}", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^/\\*",
+	                               "", "", "{tenter=multicomment}", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^locals[[:space:]]*\\{",
+	                               "", "", "{tenter=locals}", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^resource[[:space:]]\"([^\"]+)\"[[:space:]]\"([^\"]+)\"",
+	                               "\\2", "r", "", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^data[[:space:]]\"([^\"]+)\"[[:space:]]\"([^\"]+)\"",
+	                               "\\2", "d", "", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^variable[[:space:]]\"([^\"]+)\"",
+	                               "\\1", "v", "", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^provider[[:space:]]\"([^\"]+)\"",
+	                               "\\1", "p", "", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^module[[:space:]]\"([^\"]+)\"",
+	                               "\\1", "m", "", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^output[[:space:]]\"([^\"]+)\"",
+	                               "\\1", "o", "", NULL);
+	addLanguageTagMultiTableRegex (language, "toplevel",
+	                               "^.",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "comment",
+	                               "^[^\n]+",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "comment",
+	                               "^\n",
+	                               "", "", "{tleave}", NULL);
+	addLanguageTagMultiTableRegex (language, "comment",
+	                               "^.",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "locals",
+	                               "^\\}",
+	                               "", "", "{tleave}", NULL);
+	addLanguageTagMultiTableRegex (language, "locals",
+	                               "^\\{",
+	                               "", "", "{tenter=locals}", NULL);
+	addLanguageTagMultiTableRegex (language, "locals",
+	                               "^(\\#|//)",
+	                               "", "", "{tenter=comment}", NULL);
+	addLanguageTagMultiTableRegex (language, "locals",
+	                               "^/\\*",
+	                               "", "", "{tenter=multicomment}", NULL);
+	addLanguageTagMultiTableRegex (language, "locals",
+	                               "^([a-z0-9_]+)+[[:space:]]*=[[:space:]]+",
+	                               "\\1", "l", "", NULL);
+	addLanguageTagMultiTableRegex (language, "locals",
+	                               "^.",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "multicomment",
+	                               "^\\*/",
+	                               "", "", "{tleave}", NULL);
+	addLanguageTagMultiTableRegex (language, "multicomment",
+	                               "^.",
+	                               "", "", "", NULL);
 }
 
 extern parserDefinition* TerraformParser (void)
@@ -50,29 +119,15 @@ extern parserDefinition* TerraformParser (void)
 		{
 		  true, 'o', "output", "output",
 		},
+		{
+		  true, 'l', "local", "locals",
+		},
 	};
-	static tagRegexTable TerraformTagRegexTable [] = {
-		{"^[[:space:]]*(#|//)\"", "",
-		"", "{exclusive}", NULL, false},
-		{"^resource[[:space:]]\"([^\"]+)\"[[:space:]]\"([^\"]+)\"", "\\2",
-		"r", "{exclusive}", NULL, false},
-		{"^data[[:space:]]\"([^\"]+)\"[[:space:]]\"([^\"]+)\"", "\\2",
-		"d", "{exclusive}", NULL, false},
-		{"^variable[[:space:]]\"([^\"]+)\"", "\\1",
-		"v", "{exclusive}", NULL, false},
-		{"^provider[[:space:]]\"([^\"]+)\"", "\\1",
-		"p", "{exclusive}", NULL, false},
-		{"^module[[:space:]]\"([^\"]+)\"", "\\1",
-		"m", "{exclusive}", NULL, false},
-		{"^output[[:space:]]\"([^\"]+)\"", "\\1",
-		"o", "{exclusive}", NULL, false},
-	};
-
 
 	parserDefinition* const def = parserNew ("Terraform");
 
-	def->versionCurrent= 0;
-	def->versionAge    = 0;
+	def->versionCurrent= 1;
+	def->versionAge    = 1;
 	def->enabled       = true;
 	def->extensions    = extensions;
 	def->patterns      = patterns;
@@ -80,8 +135,6 @@ extern parserDefinition* TerraformParser (void)
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
 	def->kindTable     = TerraformKindTable;
 	def->kindCount     = ARRAY_SIZE(TerraformKindTable);
-	def->tagRegexTable = TerraformTagRegexTable;
-	def->tagRegexCount = ARRAY_SIZE(TerraformTagRegexTable);
 	def->initialize    = initializeTerraformParser;
 
 	return def;

--- a/optlib/terraform.ctags
+++ b/optlib/terraform.ctags
@@ -15,18 +15,15 @@
 # About the language:
 #   - https://developer.hashicorp.com/terraform/language/syntax/configuration
 #
+# There ctags regex were re-implemented into multi-table regex to support
+# multi-line comments and locals blocks 
+#
 # Changed the name from `terraform` to `tf` so vim will recognise it properly based
 # on file extension (*.tf).
 #
-# A notable abscence is `local`, because `locals` are defined inside a block and
-# it's way harder to write a good regex for that.
-#   - https://www.terraform.io/docs/language/values/locals.html
-#
-# Another notable thing is that this parser doesn't skip /* block comments */.
-#
 # .tfvars files relates code are moved to TerraformVariables parser.
 #
---langdef=Terraform
+--langdef=Terraform{version=1.1}
 
 --map-Terraform=+.tf
 
@@ -40,11 +37,36 @@
 --kinddef-Terraform=p,provider,providers
 --kinddef-Terraform=m,module,modules
 --kinddef-Terraform=o,output,output
+--kinddef-Terraform=l,local,locals
 
---regex-Terraform=/^[[:space:]]*(#|\/\/)"//{exclusive}
---regex-Terraform=/^resource[[:space:]]"([^"]+)"[[:space:]]"([^"]+)"/\2/r/{exclusive}
---regex-Terraform=/^data[[:space:]]"([^"]+)"[[:space:]]"([^"]+)"/\2/d/{exclusive}
---regex-Terraform=/^variable[[:space:]]"([^"]+)"/\1/v/{exclusive}
---regex-Terraform=/^provider[[:space:]]"([^"]+)"/\1/p/{exclusive}
---regex-Terraform=/^module[[:space:]]"([^"]+)"/\1/m/{exclusive}
---regex-Terraform=/^output[[:space:]]"([^"]+)"/\1/o/{exclusive}
+
+--_tabledef-Terraform=toplevel
+--_tabledef-Terraform=comment
+--_tabledef-Terraform=locals
+--_tabledef-Terraform=multicomment
+
+
+--_mtable-regex-Terraform=toplevel/(\#|\/\/)//{tenter=comment}
+--_mtable-regex-Terraform=toplevel/\/\*//{tenter=multicomment}
+--_mtable-regex-Terraform=toplevel/locals[[:space:]]*\{//{tenter=locals}
+--_mtable-regex-Terraform=toplevel/^resource[[:space:]]"([^"]+)"[[:space:]]"([^"]+)"/\2/r/
+--_mtable-regex-Terraform=toplevel/^data[[:space:]]"([^"]+)"[[:space:]]"([^"]+)"/\2/d/
+--_mtable-regex-Terraform=toplevel/^variable[[:space:]]"([^"]+)"/\1/v/
+--_mtable-regex-Terraform=toplevel/^provider[[:space:]]"([^"]+)"/\1/p/
+--_mtable-regex-Terraform=toplevel/^module[[:space:]]"([^"]+)"/\1/m/
+--_mtable-regex-Terraform=toplevel/^output[[:space:]]"([^"]+)"/\1/o/
+--_mtable-regex-Terraform=toplevel/.//
+
+--_mtable-regex-Terraform=comment/[^\n]+//
+--_mtable-regex-Terraform=comment/\n//{tleave}
+--_mtable-regex-Terraform=comment/.//
+
+--_mtable-regex-Terraform=multicomment/\*\///{tleave}
+--_mtable-regex-Terraform=multicomment/.//
+
+--_mtable-regex-Terraform=locals/\}//{tleave}
+--_mtable-regex-Terraform=locals/\{//{tenter=locals}
+--_mtable-regex-Terraform=locals/(\#|\/\/)//{tenter=comment}
+--_mtable-regex-Terraform=locals/\/\*//{tenter=multicomment}
+--_mtable-regex-Terraform=locals/([a-z0-9_]+)+[[:space:]]*=[[:space:]]+/\1/l/
+--_mtable-regex-Terraform=locals/.//


### PR DESCRIPTION
This release will fix two know bugs:

- [x] The parser doesn't ignore strings inside a block comment (``/* ... */``).

- [x] The parser doesn't extract variables defined with ``locals`` keyword.