### PR TITLE
C++: record "export" in the property field if the keyword is put at a "using" declaration

### DIFF
--- a/Units/parser-cxx.r/export-using.d/args.ctags
+++ b/Units/parser-cxx.r/export-using.d/args.ctags
@@ -1,0 +1,6 @@
+--sort=no
+--fields=+K
+--kinds-C++=+MtNp
+--fields-C++=+{properties}
+--extras=+r
+--fields=+r

--- a/Units/parser-cxx.r/export-using.d/expected.tags
+++ b/Units/parser-cxx.r/export-using.d/expected.tags
@@ -1,0 +1,5 @@
+Delta	input.cpp	/^export module Delta;$/;"	module	roles:def	properties:export
+Param	input.cpp	/^export using Param = int;$/;"	typedef	typeref:typename:int	file:	roles:def	properties:export
+Param	input.cpp	/^export using ::Param;$/;"	name	file:	roles:def	properties:export
+Param	input.cpp	/^export using ::Param;		\/\/ We can declare an object more than twice.$/;"	name	file:	roles:def	properties:export
+fn	input.cpp	/^export void fn();$/;"	prototype	typeref:typename:void	file:	roles:def	properties:export

--- a/Units/parser-cxx.r/export-using.d/input.cpp
+++ b/Units/parser-cxx.r/export-using.d/input.cpp
@@ -1,0 +1,7 @@
+// Derived from https://github.com/universal-ctags/ctags/issues/4003 submitted by @adrianconstantin-leroy.
+export module Delta;
+
+export using Param = int;
+export using ::Param;
+export using ::Param;		// We can declare an object more than twice.
+export void fn();

--- a/Units/parser-cxx.r/export-using.d/validator
+++ b/Units/parser-cxx.r/export-using.d/validator
@@ -1,0 +1,1 @@
+cxx20+module

--- a/parsers/cxx/cxx_parser_using.c
+++ b/parsers/cxx/cxx_parser_using.c
@@ -24,6 +24,8 @@ bool cxxParserParseUsingClause(void)
 {
 	CXX_DEBUG_ENTER();
 
+	unsigned int uInitialKeywordState = g_cxx.uKeywordState;
+
 	// using-directives for namespaces and using-declarations
 	// for namespace members
 	// using-declarations for class members
@@ -170,7 +172,18 @@ bool cxxParserParseUsingClause(void)
 			{
 				tag->isFileScope = (cxxScopeGetType() == CXXScopeTypeNamespace) &&
 							(!isInputHeaderFile());
+
+				unsigned int uProperties = 0;
+				if(uInitialKeywordState & CXXParserKeywordStateSeenExport)
+					uProperties |= CXXTagPropertyExport;
+				vString * pszProperties = NULL;
+
+				if(uProperties)
+					pszProperties = cxxTagSetProperties(uProperties);
+
 				cxxTagCommit(NULL);
+
+				vStringDelete (pszProperties);
 			}
 		}
 	}


### PR DESCRIPTION
This DOESN'T solve #4003.