### PR TITLE
iniconf: Allow dot and dash for ini keys

### DIFF
--- a/Units/parser-iniconf.r/simple-pythonLoggingConfig.d/expected.tags
+++ b/Units/parser-iniconf.r/simple-pythonLoggingConfig.d/expected.tags
@@ -11,6 +11,8 @@ handler_hand01	input.conf	/^[handler_hand01]$/;"	section	language:Iniconf
 handlers	input.conf	/^[handlers]$/;"	section	language:Iniconf
 handlers	input.conf	/^handlers=hand01$/;"	key	language:Iniconf	section:logger_parser
 handlers	input.conf	/^handlers=hand01$/;"	key	language:Iniconf	section:logger_root
+key-with-dashes	input.conf	/^key-with-dashes=value2$/;"	key	language:Iniconf	section:section.with.dots
+key.with.dots	input.conf	/^key.with.dots=value1$/;"	key	language:Iniconf	section:section.with.dots
 keys	input.conf	/^keys=form01$/;"	key	language:Iniconf	section:formatters
 keys	input.conf	/^keys=hand01$/;"	key	language:Iniconf	section:handlers
 keys	input.conf	/^keys=root,parser$/;"	key	language:Iniconf	section:loggers
@@ -24,3 +26,4 @@ parser	input.conf	/^[logger_parser]$/;"	loggerSection	language:PythonLoggingConf
 propagate	input.conf	/^propagate=1$/;"	key	language:Iniconf	section:logger_parser
 qualname	input.conf	/^qualname=compiler.parser$/;"	key	language:Iniconf	section:logger_parser
 root	input.conf	/^[logger_root]$/;"	loggerSection	language:PythonLoggingConfig
+section.with.dots	input.conf	/^[section.with.dots]$/;"	section	language:Iniconf

--- a/Units/parser-iniconf.r/simple-pythonLoggingConfig.d/input.conf
+++ b/Units/parser-iniconf.r/simple-pythonLoggingConfig.d/input.conf
@@ -31,3 +31,7 @@ args=(sys.stdout,)
 format=F1 %(asctime)s %(levelname)s %(message)s
 datefmt=
 class=logging.Formatter
+
+[section.with.dots]
+key.with.dots=value1
+key-with-dashes=value2

--- a/parsers/iniconf.c
+++ b/parsers/iniconf.c
@@ -35,7 +35,7 @@
 static bool isIdentifier (int c)
 {
     /* allow whitespace within keys and sections */
-    return (bool)(isalnum (c) || isspace (c) ||  c == '_');
+    return (bool)(isalnum (c) || isspace (c) || c == '_' || c == '-' || c == '.');
 }
 
 static bool isValue (int c)


### PR DESCRIPTION
The iniconf parser can be used as a poor man's TOML parser which can contain '.' and '-' inside keys. Also, since there's no official ini specification, I can imagine some ini dialects allow this too.

I'm now aware of https://github.com/universal-ctags/ctags/pull/3509 as mentioned in https://github.com/geany/geany/pull/3934 but right now we don't use PEG parsers in Geany and we'd have to evaluate its performance so we'll probably stick with this parser for TOML for now.