### PR TITLE
Asm: relax the condition for accepting characters within a section name

### DIFF
--- a/Units/parser-asm.r/gas-section.d/expected.tags
+++ b/Units/parser-asm.r/gas-section.d/expected.tags
@@ -5,3 +5,5 @@ limit	input.s	/^limit:	.double 0.29$/;"	label	language:Asm	roles:def
 .inittext	input-0.s	/^	.section ".inittext","ax"$/;"	inputSection	language:LdScript	roles:destination
 intcall	input-0.s	/^	.globl	intcall$/;"	symbol	language:LdScript	inputSection:.inittext	roles:def
 intcall	input-0.s	/^intcall:$/;"	label	language:Asm	roles:def
+define_ftsec	input-1.s	/^.macro define_ftsec name$/;"	macro	language:Asm	roles:def
+.head.text.\\name\\()	input-1.s	/^	.section ".head.text.\\name\\()","ax",@progbits$/;"	inputSection	language:LdScript	roles:destination

--- a/Units/parser-asm.r/gas-section.d/input-1.s
+++ b/Units/parser-asm.r/gas-section.d/input-1.s
@@ -1,0 +1,6 @@
+/* Taken from linux/arch/powerpc/include/asm/head-64.h */
+#ifdef __ASSEMBLY__
+.macro define_ftsec name
+	.section ".head.text.\name\()","ax",@progbits
+.endm
+#endif

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -491,6 +491,17 @@ static bool processCppMacroX (vString *identifier, int lastChar, vString *line)
 	return r;
 }
 
+/* If a section name is built with a macro expansion, the following
+ * strings may appear in parts of the string.
+ * - \param
+ * - \()
+ * - \@
+ */
+static bool isCharInMarcoParamref(char c)
+{
+	return (c == '\\' || c == '(' || c == ')'  || c == '@')? true: false;
+}
+
 static bool isEligibleAsSectionName (const vString *str)
 {
 	char *c = vStringValue(str);
@@ -499,7 +510,8 @@ static bool isEligibleAsSectionName (const vString *str)
 		if (!(isalnum(((unsigned char)*c))
 			  || (*c == '.')
 			  || (*c == '-')
-			  || (*c == '_')))
+			  || (*c == '_')
+			  || isCharInMarcoParamref(*c)))
 			return false;
 		c++;
 	}


### PR DESCRIPTION
If a section name is built with a macro expansion, the following strings may appear in parts of the string:

* \param,
* \(), and/or
* \@.

The original code didn't consider the characters in the strings, so it cannot extract section names from a macro definition.

Though it is debatable to extract a string including references to macro parameters, ctags may emit the following warning message if we consider the characters as parts of a section name:

    ctags: Notice: ignoring null tag ... (line: 13, language: LdScript)

By accepting the characters, we can suppress the warning messages.