### PR TITLE
Meson: extract config variables

### DIFF
--- a/docs/man-pages.rst
+++ b/docs/man-pages.rst
@@ -38,6 +38,7 @@ Man pages
 	ctags-lang-lisp(7) <man/ctags-lang-lisp.7.rst>
 	ctags-lang-make(7) <man/ctags-lang-make.7.rst>
 	ctags-lang-markdown(7) <man/ctags-lang-markdown.7.rst>
+	ctags-lang-meson(7) <man/ctags-lang-meson.7.rst>
 	ctags-lang-powershell(7) <man/ctags-lang-powershell.7.rst>
 	ctags-lang-python(7) <man/ctags-lang-python.7.rst>
 	ctags-lang-r(7) <man/ctags-lang-r.7.rst>

--- a/docs/man/ctags-lang-meson.7.rst
+++ b/docs/man/ctags-lang-meson.7.rst
@@ -1,0 +1,30 @@
+.. _ctags-lang-meson(7):
+
+==============================================================
+ctags-lang-meson
+==============================================================
+
+Random notes about tagging Meson build scripts with Universal Ctags
+
+:Version: 6.1.0
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**ctags** ... --languages=+Meson ...
+|	**ctags** ... --language-force=Meson ...
+|	**ctags** ... --map-Meson=+(meson.build) ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging Meson build scripts.
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* New kinds ``cfgdata`` and ``cfgvar``
+
+SEE ALSO
+--------
+:ref:`ctags(1) <ctags(1)>`, :ref:`ctags-client-tools(7) <ctags-client-tools(7)>`

--- a/man/GNUmakefile.am
+++ b/man/GNUmakefile.am
@@ -49,6 +49,7 @@ GEN_IN_MAN_FILES = \
 	ctags-lang-lisp.7 \
 	ctags-lang-make.7 \
 	ctags-lang-markdown.7 \
+	ctags-lang-meson.7 \
 	ctags-lang-powershell.7 \
 	ctags-lang-python.7 \
 	ctags-lang-r.7 \

--- a/man/ctags-lang-meson.7.rst.in
+++ b/man/ctags-lang-meson.7.rst.in
@@ -1,0 +1,30 @@
+.. _ctags-lang-meson(7):
+
+==============================================================
+ctags-lang-meson
+==============================================================
+-----------------------------------------------------------------------
+Random notes about tagging Meson build scripts with Universal Ctags
+-----------------------------------------------------------------------
+:Version: @VERSION@
+:Manual group: Universal Ctags
+:Manual section: 7
+
+SYNOPSIS
+--------
+|	**@CTAGS_NAME_EXECUTABLE@** ... --languages=+Meson ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --language-force=Meson ...
+|	**@CTAGS_NAME_EXECUTABLE@** ... --map-Meson=+(meson.build) ...
+
+DESCRIPTION
+-----------
+This man page gathers random notes about tagging Meson build scripts.
+
+Change since "0.0"
+~~~~~~~~~~~~~~~~~~
+
+* New kinds ``cfgdata`` and ``cfgvar``
+
+SEE ALSO
+--------
+ctags(1), ctags-client-tools(7)

--- a/optlib/meson.c
+++ b/optlib/meson.c
@@ -10,6 +10,10 @@
 
 static void initializeMesonParser (const langType language)
 {
+	addLanguageOptscriptToHook (language, SCRIPT_HOOK_PRELUDE,
+		"{{    /lastvar false def\n"
+		"    /cfgdict 5 dict def\n"
+		"}}");
 
 	addLanguageRegexTable (language, "main");
 	addLanguageRegexTable (language, "mline_string");
@@ -50,6 +54,32 @@ static void initializeMesonParser (const langType language)
 	                               "^import[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\1", "m", "{tenter=skipToArgEnd}{_role=imported}", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
+	                               "^configuration_data[ \t\n]*\\([ \t\n]*\\)[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   lastvar false ne {\n"
+		"      lastvar :name\n"
+		"      /cfgdata\n"
+		"      lastvar _tagloc\n"
+		"      _tag _commit\n"
+		"\n"
+		"      cfgdict lastvar :name 3 -1 roll put\n"
+		"\n"
+		"      % Don't emit the tag for the original variable.\n"
+		"      lastvar _markplaceholder\n"
+		"      /lastvar false def\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "main",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "main",
 	                               "^project[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\1", "P", "{tenter=skipToArgEnd}", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
@@ -60,7 +90,10 @@ static void initializeMesonParser (const langType language)
 	                               "\\1", "t", "{tenter=skipToArgEnd}", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^([a-zA-Z_][a-zA-Z_0-9]*)[ \t\n]*=([^=]|$)",
-	                               "\\1", "V", "{_advanceTo=2start}", NULL);
+	                               "\\1", "V", "{_advanceTo=2start}"
+		"{{\n"
+		"   /lastvar . def\n"
+		"}}", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^.",
 	                               "", "", "", NULL);
@@ -122,6 +155,32 @@ static void initializeMesonParser (const langType language)
 	                               "^import[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\1", "m", "{tenter=skipToArgEnd}{_role=imported}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipPair",
+	                               "^configuration_data[ \t\n]*\\([ \t\n]*\\)[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   lastvar false ne {\n"
+		"      lastvar :name\n"
+		"      /cfgdata\n"
+		"      lastvar _tagloc\n"
+		"      _tag _commit\n"
+		"\n"
+		"      cfgdict lastvar :name 3 -1 roll put\n"
+		"\n"
+		"      % Don't emit the tag for the original variable.\n"
+		"      lastvar _markplaceholder\n"
+		"      /lastvar false def\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "skipPair",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "skipPair",
 	                               "^[])}]",
 	                               "", "", "{tleave}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipPair",
@@ -157,6 +216,32 @@ static void initializeMesonParser (const langType language)
 	addLanguageTagMultiTableRegex (language, "common",
 	                               "^import[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\1", "m", "{tenter=skipToArgEnd}{_role=imported}", NULL);
+	addLanguageTagMultiTableRegex (language, "common",
+	                               "^configuration_data[ \t\n]*\\([ \t\n]*\\)[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   lastvar false ne {\n"
+		"      lastvar :name\n"
+		"      /cfgdata\n"
+		"      lastvar _tagloc\n"
+		"      _tag _commit\n"
+		"\n"
+		"      cfgdict lastvar :name 3 -1 roll put\n"
+		"\n"
+		"      % Don't emit the tag for the original variable.\n"
+		"      lastvar _markplaceholder\n"
+		"      /lastvar false def\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "common",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
 	                               "^[ \t\n]+",
 	                               "", "", "", NULL);
@@ -187,6 +272,32 @@ static void initializeMesonParser (const langType language)
 	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
 	                               "^import[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\1", "m", "{tenter=skipToArgEnd}{_role=imported}", NULL);
+	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
+	                               "^configuration_data[ \t\n]*\\([ \t\n]*\\)[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   lastvar false ne {\n"
+		"      lastvar :name\n"
+		"      /cfgdata\n"
+		"      lastvar _tagloc\n"
+		"      _tag _commit\n"
+		"\n"
+		"      cfgdict lastvar :name 3 -1 roll put\n"
+		"\n"
+		"      % Don't emit the tag for the original variable.\n"
+		"      lastvar _markplaceholder\n"
+		"      /lastvar false def\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
 	                               "^[])}]",
 	                               "", "", "{tleave}", NULL);
@@ -242,17 +353,24 @@ extern parserDefinition* MesonParser (void)
 		  true, 'm', "module", "modules",
 		  ATTACH_ROLES(MesonModuleRoleTable),
 		},
+		{
+		  true, 'D', "cfgdata", "configuration data objects",
+		},
+		{
+		  true, 'C', "cfgvar", "configuration variables",
+		},
 	};
 
 	parserDefinition* const def = parserNew ("Meson");
 
-	def->versionCurrent= 0;
-	def->versionAge    = 0;
+	def->versionCurrent= 1;
+	def->versionAge    = 1;
 	def->enabled       = true;
 	def->extensions    = extensions;
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
+	def->useCork       = CORK_QUEUE;
 	def->kindTable     = MesonKindTable;
 	def->kindCount     = ARRAY_SIZE(MesonKindTable);
 	def->initialize    = initializeMesonParser;

--- a/optlib/meson.ctags
+++ b/optlib/meson.ctags
@@ -12,7 +12,7 @@
 # - https://mesonbuild.com/Syntax.html
 #
 
---langdef=Meson
+--langdef=Meson{version=1.1}
 --map-Meson=+(meson.build)
 
 #
@@ -27,6 +27,8 @@
 --kinddef-Meson=b,benchmark,benchmark targets
 --kinddef-Meson=r,run,run targets
 --kinddef-Meson=m,module,modules
+--kinddef-Meson=D,cfgdata,configuration data objects
+--kinddef-Meson=C,cfgvar,configuration variables
 
 #
 # Role definitions
@@ -43,6 +45,11 @@
 --_tabledef-Meson=skipPair
 --_tabledef-Meson=common
 --_tabledef-Meson=skipToArgEnd
+
+--_prelude-Meson={{
+    /lastvar false def
+    /cfgdict 5 dict def
+}}
 
 #
 # Tables definitions
@@ -69,6 +76,26 @@
 --_mtable-regex-Meson=common/(alias|run)_target[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\2/r/{tenter=skipToArgEnd}
 --_mtable-regex-Meson=common/benchmark[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/b/{tenter=skipToArgEnd}
 --_mtable-regex-Meson=common/import[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/m/{tenter=skipToArgEnd}{_role=imported}
+--_mtable-regex-Meson=common/configuration_data[ \t\n]*\([ \t\n]*\)[ \t\n]*//{{
+   lastvar false ne {
+      lastvar :name
+      /cfgdata
+      lastvar _tagloc
+      _tag _commit
+
+      cfgdict lastvar :name 3 -1 roll put
+
+      % Don't emit the tag for the original variable.
+      lastvar _markplaceholder
+      /lastvar false def
+   } if
+}}
+--_mtable-regex-Meson=common/([a-zA-Z_][a-zA-Z0-9_]*)\.(set(_quoted|10)?)[ \t\n]*\('([^']*[^\\])'[ \t\n]*//{{
+   cfgdict \1 known {
+      \4 /cfgvar @4 _tag _commit
+      cfgdict \1 get scope:
+   } if
+}}
 
 --_mtable-extend-Meson=skipPair+common
 --_mtable-regex-Meson=skipPair/[])}]//{tleave}
@@ -80,5 +107,7 @@
 --_mtable-regex-Meson=main/project[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/P/{tenter=skipToArgEnd}
 --_mtable-regex-Meson=main/subdir[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/S/{tenter=skipToArgEnd}
 --_mtable-regex-Meson=main/test[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/t/{tenter=skipToArgEnd}
---_mtable-regex-Meson=main/([a-zA-Z_][a-zA-Z_0-9]*)[ \t\n]*=([^=]|$)/\1/V/{_advanceTo=2start}
+--_mtable-regex-Meson=main/([a-zA-Z_][a-zA-Z_0-9]*)[ \t\n]*=([^=]|$)/\1/V/{_advanceTo=2start}{{
+   /lastvar . def
+}}
 --_mtable-regex-Meson=main/.//


### PR DESCRIPTION
With this change, the parser can extract "version" in the following input:

    conf_data = configuration_data()
    conf_data.set('version', '1.2.3')
    configure_file(input : 'config.h.in',
		   output : 'config.h',
		   configuration : conf_data)

See also https://mesonbuild.com/Reference-manual_returned_cfg_data.html