### PR TITLE
[WIP] enhance parser versioning

### DIFF
--- a/main/colprint.c
+++ b/main/colprint.c
@@ -285,6 +285,13 @@ void colprintLineAppendColumnBool  (struct colprintLine *line, bool column)
 	colprintLineAppendColumnCString	(line, column? "yes": "no");
 }
 
+void colprintLineAppendColumnVersion (struct colprintLine *line, unsigned int version)
+{
+	char buf[12+1];
+	snprintf(buf, sizeof(buf), "%u", version);
+	colprintLineAppendColumnCString	(line, buf);
+}
+
 const char *colprintLineGetColumn (struct colprintLine *line, unsigned int column)
 {
 	stringList *slist = (stringList *)line;

--- a/main/colprint_p.h
+++ b/main/colprint_p.h
@@ -31,6 +31,7 @@ void colprintLineAppendColumnInt  (struct colprintLine *line, unsigned int colum
 
 /* Appends "yes" or "no". */
 void colprintLineAppendColumnBool (struct colprintLine *line, bool column);
+void colprintLineAppendColumnVersion (struct colprintLine *line, unsigned int version);
 
 const char *colprintLineGetColumn (struct colprintLine *line, unsigned int column);
 

--- a/main/field.c
+++ b/main/field.c
@@ -1379,6 +1379,12 @@ extern int defineField (fieldDefinition *def, langType language)
 	updateSiblingField (def->ftype, def->name);
 	installOptscriptFieldAccessor (def->ftype);
 
+	if (def->version > getLanguageVersionCurrent (language))
+		error (WARNING, "the version number (%u) of extra \"%s\" of language \"%s\" "
+			   "should be less than or equal to the current number (%u) of the language",
+			   def->version, def->name, getLanguageName (language),
+			   getLanguageVersionCurrent (language));
+
 	return def->ftype;
 }
 
@@ -1395,7 +1401,7 @@ extern struct colprintTable * fieldColprintTableNew (void)
 {
 	return colprintTableNew ("L:LETTER", "L:NAME", "L:ENABLED",
 							 "L:LANGUAGE", "L:JSTYPE", "L:FIXED",
-							 "L:OP", "L:DESCRIPTION", NULL);
+							 "L:OP", "R:VER", "L:DESCRIPTION", NULL);
 }
 
 static void  fieldColprintAddLine (struct colprintTable *table, int i)
@@ -1437,6 +1443,7 @@ static void  fieldColprintAddLine (struct colprintTable *table, int i)
 	if (fdef->setValueObject)
 		operator[1] = 'w';
 	colprintLineAppendColumnCString (line, operator);
+	colprintLineAppendColumnVersion (line, fdef->version);
 	colprintLineAppendColumnCString (line, fdef->description);
 }
 

--- a/main/field.h
+++ b/main/field.h
@@ -347,6 +347,8 @@ struct sFieldDefinition {
 
 	fieldDataType dataType; /* used in json output. See OP column in --list-fields. */
 
+	unsigned int    version;
+
 	unsigned int ftype;	/* Given from the main part */
 };
 

--- a/main/kind.c
+++ b/main/kind.c
@@ -227,6 +227,20 @@ extern int defineRole (struct kindControlBlock* kcb, int kindIndex,
 	rcb->role = xRealloc (rcb->role, rcb->count, roleObject);
 	initRoleObject (rcb->role + roleIndex, def, freeRoleDef, roleIndex);
 
+	if (def->version > getLanguageVersionCurrent (kcb->owner))
+		error (WARNING, "the version number (%u) of role \"%s\" of language \"%s\" "
+			   "should be less than or equal to the current number (%u) of the language",
+			   def->version, def->name, getLanguageName (kcb->owner),
+			   getLanguageVersionCurrent (kcb->owner));
+	kindDefinition * kdef = getKind (kcb, kindIndex);
+	if (kdef->version > def->version)
+		error (WARNING, "the version number (%u) of role \"%s\" in kind \"%c,%s\" of language \"%s\" "
+			   "should be greater than or equal to the version number (%u) of its kind",
+			   def->version, def->name,
+			   kdef->letter, kdef->name,
+			   getLanguageName (kcb->owner),
+			   kdef->version);
+
 	return roleIndex;
 }
 
@@ -602,7 +616,7 @@ extern void kindColprintTablePrint (struct colprintTable *table, bool noparser,
 extern struct colprintTable * roleColprintTableNew (void)
 {
 	return colprintTableNew ("L:LANGUAGE", "L:KIND(L/N)", "L:NAME",
-							 "L:ENABLED", "L:DESCRIPTION", NULL);
+							 "L:ENABLED", "R:VER", "L:DESCRIPTION", NULL);
 }
 
 extern void roleColprintAddRoles (struct colprintTable *table, struct kindControlBlock *kcb,
@@ -660,6 +674,7 @@ extern void roleColprintAddRoles (struct colprintTable *table, struct kindContro
 					colprintLineAppendColumnCString (line, r->name);
 					colprintLineAppendColumnCString (line,
 													 r->enabled ? "on" : "off");
+					colprintLineAppendColumnVersion (line, r->version);
 					colprintLineAppendColumnCString (line, r->description);
 				}
 				if (! (!kname && *c == KIND_WILDCARD_LETTER))

--- a/main/kind.c
+++ b/main/kind.c
@@ -196,6 +196,12 @@ extern int  defineKind (struct kindControlBlock* kcb, kindDefinition *def,
 	kcb->kind [def->id].rcb = allocRoleControlBlock(kcb->kind + def->id);
 	kcb->kind [def->id].dynamicSeparators = NULL;
 
+	if (def->version > getLanguageVersionCurrent (kcb->owner))
+		error (WARNING, "the version number (%u) of kind \"%c,%s\" of language \"%s\" "
+			   "should be less than or equal to the current number (%u) of the language",
+			   def->version, def->letter, def->name, getLanguageName (kcb->owner),
+			   getLanguageVersionCurrent (kcb->owner));
+
 	verbose ("Add kind[%d] \"%c,%s,%s\" to %s\n", def->id,
 			 def->letter, def->name, def->description,
 			 getLanguageName (kcb->owner));
@@ -526,7 +532,7 @@ extern struct colprintTable * kindColprintTableNew (void)
 {
 	return colprintTableNew ("L:LANGUAGE", "L:LETTER", "L:NAME", "L:ENABLED",
 							 "L:REFONLY", "L:NROLES", "L:MASTER",
-							 "L:DESCRIPTION",
+							 "R:VER", "L:DESCRIPTION",
 							 NULL);
 }
 
@@ -547,6 +553,7 @@ static void kindColprintFillLine (struct colprintLine *line,
 	colprintLineAppendColumnCString (line, (kdef->master
 											|| kdef->slave ) ?
 									 getLanguageName (kdef->syncWith): RSV_NONE);
+	colprintLineAppendColumnVersion (line, kdef->version);
 	colprintLineAppendColumnCString (line, kdef->description? kdef->description: "NO DESCRIPTION GIVEN");
 }
 

--- a/main/kind.h
+++ b/main/kind.h
@@ -25,6 +25,8 @@ struct sRoleDefinition {
 	char* name;		  /* role name */
 	char* description;	  /* displayed in --help output */
 
+	unsigned int    version;
+
 	int id;
 };
 

--- a/main/kind.h
+++ b/main/kind.h
@@ -79,6 +79,8 @@ struct sKindDefinition {
 	scopeSeparator *separators;
 	unsigned int separatorCount;
 
+	unsigned int    version;
+
 	int id;
 
 	/* TODO:Following fields should be moved to kindObject. */

--- a/main/options.c
+++ b/main/options.c
@@ -2306,6 +2306,107 @@ static void processListSubparsersOption (const char *const option CTAGS_ATTR_UNU
 	exit (0);
 }
 
+static void proecssDescribeLanguage(const char *const option,
+									const char *const parameter)
+{
+	/* Version, enable */
+	if (parameter == NULL || parameter[0] == '\0')
+		error (FATAL, "No language given in \"--%s\" option", option);
+
+
+	langType language = getNamedLanguage (parameter, 0);
+	if (language == LANG_IGNORE)
+		error (FATAL, "Unknown language \"--%s\" in \"%s\"", parameter, option);
+
+	initializeParser (language);
+
+	printf("About %s language\n", parameter);
+	puts("=======================================================");
+
+	printf("enabled: %s\n", isLanguageEnabled(language)? "yes": "no");
+	printf("version: %u.%u\n",
+		   getLanguageVersionCurrent (language),
+		   getLanguageVersionAge (language));
+
+	puts("");
+	puts("Mappings/patterns");
+	puts("-------------------------------------------------------");
+	printLanguageMaps (language, LMAP_PATTERN|LMAP_NO_LANG_PREFIX,
+					   localOption.withListHeader, localOption.machinable,
+					   stdout);
+
+	puts("");
+	puts("Mappings/extensions");
+	puts("-------------------------------------------------------");
+	printLanguageMaps (language, LMAP_EXTENSION|LMAP_NO_LANG_PREFIX,
+					   localOption.withListHeader, localOption.machinable,
+					   stdout);
+
+	puts("");
+	puts("Aliases");
+	puts("-------------------------------------------------------");
+	printLanguageAliases (language,
+						  localOption.withListHeader, localOption.machinable, stdout);
+
+	puts("");
+	puts("Kinds");
+	puts("-------------------------------------------------------");
+
+	printLanguageKinds (language, true,
+						localOption.withListHeader, localOption.machinable, stdout);
+
+	puts("");
+	puts("Roles");
+	puts("-------------------------------------------------------");
+	printLanguageRoles (language, "*",
+						localOption.withListHeader,
+						localOption.machinable,
+						stdout);
+
+	puts("");
+	puts("Fields");
+	puts("-------------------------------------------------------");
+	{
+		writerCheckOptions (Option.fieldsReset);
+		struct colprintTable * table = fieldColprintTableNew ();
+		fieldColprintAddLanguageLines (table, language);
+		fieldColprintTablePrint (table, localOption.withListHeader, localOption.machinable, stdout);
+		colprintTableDelete (table);
+	}
+
+	puts("");
+	puts("Extras");
+	puts("-------------------------------------------------------");
+	{
+		struct colprintTable * table = xtagColprintTableNew ();
+		xtagColprintAddLanguageLines (table, language);
+		xtagColprintTablePrint (table, localOption.withListHeader, localOption.machinable, stdout);
+		colprintTableDelete (table);
+	}
+
+	puts("");
+	puts("Parameters");
+	puts("-------------------------------------------------------");
+	printLanguageParams (language,
+						 localOption.withListHeader, localOption.machinable,
+						 stdout);
+
+	puts ("");
+	puts("Sub parsers stacked on this parser");
+	puts("-------------------------------------------------------");
+	printLanguageSubparsers(language,
+							localOption.withListHeader, localOption.machinable,
+							stdout);
+
+	puts("");
+	puts("Implementation specific status");
+	puts("-------------------------------------------------------");
+	printf("allow null tags: %s\n", doesLanguageAllowNullTag(language)? "yes": "no");
+
+	exit (0);
+
+}
+
 static void processListOperators (const char *const option CTAGS_ATTR_UNUSED,
 								  const char *const parameter)
 {
@@ -2864,6 +2965,7 @@ static void processDumpOptionsOption (const char *const option, const char *cons
 static void processDumpPreludeOption (const char *const option, const char *const parameter);
 
 static parametricOption ParametricOptions [] = {
+	{ "describe-language",      proecssDescribeLanguage,        true,   STAGE_ANY },
 	{ "etags-include",          processEtagsInclude,            false,  STAGE_ANY },
 	{ "exclude",                processExcludeOption,           false,  STAGE_ANY },
 	{ "exclude-exception",      processExcludeExceptionOption,  false,  STAGE_ANY },

--- a/main/options.c
+++ b/main/options.c
@@ -464,6 +464,8 @@ static optionDescription LongOptionDescription [] = {
  {1,0,"       --list-{aliases,extras,features,fields,kind-full,langdef-flags,params," },
  {1,0,"       pseudo-tags,regex-flags,roles,subparsers} support this option."},
  {1,0,"       Specify before --list-* option."},
+ {1,1,"  --_list-extradef-flags"},
+ {1,1,"       Output list of flags which can be used with --extradef option."},
  {1,1,"  --_list-fielddef-flags"},
  {1,1,"       Output list of flags which can be used with --fielddef option."},
  {1,1,"  --_list-kinddef-flags"},
@@ -2224,6 +2226,7 @@ defineListFunctionForOption (LangdefFlags, printLangdefFlags);
 defineListFunctionForOption (KinddefFlags, printKinddefFlags);
 defineListFunctionForOption (RoledefFlags, printKinddefFlags);
 defineListFunctionForOption (FielddefFlags, printFielddefFlags);
+defineListFunctionForOption (ExtradefFlags, printFielddefFlags);
 
 defineListFunctionForOption (OutputFormats, printOutputFormats);
 
@@ -2923,6 +2926,7 @@ static parametricOption ParametricOptions [] = {
 #ifdef HAVE_JANSSON
 	{ "_interactive",           processInteractiveOption,       true,   STAGE_ANY },
 #endif
+	{ "_list-extradef-flags",   processListExtradefFlagsOption, true,   STAGE_ANY },
 	{ "_list-fielddef-flags",   processListFielddefFlagsOption, true,   STAGE_ANY },
 	{ "_list-kinddef-flags",    processListKinddefFlagsOption,  true,   STAGE_ANY },
 	{ "_list-langdef-flags",    processListLangdefFlagsOption,  true,   STAGE_ANY },

--- a/main/options.c
+++ b/main/options.c
@@ -474,6 +474,8 @@ static optionDescription LongOptionDescription [] = {
  {1,1,"       Output list of flags which can be used in a multitable regex parser definition."},
  {1,1,"  --_list-operators"},
  {1,1,"       Output list of optscript operators."},
+ {1,1,"  --_list-roledef-flags"},
+ {1,1,"       Output list of flags which can be used with --roledef option."},
  {1,0,""},
  {1,0,"Miscellaneous Options"},
  {1,0,"  --help"},
@@ -2220,6 +2222,7 @@ defineListFunctionForOptionWithParameter (MultitableRegexFlags, printMultitableR
 
 defineListFunctionForOption (LangdefFlags, printLangdefFlags);
 defineListFunctionForOption (KinddefFlags, printKinddefFlags);
+defineListFunctionForOption (RoledefFlags, printKinddefFlags);
 defineListFunctionForOption (FielddefFlags, printFielddefFlags);
 
 defineListFunctionForOption (OutputFormats, printOutputFormats);
@@ -2925,6 +2928,7 @@ static parametricOption ParametricOptions [] = {
 	{ "_list-langdef-flags",    processListLangdefFlagsOption,  true,   STAGE_ANY },
 	{ "_list-mtable-regex-flags", processListMultitableRegexFlagsOption, true, STAGE_ANY },
 	{ "_list-operators",        processListOperators,           true,   STAGE_ANY },
+	{ "_list-roledef-flags",    processListRoledefFlagsOption,  true,   STAGE_ANY },
 #ifdef DO_TRACING
 	{ "_trace",                 processTraceOption,             false,  STAGE_ANY },
 #endif

--- a/main/parse.c
+++ b/main/parse.c
@@ -3979,6 +3979,21 @@ static void xtagDefinitionDestroy (xtagDefinition *xdef)
 	eFree (xdef);
 }
 
+static void pre_xtag_def_flag_version_long (const char* const optflag,
+											const char* const param, void* data)
+{
+	xtagDefinition *xdef = data;
+
+	if (!strToUInt (param, 10, &xdef->version))
+		error (FATAL, "Faile to parse the version number for role \"%s\": %s",
+			   xdef->name, param);
+}
+
+static flagDefinition PreXtagDefFlagDef [] = {
+	{ '\0', "version",  NULL, pre_xtag_def_flag_version_long,
+	  "VERSION", "in which version of the parser this extra is added"},
+};
+
 static bool processLangDefineExtra (const langType language,
 									const char *const option,
 									const char *const parameter)
@@ -4022,7 +4037,7 @@ static bool processLangDefineExtra (const langType language,
 	xdef->isEnabled = NULL;
 	DEFAULT_TRASH_BOX(xdef, xtagDefinitionDestroy);
 
-	flagsEval (flags, NULL, 0, xdef);
+	flagsEval (flags, PreXtagDefFlagDef, ARRAY_SIZE (PreXtagDefFlagDef), xdef);
 
 	defineXtag (xdef, language);
 
@@ -5446,6 +5461,7 @@ defineSimplePrintFLagsFunction(Langdef, PreLangDefFlagDef);
 defineSimplePrintFLagsFunction(Kinddef, PreKindDefFlagDef);
 defineSimplePrintFLagsFunction(Roledef, PreRoleDefFlagDef);
 defineSimplePrintFLagsFunction(Fielddef, FieldDefFlagDef);
+defineSimplePrintFLagsFunction(Extradef, PreXtagDefFlagDef);
 
 extern void printLanguageMultitableStatistics (langType language)
 {

--- a/main/parse.c
+++ b/main/parse.c
@@ -2695,9 +2695,21 @@ static void pre_kind_def_flag_refonly_long (const char* const optflag,
 	kdef->referenceOnly = true;
 }
 
+static void pre_kind_def_flag_version_long (const char* const optflag,
+											const char* const param, void* data)
+{
+	kindDefinition *kdef = data;
+
+	if (!strToUInt (param, 10, &kdef->version))
+		error (FATAL, "Faile to parse the version number for kind \"%s\": %s",
+			   kdef->name, param);
+}
+
 static flagDefinition PreKindDefFlagDef [] = {
 	{ '\0', "_refonly", NULL, pre_kind_def_flag_refonly_long,
 	  NULL, "use this kind reference tags only"},
+	{ '\0', "version",  NULL, pre_kind_def_flag_version_long,
+	  "VERSION", "in which version of the parser this kind is added"},
 };
 
 static bool processLangDefineKind(const langType language,

--- a/main/parse.c
+++ b/main/parse.c
@@ -4069,9 +4069,22 @@ static void field_def_flag_datatype_long (const char *const optflag CTAGS_ATTR_U
 		error (FATAL, "unknown datatype for field \"%s\": \"%s\"", fdef->name, param);
 }
 
+static void field_def_flag_version_long (const char *const optflag CTAGS_ATTR_UNUSED,
+										 const char* const param,
+										 void *data)
+{
+	fieldDefinition *fdef = data;
+
+	if (!strToUInt (param, 10, &fdef->version))
+		error (FATAL, "Faile to parse the version number for field \"%s\": %s",
+			   fdef->name, param);
+}
+
 static flagDefinition FieldDefFlagDef [] = {
 	{ '\0', "datatype", NULL, field_def_flag_datatype_long,
 	  "TYPE", "acceaptable datatype of the field (str|bool|int|str+bool)" },
+	{ '\0', "version",  NULL, field_def_flag_version_long,
+	  "VERSION", "in which version of the parser this field is added"},
 };
 
 static bool processLangDefineField (const langType language,

--- a/main/parse.c
+++ b/main/parse.c
@@ -2835,6 +2835,21 @@ static void freeRdef (roleDefinition *rdef)
 	eFree (rdef);
 }
 
+static void pre_role_def_flag_version_long (const char* const optflag,
+											const char* const param, void* data)
+{
+	roleDefinition *rdef = data;
+
+	if (!strToUInt (param, 10, &rdef->version))
+		error (FATAL, "Faile to parse the version number for role \"%s\": %s",
+			   rdef->name, param);
+}
+
+static flagDefinition PreRoleDefFlagDef [] = {
+	{ '\0', "version",  NULL, pre_role_def_flag_version_long,
+	  "VERSION", "in which version of the parser this role is added"},
+};
+
 static bool processLangDefineRole(const langType language,
 								  const char *const kindSpec,
 								  const char *const option,
@@ -2931,7 +2946,7 @@ static bool processLangDefineRole(const langType language,
 	rdef->name = name;
 	rdef->description = description;
 
-	flagsEval (flags, NULL, 0, rdef);
+	flagsEval (flags, PreRoleDefFlagDef, ARRAY_SIZE (PreRoleDefFlagDef), rdef);
 
 	defineRole (parser->kindControlBlock, kdef->id, rdef, freeRdef);
 
@@ -5416,6 +5431,7 @@ extern void printLanguageSubparsers (const langType language,
 
 defineSimplePrintFLagsFunction(Langdef, PreLangDefFlagDef);
 defineSimplePrintFLagsFunction(Kinddef, PreKindDefFlagDef);
+defineSimplePrintFLagsFunction(Roledef, PreRoleDefFlagDef);
 defineSimplePrintFLagsFunction(Fielddef, FieldDefFlagDef);
 
 extern void printLanguageMultitableStatistics (langType language)

--- a/main/parse.c
+++ b/main/parse.c
@@ -3761,7 +3761,8 @@ static void printMaps (const langType language, langmapType type)
 	unsigned int i;
 
 	parser = LanguageTable + language;
-	printf ("%-8s", parser->def->name);
+	if (! (LMAP_NO_LANG_PREFIX & type))
+		printf ("%-8s", parser->def->name);
 	if (parser->currentPatterns != NULL && (type & LMAP_PATTERN))
 		for (i = 0  ;  i < stringListCount (parser->currentPatterns)  ;  ++i)
 			printf (" %s", vStringValue (

--- a/main/parse_p.h
+++ b/main/parse_p.h
@@ -35,6 +35,7 @@ typedef enum {
 	LMAP_EXTENSION = 1 << 1,
 	LMAP_ALL       = LMAP_PATTERN | LMAP_EXTENSION,
 	LMAP_TABLE_OUTPUT = 1 << 2,
+	LMAP_NO_LANG_PREFIX = 1 << 3,
 } langmapType;
 
 enum parserCategory

--- a/main/parse_p.h
+++ b/main/parse_p.h
@@ -128,8 +128,10 @@ extern void printLanguageParams (const langType language,
 								 bool withListHeader, bool machinable, FILE *fp);
 extern void printLanguageSubparsers (const langType language,
 									 bool withListHeader, bool machinable, FILE *fp);
+extern void printExtradefFlags (bool withListHeader, bool machinable, FILE *fp);
 extern void printLangdefFlags (bool withListHeader, bool machinable, FILE *fp);
 extern void printKinddefFlags (bool withListHeader, bool machinable, FILE *fp);
+extern void printRoledefFlags (bool withListHeader, bool machinable, FILE *fp);
 extern void printFielddefFlags (bool withListHeader, bool machinable, FILE *fp);
 extern bool doesParserRequireMemoryStream (const langType language);
 extern bool parseFile (const char *const fileName);

--- a/main/ptag.c
+++ b/main/ptag.c
@@ -317,6 +317,7 @@ extern void printPtags (bool withListHeader, bool machinable, FILE *fp)
 {
 	struct colprintTable *table = colprintTableNew ("L:NAME",
 													"L:ENABLED",
+													"R:VER",
 													"L:DESCRIPTION",
 													NULL);
 	for (unsigned int i = 0; i < PTAG_COUNT; i++)
@@ -326,6 +327,7 @@ extern void printPtags (bool withListHeader, bool machinable, FILE *fp)
 		colprintLineAppendColumnCString (line, ptagDescs[i].enabled
 										 ? "on"
 										 : "off");
+		colprintLineAppendColumnVersion (line, ptagDescs[i].version);
 		colprintLineAppendColumnCString (line, ptagDescs[i].description);
 	}
 

--- a/main/ptag_p.h
+++ b/main/ptag_p.h
@@ -74,6 +74,8 @@ struct sPtagDesc {
 
 	/* See writer-json.c */
 	const char *jsonObjectKey;
+
+	unsigned int version;
 };
 
 extern bool makePtagIfEnabled (ptagType type, langType language, const void *data);

--- a/main/xtag.c
+++ b/main/xtag.c
@@ -150,7 +150,7 @@ extern xtagType  getXtagTypeForNameAndLanguage (const char *name, langType langu
 extern struct colprintTable * xtagColprintTableNew (void)
 {
 	return colprintTableNew ("L:LETTER", "L:NAME", "L:ENABLED",
-							 "L:LANGUAGE", "L:FIXED", "L:DESCRIPTION", NULL);
+							 "L:LANGUAGE", "L:FIXED", "R:VER", "L:DESCRIPTION", NULL);
 }
 
 static void  xtagColprintAddLine (struct colprintTable *table, int xtype)
@@ -171,6 +171,7 @@ static void  xtagColprintAddLine (struct colprintTable *table, int xtype)
 									 ? RSV_NONE
 									 : getLanguageName (xobj->language));
 	colprintLineAppendColumnBool (line, isXtagFixed(xdef->xtype));
+	colprintLineAppendColumnVersion (line, xdef->version);
 	colprintLineAppendColumnCString (line, xdef->description);
 }
 
@@ -378,6 +379,12 @@ extern int defineXtag (xtagDefinition *def, langType language)
 			 def->xtype,
 			 def->name, def->description,
 			 getLanguageName (language));
+
+	if (def->version > getLanguageVersionCurrent (language))
+		error (WARNING, "the version number (%u) of extra \"%s\" of language \"%s\" "
+			   "should be less than or equal to the current number (%u) of the language",
+			   def->version, def->name, getLanguageName (language),
+			   getLanguageVersionCurrent (language));
 
 	return def->xtype;
 }

--- a/main/xtag.c
+++ b/main/xtag.c
@@ -78,7 +78,8 @@ static xtagDefinition xtagDefinitions [] = {
 	{ true, '\0', "anonymous",
 	  "Include tags for non-named objects like lambda"},
 	{ false, 'z', "nulltag",
-	  "Include tags with empty strings as their names"},
+	  "Include tags with empty strings as their names",
+	  .version = 1, },
 };
 
 static unsigned int       xtagObjectUsed;

--- a/main/xtag.h
+++ b/main/xtag.h
@@ -60,6 +60,8 @@ struct sXtagDefinition {
 	bool (* isFixed)   (struct sXtagDefinition *def);
 	void (* enable)    (struct sXtagDefinition *def, bool state);
 
+	unsigned int    version;
+
 	unsigned int xtype;	/* Given from the main part */
 };
 

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -112,6 +112,13 @@ my $fielddef_flags =
        } ],
     ];
 
+my $extradef_flags =
+    [
+     [ qr/\{version=([0-9]+)\}/, sub {
+	 $_[0]->{'version'} = $1;
+       } ],
+    ];
+
 my $options =
     [
      [ qr/^--options=(.*)/, sub {
@@ -176,7 +183,7 @@ my $options =
 
 	 return 1;
        } ],
-     [ qr/^--_extradef-(.*)=([^,]+),([^\{]+)/, sub {
+     [ qr/^--_extradef-(.*)=([^,]+),([^\{]+)(.*)/, sub {
 	 die "Don't use --_extradef-<LANG>=+ option before defining the language"
 	     if (! defined $_[0]->{'langdef'});
 	 die "Adding an extra is allowed only to the language specified with --langdef: $1"
@@ -184,11 +191,14 @@ my $options =
 
 	 my $name = $2;
 	 my $desc = $3;
+	 my $rest = $4;
 
 	 die "unacceptable character is used for extra name: $name"
 	     unless ($name =~ /^[a-zA-Z0-9]+$/);
 
-	 push @{$_[0]->{'extradefs'}}, { name => $name, desc => $desc };
+	 my $xdef = { name => $name, desc => $desc, version => 0, };
+	 push @{$_[0]->{'extradefs'}}, $xdef;
+	 parse_flags ($rest, $xdef, $extradef_flags);
 	 return 1;
        } ],
      [ qr/^--_fielddef-(.*)=([^,]+),([^\{]+)(.*)/, sub {
@@ -1095,6 +1105,13 @@ EOF
 		  .enabled     = $enabled,
 		  .name        = "$_->{'name'}",
 		  .description = "$desc",
+EOF
+      if ($_->{'version'}) {
+	  print <<EOF;
+		  .version     = "$_->{'version'}",
+EOF
+      }
+      print <<EOF;
 		},
 EOF
     }

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -63,6 +63,9 @@ my $kinddef_flags =
      [ qr/\{_refonly\}/, sub {
 	 $_[0]->{'refonly'} = 1;
        } ],
+     [ qr/\{version=([0-9]+)\}/, sub {
+	 $_[0]->{'version'} = $1;
+       } ],
     ];
 
 my $fielddef_flags =
@@ -157,7 +160,7 @@ my $options =
 	     unless (substr ($name, 1) =~ /^[a-zA-Z0-9]+$/);
 
 	 my $kdef = { enabled => 1, letter => $letter, name => $name, desc => $desc,
-		      refonly => 0, roles => [], seps => [] };
+		      refonly => 0, roles => [], seps => [], version => 0 };
 	 push @{$_[0]->{'kinddefs'}}, $kdef;
 	 parse_flags ($rest, $kdef, $kinddef_flags);
 
@@ -939,6 +942,11 @@ EOF
       if (@{$_->{'seps'}}) {
 	  print <<EOF;
 		  ATTACH_SEPARATORS($opts->{'Clangdef'}${Kind}Separators),
+EOF
+      }
+      if ($_->{'version'}) {
+	  print <<EOF;
+		  .version = $_->{'version'},
 EOF
       }
       print <<EOF;

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -100,6 +100,9 @@ my $fielddef_flags =
 
 	 $_[0]->{'datatype'} = $datatype;
        } ],
+     [ qr/\{version=([0-9]+)\}/, sub {
+	 $_[0]->{'version'} = $1;
+       } ],
     ];
 
 my $options =
@@ -193,7 +196,7 @@ my $options =
 	 die "unacceptable character is used for field name: $name"
 	     unless ($name =~ /^[a-zA-Z]+$/);
 
-	 my $fdef = { name => $name, desc => $desc };
+	 my $fdef = { name => $name, desc => $desc, version => 0 };
 	 push @{$_[0]->{'fielddefs'}}, $fdef;
 	 parse_flags ($rest, $fdef, $fielddef_flags);
 
@@ -1124,6 +1127,11 @@ EOF
 		  .isValueAvailable = isValueAvailableGeneric,
 		  .getValueObject = getFieldValueGeneric,
 		  .setValueObject = setFieldValueGeneric,
+EOF
+      }
+      if ($_->{'version'}) {
+	  print <<EOF;
+		  .version     = $_->{'version'},
 EOF
       }
       print <<EOF;

--- a/misc/optlib2c
+++ b/misc/optlib2c
@@ -68,6 +68,13 @@ my $kinddef_flags =
        } ],
     ];
 
+my $roledef_flags =
+    [
+     [ qr/\{version=([0-9]+)\}/, sub {
+	 $_[0]->{'version'} = $1;
+       } ],
+    ];
+
 my $fielddef_flags =
     [
      [ qr/\{datatype=([^\}]+)\}/, sub {
@@ -202,7 +209,7 @@ my $options =
 
 	 return 1;
        } ],
-     [ qr/^--_roledef-([^.]*)\.(?:([a-zA-Z])|\{([a-zA-Z][a-zA-Z0-9]*)\})=([a-zA-Z0-9]+),([^\{]+)/, sub {
+     [ qr/^--_roledef-([^.]*)\.(?:([a-zA-Z])|\{([a-zA-Z][a-zA-Z0-9]*)\})=([a-zA-Z0-9]+),([^\{]+)(.*)/, sub {
 	   die "Don't use --_roledef-<LANG>.<KNID>=+ option before defining the language"
 	     if (! defined $_[0]->{'langdef'});
 	   die "Adding a field is allowed only to the language specified with --langdef: $1"
@@ -212,9 +219,13 @@ my $options =
 	   for (@{$_[0]->{'kinddefs'}}) {
 	       if ((defined $2 && $_->{'letter'} eq $2)
 		   || (defined $3 && $_->{'name'} eq $3)) {
-		   my $role = { name => $4, desc => $5, owner => $_ };
+		   my $role = { name => $4, desc => $5, owner => $_, version => 0 };
 		   push @{$_->{'roles'}}, $role;
 		   $kind_found = 1;
+
+		   my $rest = $6;
+		   parse_flags ($rest, $role, $roledef_flags);
+
 		   last;
 	       }
 	   }
@@ -855,9 +866,20 @@ sub emit_roledefs {
 EOF
 	for (@{$_->{'roles'}}) {
 	    my $desc = escape_as_cstr $_->{'desc'};
+	    my $close = $_->{'version'}? ',': '},';
 	    print <<EOF;
-		{ true, "$_->{'name'}", "$desc" },
+		{ true, "$_->{'name'}", "$desc" $close
 EOF
+	    if ($_->{'version'}) {
+		print <<EOF;
+		  .version = $_->{'version'},
+EOF
+	    }
+	    if ($_->{'version'}) {
+	    print <<EOF;
+		},
+EOF
+	    }
 	}
 
 	print <<EOF;

--- a/optlib/kconfig.c
+++ b/optlib/kconfig.c
@@ -61,6 +61,7 @@ extern parserDefinition* KconfigParser (void)
 		},
 		{
 		  true, 'v', "variable", "macro variables",
+		  .version = 1,
 		},
 	};
 	static xtagDefinition KconfigXtagTable [] = {

--- a/optlib/kconfig.ctags
+++ b/optlib/kconfig.ctags
@@ -23,7 +23,7 @@
 --kinddef-Kconfig=M,mainMenu,the main menu
 --kinddef-Kconfig=k,kconfig,kconfig file
 --kinddef-Kconfig=C,choice,choices
---kinddef-Kconfig=v,variable,macro variables
+--kinddef-Kconfig=v,variable,macro variables{version=1}
 
 --_roledef-Kconfig.{kconfig}=source,kconfig file loaded with source directive
 

--- a/optlib/lex.c
+++ b/optlib/lex.c
@@ -98,7 +98,9 @@ extern parserDefinition* LEXParser (void)
 	};
 
 	static roleDefinition LEXCondRoleTable [] = {
-		{ true, "grouping", " conditions used for grouping of start or exclusive condition rules" },
+		{ true, "grouping", " conditions used for grouping of start or exclusive condition rules" ,
+		  .version = 1,
+		},
 	};
 	static kindDefinition LEXKindTable [] = {
 		{

--- a/optlib/lex.ctags
+++ b/optlib/lex.ctags
@@ -44,7 +44,7 @@
 
 --kinddef-LEX=r,regex,named regular expression
 --kinddef-LEX=c,cond,definition of start or exclusive condition
---_roledef-LEX.{cond}=grouping, conditions used for grouping of start or exclusive condition rules
+--_roledef-LEX.{cond}=grouping, conditions used for grouping of start or exclusive condition rules{version=1}
 
 #
 # Table declarations

--- a/optlib/meson.c
+++ b/optlib/meson.c
@@ -355,9 +355,11 @@ extern parserDefinition* MesonParser (void)
 		},
 		{
 		  true, 'D', "cfgdata", "configuration data objects",
+		  .version = 1,
 		},
 		{
 		  true, 'C', "cfgvar", "configuration variables",
+		  .version = 1,
 		},
 	};
 

--- a/optlib/meson.ctags
+++ b/optlib/meson.ctags
@@ -27,8 +27,8 @@
 --kinddef-Meson=b,benchmark,benchmark targets
 --kinddef-Meson=r,run,run targets
 --kinddef-Meson=m,module,modules
---kinddef-Meson=D,cfgdata,configuration data objects
---kinddef-Meson=C,cfgvar,configuration variables
+--kinddef-Meson=D,cfgdata,configuration data objects{version=1}
+--kinddef-Meson=C,cfgvar,configuration variables{version=1}
 
 #
 # Role definitions

--- a/optlib/scss.c
+++ b/optlib/scss.c
@@ -201,7 +201,9 @@ extern parserDefinition* SCSSParser (void)
 	};
 
 	static roleDefinition SCSSModuleRoleTable [] = {
-		{ true, "used", "used" },
+		{ true, "used", "used" ,
+		  .version = 1,
+		},
 	};
 	static kindDefinition SCSSKindTable [] = {
 		{
@@ -227,10 +229,12 @@ extern parserDefinition* SCSSParser (void)
 		},
 		{
 		  true, 'n', "namespace", "namespaces",
+		  .version = 1,
 		},
 		{
 		  true, 'M', "module", "modules",
 		  ATTACH_ROLES(SCSSModuleRoleTable),
+		  .version = 1,
 		},
 	};
 	static fieldDefinition SCSSFieldTable [] = {
@@ -242,6 +246,7 @@ extern parserDefinition* SCSSParser (void)
 		  .isValueAvailable = isValueAvailableGeneric,
 		  .getValueObject = getFieldValueGeneric,
 		  .setValueObject = setFieldValueGeneric,
+		  .version     = 1,
 		},
 	};
 

--- a/optlib/scss.ctags
+++ b/optlib/scss.ctags
@@ -36,11 +36,11 @@
 --kinddef-SCSS=i,id,identities
 # --kinddef-SCSS=p,pseudo,pseudos
 --kinddef-SCSS=z,parameter,function parameters
---kinddef-SCSS=n,namespace,namespaces
---kinddef-SCSS=M,module,modules
---_roledef-SCSS.{module}=used,used
+--kinddef-SCSS=n,namespace,namespaces{version=1}
+--kinddef-SCSS=M,module,modules{version=1}
+--_roledef-SCSS.{module}=used,used{version=1}
 
---_fielddef-SCSS=module,the name of module behind the namespace{datatype=str}
+--_fielddef-SCSS=module,the name of module behind the namespace{datatype=str}{version=1}
 --fields-SCSS=+{module}
 
 --_tabledef-SCSS=toplevel

--- a/optlib/systemtap.c
+++ b/optlib/systemtap.c
@@ -456,7 +456,9 @@ extern parserDefinition* SystemTapParser (void)
 	};
 
 	static roleDefinition SystemTapProbeRoleTable [] = {
-		{ true, "attached", "attached by code for probing" },
+		{ true, "attached", "attached by code for probing" ,
+		  .version = 1,
+		},
 	};
 	static kindDefinition SystemTapKindTable [] = {
 		{

--- a/optlib/systemtap.ctags
+++ b/optlib/systemtap.ctags
@@ -32,7 +32,7 @@
 --alias-SystemTap=+stap
 
 --kinddef-SystemTap=p,probe,probe aliases
---_roledef-SystemTap.{probe}=attached,attached by code for probing
+--_roledef-SystemTap.{probe}=attached,attached by code for probing{version=1}
 --kinddef-SystemTap=f,function,functions
 --kinddef-SystemTap=v,variable,variables
 --kinddef-SystemTap=m,macro,macros

--- a/optlib/terraform.c
+++ b/optlib/terraform.c
@@ -121,6 +121,7 @@ extern parserDefinition* TerraformParser (void)
 		},
 		{
 		  true, 'l', "local", "locals",
+		  .version = 1,
 		},
 	};
 

--- a/optlib/terraform.ctags
+++ b/optlib/terraform.ctags
@@ -16,7 +16,7 @@
 #   - https://developer.hashicorp.com/terraform/language/syntax/configuration
 #
 # There ctags regex were re-implemented into multi-table regex to support
-# multi-line comments and locals blocks 
+# multi-line comments and locals blocks
 #
 # Changed the name from `terraform` to `tf` so vim will recognise it properly based
 # on file extension (*.tf).
@@ -37,7 +37,7 @@
 --kinddef-Terraform=p,provider,providers
 --kinddef-Terraform=m,module,modules
 --kinddef-Terraform=o,output,output
---kinddef-Terraform=l,local,locals
+--kinddef-Terraform=l,local,locals{version=1}
 
 
 --_tabledef-Terraform=toplevel

--- a/parsers/automake.c
+++ b/parsers/automake.c
@@ -94,7 +94,8 @@ static kindDefinition AutomakeKinds [] = {
 	  .referenceOnly = true, ATTACH_ROLES(AutomakeConditionRoles) },
 	{ true, 's', "subdir", "subdirs" },
 	{ false,'p', "pseudodir", "placeholder for EXTRA_, noinst_, and _check_ prefixed primaries (internal use)",
-	  .referenceOnly = true, ATTACH_ROLES(AutomakePseudodirRoles)},
+	  .referenceOnly = true, ATTACH_ROLES(AutomakePseudodirRoles),
+	  .version = 1 },
 };
 
 typedef enum {
@@ -106,6 +107,7 @@ static xtagDefinition AutomakeXtagTable [] = {
 		.enabled = true,
 		.name = "canonicalizedName",
 		.description = "Include canonicalized object name like libctags_a",
+		.version = 1
 	},
 };
 

--- a/parsers/clojure.c
+++ b/parsers/clojure.c
@@ -37,11 +37,13 @@ typedef enum {
 static fieldDefinition ClojureFields[] = {
 	{ .name = "definer",
 	  .description = "the name of the function or macro that defines the unknown/Y-kind object",
-	  .enabled = true },
+	  .enabled = true,
+	  .version = 1 },
 };
 
 static kindDefinition ClojureKinds[] = {
-	{ true, 'Y', "unknown", "unknown type of definitions" },
+	{ true, 'Y', "unknown", "unknown type of definitions",
+	  .version = 1 },
 	{ true, 'f', "function", "functions" },
 	{ true, 'n', "namespace", "namespaces" },
 };

--- a/parsers/cxx/cxx.c
+++ b/parsers/cxx/cxx.c
@@ -140,8 +140,8 @@ parserDefinition * CppParser (void)
 	def->selectLanguage = selectors;
 	def->useCork = CORK_QUEUE|CORK_SYMTAB; // We use corking to block output until the end of file
 
-	def->versionCurrent = 1;
-	def->versionAge = 1;
+	def->versionCurrent = 2;
+	def->versionAge = 2;
 
 	return def;
 }

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -39,36 +39,41 @@ CXX_COMMON_HEADER_ROLES(C);
 static roleDefinition CXXHeaderRoles [] = {
 		RoleTemplateSystem,
 		RoleTemplateLocal,
-		{ true, "imported", "imported with \"imported ...\"" },
-		{ true, "exported", "exported with \"exported imported ...\"" },
+		{ true, "imported", "imported with \"imported ...\"",
+		  .version = 2 },
+		{ true, "exported", "exported with \"exported imported ...\"",
+		  .version = 2 },
 };
 CXX_COMMON_HEADER_ROLES(CUDA);
 
 /* Currently V parser wants these items. */
-#define RoleTemplateForeignDecl { true, "foreigndecl", "declared in foreign languages" }
+#define RoleTemplateForeignDecl(V) { true, "foreigndecl", "declared in foreign languages", .version = V }
 
 #define CXX_COMMON_FUNCTION_ROLES(__langPrefix) \
 	static roleDefinition __langPrefix##FunctionRoles [] = { \
-		RoleTemplateForeignDecl, \
+		RoleTemplateForeignDecl(1), \
 	}
 
 CXX_COMMON_FUNCTION_ROLES(C);
 
 #define CXX_COMMON_STRUCT_ROLES(__langPrefix) \
 	static roleDefinition __langPrefix##StructRoles [] = { \
-		RoleTemplateForeignDecl, \
+		RoleTemplateForeignDecl(1), \
 	}
 
 CXX_COMMON_STRUCT_ROLES(C);
 
 static roleDefinition CXXModuleRoles [] = {
 
-	{ true, "partOwner", "used for specifying a partition" },
-	{ true, "imported", "imported with \"imported ...\"" },
+	{ true, "partOwner", "used for specifying a partition",
+	  .version = 2 },
+	{ true, "imported", "imported with \"imported ...\"",
+	  .version = 2 },
 };
 
 static roleDefinition CXXPartitionRoles [] = {
-	{ true, "imported", "imported with \"imported ...\"" },
+	{ true, "imported", "imported with \"imported ...\"",
+	  .version = 2 },
 };
 
 #define CXX_COMMON_KINDS(_langPrefix, _szMemberDescription, _syncWith, FUNC_ROLES, STRUCT_ROLES) \
@@ -111,9 +116,11 @@ static kindDefinition g_aCXXCPPKinds [] = {
 	{ false, 'U', "using",      "using namespace statements" },
 	{ false, 'Z', "tparam",     "template parameters" },
 	{ true,  'M', "module",     "modules",
-			.referenceOnly = false, ATTACH_ROLES(CXXModuleRoles) },
+			.referenceOnly = false, ATTACH_ROLES(CXXModuleRoles),
+			.version = 2 },
 	{ true,  'P', "partition",  "partitions",
-			.referenceOnly = false, ATTACH_ROLES(CXXPartitionRoles) },
+			.referenceOnly = false, ATTACH_ROLES(CXXPartitionRoles),
+			.version = 2 },
 };
 
 static kindDefinition g_aCXXCUDAKinds [] = {
@@ -139,11 +146,13 @@ static const char * g_aCXXAccessStrings [] = {
 	}, { \
 		.name = "section", \
 		.description = "the place where the object is placed", \
-		.enabled = false \
+		.enabled = false, \
+		.version = 1 \
 	}, { \
 		.name = "alias", \
 		.description = "the name of the alias target specified in __attribute__((alias(...)))", \
-		.enabled = false \
+		.enabled = false, \
+		.version = 1 \
 	}
 
 static fieldDefinition g_aCXXCFields [] = {

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -378,6 +378,7 @@ static xtagDefinition FortranXtagTable [] = {
 		.enabled = false,
 		.name    = "linkName",
 		.description = "Linking name used in foreign languages",
+		.version = 1
 	},
 };
 

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -252,7 +252,8 @@ typedef enum {
 
 static roleDefinition JsFunctionRoles [] = {
 	/* Currently V parser wants this items. */
-	{ true, "foreigndecl", "declared in foreign languages" },
+	{ true, "foreigndecl", "declared in foreign languages",
+	  .version = 1 },
 };
 
 static roleDefinition JsVariableRoles [] = {

--- a/parsers/ldscript.c
+++ b/parsers/ldscript.c
@@ -34,7 +34,8 @@ typedef enum {
 
 static roleDefinition LdScriptSymbolRoles [] = {
 	{ true, "entrypoint", "entry points" },
-	{ true, "aliased", "aliased with __attribute__((alias(...))) in C/C++ code" },
+	{ true, "aliased", "aliased with __attribute__((alias(...))) in C/C++ code",
+	  .version = 1 },
 };
 
 typedef enum {
@@ -46,7 +47,8 @@ typedef enum {
 static roleDefinition LdScriptInputSectionRoles [] = {
 	{ true, "mapped",  "mapped to output section" },
 	{ true, "discarded", "discarded when linking" },
-	{ true, "destination", "specified as the destination of code and data" },
+	{ true, "destination", "specified as the destination of code and data",
+	  .version = 1 },
 };
 
 typedef enum {

--- a/parsers/lisp.c
+++ b/parsers/lisp.c
@@ -51,12 +51,17 @@ static kindDefinition LispKinds [] = {
 	{ true, 'v', "variable", "variables" },
 	{ true, 'm', "macro", "macros" },
 	{ true, 'c', "const", "constants" },
-	{ true, 't', "type", "types" },
-	{ true, 'C', "class", "classes" },
-	{ true, 's', "struct", "structs" },
+	{ true, 't', "type", "types",
+	  .version = 1 },
+	{ true, 'C', "class", "classes",
+	  .version = 1 },
+	{ true, 's', "struct", "structs",
+	  .version = 1 },
 	{ true, 'M', "method", "methods" },
-	{ true, 'G', "generic", "generics" },
-	{ true, 'p', "parameter", "parameters" },
+	{ true, 'G', "generic", "generics",
+	  .version = 1 },
+	{ true, 'p', "parameter", "parameters",
+	  .version = 1 },
 };
 
 typedef enum {
@@ -66,7 +71,8 @@ typedef enum {
 static fieldDefinition LispFields[] = {
 	{ .name = "definer",
 	  .description = "the name of the function or macro that defines the unknown/Y-kind object",
-	  .enabled = true },
+	  .enabled = true,
+	  .version = 1 },
 };
 
 typedef enum {
@@ -96,7 +102,8 @@ typedef enum {
 static fieldDefinition EmacsLispFields[] = {
 	{ .name = "definer",
 	  .description = "the name of the function or macro that defines the unknown/Y-kind object",
-	  .enabled = true },
+	  .enabled = true,
+	  .version = 1 },
 };
 
 /* Following macro/builtin doesn't define a name appeared

--- a/parsers/make.c
+++ b/parsers/make.c
@@ -66,6 +66,7 @@ static xtagDefinition MakeXtagTable [] = {
 		.enabled = false,
 		.name = "CppDef",
 		.description = "Include FOO in -DFOO as as a name of CPreProcessor macro",
+		.version = 1,
 	}
 };
 

--- a/parsers/markdown.c
+++ b/parsers/markdown.c
@@ -59,7 +59,8 @@ static kindDefinition MarkdownKinds[] = {
 	{ true, 'T', "l4subsection",  "level 4 sections" },
 	{ true, 'u', "l5subsection",  "level 5 sections" },
 	{ true, 'n', "footnote",      "footnotes" },
-	{ true, 'h', "hashtag",       "hashtags"},
+	{ true, 'h', "hashtag",       "hashtags",
+	  .version = 1 },
 };
 
 static fieldDefinition MarkdownFields [] = {

--- a/parsers/powershell.c
+++ b/parsers/powershell.c
@@ -56,7 +56,8 @@ static kindDefinition PowerShellKinds[COUNT_KIND] = {
 	{ true, 'c', "class",		"classes" },
 	{ true, 'i', "filter",		"filter" },
 	{ true, 'g', "enum",		"enum names" },
-	{ true, 'e', "enumlabel",	"enum labels" },
+	{ true, 'e', "enumlabel",	"enum labels",
+	  .version = 1 },
 };
 
 

--- a/parsers/python.c
+++ b/parsers/python.c
@@ -110,7 +110,8 @@ static roleDefinition PythonModuleRoles [] = {
 	{ true, "indirectlyImported",
 	  "module imported in alternative name" },
 	{ true, "entryPoint",
-	  "specified as a module of an entry point" },
+	  "specified as a module of an entry point",
+	  .version = 1 },
 };
 
 static roleDefinition PythonUnknownRoles [] = {
@@ -121,7 +122,8 @@ static roleDefinition PythonUnknownRoles [] = {
 
 static roleDefinition PythonFunctionRoles [] = {
 	{ true, "entryPoint",
-	  "specified as an entry point" },
+	  "specified as an entry point",
+	  .version = 1 },
 };
 
 static kindDefinition PythonKinds[PYTHON_COUNT_KIND] = {

--- a/parsers/scheme.c
+++ b/parsers/scheme.c
@@ -36,11 +36,13 @@ typedef enum {
 static fieldDefinition SchemeFields[] = {
 	{ .name = "definer",
 	  .description = "the name of the function or macro that defines the unknown/Y-kind object",
-	  .enabled = true },
+	  .enabled = true,
+	  .version = 1 },
 };
 
 static kindDefinition SchemeKinds [] = {
-	{ true, 'Y', "unknown", "unknown type of definitions" },
+	{ true, 'Y', "unknown", "unknown type of definitions",
+	  .version = 1 },
 	{ true, 'f', "function", "functions" },
 	{ true, 's', "set",      "sets" }
 };

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -159,7 +159,8 @@ static roleDefinition SystemVerilogModuleRoles [] = {
 
 static kindDefinition VerilogKinds [] = {
  { true, 'c', "constant",	"constants (parameter, specparam)" },
- { true, 'd', "define",		"text macros" },
+ { true, 'd', "define",		"text macros",
+   .version = 1 },
  { true, 'e', "event",		"events" },
  { true, 'f', "function",	"functions" },
  { true, 'm', "module",		"modules",
@@ -174,7 +175,8 @@ static kindDefinition VerilogKinds [] = {
 
 static kindDefinition SystemVerilogKinds [] = {
  { true, 'c', "constant",	"constants (parameter, specparam, enum values)" },
- { true, 'd', "define",		"text macros" },
+ { true, 'd', "define",		"text macros",
+   .version = 1 },
  { true, 'e', "event",		"events" },
  { true, 'f', "function",	"functions" },
  { true, 'm', "module",		"modules",

--- a/parsers/vim.c
+++ b/parsers/vim.c
@@ -75,8 +75,10 @@ static kindDefinition VimKinds [] = {
 	{ true,  'n', "filename", "vimball filename" },
 	{ true,  'C', "constant", "constant definitions" },
 	{ false, 'h', "heredoc",  "marker for here document",
-	  .referenceOnly = false, ATTACH_ROLES (VimHeredocRoles) },
-	{ true,  'k', "class", "vim9script classes" },
+	  .referenceOnly = false, ATTACH_ROLES (VimHeredocRoles),
+	  .version = 1 },
+	{ true,  'k', "class", "vim9script classes",
+	  .version = 1 },
 };
 
 /*


### PR DESCRIPTION
When releasing, I have to update the NEWS file.
One important topic is how parsers are enhanced, with new kinds, roles, fields, and extras (KRFX).
We have added and updated the 'ctags-lang-*' man pages mainly to track the KRFX.
Updating the man pages only to track them is a boring task.
Instead, making ctags itself report new KRFX.

This change adds version members to KRFX definitions.

Various-- list* commands show the version numbers in the VER column:

```
$ ./ctags --list-kinds-full=Automake
#LETTER NAME      ENABLED REFONLY NROLES MASTER VER DESCRIPTION
D       data      yes     no      0      NONE     0 datum
L       library   yes     no      0      NONE     0 libraries
M       man       yes     no      0      NONE     0 manuals
P       program   yes     no      0      NONE     0 programs
S       script    yes     no      0      NONE     0 scripts
T       ltlibrary yes     no      0      NONE     0 ltlibraries
c       condition yes     yes     1      NONE     0 conditions
d       directory yes     no      6      NONE     0 directories
p       pseudodir no      yes     6      NONE     1 placeholder for EXTRA_, noinst_, ...
s       subdir    yes     no      0      NONE     0 subdirs
```


`--describe-language` option was added.

```
$ ./ctags --describe-language=RpmMacros          
About RpmMacros language
=======================================================
enabled: yes
version: 0.0

Mappings/patterns
-------------------------------------------------------


Mappings/extensions
-------------------------------------------------------


Aliases
-------------------------------------------------------
#ALIAS

Kinds
-------------------------------------------------------
#LETTER NAME  ENABLED REFONLY NROLES MASTER VER DESCRIPTION
m       macro yes     no      0      NONE     0 macros

Roles
-------------------------------------------------------
#KIND(L/N) NAME ENABLED VER DESCRIPTION

Fields
-------------------------------------------------------
#LETTER NAME ENABLED LANGUAGE JSTYPE FIXED OP VER DESCRIPTION

Extras
-------------------------------------------------------
#LETTER NAME ENABLED LANGUAGE FIXED VER DESCRIPTION

Parameters
-------------------------------------------------------
#NAME DESCRIPTION

Sub parsers stacked on this parser
-------------------------------------------------------
#NAME BASEPARSER DIRECTIONS

Implementation specific status
-------------------------------------------------------
allow null tags: no
```

TODO:
- [ ] implement `--list-languages-full`
- [ ] update ctags.1.rst
- [ ] add test cases
- [ ] describe versioning in hacking guide
- [ ] ...
