### PR TITLE
Fix quotes & option syntax in manpage

### DIFF
--- a/docs/man/ctags.1.rst
+++ b/docs/man/ctags.1.rst
@@ -148,7 +148,7 @@ are not listed here. They are experimental or for debugging purpose.
 
 Notation: ``<foo>`` is for a variable string ``foo``, ``[ ... ]`` for optional,
 ``|`` for selection, and ``( ... )`` for grouping.  For example
-``--foo[=(yes|no)]'' means ``--foo``, ``-foo=yes``, or ``-foo=no``.
+``--foo[=(yes|no)]`` means ``--foo``, ``--foo=yes``, or ``--foo=no``.
 
 .. _option_input_output_file:
 

--- a/man/ctags.1.rst.in
+++ b/man/ctags.1.rst.in
@@ -148,7 +148,7 @@ are not listed here. They are experimental or for debugging purpose.
 
 Notation: ``<foo>`` is for a variable string ``foo``, ``[ ... ]`` for optional,
 ``|`` for selection, and ``( ... )`` for grouping.  For example
-``--foo[=(yes|no)]'' means ``--foo``, ``-foo=yes``, or ``-foo=no``.
+``--foo[=(yes|no)]`` means ``--foo``, ``--foo=yes``, or ``--foo=no``.
 
 .. _option_input_output_file:
 


### PR DESCRIPTION
* use backticks instead of single quotes
* use double dashes for long option name