### PR TITLE
verilog: map .vh to Verilog (#4301)

### DIFF
--- a/docs/man/ctags-lang-verilog.7.rst
+++ b/docs/man/ctags-lang-verilog.7.rst
@@ -21,7 +21,7 @@ SYNOPSIS
     +===============+===============+===================+
     | SystemVerilog | SystemVerilog | .sv, .svh, svi    |
     +---------------+---------------+-------------------+
-    | Verilog       | Verilog       | .v                |
+    | Verilog       | Verilog       | .v, .vh           |
     +---------------+---------------+-------------------+
 
 DESCRIPTION
@@ -204,6 +204,7 @@ Change since "0.0"
 ~~~~~~~~~~~~~~~~~~
 
 * New kind ``define``
+* map ``.vh`` to Verilog
 
 SEE ALSO
 --------

--- a/docs/man/ctags-lang-verilog.7.rst
+++ b/docs/man/ctags-lang-verilog.7.rst
@@ -190,7 +190,7 @@ TIPS
 ~~~~
 
 If you want to map files ``*.v`` to SystemVerilog, add
-``--langmap=SystemVerilog:.v`` option.
+``--map-SystemVerilog=+.v`` option.
 
 KNOWN ISSUES
 ---------------------------------------------------------------------

--- a/man/ctags-lang-verilog.7.rst.in
+++ b/man/ctags-lang-verilog.7.rst.in
@@ -21,7 +21,7 @@ SYNOPSIS
     +===============+===============+===================+
     | SystemVerilog | SystemVerilog | .sv, .svh, svi    |
     +---------------+---------------+-------------------+
-    | Verilog       | Verilog       | .v                |
+    | Verilog       | Verilog       | .v, .vh           |
     +---------------+---------------+-------------------+
 
 DESCRIPTION
@@ -204,6 +204,7 @@ Change since "0.0"
 ~~~~~~~~~~~~~~~~~~
 
 * New kind ``define``
+* map ``.vh`` to Verilog
 
 SEE ALSO
 --------

--- a/man/ctags-lang-verilog.7.rst.in
+++ b/man/ctags-lang-verilog.7.rst.in
@@ -190,7 +190,7 @@ TIPS
 ~~~~
 
 If you want to map files ``*.v`` to SystemVerilog, add
-``--langmap=SystemVerilog:.v`` option.
+``--map-SystemVerilog=+.v`` option.
 
 KNOWN ISSUES
 ---------------------------------------------------------------------

--- a/parsers/verilog.c
+++ b/parsers/verilog.c
@@ -2193,7 +2193,7 @@ static void findVerilogTags (void)
 
 extern parserDefinition* VerilogParser (void)
 {
-	static const char *const extensions [] = { "v", NULL };
+	static const char *const extensions [] = { "v", "vh", NULL };
 	parserDefinition* def = parserNew ("Verilog");
 	static selectLanguage selectors[] = { selectVOrVerilogByKeywords, NULL };
 	def->versionCurrent = 1;


### PR DESCRIPTION
fix for #4301,

In addition to above use `--map-SystemVerilog` instead of `--langmap=SystemVerilog` in man page.