### PR TITLE
Make: parse inside define/endef

### DIFF
--- a/Units/parser-make.r/in-define.d/args.ctags
+++ b/Units/parser-make.r/in-define.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--extras=+r

--- a/Units/parser-make.r/in-define.d/expected.tags
+++ b/Units/parser-make.r/in-define.d/expected.tags
@@ -1,0 +1,3 @@
+m	input.mak	/^define m$/;"	m
+x.mak	input.mak	/^include x.mak$/;"	I
+Y	input.mak	/^	Y=1$/;"	m

--- a/Units/parser-make.r/in-define.d/expected.tags
+++ b/Units/parser-make.r/in-define.d/expected.tags
@@ -1,3 +1,3 @@
 m	input.mak	/^define m$/;"	m
-x.mak	input.mak	/^include x.mak$/;"	I
-Y	input.mak	/^	Y=1$/;"	m
+x.mak	input.mak	/^include x.mak$/;"	I	macro:m
+Y	input.mak	/^	Y=1$/;"	m	macro:m

--- a/Units/parser-make.r/in-define.d/input.mak
+++ b/Units/parser-make.r/in-define.d/input.mak
@@ -1,0 +1,6 @@
+define m
+include x.mak
+	Y=1
+endef
+
+$(eval $(call m))

--- a/Units/parser-make.r/make.include.d/expected.tags
+++ b/Units/parser-make.r/make.include.d/expected.tags
@@ -8,6 +8,7 @@ A	input.mk	/^include A$/;"	I	roles:included
 B	input.mk	/^sinclude B$/;"	I	roles:optional
 C	input.mk	/^-include C$/;"	I	roles:optional
 D	input.mk	/^define D$/;"	m	roles:def	end:11
+E	input.mk	/^include E$/;"	I	roles:included
 F	input.mk	/^include F G H$/;"	I	roles:included
 G	input.mk	/^include F G H$/;"	I	roles:included
 H	input.mk	/^include F G H$/;"	I	roles:included

--- a/Units/parser-make.r/make.include.d/expected.tags
+++ b/Units/parser-make.r/make.include.d/expected.tags
@@ -8,7 +8,7 @@ A	input.mk	/^include A$/;"	I	roles:included
 B	input.mk	/^sinclude B$/;"	I	roles:optional
 C	input.mk	/^-include C$/;"	I	roles:optional
 D	input.mk	/^define D$/;"	m	roles:def	end:11
-E	input.mk	/^include E$/;"	I	roles:included
+E	input.mk	/^include E$/;"	I	macro:D	roles:included
 F	input.mk	/^include F G H$/;"	I	roles:included
 G	input.mk	/^include F G H$/;"	I	roles:included
 H	input.mk	/^include F G H$/;"	I	roles:included

--- a/parsers/automake.c
+++ b/parsers/automake.c
@@ -343,7 +343,7 @@ static void directiveCallback (makeSubparser *make CTAGS_ATTR_UNUSED, char *dire
 }
 
 static void newMacroCallback (makeSubparser *make, char* name, bool with_define_directive,
-							  bool appending)
+							  bool appending, int scopeIndex CTAGS_ATTR_UNUSED)
 {
 	struct sAutomakeSubparser *automake = (struct sAutomakeSubparser *)make;
 

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -108,47 +108,53 @@ static bool isSpecialTarget (vString *const name)
 	return true;
 }
 
-static int makeSimpleMakeTag (vString *const name, makeKind kind)
+static int makeSimpleMakeTag (vString *const name, makeKind kind, int scopeIndex)
 {
 	if (!isLanguageEnabled (getInputLanguage ()))
 		return CORK_NIL;
 
-	return makeSimpleTag (name, kind);
+	tagEntryInfo e;
+	initTagEntry (&e, vStringValue (name), kind);
+	e.extensionFields.scopeIndex = scopeIndex;
+	return makeTagEntry (&e);
 }
 
 static void makeSimpleMakeRefTag (const vString* const name, const int kind,
-				  int roleIndex)
+				  int roleIndex, int scopeIndex)
 {
 	if (!isLanguageEnabled (getInputLanguage ()))
 		return;
 
-	makeSimpleRefTag (name, kind, roleIndex);
+	tagEntryInfo e;
+	initRefTagEntry (&e, vStringValue (name), kind, roleIndex);
+	e.extensionFields.scopeIndex = scopeIndex;
+	makeTagEntry (&e);
 }
 
-static int newTarget (vString *const name)
+static int newTarget (vString *const name, int scopeIndex)
 {
 	/* Ignore GNU Make's "special targets". */
 	if  (isSpecialTarget (name))
 	{
 		return CORK_NIL;
 	}
-	return makeSimpleMakeTag (name, K_TARGET);
+	return makeSimpleMakeTag (name, K_TARGET, scopeIndex);
 }
 
-static int newMacro (vString *const name, bool with_define_directive, bool appending)
+static int newMacro (vString *const name, bool with_define_directive, bool appending, int scopeIndex)
 {
 	int r = CORK_NIL;
 	subparser *s;
 
 	if (!appending)
-		r = makeSimpleMakeTag (name, K_MACRO);
+		r = makeSimpleMakeTag (name, K_MACRO, scopeIndex);
 
 	foreachSubparser(s, false)
 	{
 		makeSubparser *m = (makeSubparser *)s;
 		enterSubparser(s);
 		if (m->newMacroNotify)
-			m->newMacroNotify (m, vStringValue(name), with_define_directive, appending);
+			m->newMacroNotify (m, vStringValue(name), with_define_directive, appending, scopeIndex);
 		leaveSubparser();
 	}
 
@@ -181,10 +187,10 @@ static void directiveFound (vString *const name)
 	}
 }
 
-static void newInclude (vString *const name, bool optional)
+static void newInclude (vString *const name, bool optional, int scopeIndex)
 {
 	makeSimpleMakeRefTag (name, K_INCLUDE,
-			      optional? R_INCLUDE_OPTIONAL: R_INCLUDE_GENERIC);
+			      optional? R_INCLUDE_OPTIONAL: R_INCLUDE_GENERIC, scopeIndex);
 }
 
 static bool isAcceptableAsInclude (vString *const name)
@@ -301,7 +307,7 @@ static void findMakeTags (void)
 				unsigned int i;
 				for (i = 0; i < stringListCount (identifiers); i++)
 				{
-					int r = newTarget (stringListItem (identifiers, i));
+					int r = newTarget (stringListItem (identifiers, i), current_macro);
 					if (r != CORK_NIL)
 						intArrayAdd (current_targets, r);
 				}
@@ -311,7 +317,7 @@ static void findMakeTags (void)
 		else if (variable_possible && c == '=' &&
 				 stringListCount (identifiers) == 1)
 		{
-			newMacro (stringListItem (identifiers, 0), false, appending);
+			newMacro (stringListItem (identifiers, 0), false, appending, current_macro);
 
 			in_value = true;
 			unsigned long curline = getInputLineNumber ();
@@ -352,7 +358,7 @@ static void findMakeTags (void)
 						ungetcToInputFile (c);
 					vStringStripTrailing (name);
 
-					current_macro = newMacro (name, true, false);
+					current_macro = newMacro (name, true, false, CORK_NIL);
 				}
 				else if (! strcmp (vStringValue (name), "export"))
 					stringListClear (identifiers);
@@ -367,7 +373,7 @@ static void findMakeTags (void)
 						readIdentifier (c, name);
 						vStringStripTrailing (name);
 						if (isAcceptableAsInclude(name))
-							newInclude (name, optional);
+							newInclude (name, optional, current_macro);
 
 						/* non-space characters after readIdentifier() may
 						 * be rejected by the function:

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -336,7 +336,7 @@ static void findMakeTags (void)
 					setTagEndLineToCorkEntry (current_macro, getInputLineNumber ());
 					current_macro = CORK_NIL;
 				}
-				else if (current_macro != CORK_NIL)
+				else if (in_value && current_macro != CORK_NIL)
 					skipLine ();
 				else if (! strcmp (vStringValue (name), "define"))
 				{

--- a/parsers/make.h
+++ b/parsers/make.h
@@ -28,7 +28,9 @@ struct sMakeSubparser {
 	void (* newMacroNotify) (makeSubparser *s,
 							 char* name,
 							 bool withDefineDirective,
-							 bool appending);
+							 bool appending,
+							 /* If the macro is found in a define/endef area. */
+							 int scopeIndex);
 };
 
 #endif


### PR DESCRIPTION
The original code doesn't extract X in:

    define m
	   X = 1
    endef
    $(eval $(call m))

~TODO: record m as the scope of X.~ (done)