### PR TITLE
honor XDG_CONFIG_HOME environment variable on Windows as well

### DIFF
--- a/Tmain/load-conf-files-under-default-xdg-config-home.d/run.sh
+++ b/Tmain/load-conf-files-under-default-xdg-config-home.d/run.sh
@@ -5,8 +5,6 @@ CTAGS=$1
 
 . ../utils.sh
 
-exit_if_win32 "$CTAGS"
-
 # $HOME/.config/ctags/*.ctags are loaded
 export HOME=./myhome
 export XDG_CONFIG_HOME=

--- a/Tmain/load-conf-files-under-xdg-config-home.d/run.sh
+++ b/Tmain/load-conf-files-under-xdg-config-home.d/run.sh
@@ -5,8 +5,6 @@ CTAGS=$1
 
 . ../utils.sh
 
-exit_if_win32 "$CTAGS"
-
 # $XDG_CONFIG_HOME/ctags/*.ctags are loaded
 export XDG_CONFIG_HOME=./.config
 ${CTAGS}

--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -2185,7 +2185,6 @@ Preloading option files
 
 ``$XDG_CONFIG_HOME/ctags/*.ctags``, or ``$HOME/.config/ctags/*.ctags`` if
 ``$XDG_CONFIG_HOME`` is not defined
-(on other than MS Windows)
 
 ``$HOME/.ctags.d/*.ctags``
 
@@ -2226,7 +2225,6 @@ Default optlib path list
 
 ``$XDG_CONFIG_HOME/ctags``, or ``$HOME/.config/ctags`` if
 ``$XDG_CONFIG_HOME`` is not defined
-(on other than MS Windows)
 
 ``$HOME/.ctags.d``
 

--- a/docs/option-file.rst
+++ b/docs/option-file.rst
@@ -42,7 +42,7 @@ See :ref:`option-file_difference` for the differences and their intentions.
 At start-up time, ``ctags`` loads files having :file:`.ctags` as a
 file extension under the following statically defined directories:
 
-#. :file:`$XDG_CONFIG_HOME/ctags/`, or :file:`$HOME/.config/ctags/` if :file:`$XDG_CONFIG_HOME` is not defined (on other than Windows)
+#. :file:`$XDG_CONFIG_HOME/ctags/`, or :file:`$HOME/.config/ctags/` if :file:`$XDG_CONFIG_HOME` is not defined
 #. :file:`$HOME/.ctags.d/`
 #. :file:`$HOMEDRIVE$HOMEPATH/ctags.d/` (on Windows)
 #. :file:`./.ctags.d/`

--- a/main/options.c
+++ b/main/options.c
@@ -3674,7 +3674,6 @@ static char* prependEnvvar (const char *path, const char* envvar)
 	return full_path;
 }
 
-#ifndef WIN32
 static char *getConfigForXDG (const char *path CTAGS_ATTR_UNUSED,
 							  const char* extra CTAGS_ATTR_UNUSED)
 {
@@ -3684,7 +3683,6 @@ static char *getConfigForXDG (const char *path CTAGS_ATTR_UNUSED,
 
 	return prependEnvvar (".config/ctags", "HOME");
 }
-#endif
 
 #ifdef WIN32
 static char *getConfigAtHomeOnWindows (const char *path,
@@ -3760,14 +3758,12 @@ static struct preloadPathElt preload_path_list [] = {
 		.stage = OptionLoadingStageCustom,
 	},
 #endif
-#ifndef WIN32
 	{
 		.path = NULL,
 		.isDirectory = true,
 		.makePath = getConfigForXDG,
 		.stage = OptionLoadingStageXdg,
 	},
-#endif
 	{
 		.path = ".ctags.d",
 		.isDirectory = true,

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -2185,7 +2185,6 @@ Preloading option files
 
 ``$XDG_CONFIG_HOME/ctags/*.ctags``, or ``$HOME/.config/ctags/*.ctags`` if
 ``$XDG_CONFIG_HOME`` is not defined
-(on other than MS Windows)
 
 ``$HOME/.ctags.d/*.ctags``
 
@@ -2226,7 +2225,6 @@ Default optlib path list
 
 ``$XDG_CONFIG_HOME/ctags``, or ``$HOME/.config/ctags`` if
 ``$XDG_CONFIG_HOME`` is not defined
-(on other than MS Windows)
 
 ``$HOME/.ctags.d``
 


### PR DESCRIPTION
MS Windows users could benefit from honoring XDG_CONFIG_HOME environment variable as well.

Although some people might thought it was not commonly used on MS Windows.

Actually, some well-known softwares honor this environment variable, as far as I known, git honors this environment variable on all platforms including MS Windows. git introduced this feature as earlier as 2015 (git/git@ea19289) .

Many users host their personal dotfiles on a GitHub repository, they just clone their repository to XDG_CONFIG_HOME, if software do not honor this environment variable, users should do more steps.

fixed #3969