### PR TITLE
GitHub Actions: removing macos-12 runner due to it is fully unsupported as of 2024-12.03

### DIFF
--- a/.github/workflows/cross-compile-for-android-on-macos.yml
+++ b/.github/workflows/cross-compile-for-android-on-macos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [macos-14, macos-13, macos-12]
+        build-machine-os: [macos-14, macos-13]
 
     runs-on: ${{ matrix.build-machine-os }}
 

--- a/.github/workflows/cross-compile-for-windows-on-macos.yml
+++ b/.github/workflows/cross-compile-for-windows-on-macos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [macos-14, macos-13, macos-12]
+        build-machine-os: [macos-14, macos-13]
         target: [i686-w64-mingw32,x86_64-w64-mingw32]
 
     runs-on: ${{ matrix.build-machine-os }}

--- a/.github/workflows/testing-on-macos.yml
+++ b/.github/workflows/testing-on-macos.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-15, macos-14, macos-13, macos-12]
+        os: [macos-15, macos-14, macos-13]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION

Reference: https://github.com/actions/runner-images/issues/10721