### PR TITLE
C++: skip broken C++11 attributes

### DIFF
--- a/Units/parser-cxx.r/cxx11-attributes.cpp.d/input.cpp
+++ b/Units/parser-cxx.r/cxx11-attributes.cpp.d/input.cpp
@@ -1,4 +1,4 @@
-// Tkane from https://en.cppreference.com/w/cpp/language/attributes
+// Taken from https://en.cppreference.com/w/cpp/language/attributes
 [[gnu::always_inline]] [[gnu::hot]] [[gnu::const]] [[nodiscard]]
 inline int f(); // declare f with four attributes
 

--- a/Units/parser-cxx.r/cxx11-broken-nested-attributes.cpp.d/expected.tags
+++ b/Units/parser-cxx.r/cxx11-broken-nested-attributes.cpp.d/expected.tags
@@ -1,0 +1,2 @@
+i	input.cxx	/^int i;$/;"	v	typeref:typename:int
+j	input-0.cxx	/^[[)int j;$/;"	v	typeref:typename:int

--- a/Units/parser-cxx.r/cxx11-broken-nested-attributes.cpp.d/input-0.cxx
+++ b/Units/parser-cxx.r/cxx11-broken-nested-attributes.cpp.d/input-0.cxx
@@ -1,0 +1,2 @@
+[[)int j;
+// This is a broken input; extracting j is not a must.

--- a/Units/parser-cxx.r/cxx11-broken-nested-attributes.cpp.d/input.cxx
+++ b/Units/parser-cxx.r/cxx11-broken-nested-attributes.cpp.d/input.cxx
@@ -1,0 +1,3 @@
+[[[]]]
+// This is a crash test.
+int i;

--- a/parsers/cxx/cxx_parser.c
+++ b/parsers/cxx/cxx_parser.c
@@ -2013,6 +2013,8 @@ static rescanReason cxxParserMain(const unsigned int passCount)
 
 	g_cxx.iNestingLevels = 0;
 
+	g_cxx.bInCXX11Attribute = false;
+
 	bool bRet = cxxParserParseBlock(false);
 
 	cppTerminate ();

--- a/parsers/cxx/cxx_parser_internal.h
+++ b/parsers/cxx/cxx_parser_internal.h
@@ -380,6 +380,12 @@ typedef struct _CXXParserState
 	// This usually happens only with erroneous macro usage or broken input.
 	int iNestingLevels;
 
+	// The parser parsers CXX11Attribute ([[...]]).
+	// The function parsing CXX11Attribute doesn't consider
+	// CXX11Attributes nest like: [[[]]].
+	// bInCXX11Attribute guards the function being called recursively.
+	bool bInCXX11Attribute;
+
 } CXXParserState;
 
 

--- a/parsers/cxx/cxx_parser_tokenizer.c
+++ b/parsers/cxx/cxx_parser_tokenizer.c
@@ -1042,6 +1042,8 @@ static bool cxxParserParseNextTokenCondenseCXX11Attribute(void)
 			"This function should be called only after we have parsed ["
 		);
 
+	g_cxx.bInCXX11Attribute = true;
+
 	// Input stream: [[...
 	//   If the syntax is correct then this is an attribute sequence [[foo]]
 	//
@@ -1071,6 +1073,7 @@ static bool cxxParserParseNextTokenCondenseCXX11Attribute(void)
 		// Kill the token chain
 		cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 
+		g_cxx.bInCXX11Attribute = false;
 		return cxxParserParseNextToken();
 	}
 
@@ -1098,6 +1101,7 @@ static bool cxxParserParseNextTokenCondenseCXX11Attribute(void)
 	cxxTokenChainDestroyLast(g_cxx.pTokenChain);
 
 	// And finally extract yet another token.
+	g_cxx.bInCXX11Attribute = false;
 	bool bRet = cxxParserParseNextToken();
 
 	CXX_DEBUG_LEAVE();
@@ -1684,7 +1688,7 @@ bool cxxParserParseNextToken(void)
 					} while(cppIsspace(g_cxx.iChar));
 				}
 
-				if(g_cxx.iChar == '[')
+				if(g_cxx.iChar == '[' && !g_cxx.bInCXX11Attribute)
 					return cxxParserParseNextTokenCondenseCXX11Attribute();
 			break;
 			default:


### PR DESCRIPTION
Fixed #4089
An assertion failed for the input "[[[]]]".