### PR TITLE
C++: add unicode identifier name support

### DIFF
--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -24,7 +24,7 @@
 
 #include <string.h>
 
-#define UINFO(c) (((c) < 0x80 && (c) >= 0) ? g_aCharTable[c].uType : 0)
+#define UINFO(c) (((c) < 0x80 && (c) >= 0) ? g_aCharTable[c].uType : (CXXCharTypeStartOfIdentifier | CXXCharTypePartOfIdentifier))
 
 static void cxxParserSkipToNonWhiteSpace(void)
 {


### PR DESCRIPTION
Ctags currently does not support Unicode identifiers in c++, but I found that it only requires modifying one line of code to make it support them.