### PR TITLE
build-sys: utilize pegof

### DIFF
--- a/.github/workflows/building-with-pegof.yml
+++ b/.github/workflows/building-with-pegof.yml
@@ -1,0 +1,71 @@
+name: build ctags with pegof and run units target on GNU/Linux
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  testing:
+
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+        compiler: [gcc]
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CC: ${{ matrix.compiler }}
+      BUILDDIR: ${{ matrix.os }}-${{ matrix.compiler }}
+      DEBIAN_FRONTEND: noninteractive
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: update package information
+      run: sudo apt-get -y -o APT::Immediate-Configure=false update
+    - name: install tools that pegof needs
+      run: sudo apt-get -y -o APT::Immediate-Configure=false install cmake g++
+    - name: install tools and libraries  that ctags needs
+      run: sudo apt-get -y -o APT::Immediate-Configure=false install pkg-config automake bash libjansson-dev libyaml-dev libseccomp-dev libxml2-dev gdb python3-docutils libpcre2-dev
+    - name: clone the source tree and build pegof
+      run: |
+        (
+        cd ..
+        git clone https://github.com/dolik-rce/pegof.git --recursive
+        cd pegof
+        cmake -B ./build
+        cmake --build ./build
+        ./build/pegof --version
+        )
+    - name: autogen.sh
+      run: ./autogen.sh
+    - name: report the version of cc
+      run: ${{ matrix.compiler }} --version
+    - name: report the version of make
+      run: make --version
+    - name: configure
+      run: |
+        mkdir -p ${{ matrix.os }}-"$CC"
+        (
+          pegdir=$(pwd)/../pegof
+          cd $BUILDDIR
+          ../configure --enable-debugging --enable-iconv --with-pegof=${pegdir}/build/pegof ${extra_args}
+        )
+    - name: make
+      run: make -C $BUILDDIR -j2
+    - name: test pegof in the feature list
+      run: |
+        (
+          cd $BUILDDIR
+          ./ctags --list-features | grep pegof
+        )
+    - name: make units
+      run: make -C $BUILDDIR units
+    - name: make dist
+      run: make -C $BUILDDIR dist
+      # See EXTRA_DIST in Makefile.am.
+      # Currently we add .pego files.

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,6 +39,11 @@ EXTRA_DIST   = README.md NEWS.rst autogen.sh \
 	       $(PEG_INPUT) $(OPTLIB2C_INPUT) $(OPTLIB2C_PCRE2_INPUT) $(TXT2CSTR_INPUT) \
 	       docs Tmain Units m4/gnulib-cache.m4
 
+if HAVE_PEGOF
+# Keeping intermediate files for debugging pegof and u-ctags buildsys.
+EXTRA_DIST   += $(PEGO_INTERMEDIATE)
+endif
+
 CLEANFILES =
 MOSTLYCLEANFILES =
 MAINTAINERCLEANFILES = autom4te.cache
@@ -147,6 +152,9 @@ endif
 if HAVE_STRNLEN
 libctags_a_CPPFLAGS += -DUSE_SYSTEM_STRNLEN
 endif
+if HAVE_PEGOF
+libctags_a_CPPFLAGS += -DHAVE_PEGOF
+endif
 libctags_a_CPPFLAGS+= $(GNULIB_CPPFLAGS)
 libctags_a_CPPFLAGS+= -DHAVE_REPOINFO_H
 
@@ -212,10 +220,27 @@ packcc_verbose = $(packcc_verbose_@AM_V@)
 packcc_verbose_ = $(packcc_verbose_@AM_DEFAULT_V@)
 packcc_verbose_0 = @echo PACKCC "    $@";
 SUFFIXES += .peg
+
+if HAVE_PEGOF
+pegof_verbose = $(pegof_verbose_@AM_V@)
+pegof_verbose_ = $(pegof_verbose_@AM_DEFAULT_V@)
+pegof_verbose_0 = @echo PEGOF "    $@";
+SUFFIXES += .pego
+
+PEGOF_FLAGS = -O all
+.peg.pego:
+	$(pegof_verbose)$(PEGOF) $(PEGOF_FLAGS) -o $(top_builddir)/peg/$(@F) -i "$<"
+.pego.c:
+	$(packcc_verbose)$(PACKCC) -o $(top_builddir)/peg/$(*F) $(top_builddir)/peg/$(<F)
+.pego.h:
+	$(packcc_verbose)$(PACKCC) -o $(top_builddir)/peg/$(*F) $(top_builddir)/peg/$(<F)
+else
 .peg.c:
 	$(packcc_verbose)$(PACKCC) -o $(top_builddir)/peg/$(*F) "$<"
 .peg.h:
 	$(packcc_verbose)$(PACKCC) -o $(top_builddir)/peg/$(*F) "$<"
+endif
+
 # You cannot use $(PACKCC) as a target name here.
 $(PEG_SRCS) $(PEG_HEADS): $(PACKCC) Makefile
 dist_libctags_a_SOURCES = $(ALL_LIB_HEADS) $(ALL_LIB_SRCS)

--- a/configure.ac
+++ b/configure.ac
@@ -401,6 +401,14 @@ fi
 AC_SUBST(RST2MAN_OPTIONS)
 AM_CONDITIONAL([HAS_GNU_SED], [sed --version 2>/dev/null | grep -q GNU])
 
+AC_ARG_WITH([pegof],
+  AS_HELP_STRING([--with-pegof=PATH], [Location of pegof (auto)]),
+  [PEGOF="$withval"],
+  [AC_PATH_PROGS(PEGOF,
+    [pegof],
+    [no])])
+AM_CONDITIONAL([HAVE_PEGOF], [test "x$PEGOF" != "xno"])
+
 # Checks for operating environment
 # --------------------------------
 in_git_repo=no

--- a/docs/autotools.rst
+++ b/docs/autotools.rst
@@ -154,3 +154,43 @@ Here is an example show you how to use these configure variables:
        ctags readtags
 
 Simpler example for `aarch64-linux-gnu` can be found in `circle.yml` in the source tree.
+
+PEG optimization
+,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+Some parsers of Universal Ctags are written in PEG grammar.  The build
+system of Universal Ctags uses `packcc
+<https://github.com/arithy/packcc>`_ for translating the PEG source
+files to C source files. A snapshot version of `packcc` is in the
+source tree of Universal Ctags. The in-tree `packcc` is used when
+building `ctags`. So you don't have to install `packcc`.
+
+`pegof <https://github.com/dolik-rce/pegof>`_ is a PEG grammar
+optimizer (and formatter). You can use `pegof` to build `ctags` though the
+developer says it is not yet stable enough (https://github.com/universal-ctags/ctags/pull/4023).
+
+You may have to build `pegof` first.
+See `Building <https://github.com/dolik-rce/pegof/blob/master/README.md#building>`_ about
+how to build `pegof`. Following the instructions on the page, you may
+see the executable is at `./build/pegof`.
+
+When building ctags, specify the executable to `--with-pegof` option of `./configure`
+script:
+
+.. code-block:: console
+
+   $ ls -d ctags pegof
+   ctags  pegof
+   $ ls -l pegof/build/pegof
+   -rwxr-xr-x. 1 yamato yamato 1894560 Jun 30 03:01 pegof/build/pegof
+   $ cd ctags
+   $ ./configure --with-pegof=../pegof/build/pegof
+   ...
+   $ make
+   ...
+
+If your `ctags` is built with `pegof`, you can verify it with `--list-features` option:
+
+.. code-block:: console
+
+   $ ./ctags --list-features | grep pegof
+   pegof             makes peg based parser(s) optimized (experimental)

--- a/docs/autotools.rst
+++ b/docs/autotools.rst
@@ -6,7 +6,9 @@ distribution, you can install the tools and libraries that Universal Ctags
 requires (or may use) as packages. See `GNU/Linux distributions`_ about
 the packages.
 
-Like most Autotools-based projects, you need to do::
+Like most Autotools-based projects, you need to do:
+
+.. code-block:: console
 
     $ git clone https://github.com/universal-ctags/ctags.git
     $ cd ctags
@@ -27,7 +29,9 @@ GNU/Linux distributions
 
 Before running ./autogen.sh, install some packages.
 
-On Debian-based systems (including Ubuntu), do::
+On Debian-based systems (including Ubuntu), do:
+
+.. code-block:: console
 
     $ sudo apt install \
         gcc make \
@@ -38,7 +42,9 @@ On Debian-based systems (including Ubuntu), do::
         libyaml-dev \
         libxml2-dev
 
-On Fedora systems, do::
+On Fedora systems, do:
+
+.. code-block:: console
 
     $ sudo dnf install \
         gcc make \
@@ -59,13 +65,13 @@ the name of the created executable.
 
 To add a prefix 'ex' which will result in 'ctags' being renamed to 'exctags':
 
-.. code-block:: bash
+.. code-block:: console
 
 	$ ./configure --program-prefix=ex
 
 To completely change the program's name run the following:
 
-.. code-block:: bash
+.. code-block:: console
 
 	$ ./configure --program-transform-name='s/ctags/my_ctags/; s/etags/myemacs_tags/'
 
@@ -81,7 +87,7 @@ etc.
 LTO is usually beneficial to improving program performance (here refers to ctags).
 We provide the `--enable-lto` option to enable it, as in the following example:
 
-.. code-block:: bash
+.. code-block:: console
 
 	$ ./configure --enable-lto
 
@@ -93,13 +99,13 @@ to truly enable LTO optimization for ctags.
 
 For example:
 
-.. code-block:: bash
+.. code-block:: console
 
 	$ ./configure
 
 is equivalent to:
 
-.. code-block:: bash
+.. code-block:: console
 
 	$ ./configure --disable-lto
 
@@ -120,7 +126,7 @@ When native-compiling, `FOO_FOR_BUILD` is the same as `FOO`.
 
 Here is an example show you how to use these configure variables:
 
-::
+.. code-block:: console
 
        $ mkdir ./out
        $ configure \

--- a/docs/news/HEAD.rst
+++ b/docs/news/HEAD.rst
@@ -11,6 +11,9 @@ Incompatible changes
 Parser related changes
 ---------------------------------------------------------------------
 
+#4026
+   Integrate `pegof <https://github.com/dolik-rce/pegof>`_ to our build process.
+
 New parsers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/main/options.c
+++ b/main/options.c
@@ -605,6 +605,9 @@ static struct Feature {
 #ifdef HAVE_PACKCC
 	/* The test harnesses use this as hints for skipping test cases */
 	{"packcc", "has peg based parser(s)"},
+#ifdef HAVE_PEGOF
+	{"pegof", "makes peg based parser(s) optimized (experimental)"},
+#endif
 #endif
 	{"optscript", "can use the interpreter"},
 #ifdef HAVE_PCRE2

--- a/peg/.gitignore
+++ b/peg/.gitignore
@@ -2,3 +2,5 @@ varlink.[ch]
 kotlin.[ch]
 thrift.[ch]
 elm.[ch]
+
+*.pego

--- a/source.mak
+++ b/source.mak
@@ -275,6 +275,8 @@ PEG_HEADS = $(PEG_INPUT:.peg=.h)
 PEG_EXTRA_HEADS = peg/peg_common.h $(PEG_INPUT:.peg=_pre.h) $(PEG_INPUT:.peg=_post.h)
 PEG_OBJS = $(PEG_SRCS:.c=.$(OBJEXT))
 
+PEGO_INTERMEDIATE = $(PEG_INPUT:.peg=.pego)
+
 PARSER_HEADS = \
 	parsers/autoconf.h \
 	parsers/cpreprocessor.h \


### PR DESCRIPTION
Pegof is a PEG grammar optimizer and formatter developed at https://github.com/dolik-rce/pegof.

This change is for utilizing pegof for optimizing our peg based parsers.

We assume pegof is installed at ${somewhere}/pegof.

  $ ./autogen.sh
  $ ./configure ... --with-pegof=${somewhere}/pegof ...
  $ make

To verify the command line invoking pegof, pass V=1 option to make like:

  $ make V=1

Makefile runs pegof to generate a .pego file from the given .peg file. Then, it runs packcc to generate .c and .h files from the .pego file. Via make command, you can generate a specified pego file directly. e.g.

  $ make V=1 peg peg/varlink.pego

This may be helpful for debugging pegof.

If you successfully build ctags with pegof, you will see "pegof" in the output of ./ctags—-list-features.

TODO:

- [x] use pegof-enabled ctags for testing
- [x] add instructions for building pegof-enabled ctags to our document
