### PR TITLE
PHP: Fix typeref field for class properties declared after use trait

### DIFF
--- a/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/args.ctags
+++ b/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--fields=+{typeref}

--- a/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/expected.tags
+++ b/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/expected.tags
@@ -4,4 +4,6 @@ ClassWithNullableIntProperty	input.php	/^class ClassWithNullableIntProperty$/;"	
 id	input.php	/^    public ?int $id;$/;"	v	class:ClassWithNullableIntProperty	typeref:unknown:?int
 ClassWithClassTypeProperty	input.php	/^class ClassWithClassTypeProperty$/;"	c
 id	input.php	/^    public \\stdClass $id;$/;"	v	class:ClassWithClassTypeProperty	typeref:unknown:stdClass
+ClassWithNamespacedClassProperty	input.php	/^class ClassWithNamespacedClassProperty$/;"	c
+id	input.php	/^    public SomeNamespacedClass $id;$/;"	v	class:ClassWithNamespacedClassProperty	typeref:unknown:SomeNamespacedClass
 SomeTrait	input.php	/^trait SomeTrait$/;"	t

--- a/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/expected.tags
+++ b/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/expected.tags
@@ -1,3 +1,4 @@
+SomeNamespacedClass	input.php	/^use App\\SomeNamespacedClass;$/;"	a	typeref:unknown:App\\SomeNamespacedClass
 ClassWithIntProperty	input.php	/^class ClassWithIntProperty$/;"	c
 id	input.php	/^    public int $id;$/;"	v	class:ClassWithIntProperty	typeref:unknown:int
 ClassWithNullableIntProperty	input.php	/^class ClassWithNullableIntProperty$/;"	c

--- a/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/expected.tags
+++ b/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/expected.tags
@@ -1,0 +1,7 @@
+ClassWithIntProperty	input.php	/^class ClassWithIntProperty$/;"	c
+id	input.php	/^    public int $id;$/;"	v	class:ClassWithIntProperty	typeref:unknown:int
+ClassWithNullableIntProperty	input.php	/^class ClassWithNullableIntProperty$/;"	c
+id	input.php	/^    public ?int $id;$/;"	v	class:ClassWithNullableIntProperty	typeref:unknown:?int
+ClassWithClassTypeProperty	input.php	/^class ClassWithClassTypeProperty$/;"	c
+id	input.php	/^    public \\stdClass $id;$/;"	v	class:ClassWithClassTypeProperty	typeref:unknown:stdClass
+SomeTrait	input.php	/^trait SomeTrait$/;"	t

--- a/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/input.php
+++ b/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/input.php
@@ -1,0 +1,26 @@
+<?php
+
+class ClassWithIntProperty
+{
+    use SomeTrait;
+
+    public int $id;
+}
+
+class ClassWithNullableIntProperty
+{
+    use SomeTrait;
+
+    public ?int $id;
+}
+
+class ClassWithClassTypeProperty
+{
+    use SomeTrait;
+
+    public \stdClass $id;
+}
+
+trait SomeTrait
+{
+}

--- a/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/input.php
+++ b/Units/parser-php.r/php-7-4-typed-props-with-use-trait.d/input.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\SomeNamespacedClass;
+
 class ClassWithIntProperty
 {
     use SomeTrait;
@@ -19,6 +21,13 @@ class ClassWithClassTypeProperty
     use SomeTrait;
 
     public \stdClass $id;
+}
+
+class ClassWithNamespacedClassProperty
+{
+    use SomeTrait;
+
+    public SomeNamespacedClass $id;
 }
 
 trait SomeTrait

--- a/parsers/php.c
+++ b/parsers/php.c
@@ -1759,6 +1759,7 @@ static void enterScope (tokenInfo *const parentToken,
 		   token->type != TOKEN_CLOSE_CURLY)
 	{
 		bool readNext = true;
+		bool clearTypename = true;
 
 		switch (token->type)
 		{
@@ -1817,21 +1818,25 @@ static void enterScope (tokenInfo *const parentToken,
 				vStringClear (typeName);
 				vStringPut (typeName, '?');
 				readNext = true;
+				clearTypename = false;
 				break;
 			case TOKEN_IDENTIFIER:
 				vStringCat (typeName, token->string);
 				readNext = true;
+				clearTypename = false;
 				break;
 			case TOKEN_VARIABLE:
 				readNext = parseVariable (token,
 										  vStringIsEmpty(typeName)
 										  ? NULL
 										  : typeName);
-				vStringClear (typeName);
 				break;
 
 			default: break;
 		}
+
+		if (clearTypename)
+			vStringClear (typeName);
 
 		if (readNext)
 			readToken (token);


### PR DESCRIPTION
```php
<?php

trait SomeTrait
{
}

class User
{
    use SomeTrait;

    public int $id;
}
```

```diff
-id     input.php       /^    public int $id;$/;"       v       class:User      typeref:unknown:int
+id     input.php       /^    public int $id;$/;"       v       class:User      typeref:unknown:SomeTraitint
```

I do not know yet how to make it pass, but I provide a failing test.

EDIT: make it pass and added more test cases.