### PR TITLE
C#: extract methods having nullable parameters

### DIFF
--- a/Units/parser-csharp.r/nullable-parameters.d/args.ctags
+++ b/Units/parser-csharp.r/nullable-parameters.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--fields=+{signature}

--- a/Units/parser-csharp.r/nullable-parameters.d/expected.tags
+++ b/Units/parser-csharp.r/nullable-parameters.d/expected.tags
@@ -1,0 +1,2 @@
+Foo	input.cs	/^public class Foo$/;"	c
+Bar	input.cs	/^    public void Bar(decimal? p)$/;"	m	class:Foo	signature:(decimal? p)

--- a/Units/parser-csharp.r/nullable-parameters.d/input.cs
+++ b/Units/parser-csharp.r/nullable-parameters.d/input.cs
@@ -1,0 +1,6 @@
+public class Foo
+{
+    public void Bar(decimal? p)
+    {
+    }
+}

--- a/docs/news/HEAD.rst
+++ b/docs/news/HEAD.rst
@@ -20,6 +20,11 @@ JavaScript:
       member of a class is static.
     * Class member names prefixed with # are recognized as private.
 
+C#:
+
+    * Fix a bug that prevents the parser from extracting methods
+	  if the method has nullable parameters.
+
 New parsers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The following parsers have been added:

--- a/parsers/c-based.c
+++ b/parsers/c-based.c
@@ -2385,6 +2385,14 @@ static int parseParens (statementInfo *const st, parenInfo *const info)
 					++depth;
 				break;
 
+			case '?':
+				if (isInputLanguage (Lang_csharp))
+				{
+					/* C# uses '?' at the end of type name for
+					 * representing nullable parameter. */
+					break;
+				}
+				/* FALLTHROUGH */
 			default:
 				if (c == '@' && (isInputLanguage (Lang_d) || isInputLanguage (Lang_java)))
 				{


### PR DESCRIPTION
Fix https://github.com/universal-ctags/ctags/issues/4304.