### PR TITLE
iniconf: some more adjustments for parsing TOML

### DIFF
--- a/Units/parser-iniconf.r/toml-support-in-geany.d/args.ctags
+++ b/Units/parser-iniconf.r/toml-support-in-geany.d/args.ctags
@@ -1,0 +1,3 @@
+--fields=+lK
+--langmap=Iniconf:.toml
+--sort=no

--- a/Units/parser-iniconf.r/toml-support-in-geany.d/expected.tags
+++ b/Units/parser-iniconf.r/toml-support-in-geany.d/expected.tags
@@ -1,0 +1,41 @@
+table	input.toml	/^[table]$/;"	section	language:Iniconf
+key	input.toml	/^key = "value"$/;"	key	language:Iniconf	section:table
+bare_key	input.toml	/^bare_key = "value"$/;"	key	language:Iniconf	section:table
+bare-key	input.toml	/^bare-key = "value"$/;"	key	language:Iniconf	section:table
+1234	input.toml	/^1234 = "value"$/;"	key	language:Iniconf	section:table
+"127.0.0.1"	input.toml	/^"127.0.0.1" = "value"$/;"	key	language:Iniconf	section:table
+"character encoding"	input.toml	/^"character encoding" = "value"$/;"	key	language:Iniconf	section:table
+'key2'	input.toml	/^'key2' = "value"$/;"	key	language:Iniconf	section:table
+'quoted "value"'	input.toml	/^'quoted "value"' = "value"$/;"	key	language:Iniconf	section:table
+name	input.toml	/^name = "Orange"$/;"	key	language:Iniconf	section:table
+physical.color	input.toml	/^physical.color = "orange"$/;"	key	language:Iniconf	section:table
+physical.shape	input.toml	/^physical.shape = "round"$/;"	key	language:Iniconf	section:table
+site."google.com"	input.toml	/^site."google.com" = true$/;"	key	language:Iniconf	section:table
+str1	input.toml	/^str1 = """$/;"	key	language:Iniconf	section:table
+str1	input.toml	/^str1 = "The quick brown fox jumps over the lazy dog."$/;"	key	language:Iniconf	section:table
+str2	input.toml	/^str2 = """$/;"	key	language:Iniconf	section:table
+str3	input.toml	/^str3 = """\\$/;"	key	language:Iniconf	section:table
+regex2	input.toml	/^regex2 = '''I [dw]on't need \\d{2} apples'''$/;"	key	language:Iniconf	section:table
+lines	input.toml	/^lines  = '''$/;"	key	language:Iniconf	section:table
+contributors	input.toml	/^contributors = [$/;"	key	language:Iniconf	section:table
+integers2	input.toml	/^integers2 = [$/;"	key	language:Iniconf	section:table
+integers3	input.toml	/^integers3 = [$/;"	key	language:Iniconf	section:table
+table-1	input.toml	/^[table-1]$/;"	section	language:Iniconf
+key1	input.toml	/^key1 = "some string"$/;"	key	language:Iniconf	section:table-1
+key2	input.toml	/^key2 = 123$/;"	key	language:Iniconf	section:table-1
+table-2	input.toml	/^[table-2]$/;"	section	language:Iniconf
+key1	input.toml	/^key1 = "another string"$/;"	key	language:Iniconf	section:table-2
+key2	input.toml	/^key2 = 456$/;"	key	language:Iniconf	section:table-2
+dog."tater.man"	input.toml	/^[dog."tater.man"]$/;"	section	language:Iniconf
+type.name	input.toml	/^type.name = "pug"$/;"	key	language:Iniconf	section:dog."tater.man"
+a.b.c	input.toml	/^[a.b.c]            # this is best practice$/;"	section	language:Iniconf
+\x20d.e.f 	input.toml	/^[ d.e.f ]          # same as [d.e.f]$/;"	section	language:Iniconf
+\x20g .  h  . i 	input.toml	/^[ g .  h  . i ]    # same as [g.h.i]$/;"	section	language:Iniconf
+[products]	input.toml	/^[[products]]$/;"	section	language:Iniconf
+name	input.toml	/^name = "Hammer"$/;"	key	language:Iniconf	section:[products]
+sku	input.toml	/^sku = 738594937$/;"	key	language:Iniconf	section:[products]
+[products]	input.toml	/^[[products]]  # empty table within the array$/;"	section	language:Iniconf
+[products]	input.toml	/^[[products]]$/;"	section	language:Iniconf
+name	input.toml	/^name = "Nail"$/;"	key	language:Iniconf	section:[products]
+sku	input.toml	/^sku = 284758393$/;"	key	language:Iniconf	section:[products]
+points	input.toml	/^points = [ { x = 1, y = 2, z = 3 },$/;"	key	language:Iniconf	section:[products]

--- a/Units/parser-iniconf.r/toml-support-in-geany.d/input.toml
+++ b/Units/parser-iniconf.r/toml-support-in-geany.d/input.toml
@@ -1,0 +1,89 @@
+#
+# TAKEN FROM https://toml.io/en/v1.0.0#array-of-tables
+#
+
+[table]
+key = "value"
+bare_key = "value"
+bare-key = "value"
+1234 = "value"
+
+"127.0.0.1" = "value"
+"character encoding" = "value"
+'key2' = "value"
+'quoted "value"' = "value"
+
+name = "Orange"
+physical.color = "orange"
+physical.shape = "round"
+site."google.com" = true
+
+str1 = """
+Roses are red
+Violets are blue"""
+
+str1 = "The quick brown fox jumps over the lazy dog."
+
+str2 = """
+The quick brown \
+
+
+  fox jumps over \
+    the lazy dog."""
+
+str3 = """\
+       The quick brown \
+       fox jumps over \
+       the lazy dog.\
+       """
+
+regex2 = '''I [dw]on't need \d{2} apples'''
+lines  = '''
+The first newline is
+trimmed in raw strings.
+   All other whitespace
+   is preserved.
+'''
+
+contributors = [
+  "Foo Bar <foo@example.com>",
+  { name = "Baz Qux", email = "bazqux@example.com", url = "https://example.com/bazqux" }
+]
+
+integers2 = [
+  1, 2, 3
+]
+
+integers3 = [
+  1,
+  2, # this is ok
+]
+
+[table-1]
+key1 = "some string"
+key2 = 123
+
+[table-2]
+key1 = "another string"
+key2 = 456
+
+[dog."tater.man"]
+type.name = "pug"
+
+[a.b.c]            # this is best practice
+[ d.e.f ]          # same as [d.e.f]
+[ g .  h  . i ]    # same as [g.h.i]
+
+[[products]]
+name = "Hammer"
+sku = 738594937
+
+[[products]]  # empty table within the array
+
+[[products]]
+name = "Nail"
+sku = 284758393
+
+points = [ { x = 1, y = 2, z = 3 },
+           { x = 7, y = 8, z = 9 },
+           { x = 2, y = 4, z = 8 } ]

--- a/parsers/iniconf.c
+++ b/parsers/iniconf.c
@@ -32,10 +32,13 @@
 #include "subparser.h"
 #include "vstring.h"
 
+#define TOML_QUOTED_KEY_CHAR(c) ( (c) == '"' || (c) == '\'' )
+
 static bool isIdentifier (int c)
 {
-    /* allow whitespace within keys and sections */
-    return (bool)(isalnum (c) || isspace (c) || c == '_' || c == '-' || c == '.');
+	/* allow whitespace within keys and sections */
+	return (bool)(isalnum (c) || isspace (c) || c == '_' || c == '-' || c == '.'
+		|| TOML_QUOTED_KEY_CHAR(c));
 }
 
 static bool isValue (int c)

--- a/parsers/iniconf.c
+++ b/parsers/iniconf.c
@@ -130,7 +130,8 @@ static void findIniconfTags (void)
 		if (*cp == '[')
 		{
 			++cp;
-			while (*cp != '\0' && *cp != ']')
+			/* look for the final ] to support TOML [[arrays.of.tables]] */
+			while (*cp != '\0' && (*cp != ']' || *(cp+1) == ']'))
 			{
 				vStringPut (name, *cp);
 				++cp;


### PR DESCRIPTION
These two patches:
- improve parsing of TOML `[[arrays_of_tables]]`
- support `'single quoted keys' = true` and `"double quoted keys" = true`

See the individual commits for more details.