### PR TITLE
CPreProcessor: support variadic macros with GNU cpp extension syntax 

### DIFF
--- a/Units/parser-cxx.r/complex-macros.d/args.ctags
+++ b/Units/parser-cxx.r/complex-macros.d/args.ctags
@@ -7,6 +7,7 @@
 -D DECLARE_FUNCTION_2(_ret,_name)=_ret _name();
 -D DECLARE_FUNCTION_3(_ret,_name,...)=_ret _name(__VA_ARGS__);
 -D DEPRECATED(...)=__VA_ARGS__ __attribute__((deprecated))
+-D ENUM_GNUX(n,e...)=enum n { e }
 -D DECLARE_TWO_VERSIONS_OF_FUNCTIONS(_prefix1,_prefix2)=DECLARE_FUNCTION_2(int,_prefix1 ## a) DECLARE_FUNCTION_2(int,_prefix2 ## a)
 -D STRINGIFY(token)=#token
 -D IMPLEMENT_FUNCTIONS(_prefix)=void _prefix ## a(){ }; void _prefix ## b(){ };

--- a/Units/parser-cxx.r/complex-macros.d/expected.tags
+++ b/Units/parser-cxx.r/complex-macros.d/expected.tags
@@ -15,6 +15,13 @@ a	input.cpp	/^DECLARE_FUNCTION_3(int,p3,int a,int b);$/;"	z	prototype:p3	typeref
 b	input.cpp	/^DECLARE_FUNCTION_3(int,p3,int a,int b);$/;"	z	prototype:p3	typeref:typename:int	file:
 DEPRECATED	input.cpp	/^#define DEPRECATED(/;"	d	file:	signature:(...)
 p4	input.cpp	/^DEPRECATED(int p4());$/;"	p	typeref:typename:int	file:	signature:()	properties:deprecated
+n	input.cpp	/^#define ENUM_GNUX(n,e...) enum n { e }$/;"	D	macro:ENUM_GNUX
+e	input.cpp	/^#define ENUM_GNUX(n,e...) enum n { e }$/;"	D	macro:ENUM_GNUX
+ENUM_GNUX	input.cpp	/^#define ENUM_GNUX(/;"	d	file:	signature:(n,e...)
+color	input.cpp	/^ENUM_GNUX(color, red, blue, green);$/;"	g	file:
+red	input.cpp	/^ENUM_GNUX(color, red, blue, green);$/;"	e	enum:color	file:
+blue	input.cpp	/^ENUM_GNUX(color, red, blue, green);$/;"	e	enum:color	file:
+green	input.cpp	/^ENUM_GNUX(color, red, blue, green);$/;"	e	enum:color	file:
 _prefix1	input.cpp	/^#define DECLARE_TWO_VERSIONS_OF_FUNCTIONS(_prefix1,_prefix2) \\$/;"	D	macro:DECLARE_TWO_VERSIONS_OF_FUNCTIONS
 _prefix2	input.cpp	/^#define DECLARE_TWO_VERSIONS_OF_FUNCTIONS(_prefix1,_prefix2) \\$/;"	D	macro:DECLARE_TWO_VERSIONS_OF_FUNCTIONS
 DECLARE_TWO_VERSIONS_OF_FUNCTIONS	input.cpp	/^#define DECLARE_TWO_VERSIONS_OF_FUNCTIONS(/;"	d	file:	signature:(_prefix1,_prefix2)

--- a/Units/parser-cxx.r/complex-macros.d/input.cpp
+++ b/Units/parser-cxx.r/complex-macros.d/input.cpp
@@ -27,6 +27,10 @@ DECLARE_FUNCTION_3(int,p3,int a,int b);
 
 DEPRECATED(int p4());
 
+#define ENUM_GNUX(n,e...) enum n { e }
+
+ENUM_GNUX(color, red, blue, green);
+
 // Recursive macro expansion
 
 #define DECLARE_TWO_VERSIONS_OF_FUNCTIONS(_prefix1,_prefix2) \

--- a/parsers/cpreprocessor.c
+++ b/parsers/cpreprocessor.c
@@ -215,12 +215,12 @@ static int externalParserBlockNestLevel;
  */
 static bool BraceFormat = false;
 
-void cppPushExternalParserBlock(void)
+extern void cppPushExternalParserBlock(void)
 {
 	externalParserBlockNestLevel++;
 }
 
-void cppPopExternalParserBlock(void)
+extern void cppPopExternalParserBlock(void)
 {
 	externalParserBlockNestLevel--;
 }
@@ -527,13 +527,13 @@ extern void cppUngetc (const int c)
 	Cpp.ungetDataSize++;
 }
 
-int cppUngetBufferSize(void)
+extern int cppUngetBufferSize(void)
 {
 	return Cpp.ungetBufferSize;
 }
 
 /*  This puts an entire string back into the input queue for the input File. */
-void cppUngetString(const char * string,int len)
+extern void cppUngetString(const char * string,int len)
 {
 	if(!string)
 		return;
@@ -1346,7 +1346,7 @@ static int skipOverDComment (void)
 	return c;
 }
 
-const vString * cppGetLastCharOrStringContents (void)
+extern const vString * cppGetLastCharOrStringContents (void)
 {
 	CXX_DEBUG_ASSERT(Cpp.charOrStringContents,"Shouldn't be called when CPP is not initialized");
 	return Cpp.charOrStringContents;


### PR DESCRIPTION
Consider input:

  #define debug(format, args...) fprintf (stderr, format, args)

With this change,

* ctags extracts "args" with parameter kind,
* ctags extracts "debug" with "(format,args...)" as
  the signature field.

The option like

   -D'debug(format, args...)=fprintf (stderr, format, args)'

also works with this change.