### PR TITLE
sinex : unnamed blocks discarding

### DIFF
--- a/parsers/sinex.c
+++ b/parsers/sinex.c
@@ -70,8 +70,10 @@ static void findSinexTags (void)
 		if (line[0] == '+')
 		{
 			blockNameCopy(blockNameStart, (const char *)line);
-			initTagEntry (&e, (const char * const)blockNameStart, K_BLOCK);
-			inBlock = true ;
+			if (strlen(blockNameStart) > 0) {
+				initTagEntry (&e, (const char * const)blockNameStart, K_BLOCK);
+				inBlock = true ;
+			}
 		} 
 		else if (inBlock && (line[0] == '-'))
 		{


### PR DESCRIPTION
Unnamed SINEX blocks are no longer processed, otherwise a (non fatal) error message shows up in geany