### PR TITLE
verilog: support ifdef in enum

### DIFF
--- a/Units/parser-verilog.r/systemverilog-github4056.d/expected.tags
+++ b/Units/parser-verilog.r/systemverilog-github4056.d/expected.tags
@@ -29,3 +29,11 @@ enum10_e	input.sv	/^    enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	w	
 enum11_e	input.sv	/^    enum logic unsigned{A,B,C}[1:0]enum10_e,enum11_e;$/;"	w	struct:O.complex1_s
 d	input.sv	/^    bit[7:0][1:0]d,e;$/;"	w	struct:O.complex1_s
 e	input.sv	/^    bit[7:0][1:0]d,e;$/;"	w	struct:O.complex1_s
+ifdef1_e	input.sv	/^} ifdef1_e;$/;"	T
+xxx	input.sv	/^    xxx,$/;"	c	typedef:ifdef1_e
+yyy	input.sv	/^    yyy$/;"	c	typedef:ifdef1_e
+zzz	input.sv	/^    zzz = 'x$/;"	c	typedef:ifdef1_e
+ifdef2_e	input.sv	/^} ifdef2_e;$/;"	T
+aaa	input.sv	/^    aaa,$/;"	c	typedef:ifdef2_e
+bbb	input.sv	/^    bbb$/;"	c	typedef:ifdef2_e
+ccc	input.sv	/^    ,ccc$/;"	c	typedef:ifdef2_e

--- a/Units/parser-verilog.r/systemverilog-github4056.d/input.sv
+++ b/Units/parser-verilog.r/systemverilog-github4056.d/input.sv
@@ -30,3 +30,21 @@ class O;
   `include "test1.txt"
   } [1:0] complex0_s, complex1_s;
 endclass
+
+// https://github.com/universal-ctags/ctags/issues/
+typedef enum logic {
+    xxx,
+    yyy
+`ifdef foo
+    ,
+    zzz = 'x
+`endif
+} ifdef1_e;
+
+typedef enum logic {
+    aaa,
+    bbb
+`ifdef bar
+    ,ccc
+`endif
+} ifdef2_e;

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -1694,6 +1694,7 @@ static int pushEnumNames (tokenInfo* token, int c)
 			if (c == '=')
 				c = skipExpression (vGetc ());
 
+			c = skipMacro (c, token);
 			/* Skip comma */
 			if (c == ',')
 				c = skipWhite (vGetc ());


### PR DESCRIPTION
This is a fix to support the following coding style.

```verilog
typedef enum logic {
    aaa,
    bbb
`ifdef bar
    ,ccc
`endif
} ifdef2_e;
```
