### PR TITLE
main: using regex for choosing a paser for given file name

### DIFF
--- a/main/options.c
+++ b/main/options.c
@@ -1771,17 +1771,16 @@ static char* extractMapFromParameter (const langType language,
 			*tail = parameter + strlen (parameter);
 			return result;
 		}
-		else
-		{
-			tmp = *p;
-			*p = '\0';
-			result = eStrdup (parameter);
-			*p = tmp;
-			*tail = p;
-			return result;
-		}
+
+		tmp = *p;
+		*p = '\0';
+		result = eStrdup (parameter);
+		*p = tmp;
+		*tail = p;
+		return result;
 	}
-	else if (first == PATTERN_START)  /* pattern map */
+
+	if (first == PATTERN_START)  /* pattern map */
 	{
 		*mapType = LMAP_PATTERN;
 
@@ -1794,15 +1793,13 @@ static char* extractMapFromParameter (const langType language,
 		if (*p == '\0')
 			error (FATAL, "Unterminated file name pattern for %s language",
 			   getLanguageName (language));
-		else
-		{
-			tmp = *p;
-			*p = '\0';
-			result = eStrdup (parameter);
-			*p = tmp;
-			*tail = p + 1;
-			return result;
-		}
+
+		tmp = *p;
+		*p = '\0';
+		result = eStrdup (parameter);
+		*p = tmp;
+		*tail = p + 1;
+		return result;
 	}
 
 	return NULL;

--- a/main/options.c
+++ b/main/options.c
@@ -1751,7 +1751,7 @@ static char* skipPastMap (char* p)
 static char* extractMapFromParameter (const langType language,
 				      char* parameter,
 				      char** tail,
-				      bool* pattern_p,
+				      langmapType *mapType,
 				      char* (* skip) (char *))
 {
 	char* p = NULL;
@@ -1761,7 +1761,7 @@ static char* extractMapFromParameter (const langType language,
 
 	if (first == EXTENSION_SEPARATOR)  /* extension map */
 	{
-		*pattern_p = false;
+		*mapType = LMAP_EXTENSION;
 
 		++parameter;
 		p = (* skip) (parameter);
@@ -1783,7 +1783,7 @@ static char* extractMapFromParameter (const langType language,
 	}
 	else if (first == PATTERN_START)  /* pattern map */
 	{
-		*pattern_p = true;
+		*mapType = LMAP_PATTERN;
 
 		++parameter;
 		for (p = parameter  ;  *p != PATTERN_STOP  &&  *p != '\0'  ;  ++p)
@@ -1812,13 +1812,13 @@ static char* addLanguageMap (const langType language, char* map_parameter,
 			     bool exclusiveInAllLanguages)
 {
 	char* p = NULL;
-	bool pattern_p;
+	langmapType map_type;
 	char* map;
 
-	map = extractMapFromParameter (language, map_parameter, &p, &pattern_p, skipPastMap);
-	if (map && pattern_p == false)
+	map = extractMapFromParameter (language, map_parameter, &p, &map_type, skipPastMap);
+	if (map && map_type == LMAP_EXTENSION)
 		addLanguageExtensionMap (language, map, exclusiveInAllLanguages);
-	else if (map && pattern_p == true)
+	else if (map && map_type == LMAP_PATTERN)
 		addLanguagePatternMap (language, map, exclusiveInAllLanguages);
 	else
 		error (FATAL, "Badly formed language map for %s language",
@@ -1832,13 +1832,13 @@ static char* addLanguageMap (const langType language, char* map_parameter,
 static char* removeLanguageMap (const langType language, char* map_parameter)
 {
 	char* p = NULL;
-	bool pattern_p;
+	langmapType map_type;
 	char* map;
 
-	map = extractMapFromParameter (language, map_parameter, &p, &pattern_p, skipPastMap);
-	if (map && pattern_p == false)
+	map = extractMapFromParameter (language, map_parameter, &p, &map_type, skipPastMap);
+	if (map && map_type == LMAP_EXTENSION)
 		removeLanguageExtensionMap (language, map);
-	else if (map && pattern_p == true)
+	else if (map && map_type == LMAP_PATTERN)
 		removeLanguagePatternMap (language, map);
 	else
 		error (FATAL, "Badly formed language map for %s language",

--- a/main/parse.h
+++ b/main/parse.h
@@ -77,6 +77,13 @@ enum scriptHook {
 	SCRIPT_HOOK_MAX,
 };
 
+/* --map-<LANG>=[+|-|]%reguar-expresson%[i] */
+struct rExprSrc {
+	const char *expr;			/* The last element must be NULL. */
+	bool iCase;
+};
+#define REXPR_LAST_ENTRY { .expr = NULL, }
+
 struct sParserDefinition {
 	/* defined by parser */
 	char* name;                    /* name of language */
@@ -104,6 +111,8 @@ struct sParserDefinition {
 	const char *const *extensions; /* list of default extensions */
 	const char *const *patterns;   /* list of default file name patterns */
 	const char *const *aliases;    /* list of default aliases (alternative names) */
+	const struct rExprSrc * rexprs;  /* list of default file name regex patterns */
+
 	parserInitialize initialize;   /* initialization routine, if needed */
 	parserFinalize finalize;       /* finalize routine, if needed */
 	simpleParser parser;           /* simple parser (common case) */

--- a/main/parse_p.h
+++ b/main/parse_p.h
@@ -33,8 +33,9 @@
 typedef enum {
 	LMAP_PATTERN   = 1 << 0,
 	LMAP_EXTENSION = 1 << 1,
-	LMAP_ALL       = LMAP_PATTERN | LMAP_EXTENSION,
-	LMAP_TABLE_OUTPUT = 1 << 2,
+	LMAP_REXPR     = 1 << 2,
+	LMAP_ALL       = LMAP_PATTERN | LMAP_EXTENSION | LMAP_REXPR,
+	LMAP_TABLE_OUTPUT = 1 << 3,
 } langmapType;
 
 enum parserCategory
@@ -101,6 +102,9 @@ extern void addLanguageExtensionMap (const langType language, const char* extens
 				     bool exclusiveInAllLanguages);
 extern bool removeLanguagePatternMap (const langType language, const char *const pattern);
 extern void addLanguagePatternMap (const langType language, const char* ptrn,
+				   bool exclusiveInAllLanguages);
+extern bool removeLanguageRexprMap (const langType language, const char *const rexpr, bool iCase);
+extern void addLanguageRexprMap (const langType language, const char* rexpr, bool iCase,
 				   bool exclusiveInAllLanguages);
 
 extern void installLanguageAliasesDefault (const langType language);

--- a/main/rexprcode.c
+++ b/main/rexprcode.c
@@ -1,0 +1,98 @@
+/*
+*   Copyright (c) 2025, Red Hat, Inc.
+*   Copyright (c) 2025, Masatake YAMATO
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+
+*/
+
+/*
+*   INCLUDE FILES
+*/
+#include "general.h"
+
+#include "routines.h"
+#include "rexprcode_p.h"
+
+#include <regex.h>
+#include <string.h>
+
+/*
+*   DATA DECLARATIONS
+*/
+struct rExprCode {
+	regex_t *code;
+	char *src;
+	bool iCase;
+};
+
+/*
+*   FUNCTION DECLARATIONS
+*/
+extern const char *rExprCodeGetSource (const struct rExprCode *rxcode)
+{
+	return rxcode->src;
+}
+
+extern const bool rExprCodeGetICase (const struct rExprCode *rxcode)
+{
+	return rxcode->iCase;
+}
+
+extern vString *rExprCodeNewEncodedSource (const struct rExprCode *rxcode)
+{
+	vString *encoded_src = vStringNew();
+
+	vStringPut (encoded_src, '%');
+
+	for (const char *c = rExprCodeGetSource (rxcode); *c != '\0'; c++)
+	{
+		if (*c == '%')
+			vStringPut (encoded_src, '\\');
+		vStringPut (encoded_src, *c);
+	}
+
+	vStringPut (encoded_src, '%');
+	if (rExprCodeGetICase (rxcode))
+		vStringPut (encoded_src, 'i');
+
+	return encoded_src;
+}
+
+extern struct rExprCode *rExprCodeNew(const char *rxsrc, bool iCase)
+{
+	regex_t *regex_code = xMalloc (1, regex_t);
+	int errcode = regcomp (regex_code, rxsrc,
+						   REG_EXTENDED|REG_NOSUB|(iCase? REG_ICASE: 0));
+	if (errcode != 0)
+	{
+		char errmsg[256];
+		regerror (errcode, regex_code, errmsg, 256);
+		error (WARNING, "regcomp: %s", errmsg);
+		regfree (regex_code);
+		eFree (regex_code);
+		return NULL;
+	}
+
+	struct rExprCode *rxcode = xMalloc (1, struct rExprCode);
+
+	rxcode->code = regex_code;
+	rxcode->src = eStrdup (rxsrc);
+	rxcode->iCase = iCase;
+
+	return rxcode;
+}
+
+extern void rExprCodeDelete (struct rExprCode *rxcode)
+{
+	regfree (rxcode->code);
+	eFree (rxcode->code);
+	eFree (rxcode->src);
+	eFree (rxcode);
+}
+
+extern bool rExprCodeMatch (struct rExprCode *rxcode, const char *fname)
+{
+	return (regexec (rxcode->code, fname, strlen(fname), 0, 0) == 0);
+}

--- a/main/rexprcode_p.h
+++ b/main/rexprcode_p.h
@@ -1,0 +1,36 @@
+/*
+*   Copyright (c) 2025, Red Hat, Inc.
+*   Copyright (c) 2025, Masatake YAMATO
+*
+*   This source code is released for free distribution under the terms of the
+*   GNU General Public License version 2 or (at your option) any later version.
+
+*/
+
+#ifndef CTAGS_MAIN_REXPRCODE_H
+#define CTAGS_MAIN_REXPRCODE_H
+
+/*
+*   INCLUDE FILES
+*/
+#include "general.h"
+
+#include <vstring.h>
+
+/*
+*   DATA DECLARATIONS
+*/
+
+struct rExprCode;
+
+/*
+*   FUNCTION DECLARATIONS
+*/
+extern const char *rExprCodeGetSource (const struct rExprCode *rxcode);
+extern vString *rExprCodeNewEncodedSource (const struct rExprCode *rxcode);
+extern const bool rExprCodeGetICase (const struct rExprCode *rxcode);
+extern struct rExprCode *rExprCodeNew(const char *rxsrc, bool iCase);
+extern void rExprCodeDelete (struct rExprCode *rxcode);
+extern bool rExprCodeMatch (struct rExprCode *rxcode, const char *fname);
+
+#endif	/* CTAGS_MAIN_REXPRCODE_H */

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -232,7 +232,10 @@ my $options =
 	   die "Adding a map is allowed only to the language specified with --langdef: $1"
 	       unless ($_[0]->{'langdef'} eq $1);
 	   my $spec = $2;
-	   if ($spec =~ /\((.*)\)/) {
+	   if ($spec =~ /%(.+)%(i)?/) {
+	       my $rexpr = { expr => $1, iCase => (defined $2 && $2 eq 'i')? 1: 0 };
+	       push @{$_[0]->{'rexprs'}}, $rexpr;
+	   } elsif ($spec =~ /\((.*)\)/) {
 	       push @{$_[0]->{'patterns'}}, $1;
 	   } elsif ($spec =~ /\.(.*)/) {
 	       push @{$_[0]->{'extensions'}}, $1;
@@ -819,6 +822,31 @@ sub emit_patterns {
     emit_list $_[0], "patterns";
 }
 
+sub emit_rexprs {
+    my $opts = shift;
+
+    return if (! @{$opts->{'rexprs'}});
+
+    printf <<EOF;
+	static const struct rExprSrc rexprs [] = {
+EOF
+    for (@{$opts->{'rexprs'}}) {
+	my $expr = escape_as_cstr ("$_->{'expr'}");
+	my $iCase = $_->{'iCase'}? "true": "false";
+	printf <<EOF;
+		{
+		  .expr = "$expr",
+		  .iCase = $iCase,
+		},
+EOF
+    }
+    printf <<EOF;
+		REXPR_LAST_ENTRY
+	};
+
+EOF
+}
+
 # TODO: handling '\'
 sub escape_as_cstr {
     my $input = shift;
@@ -839,7 +867,6 @@ sub escape_as_cstr {
 
 sub emit_roledefs {
     my $opts = shift;
-
 
     for (@{$opts->{'kinddefs'}}) {
 	next unless @{$_->{'roles'}};
@@ -1154,6 +1181,13 @@ sub emit_fields_initialization {
 	def->enabled       = ${enabled};
 	def->extensions    = extensions;
 	def->patterns      = patterns;
+EOF
+    if (@{$opts->{'rexprs'}}) {
+	print <<EOF;
+	def->rexprs        = rexprs;
+EOF
+    }
+    print <<EOF;
 	def->aliases       = aliases;
 EOF
     if (defined $opts->{'selector'}) {
@@ -1256,6 +1290,7 @@ EOF
     emit_extensions      $opts;
     emit_aliases         $opts;
     emit_patterns        $opts;
+    emit_rexprs          $opts;
     emit_roledefs        $opts;
     emit_scopeseps       $opts;
     emit_kinddefs        $opts;
@@ -1316,6 +1351,7 @@ sub main {
 		disabled => 0,
 		patterns => [],
 		extensions => [],
+		rexprs => [],
 		aliases => [],
 		regexs => [# { regex => "", name => "", kind => "", flags => "", mline => 1|0, optscript => "" },
 			  ],

--- a/optlib/rpmMacros.c
+++ b/optlib/rpmMacros.c
@@ -113,6 +113,14 @@ extern parserDefinition* RpmMacrosParser (void)
 		NULL
 	};
 
+	static const struct rExprSrc rexprs [] = {
+		{
+		  .expr = "(.*/)?macros\\.d/macros\\.([^/]+)$",
+		  .iCase = false,
+		},
+		REXPR_LAST_ENTRY
+	};
+
 	static kindDefinition RpmMacrosKindTable [] = {
 		{
 		  true, 'm', "macro", "macros",
@@ -126,6 +134,7 @@ extern parserDefinition* RpmMacrosParser (void)
 	def->enabled       = true;
 	def->extensions    = extensions;
 	def->patterns      = patterns;
+	def->rexprs        = rexprs;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
 	def->useCork       = CORK_QUEUE;

--- a/optlib/rpmMacros.ctags
+++ b/optlib/rpmMacros.ctags
@@ -17,12 +17,7 @@
 #
 --langdef=RpmMacros
 
-# This map is too generic.
-# e.g. "macros.h" of C language input matches this pattern.
-# --map-RpmMacros=+(macros.*)
-
-# This one is too general.
-# --map-RpmMacros=+(macros)
+--map-RpmMacros=+%(.*/)?macros\.d/macros\.([^/]+)$%
 
 --kinddef-RpmMacros=m,macro,macros
 

--- a/source.mak
+++ b/source.mak
@@ -126,6 +126,7 @@ LIB_PRIVATE_HEADS =		\
 	main/promise_p.h	\
 	main/ptag_p.h		\
 	main/read_p.h		\
+	main/rexprcode_p.h	\
 	main/script_p.h		\
 	main/sort_p.h		\
 	main/stats_p.h		\
@@ -174,6 +175,7 @@ LIB_SRCS =			\
 	main/ptag.c			\
 	main/rbtree.c			\
 	main/read.c			\
+	main/rexprcode.c		\
 	main/script.c			\
 	main/seccomp.c			\
 	main/selectors.c		\


### PR DESCRIPTION
main: using regex for choosing a parser for the given file name
    
This change extends --map-<LANG> option to support regular
expression matching with the full file name.
    
The original --map-<LANG> option supports glob based matching
and extension comparison with the file basename.
However, two methods are not enough if the file names are too
generic. See https://github.com/universal-ctags/ctags/pull/3287 .
    
The regular expression passed to --map-<LANG> must be surround
by % character like

   --map-RpmMacros='%(.*/)?macros\.d/macros\.([^/]+)$%'

If you want to match in a case-insensitive way, append `i' after the second % like
    
   --map-RpmMacros='%(.*/)?macros\.d/macros\.([^/]+)$%i'
    
If you want to use % as part of an expression, put \ before % for escaping.
    
TODO:
    
- [ ] reconsider name regex, rxpr, or something
- [ ] update ctags.1
- [ ] add Tmain test cases
- [ ] add description to --help
- [X] extend optlib2c
- [X] add --list-map-regex
- [X] add --list-maps
- [ ] add pcre backend
