### PR TITLE
Tmain: don't compare the errno numeric when testing the json writer

### DIFF
--- a/Tmain/interactive-mode.d/run.sh
+++ b/Tmain/interactive-mode.d/run.sh
@@ -12,6 +12,12 @@ s()
 	sed -e s/':"'/': "'/g | jdropver
 }
 
+trim_errno()
+{
+	# The value errno depends on the platform.
+	sed -e s/' "errno": [0-9]*,'//
+}
+
 CTAGS="$CTAGS --options=NONE"
 
 echo identification message on startup
@@ -31,7 +37,7 @@ echo '{"command":"generate-tags"}' | ${CTAGS} --_interactive |s
 echo
 echo error on invalid file
 echo =======================================
-echo '{"command":"generate-tags", "filename":"test.foo"}' | ${CTAGS} --_interactive |s
+echo '{"command":"generate-tags", "filename":"test.foo"}' | ${CTAGS} --_interactive |s |trim_errno
 
 echo
 echo generate tags from file

--- a/Tmain/interactive-mode.d/stdout-expected.txt
+++ b/Tmain/interactive-mode.d/stdout-expected.txt
@@ -15,7 +15,7 @@ error on missing arguments
 error on invalid file
 =======================================
 {"_type": "program", "name": "Universal Ctags"}
-{"_type": "error", "message": "cannot open input file \"test.foo\"", "warning": true, "errno": 2, "perror": "No such file or directory"}
+{"_type": "error", "message": "cannot open input file \"test.foo\"", "warning": true, "perror": "No such file or directory"}
 {"_type": "completed", "command": "generate-tags"}
 
 generate tags from file


### PR DESCRIPTION
Fixes #4331

Quoted from #4331 submitted by Olivier Valentin:

    The numeric value of errno is not standardized,
    and comparing it to an expected value is not portable.

    In particular, this fails on gnu/hurd, where ENOENT value is 0x40000002