### PR TITLE
GitHub Actions: drop the MSYS2/CLANG32 environment

### DIFF
--- a/.github/workflows/testing-on-msys2.yml
+++ b/.github/workflows/testing-on-msys2.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msystem: [MINGW32, MINGW64, CLANG32, CLANG64]
+        msystem: [MINGW32, MINGW64, CLANG64]
 
     defaults:
       run:


### PR DESCRIPTION
Reference: https://www.msys2.org/news/#2024-09-23-starting-to-drop-the-clang32-environment