### PR TITLE
GitHub Actions: remove windows-19 due to it began deprecation on 2025-06-01 and will be fully unsupported by 2025-06-30

### DIFF
--- a/.github/workflows/building-with-nmake.yml
+++ b/.github/workflows/building-with-nmake.yml
@@ -10,8 +10,9 @@ jobs:
   test:
 
     strategy:
+      fail-fast: false
       matrix:
-        version: [2022, 2019]
+        version: [2022]
         arch: [x64, x86]
 
     runs-on: windows-${{ matrix.version }}


### PR DESCRIPTION

Reference: https://github.com/actions/runner-images/issues/12045