### PR TITLE
GitHub Actions: fix netbsd pkgin error.

### DIFF
--- a/.github/workflows/testing-on-netbsd.yml
+++ b/.github/workflows/testing-on-netbsd.yml
@@ -29,7 +29,8 @@ jobs:
               eval "$@"
             }
 
-            run sudo pkgin -y install automake autoconf gmake pkg-config jansson libyaml libxml2 libiconv
+            # DO NOT try to install libxml2, because it has already been pre-installed
+            run sudo pkgin -y install automake autoconf gmake pkg-config jansson libyaml libiconv
 
             run cc --version
 


### PR DESCRIPTION
Don't try to install libxml2. libxml2 has already been pre-installed, if we try to install it, it will result in upgrading curl and it's dependencies. we do not use curl here.