### PR TITLE
Verilog: Add final_specifier support for class parse

### DIFF
--- a/Units/parser-verilog.r/systemverilog-class.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-class.d/expected.tags
@@ -137,3 +137,7 @@ complex_class.get_next	input.sv	/^  function LinkedPacket get_next();$/;"	f	clas
 auto_class	input.sv	/^class automatic auto_class;$/;"	C
 a	input.sv	/^  logic a;$/;"	r	class:auto_class
 auto_class.a	input.sv	/^  logic a;$/;"	r	class:auto_class
+test_final_specifier_A	input.sv	/^class :final test_final_specifier_A;$/;"	C
+test_class	input.sv	/^class test_class;$/;"	C
+test_final_specifier_B	input.sv	/^virtual class :final test_final_specifier_B;$/;"	C
+TopPacket	input.sv	/^class : final TopPacket extends LinkedPacket;$/;"	C	inherits:LinkedPacket

--- a/Units/parser-verilog.r/systemverilog-class.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-class.d/input.sv
@@ -91,3 +91,21 @@ endclass
 class automatic auto_class;
   logic a;
 endclass : auto_class
+
+class :final test_final_specifier_A;
+  // The final specifier, preceded by a colon, when applied to classes:
+  // specifies that a class shall not be extended.
+endclass
+
+class test_class;
+endclass
+
+virtual class :final test_final_specifier_B;
+  // The final specifier, preceded by a colon, when applied to classes:
+  // specifies that a class shall not be extended.
+endclass
+
+class : final TopPacket extends LinkedPacket;
+  // The final specifier, preceded by a colon, when applied to classes:
+  // specifies that a class shall not be extended.
+endclass

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1355,18 +1355,24 @@ static int processParameterList (tokenInfo *token, int c)
 	return c;
 }
 
-// [ virtual ] class [ static | automatic ] class_identifier [ parameter_port_list ]
+// LRM IEEE Std 1800-2017 and previous versions
+//  [ virtual ] class [ static | automatic ] class_identifier [ parameter_port_list ]
+// LRM IEEE Std 1800-2023 ( Fixed )
+//  [ virtual ] class [ : final ] class_identifier [ parameter_port_list ]
 //	   [ extends class_type [ ( list_of_arguments ) ] ] [ implements < interface_class_type > ] ;
 // interface class class_identifier [ parameter_port_list ] [ extends < interface_class_type > ] ;
 static int processClass (tokenInfo *const token, int c, verilogKind kind)
 {
 	tokenInfo *classToken;
 
+	if (kind == K_CLASS && c == ':')
+		c = skipWhite (vGetc ());
+
 	/* Get identifiers */
 	while (isWordToken (c))
 	{
 		c = readWordToken (token, c);
-		// skip static or automatic
+		// skip static or automatic or final
 		if (token->kind != K_IGNORE)
 			break;
 	}


### PR DESCRIPTION
The syntax for class declaration is outdated and has been updated in the latest version of the LRM.

Please refer to latest [IEEE Std 1800-2023](https://standards.ieee.org/ieee/1800/7743/) 8.3 Syntax:

> ```
> [ virtual ] class [ final_specifier ] class_identifier [ parameter_port_list ]
>     final_specifier ::= : final
> ```

In any case, this PR just makes a very minor change to adapt it, making it as harmless as possible.

@hirooih Please Take a Look, Thanks a lot!