### PR TITLE
units: Restore original EOLs

### DIFF
--- a/Units/parser-ant.r/regex-based.d/.gitattributes
+++ b/Units/parser-ant.r/regex-based.d/.gitattributes
@@ -1,0 +1,1 @@
+input.xml -text

--- a/Units/parser-ant.r/xpath-based.d/.gitattributes
+++ b/Units/parser-ant.r/xpath-based.d/.gitattributes
@@ -1,0 +1,1 @@
+input.xml -text

--- a/Units/parser-cxx.r/bug1773926.cpp.d/.gitattributes
+++ b/Units/parser-cxx.r/bug1773926.cpp.d/.gitattributes
@@ -1,0 +1,1 @@
+input.cpp -text

--- a/Units/parser-flex.r/flex_comment.mxml.d/.gitattributes
+++ b/Units/parser-flex.r/flex_comment.mxml.d/.gitattributes
@@ -1,0 +1,1 @@
+input.mxml -text

--- a/Units/parser-flex.r/flex_only_mxml.mxml.d/.gitattributes
+++ b/Units/parser-flex.r/flex_only_mxml.mxml.d/.gitattributes
@@ -1,0 +1,1 @@
+input.mxml -text

--- a/Units/parser-flex.r/flex_with_actionscript.mxml.d/.gitattributes
+++ b/Units/parser-flex.r/flex_with_actionscript.mxml.d/.gitattributes
@@ -1,0 +1,1 @@
+input.mxml -text

--- a/Units/parser-javascript.r/1795612.js.d/.gitattributes
+++ b/Units/parser-javascript.r/1795612.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/1850914.js.d/.gitattributes
+++ b/Units/parser-javascript.r/1850914.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/1878155.js.d/.gitattributes
+++ b/Units/parser-javascript.r/1878155.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/2023624.js.d/.gitattributes
+++ b/Units/parser-javascript.r/2023624.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/3470609.js.d/.gitattributes
+++ b/Units/parser-javascript.r/3470609.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/bug1950327.js.d/.gitattributes
+++ b/Units/parser-javascript.r/bug1950327.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/bug3036476.js.d/.gitattributes
+++ b/Units/parser-javascript.r/bug3036476.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/bug3571233.js.d/.gitattributes
+++ b/Units/parser-javascript.r/bug3571233.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/js-broken-strings.d/.gitattributes
+++ b/Units/parser-javascript.r/js-broken-strings.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/js-crlf.d/.gitattributes
+++ b/Units/parser-javascript.r/js-crlf.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/jsFunc_tutorial.js.d/.gitattributes
+++ b/Units/parser-javascript.r/jsFunc_tutorial.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/no_terminator.js.d/.gitattributes
+++ b/Units/parser-javascript.r/no_terminator.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/regexp.js.d/.gitattributes
+++ b/Units/parser-javascript.r/regexp.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/secondary_fcn_name.js.d/.gitattributes
+++ b/Units/parser-javascript.r/secondary_fcn_name.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-javascript.r/ui5.controller.js.d/.gitattributes
+++ b/Units/parser-javascript.r/ui5.controller.js.d/.gitattributes
@@ -1,0 +1,1 @@
+input.js -text

--- a/Units/parser-julia.r/corner_cases.d/.gitattributes
+++ b/Units/parser-julia.r/corner_cases.d/.gitattributes
@@ -1,0 +1,1 @@
+input.jl -text

--- a/Units/parser-julia.r/empty_line.d/.gitattributes
+++ b/Units/parser-julia.r/empty_line.d/.gitattributes
@@ -1,0 +1,1 @@
+input.jl -text

--- a/Units/parser-julia.r/julia_test.d/.gitattributes
+++ b/Units/parser-julia.r/julia_test.d/.gitattributes
@@ -1,0 +1,1 @@
+input.jl -text

--- a/Units/parser-julia.r/scoped_macro.d/.gitattributes
+++ b/Units/parser-julia.r/scoped_macro.d/.gitattributes
@@ -1,0 +1,1 @@
+input.jl -text

--- a/Units/parser-julia.r/struct_attributes.d/.gitattributes
+++ b/Units/parser-julia.r/struct_attributes.d/.gitattributes
@@ -1,0 +1,1 @@
+input.jl -text

--- a/Units/parser-matlab.r/matlab_backtracking.m.d/.gitattributes
+++ b/Units/parser-matlab.r/matlab_backtracking.m.d/.gitattributes
@@ -1,0 +1,1 @@
+input.m -text

--- a/Units/parser-matlab.r/matlab_test.m.d/.gitattributes
+++ b/Units/parser-matlab.r/matlab_test.m.d/.gitattributes
@@ -1,0 +1,1 @@
+input.m -text

--- a/Units/parser-php.r/php-heredoc-cr.d/.gitattributes
+++ b/Units/parser-php.r/php-heredoc-cr.d/.gitattributes
@@ -1,0 +1,1 @@
+input.php -text

--- a/Units/parser-php.r/php-whitespaces.d/.gitattributes
+++ b/Units/parser-php.r/php-whitespaces.d/.gitattributes
@@ -1,0 +1,1 @@
+input.php -text

--- a/Units/parser-php.r/whitespaces.php.d/.gitattributes
+++ b/Units/parser-php.r/whitespaces.php.d/.gitattributes
@@ -1,0 +1,1 @@
+input.php -text

--- a/Units/parser-python.r/newlines-cr.b/.gitattributes
+++ b/Units/parser-python.r/newlines-cr.b/.gitattributes
@@ -1,0 +1,1 @@
+input.py -text

--- a/Units/parser-python.r/newlines-crlf.d/.gitattributes
+++ b/Units/parser-python.r/newlines-crlf.d/.gitattributes
@@ -1,0 +1,1 @@
+input.py -text

--- a/Units/parser-sql.r/3184782.sql.d/.gitattributes
+++ b/Units/parser-sql.r/3184782.sql.d/.gitattributes
@@ -1,0 +1,1 @@
+input.sql -text

--- a/Units/parser-sql.r/bug1324663.sql.d/.gitattributes
+++ b/Units/parser-sql.r/bug1324663.sql.d/.gitattributes
@@ -1,0 +1,1 @@
+input.sql -text

--- a/Units/parser-sql.r/bug1428714.sql.d/.gitattributes
+++ b/Units/parser-sql.r/bug1428714.sql.d/.gitattributes
@@ -1,0 +1,1 @@
+input.sql -text

--- a/Units/parser-sql.r/bug1570779.sql.d/.gitattributes
+++ b/Units/parser-sql.r/bug1570779.sql.d/.gitattributes
@@ -1,0 +1,1 @@
+input.sql -text

--- a/Units/parser-sql.r/bug1944150.sql.d/.gitattributes
+++ b/Units/parser-sql.r/bug1944150.sql.d/.gitattributes
@@ -1,0 +1,1 @@
+input.sql -text

--- a/Units/parser-sql.r/sql_single_quote.sql.d/.gitattributes
+++ b/Units/parser-sql.r/sql_single_quote.sql.d/.gitattributes
@@ -1,0 +1,1 @@
+input.sql -text

--- a/Units/parser-tex.r/bug2886870.tex.d/.gitattributes
+++ b/Units/parser-tex.r/bug2886870.tex.d/.gitattributes
@@ -1,0 +1,1 @@
+input.tex -text

--- a/Units/parser-tex.r/intro.tex.d/.gitattributes
+++ b/Units/parser-tex.r/intro.tex.d/.gitattributes
@@ -1,0 +1,1 @@
+input.tex -text

--- a/Units/parser-tex.r/intro_orig.tex.d/.gitattributes
+++ b/Units/parser-tex.r/intro_orig.tex.d/.gitattributes
@@ -1,0 +1,1 @@
+input.tex -text

--- a/Units/parser-vim.r/bug359.vim.d/.gitattributes
+++ b/Units/parser-vim.r/bug359.vim.d/.gitattributes
@@ -1,0 +1,1 @@
+input.vim -text

--- a/Units/regex-multiline-flag-dos.d/.gitattributes
+++ b/Units/regex-multiline-flag-dos.d/.gitattributes
@@ -1,0 +1,1 @@
+input.mlt -text

--- a/Units/review-needed.r/dosbatch_test.cmd.t/.gitattributes
+++ b/Units/review-needed.r/dosbatch_test.cmd.t/.gitattributes
@@ -1,0 +1,1 @@
+input.cmd -text

--- a/Units/review-needed.r/flex_override.mxml.t/.gitattributes
+++ b/Units/review-needed.r/flex_override.mxml.t/.gitattributes
@@ -1,0 +1,1 @@
+input.mxml -text

--- a/Units/review-needed.r/ingres_procedures.sql.t/.gitattributes
+++ b/Units/review-needed.r/ingres_procedures.sql.t/.gitattributes
@@ -1,0 +1,1 @@
+input.sql -text

--- a/Units/review-needed.r/too-large-for-reviewing-3526726.tex.t/.gitattributes
+++ b/Units/review-needed.r/too-large-for-reviewing-3526726.tex.t/.gitattributes
@@ -1,0 +1,1 @@
+input.tex -text


### PR DESCRIPTION
Do not manage EOL for any test input that have non-LF EOLs, in order to keep the tests as they were originally meant to be.

Since 1efb9b9389a88b44f9b55f26ef8f36e9b3ac679c all EOLs are converted by default, which is a problem for test files requiring a specific EOL type to work.  Those should not see any conversion whatsoever, basically treated as binary data.

The changes here are mostly generated with:

```
$ find Units/ -name 'input*' -exec file '{}' ';' | \
  grep CR | \
  sed 's/: .*$//' | \
  while read -r f; do \
    d="${f%/*}"; \
    b="${f##*/}"; \
    echo "$b -text" > "$d/.gitattributes"; \
    git add "$d/.gitattributes"; \
  done
```

---

@masatake I see there was an attempt at this before #3425, what was the exact issues it created?
Couldn't we to something like this? (remove the text attribute rather trying to remove the `auto` value)
```
/Units/**/input* -text
```