### PR TITLE
GitHub Actions: remove ubuntu-20.04 runner

### DIFF
--- a/.github/workflows/cross-compile-for-android-on-ubuntu.yml
+++ b/.github/workflows/cross-compile-for-android-on-ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
+        build-machine-os: [ubuntu-24.04, ubuntu-22.04]
 
     runs-on: ${{ matrix.build-machine-os }}
 

--- a/.github/workflows/cross-compile-for-windows-on-ubuntu.yml
+++ b/.github/workflows/cross-compile-for-windows-on-ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-machine-os: [ubuntu-22.04, ubuntu-20.04]
+        build-machine-os: [ubuntu-22.04, ubuntu-24.04]
         target: [i686-w64-mingw32,x86_64-w64-mingw32]
 
     runs-on: ${{ matrix.build-machine-os }}

--- a/.github/workflows/testing-on-ubuntu.yml
+++ b/.github/workflows/testing-on-ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
         compiler: [gcc, clang]
 
     runs-on: ${{ matrix.os }}
@@ -41,7 +41,7 @@ jobs:
         type clang > /dev/null && clang --version | head -1 | grep -q 14 \
         || sudo apt-get -y -o APT::Immediate-Configure=false install valgrind
     - name: install lcov
-      if: matrix.compiler == 'gcc' && matrix.os == 'ubuntu-20.04'
+      if: matrix.compiler == 'gcc' && matrix.os == 'ubuntu-22.04'
       run: sudo apt-get -y -o APT::Immediate-Configure=false install lcov
     - name: autogen.sh
       run: ./autogen.sh
@@ -54,7 +54,7 @@ jobs:
         mkdir -p ${{ matrix.os }}-"$CC"
         (
           cd $BUILDDIR
-          if [ ${{ matrix.compiler }} = 'gcc' -a ${{ matrix.os }} = 'ubuntu-20.04' ]; then
+          if [ ${{ matrix.compiler }} = 'gcc' -a ${{ matrix.os }} = 'ubuntu-22.04' ]; then
               extra_args=--enable-coverage-gcov
           fi
           ../configure --enable-debugging --enable-iconv ${extra_args}
@@ -96,11 +96,11 @@ jobs:
           make -C ${BUILDDIR}  clean
         )
     - name: prepare coverage info
-      if: matrix.compiler == 'gcc' && matrix.os == 'ubuntu-20.04'
+      if: matrix.compiler == 'gcc' && matrix.os == 'ubuntu-22.04'
       run: |
         (cd ${BUILDDIR}; lcov -c -b . -d . -o coverage.info)
     - name: send coverage info
-      if: matrix.compiler == 'gcc' && matrix.os == 'ubuntu-20.04'
+      if: matrix.compiler == 'gcc' && matrix.os == 'ubuntu-22.04'
       uses: codecov/codecov-action@v5
       with:
         files: ${{ env.BUILDDIR }}/coverage.info


### PR DESCRIPTION
The Ubuntu 20.04 Actions runner image is being deprecated and will be fully unsupported by 2025-04-01

Reference: https://github.com/actions/runner-images/issues/11101