### PR TITLE
JavaScript,HTML: skip JSX elements

### DIFF
--- a/Units/parser-javascript.r/simple-jsx-no-guest.d/args.ctags
+++ b/Units/parser-javascript.r/simple-jsx-no-guest.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+r
+--fields=+lr

--- a/Units/parser-javascript.r/simple-jsx-no-guest.d/expected.tags
+++ b/Units/parser-javascript.r/simple-jsx-no-guest.d/expected.tags
@@ -3,11 +3,6 @@ Comp1	input-0.jsx	/^const Comp1 = () => {$/;"	f	language:JavaScript	roles:def
 x	input-0.jsx	/^    const x = (arg) => console.log(arg)$/;"	f	language:JavaScript	function:Comp1	roles:def
 Comp2	input-0.jsx	/^const Comp2 = (props) => {$/;"	f	language:JavaScript	roles:def
 Comp3	input-0.jsx	/^const Comp3 = (str) => {$/;"	f	language:JavaScript	roles:def
-hello	input-0.jsx	/^	       <h1>hello<\/h1>$/;"	h	language:HTML	roles:def
-bye	input-0.jsx	/^	       <h1>bye<\/h1>$/;"	h	language:HTML	roles:def
 Comp4	input-0.jsx	/^const Comp4 = (str) => {$/;"	f	language:JavaScript	roles:def
-bonjour	input-0.jsx	/^	       <h1>bonjour<\/h1>$/;"	h	language:HTML	roles:def
-frag ment	input-0.jsx	/^	       {<h2>frag{subtitle}ment<\/h2>}$/;"	i	language:HTML	roles:def
-au revoir	input-0.jsx	/^	       <h1>au revoir<\/h1>$/;"	h	language:HTML	roles:def
 Comp5	input-0.jsx	/^const Comp5 = (str) => {$/;"	f	language:JavaScript	roles:def
 z0	input-0.jsx	/^var z0$/;"	v	language:JavaScript	roles:def

--- a/Units/parser-javascript.r/simple-jsx-no-guest.d/input-0.jsx
+++ b/Units/parser-javascript.r/simple-jsx-no-guest.d/input-0.jsx
@@ -1,0 +1,36 @@
+const Comp1 = () => {
+    const x = (arg) => console.log(arg)
+    x(4)
+    return(<Comp2 text={<p>Some Text</p>}/>)
+}
+
+const Comp2 = (props) => {
+    return (
+	props.text
+    )
+}
+
+const Comp3 = (str) => {
+    return(<div>
+	       <h1>hello</h1>
+	       something: {str}
+	       <h1>bye</h1>
+	   </div>)
+}
+
+const Comp4 = (str) => {
+    return(<>
+	       <h1>bonjour</h1>
+	       something: {str}
+	       {<h2>frag{subtitle}ment</h2>}
+	       <h1>au revoir</h1>
+	   </>)
+}
+
+const Comp5 = (str) => {
+    return <x/>
+}
+
+var z0
+
+// Taken from https://stackoverflow.com/questions/79395369/why-does-universal-ctags-fail-to-record-some-functions-in-the-tags-file-for-a-pr

--- a/Units/parser-javascript.r/simple-jsx-no-guest.d/input.jsx
+++ b/Units/parser-javascript.r/simple-jsx-no-guest.d/input.jsx
@@ -1,0 +1,7 @@
+function foo() {
+  var x = <div>
+    <Menu />
+  <div>;
+
+  return x;
+}

--- a/Units/parser-javascript.r/simple-jsx.d/args.ctags
+++ b/Units/parser-javascript.r/simple-jsx.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--extras=+{guest}r
+--fields=+lr

--- a/Units/parser-javascript.r/simple-jsx.d/input-0.jsx
+++ b/Units/parser-javascript.r/simple-jsx.d/input-0.jsx
@@ -1,0 +1,36 @@
+const Comp1 = () => {
+    const x = (arg) => console.log(arg)
+    x(4)
+    return(<Comp2 text={<p>Some Text</p>}/>)
+}
+
+const Comp2 = (props) => {
+    return (
+	props.text
+    )
+}
+
+const Comp3 = (str) => {
+    return(<div>
+	       <h1>hello</h1>
+	       something: {str}
+	       <h1>bye</h1>
+	   </div>)
+}
+
+const Comp4 = (str) => {
+    return(<>
+	       <h1>bonjour</h1>
+	       something: {str}
+	       {<h2>frag{subtitle}ment</h2>}
+	       <h1>au revoir</h1>
+	   </>)
+}
+
+const Comp5 = (str) => {
+    return <x/>
+}
+
+var z0
+
+// Taken from https://stackoverflow.com/questions/79395369/why-does-universal-ctags-fail-to-record-some-functions-in-the-tags-file-for-a-pr

--- a/parsers/x-html.h
+++ b/parsers/x-html.h
@@ -1,0 +1,28 @@
+/*
+*
+* Copyright (c) 2025, Red Hat, Inc.
+* Copyright (c) 2025, Masatake YAMATO
+*
+* Author: Masatake YAMATO <yamato@redhat.com>
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+* USA.
+*/
+#ifndef CTAGS_HTML_H
+#define CTAGS_HTML_H
+
+extern void htmlParseJSXElement (void);
+
+#endif

--- a/parsers/x-jscript.h
+++ b/parsers/x-jscript.h
@@ -29,4 +29,7 @@ typedef enum {
 	JSTAG_FUNCTIONRoleFOREIGNDECL
 } JSTAGFunctionRole;
 
+/* Skip over { ... } */
+void javaScriptSkipObjectExpression (void);
+
 #endif

--- a/source.mak
+++ b/source.mak
@@ -292,6 +292,7 @@ PARSER_HEADS = \
 	\
 	parsers/x-bibtex.h \
 	parsers/x-frontmatter.h \
+	parsers/x-html.h \
 	parsers/x-iniconf.h \
 	parsers/x-jscript.h \
 	parsers/x-lisp.h \

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -474,6 +474,7 @@
     <ClInclude Include="..\parsers\x-bibtex.h" />
     <ClInclude Include="..\parsers\x-cpreprocessor.h" />
     <ClInclude Include="..\parsers\x-frontmatter.h" />
+    <ClInclude Include="..\parsers\x-html.h" />
     <ClInclude Include="..\parsers\x-iniconf.h" />
     <ClInclude Include="..\parsers\x-jscript.h" />
     <ClInclude Include="..\parsers\x-lisp.h" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -941,6 +941,9 @@
     <ClInclude Include="..\parsers\x-frontmatter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\parsers\x-html.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="..\parsers\x-iniconf.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION
This may fix the issue reported at
https://stackoverflow.com/questions/79395369/why-does-universal-ctags-fail-to-record-some-functions-in-the-tags-file-for-a-pr

TODO:
* add more test cases
* extract objects in JavaScript area in HTML area in JavaScript area