### PR TITLE
 JNI: new subparser

### DIFF
--- a/Tmain/list-subparsers-all.d/stdout-expected.txt
+++ b/Tmain/list-subparsers-all.d/stdout-expected.txt
@@ -13,6 +13,8 @@ Glade                XML        base <> sub {bidirectional}
 I18nRubyGem          Yaml       base <> sub {bidirectional}
 IPythonCell          Python     base => sub {shared}
 ITcl                 Tcl        base <> sub {bidirectional}
+JNI                  C          base <> sub {bidirectional}
+JNI                  C++        base <> sub {bidirectional}
 Maven2               XML        base <> sub {bidirectional}
 Moose                Perl       base <> sub {bidirectional}
 OpenAPI              Yaml       base <> sub {bidirectional}

--- a/Tmain/nested-subparsers.d/stdout-expected.txt
+++ b/Tmain/nested-subparsers.d/stdout-expected.txt
@@ -126,14 +126,18 @@ mylib.so	input.c	/^	LOAD_PLUGIN(mylib.so, isearch);$/;"	File	language:Plugin
 List subparsers of C ( EVENT + HOOK + PLUGIN + UA )
 #NAME   BASEPARSER DIRECTIONS
 Event   C          base => sub {shared}
+JNI     C          base <> sub {bidirectional}
 Plugin  C          base => sub {shared}
 List subparsers of C ( EVENT + HOOK + PLUGIN + UA ) without the header
 Event   C          base => sub {shared}
+JNI     C          base <> sub {bidirectional}
 Plugin  C          base => sub {shared}
 List subparsers of C ( EVENT + HOOK + PLUGIN + UA ) in machinable
 #NAME	BASEPARSER	DIRECTIONS
 Event	C	base => sub {shared}
+JNI	C	base <> sub {bidirectional}
 Plugin	C	base => sub {shared}
 List subparsers of C ( EVENT + HOOK + PLUGIN + UA ) in machinable without the header
 Event	C	base => sub {shared}
+JNI	C	base <> sub {bidirectional}
 Plugin	C	base => sub {shared}

--- a/Units/parser-jni.r/broken.d/args.ctags
+++ b/Units/parser-jni.r/broken.d/args.ctags
@@ -1,0 +1,4 @@
+--sort=no
+--extras=+s
+--fields=+S
+--kinds-C=+l

--- a/Units/parser-jni.r/broken.d/expected.tags
+++ b/Units/parser-jni.r/broken.d/expected.tags
@@ -1,0 +1,18 @@
+a	input.c	/^int a;$/;"	v	typeref:typename:int
+gMethods00	input.c	/^static JNINativeMethod gMethods00[] = {$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods01	input.c	/^static JNINativeMethod gMethods01[] = {$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods02	input.c	/^static JNINativeMethod gMethods02[] = {$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods03	input.c	/^static JNINativeMethod gMethods03[] = {$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods04	input.c	/^static JNINativeMethod gMethods04[] = {$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods05	input.c	/^static JNINativeMethod gMethods05[] = {$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods06	input.c	/^static JNINativeMethod gMethods06[] = {$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods10	input.c	/^static JNINativeMethod gMethods10[] = {$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods20	input.c	/^static JNINativeMethod gMethods20[] =;$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods21	input.c	/^static JNINativeMethod gMethods21[] = 1;$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods22	input.c	/^static JNINativeMethod gMethods22[] = "a";$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods23	input.c	/^static JNINativeMethod gMethods23[] = ['a'];$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods24	input.c	/^static JNINativeMethod gMethods24[] = [NULL];$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods25	input.c	/^static JNINativeMethod gMethods25[] = [[NULL]];$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods30	input.c	/^static JNINativeMethod gMethods30[] = {$/;"	v	typeref:typename:JNINativeMethod[]	file:
+gMethods40	input.c	/^static JNINativeMethod gMethods40[] = {$/;"	v	typeref:typename:JNINativeMethod[]	file:
+b	input.c	/^int b;$/;"	v	typeref:typename:int

--- a/Units/parser-jni.r/broken.d/input.c
+++ b/Units/parser-jni.r/broken.d/input.c
@@ -1,0 +1,57 @@
+int a;
+static JNINativeMethod gMethods00[] = {
+};
+static JNINativeMethod gMethods01[] = {
+	,
+};
+static JNINativeMethod gMethods02[] = {
+	{}
+};
+static JNINativeMethod gMethods03[] = {
+	{,}
+};
+static JNINativeMethod gMethods04[] = {
+	{,,}
+};
+static JNINativeMethod gMethods05[] = {
+	,,
+};
+static JNINativeMethod gMethods06[] = {
+	,{},
+};
+
+static JNINativeMethod gMethods10[] = {
+	{"M0"},
+	{"M1",},
+	{"M2","S"},
+	{"M3",[], "S"},
+	NULL,
+	{4},
+	{NULL},
+	{""},
+	{"",},
+	{,""},
+	{NULL, ""},
+	{"",NULL},
+	{NULL,""},
+};
+
+static JNINativeMethod gMethods20[] =;
+static JNINativeMethod gMethods21[] = 1;
+static JNINativeMethod gMethods22[] = "a";
+static JNINativeMethod gMethods23[] = ['a'];
+static JNINativeMethod gMethods24[] = [NULL];
+static JNINativeMethod gMethods25[] = [[NULL]];
+
+static JNINativeMethod gMethods30[] = {
+	{"m0", "()"},
+	{"m1", "("},
+	{"m2", ")"},
+	{"m3", "i"},
+};
+
+static JNINativeMethod gMethods40[] = {
+	{"", "(I)V"},
+};
+
+int b;

--- a/Units/parser-jni.r/simple.d/args.ctags
+++ b/Units/parser-jni.r/simple.d/args.ctags
@@ -1,0 +1,4 @@
+--sort=no
+--extras=+s
+--fields=+S
+--kinds-C++=+l

--- a/Units/parser-jni.r/simple.d/expected.tags
+++ b/Units/parser-jni.r/simple.d/expected.tags
@@ -1,0 +1,22 @@
+gMethods	input.cpp	/^static JNINativeMethod gMethods[] = {$/;"	v	typeref:typename:JNINativeMethod[]	file:
+nGetMaximumTextureWidth	input.cpp	/^        {"nGetMaximumTextureWidth", "()I", (void*)android_view_DisplayListCanvas_getMaxTextureSi/;"	m	variable:gMethods	typeref:typename:I	signature:()
+nGetMaximumTextureHeight	input.cpp	/^        {"nGetMaximumTextureHeight", "()I",$/;"	m	variable:gMethods	typeref:typename:I	signature:()
+nCreateDisplayListCanvas	input.cpp	/^        {"nCreateDisplayListCanvas", "(JII)J",$/;"	m	variable:gMethods	typeref:typename:J	signature:(JII)
+nResetDisplayListCanvas	input.cpp	/^        {"nResetDisplayListCanvas", "(JJII)V",$/;"	m	variable:gMethods	typeref:typename:V	signature:(JJII)
+nEnableZ	input.cpp	/^        {"nEnableZ", "(JZ)V", (void*)android_view_DisplayListCanvas_enableZ},$/;"	m	variable:gMethods	typeref:typename:V	signature:(JZ)
+nFinishRecording	input.cpp	/^        {"nFinishRecording", "(JJ)V", (void*)android_view_DisplayListCanvas_finishRecording},$/;"	m	variable:gMethods	typeref:typename:V	signature:(JJ)
+nDrawRenderNode	input.cpp	/^        {"nDrawRenderNode", "(JJ)V", (void*)android_view_DisplayListCanvas_drawRenderNode},$/;"	m	variable:gMethods	typeref:typename:V	signature:(JJ)
+nDrawTextureLayer	input.cpp	/^        {"nDrawTextureLayer", "(JJ)V", (void*)android_view_DisplayListCanvas_drawTextureLayer},$/;"	m	variable:gMethods	typeref:typename:V	signature:(JJ)
+nDrawCircle	input.cpp	/^        {"nDrawCircle", "(JJJJJ)V", (void*)android_view_DisplayListCanvas_drawCircleProps},$/;"	m	variable:gMethods	typeref:typename:V	signature:(JJJJJ)
+nDrawRoundRect	input.cpp	/^        {"nDrawRoundRect", "(JJJJJJJJ)V", (void*)android_view_DisplayListCanvas_drawRoundRectPro/;"	m	variable:gMethods	typeref:typename:V	signature:(JJJJJJJJ)
+nDrawWebViewFunctor	input.cpp	/^        {"nDrawWebViewFunctor", "(JI)V", (void*)android_view_DisplayListCanvas_drawWebViewFuncto/;"	m	variable:gMethods	typeref:typename:V	signature:(JI)
+nDrawRipple	input.cpp	/^        {"nDrawRipple", "(JJJJJJJIJ)V", (void*)android_view_DisplayListCanvas_drawRippleProps},$/;"	m	variable:gMethods	typeref:typename:V	signature:(JJJJJJJIJ)
+languages	input.cpp	/^static Lanaguage languages [] = {$/;"	v	typeref:typename:Lanaguage[]	file:
+foo	input-0.cpp	/^static void foo()$/;"	f	typeref:typename:void	file:	signature:()
+LocalMethods	input-0.cpp	/^  static JNINativeMethod LocalMethods[] = {{"aLocalMethod", "()I", (void*)localMethod},};$/;"	l	function:foo	typeref:typename:JNINativeMethod[]	file:
+aLocalMethod	input-0.cpp	/^  static JNINativeMethod LocalMethods[] = {{"aLocalMethod", "()I", (void*)localMethod},};$/;"	m	local:foo.LocalMethods	typeref:typename:I	signature:()
+CC	input-1.cpp	/^#define CC /;"	d	file:
+FN_PTR	input-1.cpp	/^#define FN_PTR(f) CAST_FROM_FN_PTR(/;"	d	file:	signature:(f)
+LANG	input-1.cpp	/^#define LANG /;"	d	file:
+UH_methods	input-1.cpp	/^static JNINativeMethod UH_methods[] = {$/;"	v	typeref:typename:JVM_END JNINativeMethod[]	file:
+freeUpcallStub0	input-1.cpp	/^  {CC "freeUpcallStub0",     CC "(J)Z",                FN_PTR(UH_FreeUpcallStub0)}$/;"	m	variable:UH_methods	typeref:typename:Z	signature:(J)

--- a/Units/parser-jni.r/simple.d/input-0.cpp
+++ b/Units/parser-jni.r/simple.d/input-0.cpp
@@ -1,0 +1,5 @@
+static void foo()
+{
+  static JNINativeMethod LocalMethods[] = {{"aLocalMethod", "()I", (void*)localMethod},};
+}
+// The line: and the end: of LocalMethods are the same.

--- a/Units/parser-jni.r/simple.d/input-1.cpp
+++ b/Units/parser-jni.r/simple.d/input-1.cpp
@@ -1,0 +1,56 @@
+// Taken from java-21-openjdk/jdk-21.0.6+7/src/hotspot/share/prims/upcallStubs.cpp
+/*
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "code/codeBlob.hpp"
+#include "code/codeCache.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+
+JVM_ENTRY(static jboolean, UH_FreeUpcallStub0(JNIEnv *env, jobject _unused, jlong addr))
+  // safe to call 'find_blob' without code cache lock, because stub is always alive
+  CodeBlob* cb = CodeCache::find_blob((char*)addr);
+  if (cb == nullptr) {
+    return false;
+  }
+  UpcallStub::free(cb->as_upcall_stub());
+  return true;
+JVM_END
+
+#define CC (char*)  /*cast a literal from (const char*)*/
+#define FN_PTR(f) CAST_FROM_FN_PTR(void*, &f)
+#define LANG "Ljava/lang/"
+
+// These are the native methods on jdk.internal.foreign.NativeInvoker.
+static JNINativeMethod UH_methods[] = {
+  {CC "freeUpcallStub0",     CC "(J)Z",                FN_PTR(UH_FreeUpcallStub0)}
+};
+
+/**
+ * This one function is exported, used by NativeLookup.
+ */
+JVM_LEAF(void, JVM_RegisterUpcallHandlerMethods(JNIEnv *env, jclass UH_class))
+  int status = env->RegisterNatives(UH_class, UH_methods, sizeof(UH_methods)/sizeof(JNINativeMethod));
+  guarantee(status == JNI_OK && !env->ExceptionOccurred(),
+            "register jdk.internal.foreign.abi.UpcallStubs natives");
+JVM_END

--- a/Units/parser-jni.r/simple.d/input.cpp
+++ b/Units/parser-jni.r/simple.d/input.cpp
@@ -1,0 +1,43 @@
+// Taken from base/libs/hwui/jni/android_graphics_DisplayListCanvas.cpp
+// in https://android.googlesource.com/platform/frameworks/base
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+static JNINativeMethod gMethods[] = {
+        {"nGetMaximumTextureWidth", "()I", (void*)android_view_DisplayListCanvas_getMaxTextureSize},
+        {"nGetMaximumTextureHeight", "()I",
+         (void*)android_view_DisplayListCanvas_getMaxTextureSize},
+        // ------------ @CriticalNative --------------
+        {"nCreateDisplayListCanvas", "(JII)J",
+         (void*)android_view_DisplayListCanvas_createDisplayListCanvas},
+        {"nResetDisplayListCanvas", "(JJII)V",
+         (void*)android_view_DisplayListCanvas_resetDisplayListCanvas},
+        {"nEnableZ", "(JZ)V", (void*)android_view_DisplayListCanvas_enableZ},
+        {"nFinishRecording", "(JJ)V", (void*)android_view_DisplayListCanvas_finishRecording},
+        {"nDrawRenderNode", "(JJ)V", (void*)android_view_DisplayListCanvas_drawRenderNode},
+        {"nDrawTextureLayer", "(JJ)V", (void*)android_view_DisplayListCanvas_drawTextureLayer},
+        {"nDrawCircle", "(JJJJJ)V", (void*)android_view_DisplayListCanvas_drawCircleProps},
+        {"nDrawRoundRect", "(JJJJJJJJ)V", (void*)android_view_DisplayListCanvas_drawRoundRectProps},
+        {"nDrawWebViewFunctor", "(JI)V", (void*)android_view_DisplayListCanvas_drawWebViewFunctor},
+        {"nDrawRipple", "(JJJJJJJIJ)V", (void*)android_view_DisplayListCanvas_drawRippleProps},
+};
+
+
+static Lanaguage languages [] = {
+  {"C", 1},
+  {"D", 1},
+  {"Lisp", 0},
+};

--- a/docs/news/HEAD.rst
+++ b/docs/news/HEAD.rst
@@ -44,6 +44,7 @@ New parsers
 * SELinuxTypeEnforcement *optlib*
 * PythonEntryPoints *subparser*
 * Scdoc *optlib*
+* JNI *subparser*
 
 .. note:: We added a TOML as a new parser in this version. However,
 		  after adding it, we learned its implementation didn't work

--- a/main/parsers_p.h
+++ b/main/parsers_p.h
@@ -118,6 +118,7 @@
 	JavaParser, \
 	JavaPropertiesParser, \
 	JavaScriptParser, \
+	JNIParser, \
 	JsonParser, \
 	JuliaParser, \
 	KconfigParser, \

--- a/parsers/cxx/cxx_jni.c
+++ b/parsers/cxx/cxx_jni.c
@@ -1,0 +1,284 @@
+/*
+*  Copyright (c) 2025, Red Hat, Inc.
+*   Copyright (c) 2025, Masatake YAMATO
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+*
+*   This module contains functions for handling JNI names.
+*/
+
+#include "general.h"
+
+#include "entry.h"
+
+#include "cxx_tag.h"
+#include "cxx_subparser.h"
+#include "cxx_token_chain.h"
+
+#include <string.h>
+
+struct sJNISubparser {
+	struct sCxxSubparser cxx;
+	int JNINativeMethodVarIndex;
+};
+
+typedef enum {
+	K_METHOD,
+} jniKind;
+
+
+static kindDefinition JNIKinds [] = {
+	{ true, 'm', "method", "methods" },
+};
+
+static langType Lang_C;
+static langType Lang_Cxx;
+
+static void inputStart(subparser *s)
+{
+	struct sJNISubparser *pJNI = (struct sJNISubparser*)s;
+
+	pJNI->JNINativeMethodVarIndex = CORK_NIL;
+}
+
+static void makeTagEntryNotify (subparser *s, const tagEntryInfo *entry, int corkIndex)
+{
+	if ((entry->langType == Lang_C || entry->langType == Lang_Cxx)
+		&& (entry->kindIndex == CXXTagKindVARIABLE || entry->kindIndex == CXXTagKindLOCAL)
+		&& entry->extensionFields.typeRef[1]
+		&& strstr (entry->extensionFields.typeRef[1],
+				   "JNINativeMethod"))
+	{
+		struct sJNISubparser *pJNI = (struct sJNISubparser*)s;
+		pJNI->JNINativeMethodVarIndex = corkIndex;
+	}
+}
+
+static bool wantsVariableBody (struct sCxxSubparser *pSubparser, CXXToken * pEndOfRightSide)
+{
+	// JNINativeMethod varname [] = { ....
+	//                         ^
+	// pEndOfRightSide --------|
+
+	return ( cxxTokenTypeIs(pEndOfRightSide,CXXTokenTypeSquareParenthesisChain)
+			 && pEndOfRightSide->pPrev
+			 && cxxTokenTypeIs(pEndOfRightSide->pPrev,CXXTokenTypeIdentifier)
+			 && pEndOfRightSide->pPrev->pPrev
+			 && cxxTokenTypeIs(pEndOfRightSide->pPrev->pPrev,CXXTokenTypeIdentifier)
+			 && strcmp(vStringValue(pEndOfRightSide->pPrev->pPrev->pszWord),"JNINativeMethod") == 0);
+}
+
+static void jniMakeTagEntryForMethod (CXXToken * pToken, int scopeIndex,
+									  vString *signature, vString *typeref)
+{
+	tagEntryInfo tag;
+
+	const char *name = vStringValue (pToken->pszWord);
+
+	if (vStringIsEmpty (pToken->pszWord))
+		return;
+
+
+	if (vStringLastSafe (pToken->pszWord) == '"'
+		&& vStringValue (pToken->pszWord)[0] == '"')
+	{
+		if (vStringLength (pToken->pszWord) == 2)
+			return;
+
+		// surgery extracting name from "name".
+		name = vStringValue (pToken->pszWord) + 1;
+		vStringTruncate (pToken->pszWord,
+						 vStringLength (pToken->pszWord) - 1);
+	}
+
+	initTagEntry(&tag, name, K_METHOD);
+	updateTagLine (&tag, pToken->iLineNumber, pToken->oFilePosition);
+	tag.isFileScope = false;
+
+	tag.extensionFields.scopeIndex = scopeIndex;
+
+	if (signature)
+		tag.extensionFields.signature = vStringValue (signature);
+	if (typeref)
+	{
+		tag.extensionFields.typeRef [0] = "typename";
+		tag.extensionFields.typeRef [1] = vStringValue (typeref);
+	}
+
+	makeTagEntry(&tag);
+
+	if (name != vStringValue (pToken->pszWord))
+		vStringPut (pToken->pszWord, '"');
+}
+
+static vString *extractSignature0 (CXXToken *pSignature, vString *pszSignature)
+{
+	if (!pSignature)
+		return pszSignature;
+
+	if (!cxxTokenTypeIs (pSignature, CXXTokenTypeStringConstant))
+		return pszSignature;
+
+	if (!pszSignature)
+		pszSignature = vStringNew ();
+
+	for (size_t i = 0; i < vStringLength (pSignature->pszWord); i++)
+	{
+		char c = vStringChar (pSignature->pszWord, i);
+		if (c == '"')
+			continue;
+
+		vStringPut (pszSignature, c);
+	}
+
+	return extractSignature0 (pSignature->pNext, pszSignature);
+}
+
+static vString *extractSignature (CXXToken *pSignature)
+{
+	return extractSignature0 (pSignature, NULL);
+}
+
+static vString *extractTyperef (vString *pszSignature)
+{
+	vString *pszTyperef = NULL;
+	const char *str = vStringValue (pszSignature);
+	const char *t = strrchr (str, ')');
+
+	if (t && t[1])
+	{
+		pszTyperef = vStringNewInit (t + 1);
+		size_t  newlen = vStringLength (pszSignature) - vStringLength (pszTyperef);
+		vStringTruncate (pszSignature, newlen);
+	}
+
+	return pszTyperef;
+}
+
+static void parseMethodEntry (CXXToken *pMethod, int iVarCork)
+{
+	while (pMethod && !cxxTokenTypeIs (pMethod, CXXTokenTypeStringConstant))
+	{
+		if (cxxTokenTypeIs (pMethod, CXXTokenTypeComma)
+			|| cxxTokenTypeIs (pMethod, CXXTokenTypeClosingBracket))
+			return;
+
+		pMethod = pMethod->pNext;
+	}
+	if (!pMethod || !cxxTokenTypeIs (pMethod, CXXTokenTypeStringConstant))
+		return;
+
+	CXXToken *pComma = pMethod->pNext;
+	while (pComma && !cxxTokenTypeIs (pComma, CXXTokenTypeComma))
+		pComma = pComma->pNext;
+	if (!pComma || !cxxTokenTypeIs (pComma, CXXTokenTypeComma))
+		return;
+
+	CXXToken *pSignature = pComma->pNext;
+	while (pSignature && !cxxTokenTypeIs (pSignature, CXXTokenTypeStringConstant))
+		pSignature = pSignature->pNext;
+	if (!pSignature || !cxxTokenTypeIs (pSignature, CXXTokenTypeStringConstant))
+		return;
+
+	vString *pszSignature =extractSignature (pSignature);
+	if (!pszSignature)
+		return;
+
+	if (vStringValue (pszSignature) [0] != '(')
+	{
+		vStringDelete (pszSignature);
+		return;
+	}
+
+	vString *pszTyperef = extractTyperef (pszSignature);
+	if (!pszTyperef)
+	{
+		vStringDelete (pszSignature);
+		return;
+	}
+
+	if (pszSignature && pszTyperef)
+		jniMakeTagEntryForMethod (pMethod, iVarCork,
+								  pszSignature, pszTyperef);
+
+	/* NULLs are acceptable. */
+	vStringDelete (pszTyperef);
+	vStringDelete (pszSignature);
+}
+
+static void variableBodyNotify (struct sCxxSubparser *pSubparser, int iVarCork,
+								CXXToken * pStart, CXXToken * pEnd)
+{
+	struct sJNISubparser *pJNI = (struct sJNISubparser*)pSubparser;
+
+	if (iVarCork != pJNI->JNINativeMethodVarIndex)
+		return;
+
+	if (!cxxTokenTypeIs (pStart, CXXTokenTypeBracketChain))
+		return;
+
+	CXXTokenChain *pTopChain = pStart->pChain;
+	for (CXXToken *pT = pTopChain->pHead; pT; pT = pT->pNext)
+	{
+		if (!cxxTokenTypeIs (pT, CXXTokenTypeBracketChain))
+			continue;
+
+		CXXTokenChain *pEntryChain = pT->pChain;
+		if (!pEntryChain)
+			continue;
+
+		CXXToken *pEntryHead = pEntryChain->pHead;
+		if (!pEntryHead)
+			continue;
+
+		if (pEntryHead->pNext)
+			parseMethodEntry (pEntryHead->pNext, iVarCork);
+	}
+}
+
+static void initialize (langType lang)
+{
+	Lang_C = getNamedLanguage ("C", 0);
+	Lang_Cxx = getNamedLanguage ("C++", 0);
+}
+
+static void findJNITags(void)
+{
+	scheduleRunningBaseparser (0);
+}
+
+extern parserDefinition* JNIParser (void)
+{
+	parserDefinition* const def = parserNew("JNI");
+
+	static struct sJNISubparser jniSubparser = {
+		.cxx = {
+			.subparser = {
+				.direction = SUBPARSER_BI_DIRECTION,
+				.inputStart = inputStart,
+				.makeTagEntryNotify = makeTagEntryNotify,
+			},
+			.wantsVariableBody = wantsVariableBody,
+			.variableBodyNotify = variableBodyNotify,
+		},
+		. JNINativeMethodVarIndex = CORK_NIL,
+	};
+
+	static parserDependency dependencies [] = {
+		[0] = { DEPTYPE_SUBPARSER, "C++", &jniSubparser },
+		[1] = { DEPTYPE_SUBPARSER, "C", &jniSubparser },
+	};
+
+	def->dependencies = dependencies;
+	def->dependencyCount = ARRAY_SIZE (dependencies);
+
+	def->kindTable = JNIKinds;
+	def->kindCount = ARRAY_SIZE(JNIKinds);
+
+	def->parser = findJNITags;
+	def->initialize = initialize;
+	def->useCork = CORK_QUEUE;
+
+	return def;
+}

--- a/parsers/cxx/cxx_parser_variable.c
+++ b/parsers/cxx/cxx_parser_variable.c
@@ -15,6 +15,7 @@
 #include "cxx_token_chain.h"
 #include "cxx_scope.h"
 #include "cxx_side_chain.h"
+#include "cxx_subparser_internal.h"
 
 #include "vstring.h"
 #include "read.h"
@@ -930,6 +931,7 @@ got_identifier:
 			if (iCorkIndex != CORK_NIL)
 			{
 				cxxParserSetEndLineForTagInCorkQueue (iCorkIndex, t->iLineNumber);
+				cxxSubparserNotifyVariableBodyMaybe (iCorkIndex, t);
 				iCorkIndex = CORK_NIL;
 				if(iCorkIndexFQ != CORK_NIL)
 				{

--- a/parsers/cxx/cxx_subparser.h
+++ b/parsers/cxx/cxx_subparser.h
@@ -40,6 +40,9 @@ struct sCxxSubparser {
 	bool (* parseAccessSpecifierNotify) (struct sCxxSubparser *pSubparser);
 	void (* foundExtraIdentifierAsAccessSpecifier) (struct sCxxSubparser *pSubparser,
 													CXXToken * pToken);
+	bool (* wantsVariableBody) (struct sCxxSubparser *pSubparser, CXXToken * pEndOfRightSide);
+	void (* variableBodyNotify) (struct sCxxSubparser *pSubparser, int iVarCork,
+								 CXXToken * pStart, CXXToken * pEnd);
 };
 
 #endif //!ctags_cxx_subparser_h_

--- a/parsers/cxx/cxx_subparser_internal.h
+++ b/parsers/cxx/cxx_subparser_internal.h
@@ -24,4 +24,7 @@ void cxxSubparserUnknownIdentifierInClassNotify(CXXToken *pToken);
 void cxxSubparserNotifyEnterBlock (void);
 void cxxSubparserNotifyLeaveBlock (void);
 
+bool cxxSubparserWantVariableBody (CXXToken * pEndOfRightSide);
+void cxxSubparserNotifyVariableBodyMaybe (int iVarCork, CXXToken * pEnd);
+
 #endif //!ctags_cxx_subparser_interanl_h_

--- a/source.mak
+++ b/source.mak
@@ -338,6 +338,7 @@ PARSER_SRCS =				\
 	parsers/cxx/cxx.c		\
 	parsers/cxx/cxx_debug.c		\
 	parsers/cxx/cxx_debug_type.c	\
+	parsers/cxx/cxx_jni.c		\
 	parsers/cxx/cxx_keyword.c		\
 	parsers/cxx/cxx_parser.c		\
 	parsers/cxx/cxx_parser_block.c		\

--- a/win32/ctags_vs2013.vcxproj
+++ b/win32/ctags_vs2013.vcxproj
@@ -286,6 +286,7 @@
     <ClCompile Include="..\parsers\cxx\cxx.c" />
     <ClCompile Include="..\parsers\cxx\cxx_debug.c" />
     <ClCompile Include="..\parsers\cxx\cxx_debug_type.c" />
+    <ClCompile Include="..\parsers\cxx\cxx_jni.c" />
     <ClCompile Include="..\parsers\cxx\cxx_keyword.c" />
     <ClCompile Include="..\parsers\cxx\cxx_parser.c" />
     <ClCompile Include="..\parsers\cxx\cxx_parser_block.c" />

--- a/win32/ctags_vs2013.vcxproj.filters
+++ b/win32/ctags_vs2013.vcxproj.filters
@@ -381,6 +381,9 @@
     <ClCompile Include="..\parsers\cxx\cxx_debug_type.c">
       <Filter>Source Files\parsers\cxx</Filter>
     </ClCompile>
+    <ClCompile Include="..\parsers\cxx\cxx_jni.c">
+      <Filter>Source Files\parsers\cxx</Filter>
+    </ClCompile>
     <ClCompile Include="..\parsers\cxx\cxx_keyword.c">
       <Filter>Source Files\parsers\cxx</Filter>
     </ClCompile>


### PR DESCRIPTION
~This is a prototype. This must be rewritten in C when merging.~
    
See https://github.com/universal-ctags/citre/issues/189 about the background of this PR.

```
 mkdir -p ~/tmp
$ cd ~/tmp
$ git clone https://android.googlesource.com/platform/frameworks/base
$ cd base
$ time ~/bin/ctags -o ../base.tags --sort=no --fields=+l --kinds-C++=+l --extras=+s --languages=+JNI -R 
ctags: Warning: cannot open input file "native/android/include/android/multinetwork.h" : No such file or directory
~/bin/ctags -o ../base.tags --sort=no --fields=+l --kinds-C++=+l --extras=+s   221.60s user 10.06s system 62% cpu 6:09.77 total
$ ~/bin/readtags -t ../base.tags nativeForkAndSpecialize
nativeForkAndSpecialize core/jni/com_android_internal_os_Zygote.cpp     /^        {"nativeForkAndSpecialize",$/
nativeForkAndSpecialize core/java/com/android/internal/os/Zygote.java   /^    private static native int nativeForkAndSpecialize(int uid, int gid, int[] gids,$/
$ ~/bin/readtags -t ../base.tags -e ../base.tags nativeForkAndSpecialize -F '(list $name "->" $language #t)'
nativeForkAndSpecialize->JNI
nativeForkAndSpecialize->Java
```