### PR TITLE
Update mk_mvc.mak file to specify /source-charset:utf-8 option

### DIFF
--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -13,7 +13,7 @@ include source.mak
 COMMON_DEFINES =
 DEFINES = $(COMMON_DEFINES) -DHAVE_REPOINFO_H -DHAVE_PACKCC
 INCLUDES = -I. -Ignulib -Imain -Iparsers -Ilibreadtags -Idsl
-OPT = /O2 /WX /Zc:preprocessor /source-charset:utf-8
+OPT = /O2 /WX /Zc:preprocessor /wd4819
 LOPT = /FORCE:MULTIPLE
 PACKCC = packcc.exe
 GNULIB_OBJS = $(MVC_GNULIB_SRCS:.c=.obj)

--- a/mk_mvc.mak
+++ b/mk_mvc.mak
@@ -13,7 +13,7 @@ include source.mak
 COMMON_DEFINES =
 DEFINES = $(COMMON_DEFINES) -DHAVE_REPOINFO_H -DHAVE_PACKCC
 INCLUDES = -I. -Ignulib -Imain -Iparsers -Ilibreadtags -Idsl
-OPT = /O2 /WX /Zc:preprocessor
+OPT = /O2 /WX /Zc:preprocessor /source-charset:utf-8
 LOPT = /FORCE:MULTIPLE
 PACKCC = packcc.exe
 GNULIB_OBJS = $(MVC_GNULIB_SRCS:.c=.obj)


### PR DESCRIPTION
This change is needed to successfully build `ctags.exe` file on my end.

Here's the log without this PR's change.

<details>
<summary>log</summary>

```
D:\projects\ctags>nmake -f mk_mvc.mak

Microsoft (R) Program Maintenance Utility Version 14.43.34810.0
Copyright (C) Microsoft Corporation.  All rights reserved.

        copy win32\config_mvc.h config.h
        1 個のファイルをコピーしました。
        copy win32\gnulib_h\langinfo.h gnulib
        1 個のファイルをコピーしました。
        copy win32\gnulib_h\fnmatch.h gnulib
        1 個のファイルをコピーしました。
        cl /O2 /WX /Zc:preprocessor /Fepackcc.exe misc/packcc/src/packcc.obj /link setargv.obj /FORCE:MULTIPLE
Microsoft (R) C/C++ Optimizing Compiler Version 19.43.34810 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

Microsoft (R) Incremental Linker Version 14.43.34810.0
Copyright (C) Microsoft Corporation.  All rights reserved.

/out:packcc.exe
setargv.obj
/FORCE:MULTIPLE
misc/packcc/src/packcc.obj
        packcc.exe peg\varlink.peg
        packcc.exe peg\kotlin.peg
        packcc.exe peg\thrift.peg
        packcc.exe peg\elm.peg
        packcc.exe peg\toml.peg
        rc /nologo /l 0x409 /Fowin32/ctags.res win32/ctags.rc
        cl /O2 /WX /Zc:preprocessor  -DHAVE_REPOINFO_H -DHAVE_PACKCC -I. -Ignulib -Imain -Iparsers -Ilibreadtags -Idsl /Fomain\ /c main\fname.c main\htable.c main\intern.c main\numarray.c main\mio.c main\ptrarray.c main\routines.c main\trashbox.c main\vstring.c main\args.c main\colprint.c main\dependency.c main\entry.c main\entry_private.c main\error.c main\field.c main\flags.c main\fmt.c main\keyword.c main\kind.c main\lregex.c main\lregex-default.c main\lxpath.c main\main.c main\mbcs.c main\nestlevel.c main\objpool.c main\options.c main\param.c main\parse.c main\portable-scandir.c main\promise.c main\ptag.c main\rbtree.c main\read.c main\script.c main\seccomp.c main\selectors.c main\sort.c main\stats.c main\strlist.c main\trace.c main\tokeninfo.c main\unwindi.c main\utf8_str.c main\writer.c main\writer-etags.c main\writer-ctags.c main\writer-json.c main\writer-xref.c main\xtag.c main\CommonPrelude.c main\repoinfo.c main\debug.c main\cmd.c
Microsoft (R) C/C++ Optimizing Compiler Version 19.43.34810 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

fname.c
htable.c
intern.c
numarray.c
mio.c
ptrarray.c
routines.c
trashbox.c
vstring.c
args.c
colprint.c
dependency.c
entry.c
entry_private.c
error.c
field.c
flags.c
fmt.c
keyword.c
kind.c
Generating Code...
Compiling...
lregex.c
lregex-default.c
lxpath.c
main.c
mbcs.c
nestlevel.c
objpool.c
options.c
param.c
parse.c
portable-scandir.c
promise.c
ptag.c
rbtree.c
read.c
script.c
seccomp.c
selectors.c
sort.c
stats.c
Generating Code...
Compiling...
strlist.c
trace.c
tokeninfo.c
unwindi.c
utf8_str.c
writer.c
writer-etags.c
writer-ctags.c
writer-json.c
writer-xref.c
xtag.c
CommonPrelude.c
repoinfo.c
debug.c
cmd.c
Generating Code...
        cl /O2 /WX /Zc:preprocessor  -DHAVE_REPOINFO_H -DHAVE_PACKCC -I. -Ignulib -Imain -Iparsers -Ilibreadtags -Idsl /Foparsers\ /c parsers\abaqus.c parsers\abc.c parsers\ada.c parsers\ant.c parsers\asciidoc.c parsers\asm.c parsers\asp.c parsers\autoconf.c parsers\autoit.c parsers\automake.c parsers\awk.c parsers\basic.c parsers\bats.c parsers\beta.c parsers\biblatex.c parsers\bibtex.c parsers\c-based.c parsers\clojure.c parsers\css.c parsers\cobol.c parsers\cpreprocessor.c parsers\diff.c parsers\dosbatch.c parsers\dtd.c parsers\dts.c parsers\eiffel.c parsers\erlang.c parsers\falcon.c parsers\flex.c parsers\fortran.c parsers\frontmatter.c parsers\fypp.c parsers\gdscript.c parsers\gemspec.c parsers\go.c parsers\haskell.c parsers\haxe.c parsers\html.c parsers\iniconf.c parsers\itcl.c parsers\jprop.c parsers\jscript.c parsers\json.c parsers\julia.c parsers\ldscript.c parsers\lisp.c parsers\lua.c parsers\m4.c parsers\make.c parsers\markdown.c parsers\matlab.c parsers\myrddin.c parsers\nsis.c parsers\objc.c parsers\ocaml.c parsers\pascal.c parsers\perl.c parsers\perl-function-parameters.c parsers\perl-moose.c parsers\php.c parsers\powershell.c parsers\protobuf.c parsers\python.c parsers\python-entry-points.c parsers\python-logging-config.c parsers\quarto.c parsers\r-r6class.c parsers\r-s4class.c parsers\r.c parsers\rake.c parsers\raku.c parsers\rexx.c parsers\rmarkdown.c parsers\robot.c parsers\rpmspec.c parsers\rspec.c parsers\rst.c parsers\ruby.c parsers\rust.c parsers\scheme.c parsers\selinux-interface.c parsers\sh.c parsers\slang.c parsers\sml.c parsers\sql.c parsers\systemdunit.c parsers\tcl.c parsers\tcloo.c parsers\tex.c parsers\tex-beamer.c parsers\cargo.c parsers\ttcn.c parsers\txt2tags.c parsers\typescript.c parsers\v.c parsers\vera.c parsers\verilog.c parsers\vhdl.c parsers\vim.c parsers\windres.c parsers\yumrepo.c
Microsoft (R) C/C++ Optimizing Compiler Version 19.43.34810 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

abaqus.c
abc.c
ada.c
ant.c
asciidoc.c
asm.c
asp.c
autoconf.c
autoit.c
automake.c
awk.c
basic.c
bats.c
beta.c
biblatex.c
bibtex.c
c-based.c
clojure.c
css.c
cobol.c
Generating Code...
Compiling...
cpreprocessor.c
diff.c
dosbatch.c
dtd.c
dts.c
eiffel.c
erlang.c
falcon.c
flex.c
fortran.c
frontmatter.c
fypp.c
gdscript.c
gemspec.c
go.c
haskell.c
haxe.c
html.c
iniconf.c
itcl.c
Generating Code...
Compiling...
jprop.c
jscript.c
json.c
julia.c
ldscript.c
lisp.c
lua.c
m4.c
make.c
markdown.c
matlab.c
myrddin.c
nsis.c
objc.c
ocaml.c
pascal.c
perl.c
perl-function-parameters.c
perl-moose.c
php.c
Generating Code...
Compiling...
powershell.c
protobuf.c
python.c
python-entry-points.c
python-logging-config.c
quarto.c
r-r6class.c
r-s4class.c
r.c
rake.c
raku.c
rexx.c
rmarkdown.c
robot.c
rpmspec.c
rspec.c
rst.c
ruby.c
rust.c
scheme.c
Generating Code...
Compiling...
selinux-interface.c
sh.c
slang.c
sml.c
sql.c
systemdunit.c
tcl.c
tcloo.c
tex.c
tex-beamer.c
cargo.c
ttcn.c
txt2tags.c
typescript.c
v.c
parsers\v.c(1): error C2220: the following warning is treated as an error
parsers\v.c(1): warning C4819: The file contains a character that cannot be represented in the current code page (932). Save the file in Unicode format to prevent data loss
vera.c
verilog.c
vhdl.c
vim.c
windres.c
Generating Code...
Compiling...
yumrepo.c
Generating Code...
NMAKE : fatal error U1077: 'cl /O2 /WX /Zc:preprocessor  -DHAVE_REPOINFO_H -DHAVE_PACKCC -I. -Ignulib -Imain -Iparsers -Ilibreadtags -Idsl /Foparsers\ /c parsers\abaqus.c parsers\abc.c parsers\ada.c parsers\ant.c parsers\asciidoc.c parsers\asm.c parsers\asp.c parsers\autoconf.c parsers\autoit.c parsers\automake.c parsers\awk.c parsers\basic.c parsers\bats.c parsers\beta.c parsers\biblatex.c parsers\bibtex.c parsers\c-based.c parsers\clojure.c parsers\css.c parsers\cobol.c parsers\cpreprocessor.c parsers\diff.c parsers\dosbatch.c parsers\dtd.c parsers\dts.c parsers\eiffel.c parsers\erlang.c parsers\falcon.c parsers\flex.c parsers\fortran.c parsers\frontmatter.c parsers\fypp.c parsers\gdscript.c parsers\gemspec.c parsers\go.c parsers\haskell.c parsers\haxe.c parsers\html.c parsers\iniconf.c parsers\itcl.c parsers\jprop.c parsers\jscript.c parsers\json.c parsers\julia.c parsers\ldscript.c parsers\lisp.c parsers\lua.c parsers\m4.c parsers\make.c parsers\markdown.c parsers\matlab.c parsers\myrddin.c parsers\nsis.c parsers\objc.c parsers\ocaml.c parsers\pascal.c parsers\perl.c parsers\perl-function-parameters.c parsers\perl-moose.c parsers\php.c parsers\powershell.c parsers\protobuf.c parsers\python.c parsers\python-entry-points.c parsers\python-logging-config.c parsers\quarto.c parsers\r-r6class.c parsers\r-s4class.c parsers\r.c parsers\rake.c parsers\raku.c parsers\rexx.c parsers\rmarkdown.c parsers\robot.c parsers\rpmspec.c parsers\rspec.c parsers\rst.c parsers\ruby.c parsers\rust.c parsers\scheme.c parsers\selinux-interface.c parsers\sh.c parsers\slang.c parsers\sml.c parsers\sql.c parsers\systemdunit.c parsers\tcl.c parsers\tcloo.c parsers\tex.c parsers\tex-beamer.c parsers\cargo.c parsers\ttcn.c parsers\txt2tags.c parsers\typescript.c parsers\v.c parsers\vera.c parsers\verilog.c parsers\vhdl.c parsers\vim.c parsers\windres.c parsers\yumrepo.c ' : return code '0x2'
Stop.

D:\projects\ctags>nmake -f mk_mvc.mak

Microsoft (R) Program Maintenance Utility Version 14.43.34810.0
Copyright (C) Microsoft Corporation.  All rights reserved.

        copy win32\config_mvc.h config.h
        1 個のファイルをコピーしました。
        copy win32\gnulib_h\langinfo.h gnulib
        1 個のファイルをコピーしました。
        copy win32\gnulib_h\fnmatch.h gnulib
        1 個のファイルをコピーしました。
        cl /O2 /WX /Zc:preprocessor  -DHAVE_REPOINFO_H -DHAVE_PACKCC -I. -Ignulib -Imain -Iparsers -Ilibreadtags -Idsl /Foparsers\cxx\ /c parsers\cxx\cxx.c parsers\cxx\cxx_debug.c parsers\cxx\cxx_debug_type.c parsers\cxx\cxx_keyword.c parsers\cxx\cxx_parser.c parsers\cxx\cxx_parser_block.c parsers\cxx\cxx_parser_function.c parsers\cxx\cxx_parser_lambda.c parsers\cxx\cxx_parser_module.c parsers\cxx\cxx_parser_namespace.c parsers\cxx\cxx_parser_template.c parsers\cxx\cxx_parser_tokenizer.c parsers\cxx\cxx_parser_typedef.c parsers\cxx\cxx_parser_using.c parsers\cxx\cxx_parser_variable.c parsers\cxx\cxx_qtmoc.c parsers\cxx\cxx_scope.c parsers\cxx\cxx_side_chain.c parsers\cxx\cxx_subparser.c parsers\cxx\cxx_tag.c parsers\cxx\cxx_token.c parsers\cxx\cxx_token_chain.c
Microsoft (R) C/C++ Optimizing Compiler Version 19.43.34810 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

cxx.c
cxx_debug.c
cxx_debug_type.c
cxx_keyword.c
cxx_parser.c
cxx_parser_block.c
cxx_parser_function.c
cxx_parser_lambda.c
cxx_parser_module.c
cxx_parser_namespace.c
cxx_parser_template.c
cxx_parser_tokenizer.c
cxx_parser_typedef.c
cxx_parser_using.c
cxx_parser_variable.c
cxx_qtmoc.c
cxx_scope.c
cxx_side_chain.c
cxx_subparser.c
cxx_tag.c
Generating Code...
Compiling...
cxx_token.c
cxx_token_chain.c
Generating Code...
        cl /O2 /WX /Zc:preprocessor  -DHAVE_REPOINFO_H -DHAVE_PACKCC -I. -Ignulib -Imain -Iparsers -Ilibreadtags -Idsl /Foparsers\ /c parsers\v.c
Microsoft (R) C/C++ Optimizing Compiler Version 19.43.34810 for x86
Copyright (C) Microsoft Corporation.  All rights reserved.

v.c
parsers\v.c(1): error C2220: the following warning is treated as an error
parsers\v.c(1): warning C4819: The file contains a character that cannot be represented in the current code page (932). Save the file in Unicode format to prevent data loss
NMAKE : fatal error U1077: 'cl /O2 /WX /Zc:preprocessor  -DHAVE_REPOINFO_H -DHAVE_PACKCC -I. -Ignulib -Imain -Iparsers -Ilibreadtags -Idsl /Foparsers\ /c parsers\v.c ' : return code '0x2'
Stop.
```

</details>

https://learn.microsoft.com/en-us/cpp/build/reference/source-charset-set-source-character-set?view=msvc-170

Adding a UTF-8 BOM to `parsers\v.c` file also solves the build error.
