### PR TITLE
Meson: extract config vars defined inside configuration_data({...})

### DIFF
--- a/Units/parser-meson.r/config-inline.d/args.ctags
+++ b/Units/parser-meson.r/config-inline.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--map-Meson=+.meson
+--fields=+K

--- a/Units/parser-meson.r/config-inline.d/expected.tags
+++ b/Units/parser-meson.r/config-inline.d/expected.tags
@@ -1,0 +1,32 @@
+insights-client	input.meson	/^project('insights-client',$/;"	project
+python	input.meson	/^python = import('python')$/;"	variable
+python_installation	input.meson	/^python_installation = python.find_installation(get_option('python'))$/;"	variable
+python_exec	input.meson	/^python_exec = '\/usr\/bin\/python3'$/;"	variable
+systemd	input.meson	/^systemd = dependency('systemd', version: '>=231')$/;"	variable
+config_data	input.meson	/^config_data = configuration_data({$/;"	cfgdata
+bindir	input.meson	/^  'bindir': get_option('prefix') \/ get_option('bindir'),$/;"	cfgvar	cfgdata:config_data
+BINDIR	input.meson	/^  'BINDIR': get_option('prefix') \/ get_option('bindir'),$/;"	cfgvar	cfgdata:config_data
+DATADIR	input.meson	/^  'DATADIR': get_option('prefix') \/ get_option('datadir'),$/;"	cfgvar	cfgdata:config_data
+DATAROOTDIR	input.meson	/^  'DATAROOTDIR':get_option('prefix') \/ get_option('datadir'),$/;"	cfgvar	cfgdata:config_data
+DOCDIR	input.meson	/^  'DOCDIR': get_option('prefix') \/ get_option('datadir') \/ 'doc' \/ meson.project_name(),$/;"	cfgvar	cfgdata:config_data
+LIBEXECDIR	input.meson	/^  'LIBEXECDIR': get_option('prefix') \/ get_option('libexecdir'),$/;"	cfgvar	cfgdata:config_data
+LOCALSTATEDIR	input.meson	/^  'LOCALSTATEDIR': get_option('localstatedir'),$/;"	cfgvar	cfgdata:config_data
+PACKAGE	input.meson	/^  'PACKAGE': meson.project_name(),$/;"	cfgvar	cfgdata:config_data
+PACKAGE_VERSION	input.meson	/^  'PACKAGE_VERSION': meson.project_version(),$/;"	cfgvar	cfgdata:config_data
+pkgsysconfdir	input.meson	/^  'pkgsysconfdir': '\/' \/ get_option('sysconfdir') \/ meson.project_name(),$/;"	cfgvar	cfgdata:config_data
+PREFIX	input.meson	/^  'PREFIX': get_option('prefix'),$/;"	cfgvar	cfgdata:config_data
+PYTHON	input.meson	/^  'PYTHON': python_exec,$/;"	cfgvar	cfgdata:config_data
+pythondir	input.meson	/^  'pythondir': python_installation.get_install_dir(),$/;"	cfgvar	cfgdata:config_data
+SBINDIR	input.meson	/^  'SBINDIR': get_option('prefix') \/ get_option('sbindir'),$/;"	cfgvar	cfgdata:config_data
+SYSCONFDIR	input.meson	/^  'SYSCONFDIR': '\/' \/ get_option('sysconfdir'),$/;"	cfgvar	cfgdata:config_data
+sysconfdir	input.meson	/^  'sysconfdir': '\/' \/ get_option('sysconfdir'),$/;"	cfgvar	cfgdata:config_data
+top_srcdir	input.meson	/^  'top_srcdir': meson.source_root()$/;"	cfgvar	cfgdata:config_data
+update-egg	input.meson	/^run_target('update-egg', command: 'scripts\/01-upgrade-egg.sh')$/;"	run
+data	input.meson	/^subdir('data')$/;"	subdir
+docs	input.meson	/^subdir('docs')$/;"	subdir
+src	input.meson	/^subdir('src')$/;"	subdir
+configuration	input.meson	/^configuration = '**Configuration**\\n'$/;"	variable
+cfgf5631d8f0109	input-0.meson	/^configuration_data({$/;"	cfgdata
+a	input-0.meson	/^  'a': get_option('prefix') \/ get_option('bindir'),$/;"	cfgvar	cfgdata:cfgf5631d8f0109
+b	input-0.meson	/^  'b': meson.source_root()$/;"	cfgvar	cfgdata:cfgf5631d8f0109
+update-eggx	input-0.meson	/^run_target('update-eggx', command: 'scripts\/01-upgrade-egg.sh')$/;"	run

--- a/Units/parser-meson.r/config-inline.d/input-0.meson
+++ b/Units/parser-meson.r/config-inline.d/input-0.meson
@@ -1,0 +1,7 @@
+configuration_data({
+  'a': get_option('prefix') / get_option('bindir'),
+  # ...
+  'b': meson.source_root()
+})
+
+run_target('update-eggx', command: 'scripts/01-upgrade-egg.sh')

--- a/Units/parser-meson.r/config-inline.d/input.meson
+++ b/Units/parser-meson.r/config-inline.d/input.meson
@@ -1,0 +1,54 @@
+# Taken from insights-client-3.2.8/meson.build
+
+project('insights-client',
+  version: '3.2.8',
+  meson_version: '>=0.49'
+)
+
+python = import('python')
+
+python_installation = python.find_installation(get_option('python'))
+
+python_exec = '/usr/bin/python3'
+
+systemd = dependency('systemd', version: '>=231')
+
+config_data = configuration_data({
+  'bindir': get_option('prefix') / get_option('bindir'),
+  'BINDIR': get_option('prefix') / get_option('bindir'),
+  'DATADIR': get_option('prefix') / get_option('datadir'),
+  'DATAROOTDIR':get_option('prefix') / get_option('datadir'),
+  'DOCDIR': get_option('prefix') / get_option('datadir') / 'doc' / meson.project_name(),
+  'LIBEXECDIR': get_option('prefix') / get_option('libexecdir'),
+  'LOCALSTATEDIR': get_option('localstatedir'),
+  'PACKAGE': meson.project_name(),
+  'PACKAGE_VERSION': meson.project_version(),
+  'pkgsysconfdir': '/' / get_option('sysconfdir') / meson.project_name(),
+  'PREFIX': get_option('prefix'),
+  'PYTHON': python_exec,
+  'pythondir': python_installation.get_install_dir(),
+  'SBINDIR': get_option('prefix') / get_option('sbindir'),
+  'SYSCONFDIR': '/' / get_option('sysconfdir'),
+  'sysconfdir': '/' / get_option('sysconfdir'),
+  'top_srcdir': meson.source_root()
+})
+
+run_target('update-egg', command: 'scripts/01-upgrade-egg.sh')
+
+subdir('data')
+subdir('docs')
+subdir('src')
+
+configuration = '**Configuration**\n'
+configuration += '\tpython\t\t\t: ' + get_option('python') + '\n'
+if get_option('checkin').enabled()
+ configuration += '\tcheckin\t: ' + 'enabled' + '\n'
+else
+ configuration += '\tcheckin\t: ' + 'disabled' + '\n'
+endif
+if get_option('auto_registration').enabled()
+  configuration += '\tauto_registration\t: ' + 'enabled' + '\n'
+else 
+  configuration += '\tauto_registration\t: ' + 'disabled' + '\n'
+endif
+message(configuration)

--- a/docs/news/HEAD.rst
+++ b/docs/news/HEAD.rst
@@ -25,6 +25,10 @@ C#:
     * Fix a bug that prevents the parser from extracting methods
 	  if the method has nullable parameters.
 
+Meson:
+
+    * Extract config vars defined inside configuration_data({...}).
+
 New parsers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The following parsers have been added:

--- a/optlib/meson.c
+++ b/optlib/meson.c
@@ -22,6 +22,9 @@ static void initializeMesonParser (const langType language)
 	addLanguageRegexTable (language, "skipPair");
 	addLanguageRegexTable (language, "common");
 	addLanguageRegexTable (language, "skipToArgEnd");
+	addLanguageRegexTable (language, "configBody");
+	addLanguageRegexTable (language, "configElt");
+	addLanguageRegexTable (language, "configValue");
 
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^[ \t\n]+",
@@ -54,8 +57,8 @@ static void initializeMesonParser (const langType language)
 	                               "^import[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\1", "m", "{tenter=skipToArgEnd}{_role=imported}", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
-	                               "^configuration_data[ \t\n]*\\([ \t\n]*\\)[ \t\n]*",
-	                               "", "", ""
+	                               "^(configuration_data)[ \t\n]*\\([ \t\n]*",
+	                               "", "", "{tenter=configBody}"
 		"{{\n"
 		"   lastvar false ne {\n"
 		"      lastvar :name\n"
@@ -63,12 +66,23 @@ static void initializeMesonParser (const langType language)
 		"      lastvar _tagloc\n"
 		"      _tag _commit\n"
 		"\n"
+		"      % Keep the newly created /cfgdata tag on the stack\n"
+		"      % till leaving /configBody table.\n"
+		"      dup\n"
+		"\n"
 		"      cfgdict lastvar :name 3 -1 roll put\n"
 		"\n"
 		"      % Don't emit the tag for the original variable.\n"
 		"      lastvar _markplaceholder\n"
 		"      /lastvar false def\n"
-		"   } if\n"
+		"   } {\n"
+		"      % Looks broken input. There is no left side for the configuration_data(...).\n"
+		"      % Push a dummy tag.\n"
+		"      (cfg) /cfgdata _anongen /cfgdata @1 _tag _commit\n"
+		"      dup /anonymous _markextra\n"
+		"   } ifelse\n"
+		"   % The configElt table refers to the cork index pushed by this table\n"
+		"   % for filling the scope of cfgvar/C tags.\n"
 		"}}", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
@@ -155,8 +169,8 @@ static void initializeMesonParser (const langType language)
 	                               "^import[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\1", "m", "{tenter=skipToArgEnd}{_role=imported}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipPair",
-	                               "^configuration_data[ \t\n]*\\([ \t\n]*\\)[ \t\n]*",
-	                               "", "", ""
+	                               "^(configuration_data)[ \t\n]*\\([ \t\n]*",
+	                               "", "", "{tenter=configBody}"
 		"{{\n"
 		"   lastvar false ne {\n"
 		"      lastvar :name\n"
@@ -164,12 +178,23 @@ static void initializeMesonParser (const langType language)
 		"      lastvar _tagloc\n"
 		"      _tag _commit\n"
 		"\n"
+		"      % Keep the newly created /cfgdata tag on the stack\n"
+		"      % till leaving /configBody table.\n"
+		"      dup\n"
+		"\n"
 		"      cfgdict lastvar :name 3 -1 roll put\n"
 		"\n"
 		"      % Don't emit the tag for the original variable.\n"
 		"      lastvar _markplaceholder\n"
 		"      /lastvar false def\n"
-		"   } if\n"
+		"   } {\n"
+		"      % Looks broken input. There is no left side for the configuration_data(...).\n"
+		"      % Push a dummy tag.\n"
+		"      (cfg) /cfgdata _anongen /cfgdata @1 _tag _commit\n"
+		"      dup /anonymous _markextra\n"
+		"   } ifelse\n"
+		"   % The configElt table refers to the cork index pushed by this table\n"
+		"   % for filling the scope of cfgvar/C tags.\n"
 		"}}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipPair",
 	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
@@ -217,8 +242,8 @@ static void initializeMesonParser (const langType language)
 	                               "^import[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\1", "m", "{tenter=skipToArgEnd}{_role=imported}", NULL);
 	addLanguageTagMultiTableRegex (language, "common",
-	                               "^configuration_data[ \t\n]*\\([ \t\n]*\\)[ \t\n]*",
-	                               "", "", ""
+	                               "^(configuration_data)[ \t\n]*\\([ \t\n]*",
+	                               "", "", "{tenter=configBody}"
 		"{{\n"
 		"   lastvar false ne {\n"
 		"      lastvar :name\n"
@@ -226,12 +251,23 @@ static void initializeMesonParser (const langType language)
 		"      lastvar _tagloc\n"
 		"      _tag _commit\n"
 		"\n"
+		"      % Keep the newly created /cfgdata tag on the stack\n"
+		"      % till leaving /configBody table.\n"
+		"      dup\n"
+		"\n"
 		"      cfgdict lastvar :name 3 -1 roll put\n"
 		"\n"
 		"      % Don't emit the tag for the original variable.\n"
 		"      lastvar _markplaceholder\n"
 		"      /lastvar false def\n"
-		"   } if\n"
+		"   } {\n"
+		"      % Looks broken input. There is no left side for the configuration_data(...).\n"
+		"      % Push a dummy tag.\n"
+		"      (cfg) /cfgdata _anongen /cfgdata @1 _tag _commit\n"
+		"      dup /anonymous _markextra\n"
+		"   } ifelse\n"
+		"   % The configElt table refers to the cork index pushed by this table\n"
+		"   % for filling the scope of cfgvar/C tags.\n"
 		"}}", NULL);
 	addLanguageTagMultiTableRegex (language, "common",
 	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
@@ -273,8 +309,8 @@ static void initializeMesonParser (const langType language)
 	                               "^import[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\1", "m", "{tenter=skipToArgEnd}{_role=imported}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
-	                               "^configuration_data[ \t\n]*\\([ \t\n]*\\)[ \t\n]*",
-	                               "", "", ""
+	                               "^(configuration_data)[ \t\n]*\\([ \t\n]*",
+	                               "", "", "{tenter=configBody}"
 		"{{\n"
 		"   lastvar false ne {\n"
 		"      lastvar :name\n"
@@ -282,12 +318,23 @@ static void initializeMesonParser (const langType language)
 		"      lastvar _tagloc\n"
 		"      _tag _commit\n"
 		"\n"
+		"      % Keep the newly created /cfgdata tag on the stack\n"
+		"      % till leaving /configBody table.\n"
+		"      dup\n"
+		"\n"
 		"      cfgdict lastvar :name 3 -1 roll put\n"
 		"\n"
 		"      % Don't emit the tag for the original variable.\n"
 		"      lastvar _markplaceholder\n"
 		"      /lastvar false def\n"
-		"   } if\n"
+		"   } {\n"
+		"      % Looks broken input. There is no left side for the configuration_data(...).\n"
+		"      % Push a dummy tag.\n"
+		"      (cfg) /cfgdata _anongen /cfgdata @1 _tag _commit\n"
+		"      dup /anonymous _markextra\n"
+		"   } ifelse\n"
+		"   % The configElt table refers to the cork index pushed by this table\n"
+		"   % for filling the scope of cfgvar/C tags.\n"
 		"}}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
 	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
@@ -302,6 +349,239 @@ static void initializeMesonParser (const langType language)
 	                               "^[])}]",
 	                               "", "", "{tleave}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
+	                               "^.",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^\\{",
+	                               "", "", "{tenter=configElt}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^\\)",
+	                               "", "", "{tleave}"
+		"{{\n"
+		"    pop\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^[ \t\n]+",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^#",
+	                               "", "", "{tenter=comment}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^'''",
+	                               "", "", "{tenter=mline_string}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^'",
+	                               "", "", "{tenter=string}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^[[({]",
+	                               "", "", "{tenter=skipPair}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^(jar|executable|shared_module|(both_|shared_|static_)?library)[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\3", "B", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^custom_target[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "c", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^(alias|run)_target[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\2", "r", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^benchmark[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "b", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^import[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "m", "{tenter=skipToArgEnd}{_role=imported}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^(configuration_data)[ \t\n]*\\([ \t\n]*",
+	                               "", "", "{tenter=configBody}"
+		"{{\n"
+		"   lastvar false ne {\n"
+		"      lastvar :name\n"
+		"      /cfgdata\n"
+		"      lastvar _tagloc\n"
+		"      _tag _commit\n"
+		"\n"
+		"      % Keep the newly created /cfgdata tag on the stack\n"
+		"      % till leaving /configBody table.\n"
+		"      dup\n"
+		"\n"
+		"      cfgdict lastvar :name 3 -1 roll put\n"
+		"\n"
+		"      % Don't emit the tag for the original variable.\n"
+		"      lastvar _markplaceholder\n"
+		"      /lastvar false def\n"
+		"   } {\n"
+		"      % Looks broken input. There is no left side for the configuration_data(...).\n"
+		"      % Push a dummy tag.\n"
+		"      (cfg) /cfgdata _anongen /cfgdata @1 _tag _commit\n"
+		"      dup /anonymous _markextra\n"
+		"   } ifelse\n"
+		"   % The configElt table refers to the cork index pushed by this table\n"
+		"   % for filling the scope of cfgvar/C tags.\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^'([^']+)'[ \t\n]*:",
+	                               "\\1", "C", "{tenter=configValue}"
+		"{{\n"
+		"    count 1 ge {\n"
+		"       dup . exch scope:\n"
+		"    } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^\\}",
+	                               "", "", "{tleave}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^[ \t\n]+",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^#",
+	                               "", "", "{tenter=comment}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^'''",
+	                               "", "", "{tenter=mline_string}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^'",
+	                               "", "", "{tenter=string}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^[[({]",
+	                               "", "", "{tenter=skipPair}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^(jar|executable|shared_module|(both_|shared_|static_)?library)[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\3", "B", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^custom_target[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "c", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^(alias|run)_target[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\2", "r", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^benchmark[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "b", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^import[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "m", "{tenter=skipToArgEnd}{_role=imported}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^(configuration_data)[ \t\n]*\\([ \t\n]*",
+	                               "", "", "{tenter=configBody}"
+		"{{\n"
+		"   lastvar false ne {\n"
+		"      lastvar :name\n"
+		"      /cfgdata\n"
+		"      lastvar _tagloc\n"
+		"      _tag _commit\n"
+		"\n"
+		"      % Keep the newly created /cfgdata tag on the stack\n"
+		"      % till leaving /configBody table.\n"
+		"      dup\n"
+		"\n"
+		"      cfgdict lastvar :name 3 -1 roll put\n"
+		"\n"
+		"      % Don't emit the tag for the original variable.\n"
+		"      lastvar _markplaceholder\n"
+		"      /lastvar false def\n"
+		"   } {\n"
+		"      % Looks broken input. There is no left side for the configuration_data(...).\n"
+		"      % Push a dummy tag.\n"
+		"      (cfg) /cfgdata _anongen /cfgdata @1 _tag _commit\n"
+		"      dup /anonymous _markextra\n"
+		"   } ifelse\n"
+		"   % The configElt table refers to the cork index pushed by this table\n"
+		"   % for filling the scope of cfgvar/C tags.\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^,",
+	                               "", "", "{tjump=configElt}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^\\}",
+	                               "", "", "{_advanceTo=0start}{tleave}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^[ \t\n]+",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^#",
+	                               "", "", "{tenter=comment}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^'''",
+	                               "", "", "{tenter=mline_string}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^'",
+	                               "", "", "{tenter=string}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^[[({]",
+	                               "", "", "{tenter=skipPair}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^(jar|executable|shared_module|(both_|shared_|static_)?library)[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\3", "B", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^custom_target[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "c", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^(alias|run)_target[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\2", "r", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^benchmark[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "b", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^import[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "m", "{tenter=skipToArgEnd}{_role=imported}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^(configuration_data)[ \t\n]*\\([ \t\n]*",
+	                               "", "", "{tenter=configBody}"
+		"{{\n"
+		"   lastvar false ne {\n"
+		"      lastvar :name\n"
+		"      /cfgdata\n"
+		"      lastvar _tagloc\n"
+		"      _tag _commit\n"
+		"\n"
+		"      % Keep the newly created /cfgdata tag on the stack\n"
+		"      % till leaving /configBody table.\n"
+		"      dup\n"
+		"\n"
+		"      cfgdict lastvar :name 3 -1 roll put\n"
+		"\n"
+		"      % Don't emit the tag for the original variable.\n"
+		"      lastvar _markplaceholder\n"
+		"      /lastvar false def\n"
+		"   } {\n"
+		"      % Looks broken input. There is no left side for the configuration_data(...).\n"
+		"      % Push a dummy tag.\n"
+		"      (cfg) /cfgdata _anongen /cfgdata @1 _tag _commit\n"
+		"      dup /anonymous _markextra\n"
+		"   } ifelse\n"
+		"   % The configElt table refers to the cork index pushed by this table\n"
+		"   % for filling the scope of cfgvar/C tags.\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^[])}]",
+	                               "", "", "{tleave}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
 	                               "^.",
 	                               "", "", "", NULL);
 }

--- a/optlib/meson.c
+++ b/optlib/meson.c
@@ -27,6 +27,21 @@ static void initializeMesonParser (const langType language)
 	addLanguageRegexTable (language, "configValue");
 
 	addLanguageTagMultiTableRegex (language, "main",
+	                               "^([a-zA-Z_][a-zA-Z_0-9]*)[ \t\n]*=([^=]|$)",
+	                               "\\1", "V", "{_advanceTo=2start}"
+		"{{\n"
+		"   /lastvar . def\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "main",
+	                               "^project[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "P", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "main",
+	                               "^subdir[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "S", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "main",
+	                               "^test[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
+	                               "\\1", "t", "{tenter=skipToArgEnd}", NULL);
+	addLanguageTagMultiTableRegex (language, "main",
 	                               "^[ \t\n]+",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
@@ -41,6 +56,18 @@ static void initializeMesonParser (const langType language)
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^[[({]",
 	                               "", "", "{tenter=skipPair}", NULL);
+	addLanguageTagMultiTableRegex (language, "main",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "main",
+	                               "^[df-hkm-qt-z][a-zA-Z0-9_]*",
+	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^(jar|executable|shared_module|(both_|shared_|static_)?library)[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\3", "B", "{tenter=skipToArgEnd}", NULL);
@@ -83,30 +110,6 @@ static void initializeMesonParser (const langType language)
 		"   } ifelse\n"
 		"   % The configElt table refers to the cork index pushed by this table\n"
 		"   % for filling the scope of cfgvar/C tags.\n"
-		"}}", NULL);
-	addLanguageTagMultiTableRegex (language, "main",
-	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
-	                               "", "", ""
-		"{{\n"
-		"   cfgdict \\1 known {\n"
-		"      \\4 /cfgvar @4 _tag _commit\n"
-		"      cfgdict \\1 get scope:\n"
-		"   } if\n"
-		"}}", NULL);
-	addLanguageTagMultiTableRegex (language, "main",
-	                               "^project[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
-	                               "\\1", "P", "{tenter=skipToArgEnd}", NULL);
-	addLanguageTagMultiTableRegex (language, "main",
-	                               "^subdir[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
-	                               "\\1", "S", "{tenter=skipToArgEnd}", NULL);
-	addLanguageTagMultiTableRegex (language, "main",
-	                               "^test[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
-	                               "\\1", "t", "{tenter=skipToArgEnd}", NULL);
-	addLanguageTagMultiTableRegex (language, "main",
-	                               "^([a-zA-Z_][a-zA-Z_0-9]*)[ \t\n]*=([^=]|$)",
-	                               "\\1", "V", "{_advanceTo=2start}"
-		"{{\n"
-		"   /lastvar . def\n"
 		"}}", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^.",
@@ -124,11 +127,11 @@ static void initializeMesonParser (const langType language)
 	                               "^[^\\\\']+",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "string",
-	                               "^\\\\.",
-	                               "", "", "", NULL);
-	addLanguageTagMultiTableRegex (language, "string",
 	                               "^'",
 	                               "", "", "{tleave}", NULL);
+	addLanguageTagMultiTableRegex (language, "string",
+	                               "^\\\\.",
+	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "string",
 	                               "^.",
 	                               "", "", "", NULL);
@@ -139,6 +142,9 @@ static void initializeMesonParser (const langType language)
 	                               "^\n",
 	                               "", "", "{tleave}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipPair",
+	                               "^[])}]",
+	                               "", "", "{tleave}", NULL);
+	addLanguageTagMultiTableRegex (language, "skipPair",
 	                               "^[ \t\n]+",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "skipPair",
@@ -153,6 +159,18 @@ static void initializeMesonParser (const langType language)
 	addLanguageTagMultiTableRegex (language, "skipPair",
 	                               "^[[({]",
 	                               "", "", "{tenter=skipPair}", NULL);
+	addLanguageTagMultiTableRegex (language, "skipPair",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "skipPair",
+	                               "^[df-hkm-qt-z][a-zA-Z0-9_]*",
+	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "skipPair",
 	                               "^(jar|executable|shared_module|(both_|shared_|static_)?library)[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\3", "B", "{tenter=skipToArgEnd}", NULL);
@@ -196,18 +214,6 @@ static void initializeMesonParser (const langType language)
 		"   % The configElt table refers to the cork index pushed by this table\n"
 		"   % for filling the scope of cfgvar/C tags.\n"
 		"}}", NULL);
-	addLanguageTagMultiTableRegex (language, "skipPair",
-	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
-	                               "", "", ""
-		"{{\n"
-		"   cfgdict \\1 known {\n"
-		"      \\4 /cfgvar @4 _tag _commit\n"
-		"      cfgdict \\1 get scope:\n"
-		"   } if\n"
-		"}}", NULL);
-	addLanguageTagMultiTableRegex (language, "skipPair",
-	                               "^[])}]",
-	                               "", "", "{tleave}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipPair",
 	                               "^.",
 	                               "", "", "", NULL);
@@ -227,6 +233,18 @@ static void initializeMesonParser (const langType language)
 	                               "^[[({]",
 	                               "", "", "{tenter=skipPair}", NULL);
 	addLanguageTagMultiTableRegex (language, "common",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "common",
+	                               "^[df-hkm-qt-z][a-zA-Z0-9_]*",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "common",
 	                               "^(jar|executable|shared_module|(both_|shared_|static_)?library)[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\3", "B", "{tenter=skipToArgEnd}", NULL);
 	addLanguageTagMultiTableRegex (language, "common",
@@ -269,15 +287,9 @@ static void initializeMesonParser (const langType language)
 		"   % The configElt table refers to the cork index pushed by this table\n"
 		"   % for filling the scope of cfgvar/C tags.\n"
 		"}}", NULL);
-	addLanguageTagMultiTableRegex (language, "common",
-	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
-	                               "", "", ""
-		"{{\n"
-		"   cfgdict \\1 known {\n"
-		"      \\4 /cfgvar @4 _tag _commit\n"
-		"      cfgdict \\1 get scope:\n"
-		"   } if\n"
-		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
+	                               "^[])}]",
+	                               "", "", "{tleave}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
 	                               "^[ \t\n]+",
 	                               "", "", "", NULL);
@@ -294,6 +306,18 @@ static void initializeMesonParser (const langType language)
 	                               "^[[({]",
 	                               "", "", "{tenter=skipPair}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
+	                               "^[df-hkm-qt-z][a-zA-Z0-9_]*",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
 	                               "^(jar|executable|shared_module|(both_|shared_|static_)?library)[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\3", "B", "{tenter=skipToArgEnd}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
@@ -336,18 +360,6 @@ static void initializeMesonParser (const langType language)
 		"   % The configElt table refers to the cork index pushed by this table\n"
 		"   % for filling the scope of cfgvar/C tags.\n"
 		"}}", NULL);
-	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
-	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
-	                               "", "", ""
-		"{{\n"
-		"   cfgdict \\1 known {\n"
-		"      \\4 /cfgvar @4 _tag _commit\n"
-		"      cfgdict \\1 get scope:\n"
-		"   } if\n"
-		"}}", NULL);
-	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
-	                               "^[])}]",
-	                               "", "", "{tleave}", NULL);
 	addLanguageTagMultiTableRegex (language, "skipToArgEnd",
 	                               "^.",
 	                               "", "", "", NULL);
@@ -376,6 +388,18 @@ static void initializeMesonParser (const langType language)
 	                               "^[[({]",
 	                               "", "", "{tenter=skipPair}", NULL);
 	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
+	                               "^[df-hkm-qt-z][a-zA-Z0-9_]*",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "configBody",
 	                               "^(jar|executable|shared_module|(both_|shared_|static_)?library)[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\3", "B", "{tenter=skipToArgEnd}", NULL);
 	addLanguageTagMultiTableRegex (language, "configBody",
@@ -417,15 +441,6 @@ static void initializeMesonParser (const langType language)
 		"   } ifelse\n"
 		"   % The configElt table refers to the cork index pushed by this table\n"
 		"   % for filling the scope of cfgvar/C tags.\n"
-		"}}", NULL);
-	addLanguageTagMultiTableRegex (language, "configBody",
-	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
-	                               "", "", ""
-		"{{\n"
-		"   cfgdict \\1 known {\n"
-		"      \\4 /cfgvar @4 _tag _commit\n"
-		"      cfgdict \\1 get scope:\n"
-		"   } if\n"
 		"}}", NULL);
 	addLanguageTagMultiTableRegex (language, "configElt",
 	                               "^'([^']+)'[ \t\n]*:",
@@ -454,6 +469,18 @@ static void initializeMesonParser (const langType language)
 	                               "^[[({]",
 	                               "", "", "{tenter=skipPair}", NULL);
 	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
+	                               "^[df-hkm-qt-z][a-zA-Z0-9_]*",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "configElt",
 	                               "^(jar|executable|shared_module|(both_|shared_|static_)?library)[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\3", "B", "{tenter=skipToArgEnd}", NULL);
 	addLanguageTagMultiTableRegex (language, "configElt",
@@ -496,21 +523,15 @@ static void initializeMesonParser (const langType language)
 		"   % The configElt table refers to the cork index pushed by this table\n"
 		"   % for filling the scope of cfgvar/C tags.\n"
 		"}}", NULL);
-	addLanguageTagMultiTableRegex (language, "configElt",
-	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
-	                               "", "", ""
-		"{{\n"
-		"   cfgdict \\1 known {\n"
-		"      \\4 /cfgvar @4 _tag _commit\n"
-		"      cfgdict \\1 get scope:\n"
-		"   } if\n"
-		"}}", NULL);
 	addLanguageTagMultiTableRegex (language, "configValue",
 	                               "^,",
 	                               "", "", "{tjump=configElt}", NULL);
 	addLanguageTagMultiTableRegex (language, "configValue",
 	                               "^\\}",
 	                               "", "", "{_advanceTo=0start}{tleave}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^[])}]",
+	                               "", "", "{tleave}", NULL);
 	addLanguageTagMultiTableRegex (language, "configValue",
 	                               "^[ \t\n]+",
 	                               "", "", "", NULL);
@@ -527,6 +548,18 @@ static void initializeMesonParser (const langType language)
 	                               "^[[({]",
 	                               "", "", "{tenter=skipPair}", NULL);
 	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
+	                               "", "", ""
+		"{{\n"
+		"   cfgdict \\1 known {\n"
+		"      \\4 /cfgvar @4 _tag _commit\n"
+		"      cfgdict \\1 get scope:\n"
+		"   } if\n"
+		"}}", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
+	                               "^[df-hkm-qt-z][a-zA-Z0-9_]*",
+	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "configValue",
 	                               "^(jar|executable|shared_module|(both_|shared_|static_)?library)[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*",
 	                               "\\3", "B", "{tenter=skipToArgEnd}", NULL);
 	addLanguageTagMultiTableRegex (language, "configValue",
@@ -569,18 +602,6 @@ static void initializeMesonParser (const langType language)
 		"   % The configElt table refers to the cork index pushed by this table\n"
 		"   % for filling the scope of cfgvar/C tags.\n"
 		"}}", NULL);
-	addLanguageTagMultiTableRegex (language, "configValue",
-	                               "^([a-zA-Z_][a-zA-Z0-9_]*)\\.(set(_quoted|10)?)[ \t\n]*\\('([^']*[^\\\\])'[ \t\n]*",
-	                               "", "", ""
-		"{{\n"
-		"   cfgdict \\1 known {\n"
-		"      \\4 /cfgvar @4 _tag _commit\n"
-		"      cfgdict \\1 get scope:\n"
-		"   } if\n"
-		"}}", NULL);
-	addLanguageTagMultiTableRegex (language, "configValue",
-	                               "^[])}]",
-	                               "", "", "{tleave}", NULL);
 	addLanguageTagMultiTableRegex (language, "configValue",
 	                               "^.",
 	                               "", "", "", NULL);

--- a/optlib/meson.ctags
+++ b/optlib/meson.ctags
@@ -45,6 +45,9 @@
 --_tabledef-Meson=skipPair
 --_tabledef-Meson=common
 --_tabledef-Meson=skipToArgEnd
+--_tabledef-Meson=configBody
+--_tabledef-Meson=configElt
+--_tabledef-Meson=configValue
 
 --_prelude-Meson={{
     /lastvar false def
@@ -76,20 +79,33 @@
 --_mtable-regex-Meson=common/(alias|run)_target[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\2/r/{tenter=skipToArgEnd}
 --_mtable-regex-Meson=common/benchmark[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/b/{tenter=skipToArgEnd}
 --_mtable-regex-Meson=common/import[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/m/{tenter=skipToArgEnd}{_role=imported}
---_mtable-regex-Meson=common/configuration_data[ \t\n]*\([ \t\n]*\)[ \t\n]*//{{
+
+--_mtable-regex-Meson=common/(configuration_data)[ \t\n]*\([ \t\n]*//{tenter=configBody}{{
    lastvar false ne {
       lastvar :name
       /cfgdata
       lastvar _tagloc
       _tag _commit
 
+      % Keep the newly created /cfgdata tag on the stack
+      % till leaving /configBody table.
+      dup
+
       cfgdict lastvar :name 3 -1 roll put
 
       % Don't emit the tag for the original variable.
       lastvar _markplaceholder
       /lastvar false def
-   } if
+   } {
+      % Looks broken input. There is no left side for the configuration_data(...).
+      % Push a dummy tag.
+      (cfg) /cfgdata _anongen /cfgdata @1 _tag _commit
+      dup /anonymous _markextra
+   } ifelse
+   % The configElt table refers to the cork index pushed by this table
+   % for filling the scope of cfgvar/C tags.
 }}
+
 --_mtable-regex-Meson=common/([a-zA-Z_][a-zA-Z0-9_]*)\.(set(_quoted|10)?)[ \t\n]*\('([^']*[^\\])'[ \t\n]*//{{
    cfgdict \1 known {
       \4 /cfgvar @4 _tag _commit
@@ -102,6 +118,24 @@
 --_mtable-regex-Meson=skipPair/.//
 
 --_mtable-extend-Meson=skipToArgEnd+skipPair
+
+--_mtable-regex-Meson=configBody/\{//{tenter=configElt}
+--_mtable-regex-Meson=configBody/\)//{tleave}{{
+    pop
+}}
+--_mtable-extend-Meson=configBody+common
+
+--_mtable-regex-Meson=configElt/'([^']+)'[ \t\n]*:/\1/C/{tenter=configValue}{{
+    count 1 ge {
+       dup . exch scope:
+    } if
+}}
+--_mtable-regex-Meson=configElt/\}//{tleave}
+--_mtable-extend-Meson=configElt+common
+
+--_mtable-regex-Meson=configValue/,//{tjump=configElt}
+--_mtable-regex-Meson=configValue/\}//{_advanceTo=0start}{tleave}
+--_mtable-extend-Meson=configValue+skipToArgEnd
 
 --_mtable-extend-Meson=main+common
 --_mtable-regex-Meson=main/project[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/P/{tenter=skipToArgEnd}

--- a/optlib/meson.ctags
+++ b/optlib/meson.ctags
@@ -61,8 +61,8 @@
 --_mtable-regex-Meson=comment/\n//{tleave}
 
 --_mtable-regex-Meson=string/[^\\']+//
---_mtable-regex-Meson=string/\\.//
 --_mtable-regex-Meson=string/'//{tleave}
+--_mtable-regex-Meson=string/\\.//
 --_mtable-regex-Meson=string/.//
 
 --_mtable-regex-Meson=mline_string/'''//{tleave}
@@ -74,6 +74,20 @@
 --_mtable-regex-Meson=common/'''//{tenter=mline_string}
 --_mtable-regex-Meson=common/'//{tenter=string}
 --_mtable-regex-Meson=common/[[({]//{tenter=skipPair}
+--_mtable-regex-Meson=common/([a-zA-Z_][a-zA-Z0-9_]*)\.(set(_quoted|10)?)[ \t\n]*\('([^']*[^\\])'[ \t\n]*//{{
+   cfgdict \1 known {
+      \4 /cfgvar @4 _tag _commit
+      cfgdict \1 get scope:
+   } if
+}}
+
+#
+# Skip an unintersting token for optimization
+# ./ctags -o -  /home/yamato/backup/var/util-linux/util-linux-2.41.devel-232-07aac-dirty/meson.build > /dev/null 2> /tmp/logf  0.46s user 0.01s system 97% cpu 0.483 total
+# => ./ctags -o -  /home/yamato/backup/var/util-linux/util-linux-2.41.devel-232-07aac-dirty/meson.build > /dev/null 2> /tmp/logf  0.19s user 0.01s system 97% cpu 0.209 total
+#
+--_mtable-regex-Meson=common/[df-hkm-qt-z][a-zA-Z0-9_]*//
+
 --_mtable-regex-Meson=common/(jar|executable|shared_module|(both_|shared_|static_)?library)[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\3/B/{tenter=skipToArgEnd}
 --_mtable-regex-Meson=common/custom_target[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/c/{tenter=skipToArgEnd}
 --_mtable-regex-Meson=common/(alias|run)_target[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\2/r/{tenter=skipToArgEnd}
@@ -106,15 +120,8 @@
    % for filling the scope of cfgvar/C tags.
 }}
 
---_mtable-regex-Meson=common/([a-zA-Z_][a-zA-Z0-9_]*)\.(set(_quoted|10)?)[ \t\n]*\('([^']*[^\\])'[ \t\n]*//{{
-   cfgdict \1 known {
-      \4 /cfgvar @4 _tag _commit
-      cfgdict \1 get scope:
-   } if
-}}
-
---_mtable-extend-Meson=skipPair+common
 --_mtable-regex-Meson=skipPair/[])}]//{tleave}
+--_mtable-extend-Meson=skipPair+common
 --_mtable-regex-Meson=skipPair/.//
 
 --_mtable-extend-Meson=skipToArgEnd+skipPair
@@ -137,11 +144,11 @@
 --_mtable-regex-Meson=configValue/\}//{_advanceTo=0start}{tleave}
 --_mtable-extend-Meson=configValue+skipToArgEnd
 
---_mtable-extend-Meson=main+common
---_mtable-regex-Meson=main/project[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/P/{tenter=skipToArgEnd}
---_mtable-regex-Meson=main/subdir[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/S/{tenter=skipToArgEnd}
---_mtable-regex-Meson=main/test[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/t/{tenter=skipToArgEnd}
 --_mtable-regex-Meson=main/([a-zA-Z_][a-zA-Z_0-9]*)[ \t\n]*=([^=]|$)/\1/V/{_advanceTo=2start}{{
    /lastvar . def
 }}
+--_mtable-regex-Meson=main/project[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/P/{tenter=skipToArgEnd}
+--_mtable-regex-Meson=main/subdir[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/S/{tenter=skipToArgEnd}
+--_mtable-regex-Meson=main/test[ \t\n]*\([ \t\n]*'([^']*[^\\])'[ \t\n]*/\1/t/{tenter=skipToArgEnd}
+--_mtable-extend-Meson=main+common
 --_mtable-regex-Meson=main/.//


### PR DESCRIPTION
I should pull this request into two.

(
This random should be removed from here:
```
input : "\n" L3781
match :'\n'            main[ 0] / ^([a-zA-Z_][a-zA-Z_0-9]*)[ \t\n]*=([^=]|$)/
match :'\n'            main[ 1] / ^project[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*/
match :'\n'            main[ 2] / ^subdir[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*/
match :'\n'            main[ 3] / ^test[ \t\n]*\\([ \t\n]*'([^']*[^\\\\])'[ \t\n]*/
match :'\n'            main[ 4] / ^[ \t\n]+/

...                   TABLE[ N] ...
result: matched 1 bytes
scope : 
action: NOP in {main}, stack: /
```

It would be helpful for optimization if ctags could report per-TABLE statistics (average N, s.d. N, max N).
)