### PR TITLE
JavaScript: Fix held tokens breaking implicit semicolon insertion

### DIFF
--- a/Units/parser-javascript.r/js-implicit-semicolons.d/expected.tags
+++ b/Units/parser-javascript.r/js-implicit-semicolons.d/expected.tags
@@ -12,3 +12,6 @@ k	input.js	/^var k = new Function('a','b','return a+b')$/;"	f
 l	input.js	/^function l() {}$/;"	f
 m	input.js	/^var m = 0 \/\/ a single comment doesn't eat the newline$/;"	v
 n	input.js	/^function n() {}$/;"	f
+o	input.js	/^var o = () => {$/;"	f
+p	input.js	/^var p$/;"	v
+q	input.js	/^function q() {}$/;"	f

--- a/Units/parser-javascript.r/js-implicit-semicolons.d/input.js
+++ b/Units/parser-javascript.r/js-implicit-semicolons.d/input.js
@@ -14,3 +14,9 @@ var k = new Function('a','b','return a+b')
 function l() {}
 var m = 0 // a single comment doesn't eat the newline
 function n() {}
+/* test from https://github.com/universal-ctags/ctags/issues/4192 */
+var o = () => {
+  return 0
+}
+var p
+function q() {}

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -1050,6 +1050,7 @@ static void readTokenFullRaw (tokenInfo *const token, bool include_newlines, vSt
 		copyToken (token, NextToken, false);
 		deleteToken (NextToken);
 		NextToken = NULL;
+		LastTokenType = token->type;
 		if (repr)
 			reprToken (token, repr);
 		return;


### PR DESCRIPTION
When emitting a held token, the previous token type was not properly updated, breaking the implicit semicolon emission logic for the next token.

Fixes #4192.