### PR TITLE
Remove the errno numeric value from json perror

### DIFF
--- a/Tmain/interactive-mode.d/stdout-expected.txt
+++ b/Tmain/interactive-mode.d/stdout-expected.txt
@@ -15,7 +15,7 @@ error on missing arguments
 error on invalid file
 =======================================
 {"_type": "program", "name": "Universal Ctags"}
-{"_type": "error", "message": "cannot open input file \"test.foo\"", "warning": true, "errno": 2, "perror": "No such file or directory"}
+{"_type": "error", "message": "cannot open input file \"test.foo\"", "warning": true, "perror": "No such file or directory"}
 {"_type": "completed", "command": "generate-tags"}
 
 generate tags from file

--- a/main/error.c
+++ b/main/error.c
@@ -89,7 +89,6 @@ bool jsonErrorPrinter (const errorSelection selection, const char *const format,
 		json_object_set_new (response, "fatal", json_true ());
 	if (selected (selection, PERROR))
 	{
-		json_object_set_new (response, "errno", json_integer (errno));
 		json_object_set_new (response, "perror", json_string (strerror (errno)));
 	}
 	json_dumpf (response, stdout, JSON_PRESERVE_ORDER);


### PR DESCRIPTION
The numeric value of errno is not standardized,
and comparing it to an expected value is not portable.

In particular, this fails on gnu/hurd, where ENOENT value is `0x40000002`