### PR TITLE
main: don't allocate a buffer for tagEntryInfoX::sourceFileName if possible

### DIFF
--- a/main/entry.h
+++ b/main/entry.h
@@ -72,6 +72,8 @@ struct sTagEntryInfo {
 	unsigned int inCorkQueue:1;
 	unsigned int isInputFileNameShared: 1; /* shares the value for inputFileName.
 											* Set in the cork queue; don't touch this.*/
+	unsigned int isSourceFileNameShared: 1; /* shares the value for sourceFileName.
+											 * Set in the cork queue; don't touch this.*/
 	unsigned int boundaryInfo: 2; /* info about nested input stream */
 	unsigned int inIntevalTab:1;
 


### PR DESCRIPTION
When queuing a tagEntryInfo to the cork queue, sourceFileName was strdup'ed.  However, in many cases, the strings for entries in the queue have the same value.  We can reduce memory allocations by using the same buffer as we did in the inputFileName member.

Under massif, I measured the peek memory usage of ctags processes indexing the source tree of the Linux kernel.

Without this change, the peak is 132.7 MiB.
With this change, the peak is 121.9 MiB.