### PR TITLE
DOC: parser-iPythonCell.r / input.py: Note about the percent format

### DIFF
--- a/Units/parser-iPythonCell.r/default-formats.d/input.py
+++ b/Units/parser-iPythonCell.r/default-formats.d/input.py
@@ -1,5 +1,9 @@
 # Derived from https://github.com/universal-ctags/ctags/issues/2978
 # submitted by @gerazov.
+
+# This is the 'percent' notebook format supported by Spyder, VScode,: 
+# https://jupytext.readthedocs.io/en/latest/formats-scripts.html#the-percent-format
+
 import numpy as np
 from matplotlib import pyplot as plt
 from scipy.io import wavfile


### PR DESCRIPTION
Possibly also worth noting somewhere that the linked docs have the percent format grammar as:

```
# %% Optional title [cell type] key="value"
```

https://jupytext.readthedocs.io/en/latest/formats-scripts.html#the-percent-format