### PR TITLE
main: extend --list-languages option to list only parsers using packcc

### DIFF
--- a/.github/workflows/building-with-pegof.yml
+++ b/.github/workflows/building-with-pegof.yml
@@ -44,7 +44,8 @@ jobs:
 
       - run: ./ctags --list-features | grep pegof
 
-      - run: make units
+      - run: echo "Targets: $(./ctags --list-languages=_packcc |  tr '\n' ',')"
+      - run: make units LANGUAGES="$(./ctags --list-languages=_packcc |  tr '\n' ',')"
       - run: make dist
         # See EXTRA_DIST in Makefile.am.
         # Currently we add .pego files.

--- a/main/options.c
+++ b/main/options.c
@@ -2166,9 +2166,21 @@ static void processListMapsOption (
 
 static void processListLanguagesOption (
 		const char *const option CTAGS_ATTR_UNUSED,
-		const char *const parameter CTAGS_ATTR_UNUSED)
+		const char *const parameter)
 {
-	printLanguageList ();
+	enum parserCategory category = PARSER_CATEGORY_NONE;
+
+	if (parameter)
+	{
+		if (strcmp(parameter, "_libxml") == 0)
+			category = PARSER_CATEGORY_LIBXML;
+		else if (strcmp(parameter, "_libyaml") == 0)
+			category = PARSER_CATEGORY_LIBYAML;
+		else if (strcmp(parameter, "_packcc") == 0)
+			category = PARSER_CATEGORY_PACKCC;
+	}
+
+	printLanguageList (category);
 	exit (0);
 }
 

--- a/main/parse_p.h
+++ b/main/parse_p.h
@@ -37,6 +37,14 @@ typedef enum {
 	LMAP_TABLE_OUTPUT = 1 << 2,
 } langmapType;
 
+enum parserCategory
+{
+	PARSER_CATEGORY_NONE,
+	PARSER_CATEGORY_LIBXML,
+	PARSER_CATEGORY_LIBYAML,
+	PARSER_CATEGORY_PACKCC,
+};
+
 /*
 *   FUNCTION PROTOTYPES
 */
@@ -115,7 +123,7 @@ extern void printLanguageRoles (const langType language, const char* letters,
 								bool withListHeader, bool machinable, FILE *fp);
 extern void printLanguageAliases (const langType language,
 								  bool withListHeader, bool machinable, FILE *fp);
-extern void printLanguageList (void);
+extern void printLanguageList (enum parserCategory category);
 extern void printLanguageParams (const langType language,
 								 bool withListHeader, bool machinable, FILE *fp);
 extern void printLanguageSubparsers (const langType language,


### PR DESCRIPTION
NOTE: This is a hidden extension. We don't update the help messages and the description of the man pages for this extension.

This extension is for choosing parsers for testing. e.g. running test cases related to PEG-based parsers only:

  make units LANGUAGES="$(./ctags --list-languages=_packcc |  tr '\n' ',')"

As the alternative to "_packcc", you can specify "_libxml" or "_libyaml" as the argument for the option.