### PR TITLE
powershell: Parse enum labels

### DIFF
--- a/Units/parser-powershell.r/enum-powershell.d/expected.tags
+++ b/Units/parser-powershell.r/enum-powershell.d/expected.tags
@@ -1,4 +1,12 @@
 EnumName1	input.ps1	/^enum EnumName1 {$/;"	g
+Label11	input.ps1	/^    Label11$/;"	e	enum:EnumName1
+Label12	input.ps1	/^    Label12 = 10$/;"	e	enum:EnumName1
 EnumName2	input.ps1	/^enum EnumName2 {$/;"	g
+Label21	input.ps1	/^    Label21$/;"	e	enum:EnumName2
+Label22	input.ps1	/^    Label22 = 20$/;"	e	enum:EnumName2
 EnumName3	input.ps1	/^Enum EnumName3 {$/;"	g
+Label31	input.ps1	/^    Label31$/;"	e	enum:EnumName3
+Label32	input.ps1	/^    Label32 = 30$/;"	e	enum:EnumName3
 EnumName4	input.ps1	/^[Flags()] enum EnumName4 {$/;"	g
+Label41	input.ps1	/^    Label41$/;"	e	enum:EnumName4
+Label42	input.ps1	/^    Label42 = 40$/;"	e	enum:EnumName4

--- a/docs/man-pages.rst
+++ b/docs/man-pages.rst
@@ -34,6 +34,7 @@ Man pages
 	ctags-lang-ldscript(7) <man/ctags-lang-ldscript.7.rst>
 	ctags-lang-lex(7) <man/ctags-lang-lex.7.rst>
 	ctags-lang-markdown(7) <man/ctags-lang-markdown.7.rst>
+	ctags-lang-powershell(7) <man/ctags-lang-powershell.7.rst>
 	ctags-lang-python(7) <man/ctags-lang-python.7.rst>
 	ctags-lang-r(7) <man/ctags-lang-r.7.rst>
 	ctags-lang-rmarkdown(7) <man/ctags-lang-rmarkdown.7.rst>

--- a/docs/man/ctags-lang-powershell.7.rst
+++ b/docs/man/ctags-lang-powershell.7.rst
@@ -1,0 +1,34 @@
+.. _ctags-lang-powershell(7):
+
+==============================================================
+ctags-lang-powershell
+==============================================================
+
+Random notes about tagging PowerShell source code with Universal Ctags
+
+:Version: 6.1.0
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|  **ctags** ... --languages=+PowerShell ...
+|  **ctags** ... --language-force=PowerShell ...
+|  **ctags** ... --map-powershell=+.ps1 ...
+|  **ctags** ... --map-powershell=+.psm1 ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging PowerShell source code.
+
+VERSIONS
+--------
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* New kind ``enumlabel``
+
+SEE ALSO
+--------
+:ref:`ctags(1) <ctags(1)>`

--- a/man/GNUmakefile.am
+++ b/man/GNUmakefile.am
@@ -45,6 +45,7 @@ GEN_IN_MAN_FILES = \
 	ctags-lang-ldscript.7 \
 	ctags-lang-lex.7 \
 	ctags-lang-markdown.7 \
+	ctags-lang-powershell.7 \
 	ctags-lang-python.7 \
 	ctags-lang-r.7 \
 	ctags-lang-rmarkdown.7 \

--- a/man/ctags-lang-powershell.7.rst.in
+++ b/man/ctags-lang-powershell.7.rst.in
@@ -1,0 +1,34 @@
+.. _ctags-lang-powershell(7):
+
+==============================================================
+ctags-lang-powershell
+==============================================================
+-----------------------------------------------------------------------
+Random notes about tagging PowerShell source code with Universal Ctags
+-----------------------------------------------------------------------
+:Version: @VERSION@
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|  **@CTAGS_NAME_EXECUTABLE@** ... --languages=+PowerShell ...
+|  **@CTAGS_NAME_EXECUTABLE@** ... --language-force=PowerShell ...
+|  **@CTAGS_NAME_EXECUTABLE@** ... --map-powershell=+.ps1 ...
+|  **@CTAGS_NAME_EXECUTABLE@** ... --map-powershell=+.psm1 ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging PowerShell source code.
+
+VERSIONS
+--------
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* New kind ``enumlabel``
+
+SEE ALSO
+--------
+ctags(1)


### PR DESCRIPTION
https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_enum?view=powershell-7.4

---

:warning: Beware, I don't know anything about PowerShell!  Yet, this seemed easy and useful enough.

If anybody with actual PowerShell knowledge could give this an overview that'd be great.  @eht16 @kumarstack55 @iaalm maybe?
The thing that most likely might need changing is the kind name.  I used the "common" name for this type of construct, but maybe a more PowerShell-y one would be better, I don't know.