### PR TITLE
cosmetic: gitignore packcc.dSYM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /Makefile
 /packcc
 /packcc.exe
+/packcc.dSYM
 .cache
 .deps
 .dirstamp


### PR DESCRIPTION
packcc.dSYM is generated during compile in OSX