### PR TITLE
GitHub Actions: set timeout to tests on Qemu

### DIFF
--- a/.github/workflows/testing-on-alpine.yml
+++ b/.github/workflows/testing-on-alpine.yml
@@ -46,6 +46,8 @@ jobs:
       matrix:
         target-arch: [loongarch64, aarch64, ppc64le, riscv64, s390x]
 
+    timeout-minutes: 45
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The tests on Qemu hung frequently.
I had to cancel them before manually restarting them. 
The timeout reduced the steps I have to take to restart.
