### PR TITLE
Circleci:  (fedora41) update libsqlite.so explicitly

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,9 @@ jobs:
              dnf -y install jq puppet python3-sphinx
              # These are for input-validation.
              dnf -y install g++ jq puppet nodejs gcc-gfortran
+             # nodejs requires libsqlite.so.0 with sqlite-session feature
+             # It was tured off in 3.46.1-1.
+             dnf -y update sqlite-libs
        - run:
            name: Build
            command: |


### PR DESCRIPTION
In sqlite-libs 3.46.1-1, sqlite-session feature was turned off. It was turned on in 3.46.1-2.
Nodejs that we used in a validitor requires the feature.
