### PR TITLE
Tcl: consider escaping with backslash chars when reading an identifier

### DIFF
--- a/Units/parser-tcl.r/escaping.d/expected.tags
+++ b/Units/parser-tcl.r/escaping.d/expected.tags
@@ -1,2 +1,4 @@
+a	input-0.tcl	/^proc a {} {set quotedText a\\"}$/;"	p
+b	input-0.tcl	/^proc b {} {}$/;"	p
 proc1	input.tcl	/^proc proc1 {} {$/;"	p
 proc2	input.tcl	/^proc proc2  {} {}$/;"	p

--- a/Units/parser-tcl.r/escaping.d/input-0.tcl
+++ b/Units/parser-tcl.r/escaping.d/input-0.tcl
@@ -1,0 +1,3 @@
+proc a {} {set quotedText a\"}
+proc b {} {}
+# Taken from the issue #4283 submitted by @torstenberg.

--- a/parsers/tcl.c
+++ b/parsers/tcl.c
@@ -174,11 +174,25 @@ static void readString (vString *string)
 
 static void readIdentifier (vString *string)
 {
+	bool seen_backslash = false;
+
 	while (1)
 	{
 		int c = getcFromInputFile ();
-		if (isgraph (c) && (!strchr ("{}[]\"", c)))
+		if (c == EOF)
+			break;
+
+		if (c == '\\')
+		{
 			vStringPut (string, c);
+			seen_backslash = true;
+		}
+		else if (isgraph (c) &&
+				 (seen_backslash ||  (!strchr ("{}[]\"", c))))
+		{
+			vStringPut (string, c);
+			seen_backslash = false;
+		}
 		else
 		{
 			ungetcToInputFile (c);


### PR DESCRIPTION
Fix #4283