### PR TITLE
Lisp: introduce version 0.0 of lisp meta parser

### DIFF
--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -48,6 +48,7 @@ x       UCTAGSxpath          no      NONE             s--    no    -- xpath for 
 -       UCTAGSoverline       no      ReStructuredText --b    no    -- whether using overline & underline for declaring section
 -       UCTAGSsectionMarker  no      ReStructuredText s--    no    -- character used for declaring section
 -       UCTAGSmixin          yes     Ruby             s--    no    -- how the class or module is mixed in (mixin:HOW:MODULE)
+-       UCTAGSdefiner        yes     Scheme           s--    no    -- the name of the function or macro that defines the unknown/Y-kind object
 -       UCTAGSparameter      no      SystemVerilog    --b    no    -- parameter whose value can be overridden.
 -       UCTAGStarget         yes     Thrift           s--    no    -- the target language specified at "namespace"
 -       UCTAGSthrows         yes     Thrift           s--    no    -- throws list of function

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -66,6 +66,7 @@ z	kind	no	NONE	s--	no	r-	[tags output] prepend "kind:" to k/ (or K/) field outpu
 -	overline	no	ReStructuredText	--b	no	--	whether using overline & underline for declaring section
 -	sectionMarker	no	ReStructuredText	s--	no	--	character used for declaring section
 -	mixin	yes	Ruby	s--	no	--	how the class or module is mixed in (mixin:HOW:MODULE)
+-	definer	yes	Scheme	s--	no	--	the name of the function or macro that defines the unknown/Y-kind object
 -	parameter	no	SystemVerilog	--b	no	--	parameter whose value can be overridden.
 -	target	yes	Thrift	s--	no	--	the target language specified at "namespace"
 -	throws	yes	Thrift	s--	no	--	throws list of function

--- a/Units/option-regex-attaching-role.r/extending-existing-parser.d/expected.tags
+++ b/Units/option-regex-attaching-role.r/extending-existing-parser.d/expected.tags
@@ -1,4 +1,4 @@
-foo	input.scm	/^(define-module foo$/;"	function	language:Scheme	roles:def
+foo	input.scm	/^(define-module foo$/;"	unknown	language:Scheme	roles:def	definer:DEFINE-MODULE
 foobar	input.scm	/^(define (foobar)$/;"	function	language:Scheme	roles:def
 foo	input.scm	/^(define-module foo$/;"	module	language:myGauche	roles:def
 bar	input.scm	/^  (use bar)$/;"	module	language:myGauche	scope:module:foo	roles:used

--- a/docs/man-pages.rst
+++ b/docs/man-pages.rst
@@ -21,6 +21,7 @@ Man pages
 	ctags-lang-automake(7) <man/ctags-lang-automake.7.rst>
 	ctags-lang-c(7) <man/ctags-lang-c.7.rst>
 	ctags-lang-c++(7) <man/ctags-lang-c++.7.rst>
+	ctags-lang-clojure(7) <man/ctags-lang-clojure.7.rst>
 	ctags-lang-cuda(7) <man/ctags-lang-cuda.7.rst>
 	ctags-lang-elm(7) <man/ctags-lang-elm.7.rst>
 	ctags-lang-emacslisp(7) <man/ctags-lang-emacslisp.7.rst>

--- a/docs/man-pages.rst
+++ b/docs/man-pages.rst
@@ -42,6 +42,7 @@ Man pages
 	ctags-lang-python(7) <man/ctags-lang-python.7.rst>
 	ctags-lang-r(7) <man/ctags-lang-r.7.rst>
 	ctags-lang-rmarkdown(7) <man/ctags-lang-rmarkdown.7.rst>
+	ctags-lang-scheme(7) <man/ctags-lang-scheme.7.rst>
 	ctags-lang-scss(7) <man/ctags-lang-scss.7.rst>
 	ctags-lang-sql(7) <man/ctags-lang-sql.7.rst>
 	ctags-lang-systemtap(7) <man/ctags-lang-systemtap.7.rst>

--- a/docs/man/ctags-lang-clojure.7.rst
+++ b/docs/man/ctags-lang-clojure.7.rst
@@ -1,0 +1,37 @@
+.. _ctags-lang-clojure(7):
+
+==============================================================
+ctags-lang-clojure
+==============================================================
+
+Random notes about tagging Clojure source code with Universal Ctags
+
+:Version: 6.1.0
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**ctags** ... --languages=+Clojure ...
+|	**ctags** ... --language-force=Clojure ...
+|	**ctags** ... --map-Clojure=+.clj ...
+|	**ctags** ... --map-Clojure=+.cljs ...
+|	**ctags** ... --map-Clojure=+.cljc ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging Clojure source code.
+
+VERSIONS
+--------
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* Add ``unknown`` kind.
+
+* Add ``definer`` field.
+
+SEE ALSO
+--------
+:ref:`ctags(1) <ctags(1)>`

--- a/docs/man/ctags-lang-scheme.7.rst
+++ b/docs/man/ctags-lang-scheme.7.rst
@@ -1,0 +1,41 @@
+.. _ctags-lang-scheme(7):
+
+==============================================================
+ctags-lang-scheme
+==============================================================
+
+Random notes about tagging Scheme source code with Universal Ctags
+
+:Version: 6.1.0
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**ctags** ... --languages=+Scheme ...
+|	**ctags** ... --language-force=Scheme ...
+|	**ctags** ... --map-Scheme=+.SCM ...
+|	**ctags** ... --map-Scheme=+.SM ...
+|	**ctags** ... --map-Scheme=+.sch ...
+|	**ctags** ... --map-Scheme=+.scheme ...
+|	**ctags** ... --map-Scheme=+.scm ...
+|	**ctags** ... --map-Scheme=+.sm ...
+|	**ctags** ... --map-Scheme=+.rkt ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging Scheme source code.
+
+VERSIONS
+--------
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* Add ``unknown`` kind.
+
+* Add ``definer`` field.
+
+SEE ALSO
+--------
+:ref:`ctags(1) <ctags(1)>`

--- a/man/GNUmakefile.am
+++ b/man/GNUmakefile.am
@@ -32,6 +32,7 @@ GEN_IN_MAN_FILES = \
 	ctags-lang-automake.7 \
 	ctags-lang-c.7 \
 	ctags-lang-c++.7 \
+	ctags-lang-clojure.7 \
 	ctags-lang-cuda.7 \
 	ctags-lang-elm.7 \
 	ctags-lang-emacslisp.7 \

--- a/man/GNUmakefile.am
+++ b/man/GNUmakefile.am
@@ -53,6 +53,7 @@ GEN_IN_MAN_FILES = \
 	ctags-lang-python.7 \
 	ctags-lang-r.7 \
 	ctags-lang-rmarkdown.7 \
+	ctags-lang-scheme.7 \
 	ctags-lang-scss.7 \
 	ctags-lang-sql.7 \
 	ctags-lang-systemtap.7 \

--- a/man/ctags-lang-clojure.7.rst.in
+++ b/man/ctags-lang-clojure.7.rst.in
@@ -1,0 +1,37 @@
+.. _ctags-lang-clojure(7):
+
+==============================================================
+ctags-lang-clojure
+==============================================================
+---------------------------------------------------------------------
+Random notes about tagging Clojure source code with Universal Ctags
+---------------------------------------------------------------------
+:Version: @VERSION@
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**@CTAGS_NAME_EXECUTABLE@** ... --languages=+Clojure ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --language-force=Clojure ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Clojure=+.clj ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Clojure=+.cljs ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Clojure=+.cljc ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging Clojure source code.
+
+VERSIONS
+--------
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* Add ``unknown`` kind.
+
+* Add ``definer`` field.
+
+SEE ALSO
+--------
+ctags(1)

--- a/man/ctags-lang-scheme.7.rst.in
+++ b/man/ctags-lang-scheme.7.rst.in
@@ -1,0 +1,41 @@
+.. _ctags-lang-scheme(7):
+
+==============================================================
+ctags-lang-scheme
+==============================================================
+---------------------------------------------------------------------
+Random notes about tagging Scheme source code with Universal Ctags
+---------------------------------------------------------------------
+:Version: @VERSION@
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**@CTAGS_NAME_EXECUTABLE@** ... --languages=+Scheme ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --language-force=Scheme ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Scheme=+.SCM ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Scheme=+.SM ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Scheme=+.sch ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Scheme=+.scheme ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Scheme=+.scm ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Scheme=+.sm ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Scheme=+.rkt ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging Scheme source code.
+
+VERSIONS
+--------
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* Add ``unknown`` kind.
+
+* Add ``definer`` field.
+
+SEE ALSO
+--------
+ctags(1)

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -18,12 +18,13 @@
 #include "general.h"  /* must always come first */
 
 #include "entry.h"
-#include "field.h"
 #include "parse.h"
 #include "read.h"
 #include "routines.h"
 #include "selectors.h"
 #include "vstring.h"
+
+#include "x-lisp.h"
 
 #include <string.h>
 
@@ -123,19 +124,6 @@ static kindDefinition EmacsLispKinds [] = {
 	{ true, 'G', "group", "customization groups" },
 	{ true, 'H', "face", "customizable faces" }, /* 'F' is reserved by ctags */
 	{ true, 'T', "theme", "custom themes" },
-};
-
-struct lispDialect {
-	int (* definer2kind) (const vString *const hint, const char *namespace);
-	bool case_insensitive;
-	unsigned char namespace_sep;
-	int unknown_kind;
-	fieldDefinition *definer_field;
-	bool skip_initial_spaces;
-	bool (* is_def) (struct lispDialect *, const unsigned char *);
-	int (* get_it) (struct lispDialect *,
-					vString *const, const unsigned char *, vString *,
-					const char *);
 };
 
 /*
@@ -388,7 +376,7 @@ static int lisp_get_it (struct lispDialect *dialect,
 
 /* Algorithm adapted from from GNU etags.
  */
-static void findLispTagsCommon (struct lispDialect *dialect)
+void findLispTagsCommon (struct lispDialect *dialect)
 {
 	vString *name = vStringNew ();
 	vString *kind_hint = vStringNew ();

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -134,7 +134,7 @@ static kindDefinition EmacsLispKinds [] = {
  * lisp tag functions
  *  look for (def or (DEF, quote or QUOTE
  */
-static bool lisp_is_def (struct lispDialect *dialect, const unsigned char *strp)
+bool lispIsDef (struct lispDialect *dialect, const unsigned char *strp)
 {
 	bool cis = dialect->case_insensitive; /* Renaming for making code short */
 	bool is_def = ( (strp [1] == 'd' || (cis && strp [1] == 'D'))
@@ -480,7 +480,7 @@ static void findLispTags (void)
 		.definer_field = LispFields + F_DEFINER,
 		.skip_initial_spaces = false,
 		.lambda_syntax_sugar = false,
-		.is_def = lisp_is_def,
+		.is_def = lispIsDef,
 		.get_it = lispGetIt,
 		.scope = CORK_NIL,
 	};
@@ -498,7 +498,7 @@ static void findEmacsLispTags (void)
 		.definer_field = EmacsLispFields + eF_DEFINER,
 		.skip_initial_spaces = false,
 		.lambda_syntax_sugar = false,
-		.is_def = lisp_is_def,
+		.is_def = lispIsDef,
 		.get_it = lispGetIt,
 		.scope = CORK_NIL,
 	};

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -132,8 +132,8 @@ struct lispDialect {
 	int unknown_kind;
 	fieldDefinition *definer_field;
 	bool (* is_def) (struct lispDialect *, const unsigned char *);
-	void (* get_it) (struct lispDialect *,
-					 vString *const, const unsigned char *, vString *);
+	int (* get_it) (struct lispDialect *,
+					vString *const, const unsigned char *, vString *);
 };
 
 /*
@@ -335,9 +335,10 @@ static int  elisp_hint2kind (const vString *const hint)
 }
 
 
-static void lisp_get_it (struct lispDialect *dialect,
-						 vString *const name, const unsigned char *dbp, vString *kind_hint)
+static int lisp_get_it (struct lispDialect *dialect,
+						vString *const name, const unsigned char *dbp, vString *kind_hint)
 {
+	int index = CORK_NIL;
 	const unsigned char *p;
 
 	if (*dbp == '\'')  /* Skip prefix quote */
@@ -371,13 +372,15 @@ static void lisp_get_it (struct lispDialect *dialect,
 
 		if (kind != KIND_GHOST_INDEX)
 		{
-			int index = makeSimpleTag (name, kind);
+			index = makeSimpleTag (name, kind);
 			if (dialect->definer_field && dialect->definer_field->enabled
 				&& definer && index != CORK_NIL)
 				attachParserFieldToCorkEntry (index, dialect->definer_field->ftype, definer);
 		}
 	}
 	vStringClear (name);
+
+	return index;
 }
 
 /* Algorithm adapted from from GNU etags.

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -324,10 +324,9 @@ static int  elisp_hint2kind (const vString *const hint, const char *namespace CT
 	return k;
 }
 
-
-static int lisp_get_it (struct lispDialect *dialect,
-						vString *const name, const unsigned char *dbp, vString *kind_hint,
-						const char *namespace)
+ int lispGetIt (struct lispDialect *dialect,
+				vString *const name, const unsigned char *dbp, vString *kind_hint,
+				const char *namespace)
 {
 	int index = CORK_NIL;
 	const unsigned char *p;
@@ -458,7 +457,8 @@ static void findLispTags (void)
 		.definer_field = LispFields + F_DEFINER,
 		.skip_initial_spaces = false,
 		.is_def = lisp_is_def,
-		.get_it = lisp_get_it,
+		.get_it = lispGetIt,
+		.scope = CORK_NIL,
 	};
 
 	findLispTagsCommon (&lisp_dialect);
@@ -474,11 +474,13 @@ static void findEmacsLispTags (void)
 		.definer_field = EmacsLispFields + eF_DEFINER,
 		.skip_initial_spaces = false,
 		.is_def = lisp_is_def,
-		.get_it = lisp_get_it,
+		.get_it = lispGetIt,
+		.scope = CORK_NIL,
 	};
 
 	findLispTagsCommon (&elisp_dialect);
 }
+
 
 extern parserDefinition* LispParser (void)
 {

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -131,6 +131,7 @@ struct lispDialect {
 	unsigned char namespace_sep;
 	int unknown_kind;
 	fieldDefinition *definer_field;
+	bool skip_initial_spaces;
 	bool (* is_def) (struct lispDialect *, const unsigned char *);
 	int (* get_it) (struct lispDialect *,
 					vString *const, const unsigned char *, vString *);
@@ -394,6 +395,12 @@ static void findLispTagsCommon (struct lispDialect *dialect)
 
 	while ((p = readLineFromInputFile ()) != NULL)
 	{
+		if (dialect->skip_initial_spaces)
+		{
+			while (isspace ((unsigned char) *p))
+				p++;
+		}
+
 		if (*p == '(')
 		{
 			if (dialect->is_def (dialect, p))
@@ -450,6 +457,7 @@ static void findLispTags (void)
 		.namespace_sep = ':',
 		.unknown_kind = K_UNKNOWN,
 		.definer_field = LispFields + F_DEFINER,
+		.skip_initial_spaces = false,
 		.is_def = lisp_is_def,
 		.get_it = lisp_get_it,
 	};
@@ -465,6 +473,7 @@ static void findEmacsLispTags (void)
 		.namespace_sep = 0,
 		.unknown_kind = eK_UNKNOWN,
 		.definer_field = EmacsLispFields + eF_DEFINER,
+		.skip_initial_spaces = false,
 		.is_def = lisp_is_def,
 		.get_it = lisp_get_it,
 	};

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -128,7 +128,7 @@ static kindDefinition EmacsLispKinds [] = {
 struct lispDialect {
 	int (* definer2kind) (const vString *const hint);
 	bool case_insensitive;
-	bool has_namespace;
+	unsigned char namespace_sep;
 	int unknown_kind;
 	fieldDefinition *definer_field;
 };
@@ -403,17 +403,17 @@ static void findLispTagsCommon (struct lispDialect *dialect)
 					p++;
 				L_getit (name, p, dialect, kind_hint);
 			}
-			else if (dialect->has_namespace)
+			else if (dialect->namespace_sep != 0)
 			{
 				do
 					p++;
 				while (*p != '\0' && !isspace (*p)
-						&& *p != ':' && *p != '(' && *p != ')');
-				if (*p == ':')
+						&& *p != dialect->namespace_sep && *p != '(' && *p != ')');
+				if (*p == dialect->namespace_sep)
 				{
 					do
 						p++;
-					while (*p == ':');
+					while (*p == dialect->namespace_sep);
 
 					if (L_isdef (p - 1, dialect->case_insensitive))
 					{
@@ -441,7 +441,7 @@ static void findLispTags (void)
 	struct lispDialect lisp_dialect = {
 		.definer2kind = lisp_hint2kind,
 		.case_insensitive = true,
-		.has_namespace = true,
+		.namespace_sep = ':',
 		.unknown_kind = K_UNKNOWN,
 		.definer_field = LispFields + F_DEFINER,
 	};
@@ -454,7 +454,7 @@ static void findEmacsLispTags (void)
 	struct lispDialect elisp_dialect = {
 		.definer2kind = elisp_hint2kind,
 		.case_insensitive = false,
-		.has_namespace = false,
+		.namespace_sep = 0,
 		.unknown_kind = eK_UNKNOWN,
 		.definer_field = EmacsLispFields + eF_DEFINER,
 	};

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -132,6 +132,8 @@ struct lispDialect {
 	int unknown_kind;
 	fieldDefinition *definer_field;
 	bool (* is_def) (struct lispDialect *, const unsigned char *);
+	void (* get_it) (struct lispDialect *,
+					 vString *const, const unsigned char *, vString *);
 };
 
 /*
@@ -332,9 +334,9 @@ static int  elisp_hint2kind (const vString *const hint)
 	return k;
 }
 
-static void L_getit (vString *const name, const unsigned char *dbp,
-					 struct lispDialect *dialect,
-					 vString *kind_hint)
+
+static void lisp_get_it (struct lispDialect *dialect,
+						 vString *const name, const unsigned char *dbp, vString *kind_hint)
 {
 	const unsigned char *p;
 
@@ -402,7 +404,7 @@ static void findLispTagsCommon (struct lispDialect *dialect)
 				}
 				while (isspace (*p))
 					p++;
-				L_getit (name, p, dialect, kind_hint);
+				dialect->get_it(dialect, name, p, kind_hint);
 			}
 			else if (dialect->namespace_sep != 0)
 			{
@@ -427,7 +429,7 @@ static void findLispTagsCommon (struct lispDialect *dialect)
 						}
 						while (isspace (*p))
 							p++;
-						L_getit (name, p, dialect, kind_hint);
+						dialect->get_it(dialect, name, p, kind_hint);
 					}
 				}
 			}
@@ -446,6 +448,7 @@ static void findLispTags (void)
 		.unknown_kind = K_UNKNOWN,
 		.definer_field = LispFields + F_DEFINER,
 		.is_def = lisp_is_def,
+		.get_it = lisp_get_it,
 	};
 
 	findLispTagsCommon (&lisp_dialect);
@@ -460,6 +463,7 @@ static void findEmacsLispTags (void)
 		.unknown_kind = eK_UNKNOWN,
 		.definer_field = EmacsLispFields + eF_DEFINER,
 		.is_def = lisp_is_def,
+		.get_it = lisp_get_it,
 	};
 
 	findLispTagsCommon (&elisp_dialect);

--- a/parsers/x-lisp.h
+++ b/parsers/x-lisp.h
@@ -1,0 +1,32 @@
+/*
+ *   Copyright (c) 2011, Colomban Wendling <colomban@geany.org>
+ *
+ *   This source code is released for free distribution under the terms of the
+ *   GNU General Public License version 2 or (at your option) any later version.
+ *
+ *   List meata parser interface exported to the other lisp families
+ */
+
+#ifndef CTAGS_LISP_H
+#define CTAGS_LISP_H
+
+#include "general.h"
+
+#include "field.h"
+
+struct lispDialect {
+	int (* definer2kind) (const vString *const hint, const char *namespace);
+	bool case_insensitive;
+	unsigned char namespace_sep;
+	int unknown_kind;
+	fieldDefinition *definer_field;
+	bool skip_initial_spaces;
+	bool (* is_def) (struct lispDialect *, const unsigned char *);
+	int (* get_it) (struct lispDialect *,
+					vString *const, const unsigned char *, vString *,
+					const char *);
+};
+
+void findLispTagsCommon (struct lispDialect *dialect);
+
+#endif	/* CTAGS_LISP_H */

--- a/parsers/x-lisp.h
+++ b/parsers/x-lisp.h
@@ -25,8 +25,13 @@ struct lispDialect {
 	int (* get_it) (struct lispDialect *,
 					vString *const, const unsigned char *, vString *,
 					const char *);
+	int scope;
 };
 
 void findLispTagsCommon (struct lispDialect *dialect);
+
+int lispGetIt (struct lispDialect *dialect,
+			   vString *const name, const unsigned char *dbp, vString *kind_hint,
+			   const char *namespace);
 
 #endif	/* CTAGS_LISP_H */

--- a/parsers/x-lisp.h
+++ b/parsers/x-lisp.h
@@ -34,5 +34,6 @@ void findLispTagsCommon (struct lispDialect *dialect);
 int lispGetIt (struct lispDialect *dialect,
 			   vString *const name, const unsigned char *dbp, vString *kind_hint,
 			   const char *namespace);
+bool lispIsDef (struct lispDialect *dialect, const unsigned char *strp);
 
 #endif	/* CTAGS_LISP_H */

--- a/parsers/x-lisp.h
+++ b/parsers/x-lisp.h
@@ -21,6 +21,7 @@ struct lispDialect {
 	int unknown_kind;
 	fieldDefinition *definer_field;
 	bool skip_initial_spaces;
+	bool lambda_syntax_sugar;
 	bool (* is_def) (struct lispDialect *, const unsigned char *);
 	int (* get_it) (struct lispDialect *,
 					vString *const, const unsigned char *, vString *,

--- a/source.mak
+++ b/source.mak
@@ -294,6 +294,7 @@ PARSER_HEADS = \
 	parsers/x-frontmatter.h \
 	parsers/x-iniconf.h \
 	parsers/x-jscript.h \
+	parsers/x-lisp.h \
 	parsers/x-m4.h \
 	parsers/x-make.h \
 	parsers/x-markdown.h \

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -476,6 +476,7 @@
     <ClInclude Include="..\parsers\x-frontmatter.h" />
     <ClInclude Include="..\parsers\x-iniconf.h" />
     <ClInclude Include="..\parsers\x-jscript.h" />
+    <ClInclude Include="..\parsers\x-lisp.h" />
     <ClInclude Include="..\parsers\x-m4.h" />
     <ClInclude Include="..\parsers\x-make.h" />
     <ClInclude Include="..\parsers\x-markdown.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -947,6 +947,9 @@
     <ClInclude Include="..\parsers\x-jscript.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\parsers\x-lisp.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\parsers\x-m4.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
This one is not S expression-based but still line-oriented. However, the meta parser supports all Lisp, EmacsLisp, Clojure, and Scheme like before.

- [x] parser versioning: `definer:` field and `unknown/Y` kind are introduced to Clojure and Scheme as a side effect.