### PR TITLE
build-sys: fix checking Windows platform with _WIN32 macro

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -75,7 +75,7 @@
 
 /*  Hack for ridiculous practice of Microsoft Visual C++.
  */
-#if defined (WIN32) && defined (_MSC_VER)
+#if defined (_WIN32) && defined (_MSC_VER)
 # define chsize         _chsize
 # define open           _open
 # define close          _close
@@ -1739,7 +1739,7 @@ static void writeTagEntry (const tagEntryInfo *const tag)
 
 	DebugStatement ( debugEntry (tag); )
 
-#ifdef WIN32
+#ifdef _WIN32
 	if (getFilenameSeparator(Option.useSlashAsFilenameSeparator) == FILENAME_SEP_USE_SLASH)
 	{
 		Assert (((const tagEntryInfo *)tag)->inputFileName);

--- a/main/general.h
+++ b/main/general.h
@@ -14,7 +14,7 @@
 */
 #if defined (HAVE_CONFIG_H)
 # include <config.h>
-#elif defined (WIN32)
+#elif defined (_WIN32)
 # include "e_msoft.h"
 #endif
 

--- a/main/main.c
+++ b/main/main.c
@@ -552,7 +552,7 @@ extern int ctags_cli_main (int argc CTAGS_ATTR_UNUSED, char **argv)
 {
 	cookedArgs *args;
 
-#if defined(WIN32) && defined(HAVE_MKSTEMP)
+#if defined(_WIN32) && defined(HAVE_MKSTEMP)
 	/* MinGW-w64's mkstemp() uses rand() for generating temporary files. */
 	srand ((unsigned int) clock ());
 #endif

--- a/main/options.c
+++ b/main/options.c
@@ -175,7 +175,7 @@ optionValues Option = {
 	.maxRecursionDepth = 0xffffffff,
 	.interactive = false,
 	.fieldsReset = false,
-#ifdef WIN32
+#ifdef _WIN32
 	.useSlashAsFilenameSeparator = FILENAME_SEP_UNSET,
 #endif
 #ifdef DEBUG
@@ -344,7 +344,7 @@ static optionDescription LongOptionDescription [] = {
  {0,0,"       Should paths be relative to location of tag file [no; yes when -e]?"},
  {0,0,"       always: be relative even if input files are passed in with absolute paths" },
  {0,0,"       never:  be absolute even if input files are passed in with relative paths" },
-#ifdef WIN32
+#ifdef _WIN32
  {1,0,"  --use-slash-as-filename-separator[=(yes|no)]"},
  {1,0,"       Use slash as filename separator [yes] for u-ctags output format."},
 #endif
@@ -552,7 +552,7 @@ static struct Feature {
 	const char *name;
 	const char *description;
 } Features [] = {
-#ifdef WIN32
+#ifdef _WIN32
 	{"win32", "TO BE WRITTEN"},
 #endif
 	/* Following two features are always available on universal ctags */
@@ -571,7 +571,7 @@ static struct Feature {
 #ifdef CUSTOM_CONFIGURATION_FILE
 	{"custom-conf", "read \"" CUSTOM_CONFIGURATION_FILE "\" as config file"},
 #endif
-#if defined (WIN32)
+#if defined (_WIN32)
 	{"unix-path-separator", "can use '/' as file name separator"},
 #endif
 #ifdef HAVE_ICONV
@@ -1185,7 +1185,7 @@ static void processExcludeOptionCommon (
 	else
 	{
 		vString *const item = vStringNewInit (parameter);
-#if defined (WIN32)
+#if defined (_WIN32)
 		vStringTranslate(item, PATH_SEPARATOR, OUTPUT_PATH_SEPARATOR);
 #endif
 		if (*list == NULL)
@@ -2602,7 +2602,7 @@ static void processIgnoreOption (const char *const list, int IgnoreOrDefine)
 		const char* fileName = (*list == '@') ? list + 1 : list;
 		addIgnoreListFromFile (lang, fileName);
 	}
-#if defined (WIN32)
+#if defined (_WIN32)
 	else if (isalpha ((unsigned char) list [0])  &&  list [1] == ':')
 		addIgnoreListFromFile (lang, list);
 #endif
@@ -2914,7 +2914,7 @@ static booleanOption BooleanOptions [] = {
 	{ "recurse",        &Option.recurse,                false, STAGE_ANY },
 #endif
 	{ "verbose",        &ctags_verbose,                 false, STAGE_ANY },
-#ifdef WIN32
+#ifdef _WIN32
 	{ "use-slash-as-filename-separator", (bool *)&Option.useSlashAsFilenameSeparator, false, STAGE_ANY },
 #endif
 	{ "with-list-header", &localOption.withListHeader,  true,  STAGE_ANY },
@@ -3684,7 +3684,7 @@ static char *getConfigForXDG (const char *path CTAGS_ATTR_UNUSED,
 	return prependEnvvar (".config/ctags", "HOME");
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 static char *getConfigAtHomeOnWindows (const char *path,
 									   const char* extra CTAGS_ATTR_UNUSED)
 {
@@ -3771,7 +3771,7 @@ static struct preloadPathElt preload_path_list [] = {
 		.extra = "HOME",
 		.stage = OptionLoadingStageHomeDir,
 	},
-#ifdef WIN32
+#ifdef _WIN32
 	{
 		.path = "ctags.d",
 		.isDirectory = true,

--- a/main/options_p.h
+++ b/main/options_p.h
@@ -108,7 +108,7 @@ typedef struct sOptionValues {
 	enum interactiveMode { INTERACTIVE_NONE = 0,
 						   INTERACTIVE_DEFAULT,
 						   INTERACTIVE_SANDBOX, } interactive; /* --interactive */
-#ifdef WIN32
+#ifdef _WIN32
 	enum filenameSepOp { FILENAME_SEP_NO_REPLACE = false,
 						 FILENAME_SEP_USE_SLASH  = true,
 						 FILENAME_SEP_UNSET,

--- a/main/routines.c
+++ b/main/routines.c
@@ -121,7 +121,7 @@
 
 /*  Hack for ridiculous practice of Microsoft Visual C++.
  */
-#if defined (WIN32)
+#if defined (_WIN32)
 # if defined (_MSC_VER) || defined (__MINGW32__)
 #  ifndef stat
 #   define stat    _stat
@@ -163,7 +163,7 @@ extern int stat (const char *, struct stat *);
 #ifdef NEED_PROTO_LSTAT
 extern int lstat (const char *, struct stat *);
 #endif
-#if defined (WIN32)
+#if defined (_WIN32)
 # define lstat(fn,buf) stat(fn,buf)
 #endif
 
@@ -204,7 +204,7 @@ extern const char *getExecutablePath (void)
  */
 static bool fnmChEq (int c1, int c2)
 {
-#ifdef WIN32
+#ifdef _WIN32
 	return tolower( c1 ) == tolower( c2 );  /* case-insensitive */
 #else
 	return          c1   ==          c2  ;  /* case-  sensitive */
@@ -890,7 +890,7 @@ extern FILE *tempFileFP (const char *const mode, char **const pName)
 	const char *const pattern = "tags.XXXXXX";
 	const char *tmpdir = NULL;
 	fileStatus *file = eStat (ExecutableProgram);
-# ifdef WIN32
+# ifdef _WIN32
 	tmpdir = getenv ("TMP");
 # else
 	if (! file->isSetuid)
@@ -901,7 +901,7 @@ extern FILE *tempFileFP (const char *const mode, char **const pName)
 	name = xMalloc (strlen (tmpdir) + 1 + strlen (pattern) + 1, char);
 	sprintf (name, "%s%c%s", tmpdir, OUTPUT_PATH_SEPARATOR, pattern);
 	fd = mkstemp (name);
-# ifdef WIN32
+# ifdef _WIN32
 	if (fd == -1)
 	{
 		/* mkstemp() sometimes fails with unknown reasons.
@@ -917,7 +917,7 @@ extern FILE *tempFileFP (const char *const mode, char **const pName)
 	eStatFree (file);
 #elif defined(HAVE_TEMPNAM)
 	const char *tmpdir = NULL;
-# ifdef WIN32
+# ifdef _WIN32
 	tmpdir = getenv ("TMP");
 # endif
 	if (tmpdir == NULL)

--- a/main/sort.c
+++ b/main/sort.c
@@ -68,7 +68,7 @@ extern void catFile (MIO *mio)
 */
 static void appendCstringWithQuotes (vString *dest, const char* cstr)
 {
-#ifdef WIN32
+#ifdef _WIN32
 	vStringCatS (dest, cstr);
 #else
 	vStringPut (dest, '\'');

--- a/main/strlist.c
+++ b/main/strlist.c
@@ -255,7 +255,7 @@ extern vString* stringListFileFinds (
 	unsigned int i;
 	const char * normalized = fileName;
 
-#if defined (WIN32)
+#if defined (_WIN32)
 	vString *tmp = vStringNewInit (fileName);
 	vStringTranslate (tmp, PATH_SEPARATOR, OUTPUT_PATH_SEPARATOR);
 	normalized = vStringValue (tmp);
@@ -267,7 +267,7 @@ extern vString* stringListFileFinds (
 		matched = fileNameMatched (vstr, normalized);
 	}
 
-#if defined (WIN32)
+#if defined (_WIN32)
 	vStringDelete (tmp);
 #endif
 

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -38,9 +38,9 @@ static int writeCtagsPtagEntry (tagWriter *writer CTAGS_ATTR_UNUSED,
 static bool treatFieldAsFixed (int fieldType);
 static void checkCtagsOptions (tagWriter *writer, bool fieldsWereReset);
 
-#ifdef WIN32
+#ifdef _WIN32
 static enum filenameSepOp overrideFilenameSeparator (enum filenameSepOp currentSetting);
-#endif	/* WIN32 */
+#endif	/* _WIN32 */
 
 struct rejection {
 	bool rejectionInThisInput;
@@ -55,7 +55,7 @@ tagWriter uCtagsWriter = {
 	.rescanFailedEntry = NULL,
 	.treatFieldAsFixed = treatFieldAsFixed,
 	.checkOptions = checkCtagsOptions,
-#ifdef WIN32
+#ifdef _WIN32
 	.overrideFilenameSeparator = overrideFilenameSeparator,
 #endif
 	.defaultFileName = CTAGS_FILE,
@@ -78,7 +78,7 @@ static bool endECTagsFile (tagWriter *writer, MIO * mio CTAGS_ATTR_UNUSED, const
 	return rej->rejectionInThisInput;
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 static enum filenameSepOp overrideFilenameSeparator (enum filenameSepOp currentSetting)
 {
 	if (currentSetting == FILENAME_SEP_UNSET)
@@ -398,7 +398,7 @@ static int writeCtagsPtagEntry (tagWriter *writer,
 
 	vString *vfileName = vStringNew ();
 	if (writer->type == WRITER_U_CTAGS
-#ifdef WIN32
+#ifdef _WIN32
 		&& getFilenameSeparator(Option.useSlashAsFilenameSeparator) == FILENAME_SEP_USE_SLASH
 #endif
 		)

--- a/main/writer.c
+++ b/main/writer.c
@@ -124,7 +124,7 @@ extern bool writerDoesTreatFieldAsFixed (int fieldType)
 	return false;
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 extern enum filenameSepOp getFilenameSeparator (enum filenameSepOp currentSetting)
 {
 	if (writer->overrideFilenameSeparator)
@@ -138,7 +138,7 @@ extern bool ptagMakeCtagsOutputFilesep (ptagDesc *desc,
 										const void *data)
 {
 	const char *sep = "slash";
-#ifdef WIN32
+#ifdef _WIN32
 	const optionValues *opt = data;
 	if (getFilenameSeparator (opt->useSlashAsFilenameSeparator)
 		!= FILENAME_SEP_USE_SLASH)

--- a/main/writer_p.h
+++ b/main/writer_p.h
@@ -54,9 +54,9 @@ struct sTagWriter {
 
 	void (* checkOptions) (tagWriter *writer, bool fieldsWereReset);
 
-#ifdef WIN32
+#ifdef _WIN32
 	enum filenameSepOp (* overrideFilenameSeparator) (enum filenameSepOp currentSetting);
-#endif	/* WIN32 */
+#endif	/* _WIN32 */
 
 	const char *defaultFileName;
 
@@ -100,7 +100,7 @@ extern bool writerDoesTreatFieldAsFixed (int fieldType);
 extern void writerCheckOptions (bool fieldsWereReset);
 extern bool writerPrintPtagByDefault (void);
 
-#ifdef WIN32
+#ifdef _WIN32
 extern enum filenameSepOp getFilenameSeparator (enum filenameSepOp currentSetting);
-#endif	/* WIN32 */
+#endif	/* _WIN32 */
 #endif	/* CTAGS_MAIN_WRITER_PRIVATE_H */

--- a/mk_mingw.mak
+++ b/mk_mingw.mak
@@ -7,7 +7,7 @@ GNULIB_OBJS = $(MINGW_GNULIB_SRCS:.c=.$(OBJEXT))
 
 CFLAGS = -Wall -std=gnu99
 COMMON_DEFINES =
-DEFINES = -DWIN32 $(COMMON_DEFINES) -DHAVE_CONFIG_H -DHAVE_PACKCC
+DEFINES = $(COMMON_DEFINES) -DHAVE_CONFIG_H -DHAVE_PACKCC
 INCLUDES = -I. -Ignulib -Ilibreadtags -iquote parsers -iquote main -iquote dsl
 CC = gcc
 WINDRES = windres
@@ -115,9 +115,9 @@ $(RES_OBJ): win32/ctags.rc win32/ctags.exe.manifest win32/resource.h
 	$(V_WINDRES) $(WINDRES) -o $@ -O coff $<
 
 extra-cmds/%.o: extra-cmds/%.c
-	$(V_CC) $(CC) -c $(OPT) $(CFLAGS) -DWIN32 $(INCLUDES) -o $@ $<
+	$(V_CC) $(CC) -c $(OPT) $(CFLAGS) $(INCLUDES) -o $@ $<
 libreadtags/%.o: libreadtags/%.c
-	$(V_CC) $(CC) -c $(OPT) $(CFLAGS) -DWIN32 -Ilibreadtags -o $@ $<
+	$(V_CC) $(CC) -c $(OPT) $(CFLAGS) -Ilibreadtags -o $@ $<
 
 readtags.exe: $(READTAGS_OBJS) $(READTAGS_HEADS) $(UTIL_OBJS) $(UTIL_HEADS) $(READTAGS_DSL_OBJS) $(READTAGS_DSL_HEADS) $(GNULIB_OBJS) $(MINGW_GNULIB_HEADS)
 	$(V_CC) $(CC) $(OPT) -o $@ $(READTAGS_OBJS) $(UTIL_OBJS) $(READTAGS_DSL_OBJS) $(GNULIB_OBJS) $(LIBS)

--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -11,7 +11,7 @@ OBJEXT = obj
 include source.mak
 
 COMMON_DEFINES =
-DEFINES = -DWIN32 $(COMMON_DEFINES) -DHAVE_REPOINFO_H -DHAVE_PACKCC -DREADTAGS_DSL
+DEFINES = $(COMMON_DEFINES) -DHAVE_REPOINFO_H -DHAVE_PACKCC -DREADTAGS_DSL
 INCLUDES = -I. -Ignulib -Imain -Iparsers -Ilibreadtags -Idsl
 OPT = /O2 /WX /Zc:preprocessor
 PACKCC = packcc.exe


### PR DESCRIPTION

    This replaces WIN32 with _WIN32 macro to check Windows platform.
    The correct one is _WIN32 as documented in the official documentation.
    https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros
