### PR TITLE
C++: fix incorrect parser version

### DIFF
--- a/parsers/cxx/cxx.c
+++ b/parsers/cxx/cxx.c
@@ -140,8 +140,8 @@ parserDefinition * CppParser (void)
 	def->selectLanguage = selectors;
 	def->useCork = CORK_QUEUE|CORK_SYMTAB; // We use corking to block output until the end of file
 
-	def->versionCurrent = 1;
-	def->versionAge = 1;
+	def->versionCurrent = 2;
+	def->versionAge = 2;
 
 	return def;
 }


### PR DESCRIPTION
Fix #4264.

In d469bf986acc7837514680434e90bc6087fe2827, I should update the parser version to 2.2.