### PR TITLE
Remove OpenBSD 7.6 from build matrix

### DIFF
--- a/.github/workflows/cross-compile-for-openbsd-on-ubuntu.yml
+++ b/.github/workflows/cross-compile-for-openbsd-on-ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        openbsd-release-version: ['7.7', '7.6']
+        openbsd-release-version: ['7.7']
         # https://cdn.openbsd.org/pub/OpenBSD/
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
OpenBSD 7.6 was removed from the openbsd cdn causing a failure in CI.
Can switch to a different CDN like planetunix.net