### PR TITLE
C++: (bugfix) use the root scope representation of a lambda in enum {}

### DIFF
--- a/Units/parser-cxx.r/scope-of-using-in-lambda-in-enum.d/args.ctags
+++ b/Units/parser-cxx.r/scope-of-using-in-lambda-in-enum.d/args.ctags
@@ -1,0 +1,2 @@
+--sort=no
+--extras=+q

--- a/Units/parser-cxx.r/scope-of-using-in-lambda-in-enum.d/expected.tags
+++ b/Units/parser-cxx.r/scope-of-using-in-lambda-in-enum.d/expected.tags
@@ -1,0 +1,5 @@
+e	input.cpp	/^enum e {$/;"	g	file:
+__anon92a0b9a90102	input.cpp	/^  x = [] {$/;"	f	enum:e	file:
+T3	input.cpp	/^    using T3 = int;$/;"	t	function:e::__anon92a0b9a90102	typeref:typename:int	file:
+x	input.cpp	/^  x = [] {$/;"	e	enum:e	file:
+main	input.cpp	/^int main(void)$/;"	f	typeref:typename:int

--- a/Units/parser-cxx.r/scope-of-using-in-lambda-in-enum.d/input.cpp
+++ b/Units/parser-cxx.r/scope-of-using-in-lambda-in-enum.d/input.cpp
@@ -1,0 +1,12 @@
+enum e {
+  x = [] {
+    using T3 = int;
+    return 1;
+  }()
+};
+
+
+int main(void)
+{
+  return e::x;
+}

--- a/Units/parser-cxx.r/scope-of-using-in-lambda-in-enum.d/validator
+++ b/Units/parser-cxx.r/scope-of-using-in-lambda-in-enum.d/validator
@@ -1,0 +1,1 @@
+cxx20+module

--- a/parsers/cxx/cxx_tag.c
+++ b/parsers/cxx/cxx_tag.c
@@ -803,7 +803,7 @@ int cxxTagCommit(int *piCorkQueueIndexFQ)
 		// If the scope kind is enumeration then we need to remove the
 		// last scope part. This is what old ctags did.
 		if(cxxScopeGetSize() < 2)
-			return -1; // toplevel enum
+			return CORK_NIL; // toplevel enum
 
 		x = cxxScopeGetFullNameExceptLastComponentAsString();
 		CXX_DEBUG_ASSERT(x,"Scope with size >= 2 should have returned a value here");


### PR DESCRIPTION
Fixes #4363.

The original code used -1 to specify the root scope. Assigning -1 as a scope index  caused a crash as reported in #4363.