### PR TITLE
ObjectiveC: (bugfix) extract the line numbers for methods correctly

### DIFF
--- a/Units/noext-tg-objc.d/expected.tags
+++ b/Units/noext-tg-objc.d/expected.tags
@@ -1,17 +1,17 @@
 FileTree	input.nolang	/^@implementation FileTree$/;"	I
 FolderTree	input.nolang	/^@implementation FolderTree$/;"	I
 MyClass	input.nolang	/^@implementation MyClass$/;"	I
-addChild:	input.nolang	/^{$/;"	m	implementation:FolderTree
-createFileList:atPlace:	input.nolang	/^{$/;"	c	implementation:FolderTree
-createLayoutTree	input.nolang	/^{$/;"	m	implementation:FileTree
-createLayoutTree	input.nolang	/^{$/;"	m	implementation:FolderTree
-dealloc	input.nolang	/^{$/;"	m	implementation:FileTree
-dealloc	input.nolang	/^{$/;"	m	implementation:FolderTree
-getDiskSize	input.nolang	/^{$/;"	m	implementation:FileTree
-initWithName:andSize:atPlace:	input.nolang	/^{$/;"	m	implementation:FileTree
-initWithName:atPlace:	input.nolang	/^{$/;"	m	implementation:FileTree
-initWithName:atPlace:	input.nolang	/^{$/;"	m	implementation:FolderTree
+addChild:	input.nolang	/^- (FolderTree*)addChild:(FileTree*)subTree$/;"	m	implementation:FolderTree
+createFileList:atPlace:	input.nolang	/^+ (void) createFileList: (NSString*)root atPlace:(FolderTree*)parentFolder$/;"	c	implementation:FolderTree
+createLayoutTree	input.nolang	/^- (LayoutTree*)createLayoutTree$/;"	m	implementation:FileTree
+createLayoutTree	input.nolang	/^- (LayoutTree*)createLayoutTree$/;"	m	implementation:FolderTree
+dealloc	input.nolang	/^- (void)dealloc$/;"	m	implementation:FileTree
+dealloc	input.nolang	/^- (void)dealloc$/;"	m	implementation:FolderTree
+getDiskSize	input.nolang	/^- (FileSize)getDiskSize$/;"	m	implementation:FileTree
+initWithName:andSize:atPlace:	input.nolang	/^- (id)initWithName:(NSString*)treeName$/;"	m	implementation:FileTree
+initWithName:atPlace:	input.nolang	/^- (id)initWithName:(NSString*)treeName$/;"	m	implementation:FileTree
+initWithName:atPlace:	input.nolang	/^- (id)initWithName:(NSString*)treeName$/;"	m	implementation:FolderTree
 main	input.nolang	/^int main(int argc, char** argv)$/;"	f
 myClassMethod:with:	input.nolang	/^+ (void)myClassMethod:(int)arg1 with:(id)arg2;$/;"	c	implementation:MyClass
 myInstanceMethod:with:	input.nolang	/^- (void)myInstanceMethod:(int)arg1 with:(id)arg2;$/;"	m	implementation:MyClass
-populateChildList:	input.nolang	/^{$/;"	m	implementation:FolderTree
+populateChildList:	input.nolang	/^- (void) populateChildList:(NSString*)root$/;"	m	implementation:FolderTree

--- a/Units/objc-tg-corpus.d/expected.tags
+++ b/Units/objc-tg-corpus.d/expected.tags
@@ -1,17 +1,17 @@
 FileTree	input.m	/^@implementation FileTree$/;"	I
 FolderTree	input.m	/^@implementation FolderTree$/;"	I
 MyClass	input.m	/^@implementation MyClass$/;"	I
-addChild:	input.m	/^{$/;"	m	implementation:FolderTree
-createFileList:atPlace:	input.m	/^{$/;"	c	implementation:FolderTree
-createLayoutTree	input.m	/^{$/;"	m	implementation:FileTree
-createLayoutTree	input.m	/^{$/;"	m	implementation:FolderTree
-dealloc	input.m	/^{$/;"	m	implementation:FileTree
-dealloc	input.m	/^{$/;"	m	implementation:FolderTree
-getDiskSize	input.m	/^{$/;"	m	implementation:FileTree
-initWithName:andSize:atPlace:	input.m	/^{$/;"	m	implementation:FileTree
-initWithName:atPlace:	input.m	/^{$/;"	m	implementation:FileTree
-initWithName:atPlace:	input.m	/^{$/;"	m	implementation:FolderTree
+addChild:	input.m	/^- (FolderTree*)addChild:(FileTree*)subTree$/;"	m	implementation:FolderTree
+createFileList:atPlace:	input.m	/^+ (void) createFileList: (NSString*)root atPlace:(FolderTree*)parentFolder$/;"	c	implementation:FolderTree
+createLayoutTree	input.m	/^- (LayoutTree*)createLayoutTree$/;"	m	implementation:FileTree
+createLayoutTree	input.m	/^- (LayoutTree*)createLayoutTree$/;"	m	implementation:FolderTree
+dealloc	input.m	/^- (void)dealloc$/;"	m	implementation:FileTree
+dealloc	input.m	/^- (void)dealloc$/;"	m	implementation:FolderTree
+getDiskSize	input.m	/^- (FileSize)getDiskSize$/;"	m	implementation:FileTree
+initWithName:andSize:atPlace:	input.m	/^- (id)initWithName:(NSString*)treeName$/;"	m	implementation:FileTree
+initWithName:atPlace:	input.m	/^- (id)initWithName:(NSString*)treeName$/;"	m	implementation:FileTree
+initWithName:atPlace:	input.m	/^- (id)initWithName:(NSString*)treeName$/;"	m	implementation:FolderTree
 main	input.m	/^int main(int argc, char** argv)$/;"	f
 myClassMethod:with:	input.m	/^+ (void)myClassMethod:(int)arg1 with:(id)arg2;$/;"	c	implementation:MyClass
 myInstanceMethod:with:	input.m	/^- (void)myInstanceMethod:(int)arg1 with:(id)arg2;$/;"	m	implementation:MyClass
-populateChildList:	input.m	/^{$/;"	m	implementation:FolderTree
+populateChildList:	input.m	/^- (void) populateChildList:(NSString*)root$/;"	m	implementation:FolderTree

--- a/Units/parser-objectivec.r/objc-signature.d/expected.tags
+++ b/Units/parser-objectivec.r/objc-signature.d/expected.tags
@@ -16,6 +16,6 @@ doVoidPtr:andWith:	input.m	/^- (void*)doVoidPtr: idarg1 andWith: (id**) idarg2Pt
 doVoidPtr:andWithStruct:	input.m	/^- (void*)doVoidPtr: idarg1 andWithStruct: (struct foo *) idarg2PtrExplicit;$/;"	m	interface:X	signature:(id,struct foo*)
 doVoidUInt:andWithStruct:	input.m	/^- (void*)doVoidUInt: (unsigned int) idarg1 andWithStruct: (struct foo *) idarg2PtrExplicit;$/;"	m	interface:X	signature:(unsigned int,struct foo*)
 X	input.m	/^@implementation X$/;"	I
-doNothing	input.m	/^{$/;"	m	implementation:X	signature:()
-doNothing:	input.m	/^{$/;"	m	implementation:X	signature:(id)
-doVoidUInt:andWithStruct:	input.m	/^{$/;"	m	implementation:X	signature:(unsigned int,struct foo*)
+doNothing	input.m	/^- doNothing$/;"	m	implementation:X	signature:()
+doNothing:	input.m	/^- doNothing: idarg$/;"	m	implementation:X	signature:(id)
+doVoidUInt:andWithStruct:	input.m	/^- (void*)doVoidUInt: (unsigned int) idarg1 andWithStruct: (struct foo *) idarg2PtrExplicit$/;"	m	implementation:X	signature:(unsigned int,struct foo*)

--- a/Units/parser-objectivec.r/objectivec_implementation.m.d/expected.tags
+++ b/Units/parser-objectivec.r/objectivec_implementation.m.d/expected.tags
@@ -2,15 +2,15 @@ Extension	input.m	/^@implementation NSString (Extension)$/;"	C	implementation:NS
 FileTree	input.m	/^@implementation FileTree$/;"	I
 FolderTree	input.m	/^@implementation FolderTree$/;"	I
 NSString	input.m	/^@implementation NSString (Extension)$/;"	I	category:Extension
-addChild:	input.m	/^{$/;"	m	implementation:FolderTree
-createFileList:atPlace:	input.m	/^{$/;"	c	implementation:FolderTree
-createLayoutTree	input.m	/^{$/;"	m	implementation:FileTree
-createLayoutTree	input.m	/^{$/;"	m	implementation:FolderTree
-dealloc	input.m	/^{$/;"	m	implementation:FileTree
-dealloc	input.m	/^{$/;"	m	implementation:FolderTree
-doSomething	input.m	/^{$/;"	m	implementation:NSString	category:Extension
-getDiskSize	input.m	/^{$/;"	m	implementation:FileTree
-initWithName:andSize:atPlace:	input.m	/^{$/;"	m	implementation:FileTree
-initWithName:atPlace:	input.m	/^{$/;"	m	implementation:FileTree
-initWithName:atPlace:	input.m	/^{$/;"	m	implementation:FolderTree
-populateChildList:	input.m	/^{$/;"	m	implementation:FolderTree
+addChild:	input.m	/^- (FolderTree*)addChild:(FileTree*)subTree$/;"	m	implementation:FolderTree
+createFileList:atPlace:	input.m	/^+ (void) createFileList: (NSString*)root atPlace:(FolderTree*)parentFolder$/;"	c	implementation:FolderTree
+createLayoutTree	input.m	/^- (LayoutTree*)createLayoutTree$/;"	m	implementation:FileTree
+createLayoutTree	input.m	/^- (LayoutTree*)createLayoutTree$/;"	m	implementation:FolderTree
+dealloc	input.m	/^- (void)dealloc$/;"	m	implementation:FileTree
+dealloc	input.m	/^- (void)dealloc$/;"	m	implementation:FolderTree
+doSomething	input.m	/^- (void)doSomething$/;"	m	implementation:NSString	category:Extension
+getDiskSize	input.m	/^- (FileSize)getDiskSize$/;"	m	implementation:FileTree
+initWithName:andSize:atPlace:	input.m	/^- (id)initWithName:(NSString*)treeName$/;"	m	implementation:FileTree
+initWithName:atPlace:	input.m	/^- (id)initWithName:(NSString*)treeName$/;"	m	implementation:FileTree
+initWithName:atPlace:	input.m	/^- (id)initWithName:(NSString*)treeName$/;"	m	implementation:FolderTree
+populateChildList:	input.m	/^- (void) populateChildList:(NSString*)root$/;"	m	implementation:FolderTree

--- a/Units/parser-objectivec.r/objectivec_interface.h.d/expected.tags
+++ b/Units/parser-objectivec.r/objectivec_interface.h.d/expected.tags
@@ -27,9 +27,9 @@ doSomething34	input.h	/^- (void)doSomething34;$/;"	kind:method	line:74	language:
 doSomething5	input.h	/^- (void)doSomething5;$/;"	kind:method	line:78	language:ObjectiveC	interface:MyString	signature:()	roles:def
 doSomething67	input.h	/^- (void)doSomething67;$/;"	kind:method	line:82	language:ObjectiveC	interface:YourString	signature:()	roles:def
 getDiskSize	input.h	/^- (FileSize)getDiskSize;$/;"	kind:method	line:48	language:ObjectiveC	interface:FileTree	signature:()	roles:def
-initWithName:andSize:atPlace:	input.h	/^           atPlace:(FolderTree*)parentFolder;$/;"	kind:method	line:41	language:ObjectiveC	interface:FileTree	signature:(NSString*,uint64_t,FolderTree*)	roles:def
-initWithName:atPlace:	input.h	/^           atPlace:(FolderTree*)parentFolder;$/;"	kind:method	line:44	language:ObjectiveC	interface:FileTree	signature:(NSString*,FolderTree*)	roles:def
-initWithName:atPlace:	input.h	/^           atPlace:(FolderTree*)parentFolder;$/;"	kind:method	line:57	language:ObjectiveC	interface:FolderTree	signature:(NSString*,FolderTree*)	roles:def
+initWithName:andSize:atPlace:	input.h	/^- (id)initWithName:(NSString*)treeName$/;"	kind:method	line:39	language:ObjectiveC	interface:FileTree	signature:(NSString*,uint64_t,FolderTree*)	roles:def
+initWithName:atPlace:	input.h	/^- (id)initWithName:(NSString*)treeName$/;"	kind:method	line:43	language:ObjectiveC	interface:FileTree	signature:(NSString*,FolderTree*)	roles:def
+initWithName:atPlace:	input.h	/^- (id)initWithName:(NSString*)treeName$/;"	kind:method	line:56	language:ObjectiveC	interface:FolderTree	signature:(NSString*,FolderTree*)	roles:def
 name	input.h	/^	NSString	*name;$/;"	kind:field	line:34	language:ObjectiveC	interface:FileTree	roles:def
 parent	input.h	/^    FolderTree  *parent[THISISNOTATAG];$/;"	kind:field	line:36	language:ObjectiveC	interface:FileTree	roles:def
 populateChildList:	input.h	/^- (void) populateChildList:(NSString*)root;$/;"	kind:method	line:61	language:ObjectiveC	interface:FolderTree	signature:(NSString*)	roles:def

--- a/Units/writer-xref.r/format-NlKkFnP.d/expected.tags-x
+++ b/Units/writer-xref.r/format-NlKkFnP.d/expected.tags-x
@@ -8,5 +8,5 @@
              x ObjectiveC:function(f) input.m 18 - static int x(void)
              y ObjectiveC:function(f) input.m 23 - int y(void)
              B ObjectiveC:implementation(I) input.m 28 - @implementation B
-       aMethod ObjectiveC:method(m) input.m 30 - {
-   doSomething ObjectiveC:method(m) input.m 34 - {
+       aMethod ObjectiveC:method(m) input.m 29 - - aMethod
+   doSomething ObjectiveC:method(m) input.m 33 - - doSomething

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -536,6 +536,16 @@ static int addTag (vString * const ident, int kind)
 	return makeTagEntry (&toCreate);
 }
 
+static int objcAddTag (objcString * const ident, int kind)
+{
+	int q = addTag (ident->name, kind);
+	tagEntryInfo *e = getEntryInCorkQueue (q);
+	if (e)
+		updateTagLine (e, ident->ln, ident->pos);
+
+	return q;
+}
+
 static objcToken waitedToken, fallBackToken;
 
 /* Ignore everything till waitedToken and jump to comeAfter.
@@ -759,11 +769,11 @@ static void parseMethodsNameCommon (vString * const ident, objcToken what,
 		/* method name is not simple */
 		if (!objcStringIsEmpty (fullMethodName))
 		{
-			index = addTag (fullMethodName->name, methodKind);
+			index = objcAddTag (fullMethodName, methodKind);
 			objcStringClear (fullMethodName);
 		}
 		else
-			index = addTag (prevIdent->name, methodKind);
+			index = objcAddTag (prevIdent, methodKind);
 
 		toDoNext = nextAction;
 		parseImplemMethods (ident, what, ln, pos);

--- a/parsers/objc.c
+++ b/parsers/objc.c
@@ -469,7 +469,7 @@ static void prepareTag (tagEntryInfo * tag, vString const *name, objcKind kind)
 {
 	initTagEntry (tag, vStringValue (name), kind);
 
-	if (vStringLength (parentName) > 0)
+	if (!vStringIsEmpty (parentName))
 	{
 		tag->extensionFields.scopeKindIndex = parentType;
 		tag->extensionFields.scopeName = vStringValue (parentName);
@@ -614,7 +614,7 @@ static void tillTokenWithCapturingSignature (vString * const ident, objcToken wh
 	{
 		if (what == Tok_Asterisk)
 			vStringPut (signature, '*');
-		else if (vStringLength (ident) > 0)
+		else if (!vStringIsEmpty (ident))
 		{
 			if (! (vStringLast (signature) == ','
 				   || vStringLast (signature) == '('
@@ -639,8 +639,8 @@ static void parseMethodsNameCommon (vString * const ident, objcToken what,
 		comeAfter = reEnter;
 		waitedToken = Tok_PARR;
 
-		if (! (vStringLength(prevIdent) == 0
-			   && vStringLength(fullMethodName) == 0))
+		if (! (vStringIsEmpty(prevIdent)
+			   && vStringIsEmpty(fullMethodName)))
 			toDoNext = &tillTokenWithCapturingSignature;
 		break;
 
@@ -654,7 +654,7 @@ static void parseMethodsNameCommon (vString * const ident, objcToken what,
 		break;
 
 	case ObjcIDENTIFIER:
-		if ((vStringLength (prevIdent) > 0
+		if (((!vStringIsEmpty (prevIdent))
 			 /* "- initWithObject: o0 withAnotherObject: o1;"
 				Overwriting the last value of prevIdent ("o0");
 				a parameter name ("o0") was stored to prevIdent,
@@ -670,8 +670,8 @@ static void parseMethodsNameCommon (vString * const ident, objcToken what,
 				   In this case no overwriting happens.
 				   However, "id" for "object" is part
 				   of signature. */
-				vStringLength (prevIdent) == 0
-				&& vStringLength (fullMethodName) > 0
+				vStringIsEmpty (prevIdent)
+				&& (!vStringIsEmpty (fullMethodName))
 				&& vStringLast (signature) == '('))
 			vStringCatS (signature, "id");
 
@@ -681,7 +681,7 @@ static void parseMethodsNameCommon (vString * const ident, objcToken what,
 	case Tok_CurlL:
 	case Tok_semi:
 		/* method name is not simple */
-		if (vStringLength (fullMethodName) != '\0')
+		if (!vStringIsEmpty (fullMethodName))
 		{
 			index = addTag (fullMethodName, methodKind);
 			vStringClear (fullMethodName);


### PR DESCRIPTION
The original code records the line numbers of ';' or '{' at the end of method declarations or definitions.

Close #4161
