### PR TITLE
Python: parse simple type statements

### DIFF
--- a/parsers/python.c
+++ b/parsers/python.c
@@ -47,6 +47,7 @@ enum {
 	KEYWORD_lambda,
 	KEYWORD_pass,
 	KEYWORD_return,
+	KEYWORD_type,
 	KEYWORD_REST
 };
 typedef int keywordId; /* to allow KEYWORD_NONE */
@@ -157,6 +158,7 @@ static const keywordTable PythonKeywordTable[] = {
 	{ "lambda",			KEYWORD_lambda			},
 	{ "pass",			KEYWORD_pass			},
 	{ "return",			KEYWORD_return			},
+	{ "type",			KEYWORD_type			},  /* not a real keyword */
 };
 
 /* Taken from https://docs.python.org/3/reference/lexical_analysis.html#keywords */
@@ -1767,6 +1769,11 @@ static void findPythonTags (void)
 
 		/* skip async keyword that confuses decorator parsing before a def */
 		if (token->keyword == KEYWORD_async)
+			readToken (token);
+
+		/* skip type soft keyword that precedes type assignments and treat the
+		 * rest as a simple variable assignment */
+		if (token->keyword == KEYWORD_type)
 			readToken (token);
 
 		if (token->type == TOKEN_INDENT)


### PR DESCRIPTION
Recognizes and skip 'type' at the beginning of a statement, and then proceed to parse the rest as a simple variable assignment.  This works fine for simple types like

    type MyList = list[str]

Partially fixes #4351.

It doesn't work with parameters like

    type MyList[T] = list[T]

but this is low priority for me, as I don't have any code using those (yet?), and I'm not used to working in C.

A proper solution would also generate different kind for type statements, instead of treating them like simple variable assignments.