### PR TITLE
html: Do not parse comments in JSX mode

### DIFF
--- a/Units/parser-html.r/comment-in-js.d/args.ctags
+++ b/Units/parser-html.r/comment-in-js.d/args.ctags
@@ -1,0 +1,3 @@
+--sort=no
+--fields=+l
+--extras=+g

--- a/Units/parser-html.r/comment-in-js.d/expected.tags
+++ b/Units/parser-html.r/comment-in-js.d/expected.tags
@@ -1,0 +1,5 @@
+simple_anchor	input.html	/^  <a name="simple_anchor"><\/a>$/;"	a	language:HTML
+unquoted_anchor	input.html	/^  <a name=unquoted_anchor><\/a>$/;"	a	language:HTML
+prefixed_anchor	input.html	/^  <a title="Title" name="prefixed_anchor"><\/a>$/;"	a	language:HTML
+postfixed_anchor	input.html	/^  <a name=postfixed_anchor href="http:\/\/darrenhiebert.com"><\/a>$/;"	a	language:HTML
+message	input.html	/^function message()$/;"	f	language:JavaScript

--- a/Units/parser-html.r/comment-in-js.d/input.html
+++ b/Units/parser-html.r/comment-in-js.d/input.html
@@ -1,0 +1,29 @@
+<html >
+<head>
+<script language="Javascript" src="./test.js"></script> 
+<script language="JavaScript">
+<!--
+
+//	function commented_function1 () {}
+/* 
+	function commented_function2 () {} 
+*/
+
+function message()
+{
+      alert( "Hello.");     
+}
+
+//-->
+</script>
+<body>
+  <a name="simple_anchor"></a>
+  <a name=unquoted_anchor></a>
+  <a title="Title" name="prefixed_anchor"></a>
+  <a name=postfixed_anchor href="http://darrenhiebert.com"></a>
+  <!-- <a name="commented_anchor"></a> -->
+</body>
+</html>
+
+
+

--- a/parsers/html.c
+++ b/parsers/html.c
@@ -334,23 +334,26 @@ getNextChar:
 					d = getcFromInputFile ();
 					if (d == '-')
 					{
-						int e = ' ';
-						int f = ' ';
-						do
+						/* JSX does not support HTML comments, so don't skip
+						 * over them */
+						if (!asJSX)
 						{
-							d = e;
-							e = f;
-							f = getcFromInputFile ();
-						}
-						while (f != EOF && ! (d == '-' && e == '-' && f == '>'));
+							int e = ' ';
+							int f = ' ';
+							do
+							{
+								d = e;
+								e = f;
+								f = getcFromInputFile ();
+							}
+							while (f != EOF && ! (d == '-' && e == '-' && f == '>'));
 
-						if (skipComments)
-							goto getNextChar;
-						else
-						{
-							token->type = TOKEN_COMMENT;
-							break;
+							if (skipComments)
+								goto getNextChar;
 						}
+
+						token->type = TOKEN_COMMENT;
+						break;
 					}
 				}
 				ungetcToInputFile (d);
@@ -843,7 +846,7 @@ extern void htmlParseJSXElement (void)
 		tokenInfo token;
 		token.string = vStringNew ();
 
-		readToken (&token, true, true);
+		readToken (&token, false, true);
 		if (token.type == TOKEN_OPEN_TAG_START)
 			readTag (&token, NULL, 0, true);
 


### PR DESCRIPTION
JSX doesn't support XML comments, and their presence can prevent further parsing of JS code.

Fixes #4373.