### PR TITLE
Asm: support Cpp macro arguments spanning multiple lines

### DIFF
--- a/Units/parser-asm.r/asm-cpp-macro-expansion-with-multi-line-args.d/args.ctags
+++ b/Units/parser-asm.r/asm-cpp-macro-expansion-with-multi-line-args.d/args.ctags
@@ -1,0 +1,7 @@
+--sort=no
+--param-Asm.useCPreProcessor=1
+--param-CPreProcessor._expand=1
+--fields=+{signature}
+--fields-CPreProcessor=+{macrodef}
+--param-Asm.commentCharsAtBOL=#
+--param-Asm.extraLinesepChars=;

--- a/Units/parser-asm.r/asm-cpp-macro-expansion-with-multi-line-args.d/expected.tags
+++ b/Units/parser-asm.r/asm-cpp-macro-expansion-with-multi-line-args.d/expected.tags
@@ -1,0 +1,11 @@
+ENTRY	input.S	/^#define ENTRY(/;"	d	file:	signature:(SYMBOL,LABEL)	macrodef:.global SYMBOL ;LABEL: nop
+A	input.S	/^ENTRY(A, B)$/;"	s
+B	input.S	/^ENTRY(A, B)$/;"	l
+C	input.S	/^	D)$/;"	s
+D	input.S	/^	D)$/;"	l
+E	input.S	/^	F)$/;"	s
+F	input.S	/^	F)$/;"	l
+G	input.S	/^	)$/;"	s
+H	input.S	/^	)$/;"	l
+I	input.S	/^	)$/;"	s
+J	input.S	/^	)$/;"	l

--- a/Units/parser-asm.r/asm-cpp-macro-expansion-with-multi-line-args.d/input.S
+++ b/Units/parser-asm.r/asm-cpp-macro-expansion-with-multi-line-args.d/input.S
@@ -1,0 +1,20 @@
+#define ENTRY(SYMBOL,LABEL) .global SYMBOL	;\
+LABEL: \
+	nop
+
+ENTRY(A, B)
+ENTRY(C,
+	D)
+ENTRY(
+	E,
+	F)
+ENTRY(
+	G,
+	H
+	)
+
+ENTRY(
+	I,
+	J,K,
+	L
+	)

--- a/Units/parser-asm.r/asm-cpp-macro-expansion.d/expected.tags
+++ b/Units/parser-asm.r/asm-cpp-macro-expansion.d/expected.tags
@@ -14,10 +14,7 @@ SYM_START	input.S	/^#define SYM_START(/;"	d	file:	signature:(name,linkage,align.
 SYM_CODE_START	input.S	/^#define SYM_CODE_START(/;"	d	file:	signature:(name)	macrodef:SYM_START(name, SYM_L_GLOBAL, SYM_A_ALIGN)
 asm_exc_nmi	input.S	/^SYM_CODE_START(asm_exc_nmi)$/;"	l
 ENTRY0	input-0.S	/^#define ENTRY0(/;"	d	file:	signature:(LABEL)	macrodef:.global LABEL ;LABEL
-exit0	input-0.S	/^exit0:$/;"	l
 ENTRY1	input-1.S	/^#define ENTRY1(/;"	d	file:	signature:(LABEL)	macrodef:.global LABEL ;LABEL
-exit1	input-1.S	/^ENTRY1(exit1):$/;"	s
-exit1	input-1.S	/^ENTRY1(exit1):$/;"	l
 ENTRY2	input-2.S	/^#define ENTRY2(/;"	d	file:	signature:(LABEL)	macrodef:.global LABEL ;LABEL
 exit2	input-2.S	/^ENTRY2(exit2):$/;"	s
 exit2	input-2.S	/^ENTRY2(exit2):$/;"	l

--- a/parsers/asm.c
+++ b/parsers/asm.c
@@ -374,13 +374,14 @@ static bool collectCppMacroArguments (ptrArray *args)
 	do
 	{
 		c = cppGetc ();
-		if (c == EOF || c == '\n')
+		if (c == EOF)
 			break;
 		else if (c == ')')
 		{
 			depth--;
 			if (depth == 0)
 			{
+				vStringStripTrailing(s);
 				char *cstr = vStringDeleteUnwrap (s);
 				ptrArrayAdd (args, cstr);
 				s = NULL;
@@ -395,12 +396,19 @@ static bool collectCppMacroArguments (ptrArray *args)
 		}
 		else if (c == ',')
 		{
+			vStringStripTrailing(s);
 			char *cstr = vStringDeleteUnwrap (s);
 			ptrArrayAdd (args, cstr);
 			s = vStringNew ();
 		}
 		else if (c == CPP_STRING_SYMBOL || c == CPP_CHAR_SYMBOL)
 			vStringPut (s, ' ');
+		else if (isspace(c))
+		{
+			if (!vStringIsEmpty (s) &&
+				!isspace ((unsigned char)vStringLast (s)))
+				vStringPut (s, ' ');
+		}
 		else
 			vStringPut (s, c);
 	}


### PR DESCRIPTION
The patterns in expected.tags are unexpected.
Some parts of them may be fixed in #4198 I'm working on.