### PR TITLE
Various fixes related to makePromise() pointing behind EOF

### DIFF
--- a/main/mio.c
+++ b/main/mio.c
@@ -1082,8 +1082,13 @@ int mio_seek (MIO *mio, long offset, int whence)
 		switch (whence)
 		{
 			case SEEK_SET:
-				if (offset < 0 || (size_t)offset > mio->impl.mem.size)
+				if (offset < 0)
 					errno = EINVAL;
+				else if ((size_t)offset > mio->impl.mem.size)
+				{
+					errno = EINVAL;
+					mio->impl.mem.pos = mio->impl.mem.size;
+				}
 				else
 				{
 					mio->impl.mem.pos = (size_t)offset;
@@ -1092,10 +1097,12 @@ int mio_seek (MIO *mio, long offset, int whence)
 				break;
 
 			case SEEK_CUR:
-				if ((offset < 0 && (size_t)-offset > mio->impl.mem.pos) ||
-					mio->impl.mem.pos + (size_t)offset > mio->impl.mem.size)
+				if (offset < 0 && (size_t)-offset > mio->impl.mem.pos)
+					errno = EINVAL;
+				else if (mio->impl.mem.pos + (size_t)offset > mio->impl.mem.size)
 				{
 					errno = EINVAL;
+					mio->impl.mem.pos = mio->impl.mem.size;
 				}
 				else
 				{
@@ -1282,7 +1289,10 @@ int mio_setpos (MIO *mio, MIOPos *pos)
 		rv = -1;
 
 		if (pos->impl.mem > mio->impl.mem.size)
+		{
 			errno = EINVAL;
+			mio->impl.mem.pos = mio->impl.mem.size;
+		}
 		else
 		{
 			mio->impl.mem.ungetch = EOF;

--- a/main/mio.c
+++ b/main/mio.c
@@ -1082,13 +1082,8 @@ int mio_seek (MIO *mio, long offset, int whence)
 		switch (whence)
 		{
 			case SEEK_SET:
-				if (offset < 0)
+				if (offset < 0 || (size_t)offset > mio->impl.mem.size)
 					errno = EINVAL;
-				else if ((size_t)offset > mio->impl.mem.size)
-				{
-					errno = EINVAL;
-					mio->impl.mem.pos = mio->impl.mem.size;
-				}
 				else
 				{
 					mio->impl.mem.pos = (size_t)offset;
@@ -1097,12 +1092,10 @@ int mio_seek (MIO *mio, long offset, int whence)
 				break;
 
 			case SEEK_CUR:
-				if (offset < 0 && (size_t)-offset > mio->impl.mem.pos)
-					errno = EINVAL;
-				else if (mio->impl.mem.pos + (size_t)offset > mio->impl.mem.size)
+				if ((offset < 0 && (size_t)-offset > mio->impl.mem.pos) ||
+					mio->impl.mem.pos + (size_t)offset > mio->impl.mem.size)
 				{
 					errno = EINVAL;
-					mio->impl.mem.pos = mio->impl.mem.size;
 				}
 				else
 				{
@@ -1289,10 +1282,7 @@ int mio_setpos (MIO *mio, MIOPos *pos)
 		rv = -1;
 
 		if (pos->impl.mem > mio->impl.mem.size)
-		{
 			errno = EINVAL;
-			mio->impl.mem.pos = mio->impl.mem.size;
-		}
 		else
 		{
 			mio->impl.mem.ungetch = EOF;

--- a/main/mio.c
+++ b/main/mio.c
@@ -317,6 +317,9 @@ MIO *mio_new_mio (MIO *base, long start, long size)
 	MIO *submio;
 	size_t r;
 
+	if (start < 0 || size < -1)
+		return NULL;
+
 	original_pos = mio_tell (base);
 
 	if (size == -1)

--- a/main/parse.c
+++ b/main/parse.c
@@ -4322,7 +4322,7 @@ extern bool runParserInArea (const langType language,
 							 unsigned long sourceLineOffset,
 							 int promise)
 {
-	bool tagFileResized;
+	bool tagFileResized = false;
 
 	verbose ("runParserInArea: %s; "
 			 "file: %s, "
@@ -4334,13 +4334,15 @@ extern bool runParserInArea (const langType language,
 			 startLine, startCharOffset, sourceLineOffset,
 			 endLine, endCharOffset);
 
-	pushArea (doesParserRequireMemoryStream (language),
+	if (pushArea (doesParserRequireMemoryStream (language),
 			  startLine, startCharOffset,
 			  endLine, endCharOffset,
 			  sourceLineOffset,
-			  promise);
-	tagFileResized = createTagsWithFallback1 (language, NULL);
-	popArea  ();
+			  promise))
+	{
+		tagFileResized = createTagsWithFallback1 (language, NULL);
+		popArea  ();
+	}
 	return tagFileResized;
 
 }

--- a/main/read.c
+++ b/main/read.c
@@ -1394,7 +1394,7 @@ extern char *readLineFromBypass (
 	return data.result;
 }
 
-extern void   pushArea (
+extern bool   pushArea (
 				       bool useMemoryStreamInput,
 				       unsigned long startLine, long startColumn,
 				       unsigned long endLine, long endColumn,
@@ -1415,7 +1415,7 @@ extern void   pushArea (
 		{
 			File.thinDepth++;
 			verbose ("push thin area (%d)\n", File.thinDepth);
-			return;
+			return true;
 		}
 		error(WARNING, "INTERNAL ERROR: though pushing MEMORY based thin area, "
 			  "underlying area is a FILE base: %s@%s",
@@ -1448,6 +1448,9 @@ extern void   pushArea (
 
 	mio_setpos (File.mio, &original);
 
+	if (q <= p)
+		return false;
+
 	invalidatePatternCache();
 
 	size_t size = q - p;
@@ -1473,6 +1476,8 @@ extern void   pushArea (
 
 	File.input.lineNumberOrigin = ((startLine == 0)? 0: startLine - 1);
 	File.source.lineNumberOrigin = ((sourceLineOffset == 0)? 0: sourceLineOffset - 1);
+
+	return true;
 }
 
 extern bool isAreaStacked (void)

--- a/main/read_p.h
+++ b/main/read_p.h
@@ -82,7 +82,7 @@ extern char *readLineFromBypass (vString *const vLine, MIOPos pos, long *const o
  * args (endColumn): [absolute]
  * args (sourceLineOffset): [buggy]
  */
-extern void   pushArea (
+extern bool   pushArea (
 				       bool useMemoryStreamInput,
 				       unsigned long startLine, long startColumn,
 				       unsigned long endLine, long endColumn,


### PR DESCRIPTION
For more info, see the individual commit messages and the discussion in https://github.com/geany/geany/pull/4303

To reproduce the crash, use https://github.com/geany/geany/pull/4303/commits/79fb41516f746c588a52b1b01aa805cdf31da852 from https://github.com/geany/geany/pull/4303. Note that to reproduce this issue, it has to use CRLF line endings (might get lost when copy/pasting from the github web interface).

The issue can be reproduced using `ctags --extras=+rg -o- wp-guest.php`.