### PR TITLE
jscript: Split JSX out of the JavaScript parser

### DIFF
--- a/Tmain/list-fields-with-prefix.d/stdout-expected.txt
+++ b/Tmain/list-fields-with-prefix.d/stdout-expected.txt
@@ -33,6 +33,7 @@ x       UCTAGSxpath          no      NONE             s--    no    --   0 xpath 
 -       UCTAGSpackageName    yes     Go               s--    no    --   0 the name for referring the package
 -       UCTAGSreceiver       no      Go               s--    no    --   1 the name of the receiver
 -       UCTAGSimplements     yes     Inko             s--    no    rw   0 Trait being implemented
+-       UCTAGSproperties     no      JSX              s--    no    --   2 properties (static)
 -       UCTAGSproperties     no      JavaScript       s--    no    --   2 properties (static)
 -       UCTAGSassignment     yes     LdScript         s--    no    --   0 how a value is assigned to the symbol
 -       UCTAGSdefiner        yes     Lisp             s--    no    --   1 the name of the function or macro that defines the unknown/Y-kind object

--- a/Tmain/list-fields.d/stdout-expected.txt
+++ b/Tmain/list-fields.d/stdout-expected.txt
@@ -51,6 +51,7 @@ z	kind	no	NONE	s--	no	r-	0	[tags output] prepend "kind:" to k/ (or K/) field out
 -	packageName	yes	Go	s--	no	--	0	the name for referring the package
 -	receiver	no	Go	s--	no	--	1	the name of the receiver
 -	implements	yes	Inko	s--	no	rw	0	Trait being implemented
+-	properties	no	JSX	s--	no	--	2	properties (static)
 -	properties	no	JavaScript	s--	no	--	2	properties (static)
 -	assignment	yes	LdScript	s--	no	--	0	how a value is assigned to the symbol
 -	definer	yes	Lisp	s--	no	--	1	the name of the function or macro that defines the unknown/Y-kind object

--- a/Tmain/list-roles.d/stdout-expected.txt
+++ b/Tmain/list-roles.d/stdout-expected.txt
@@ -67,6 +67,9 @@ Go                      p/package         imported           on        0 importe
 HTML                    C/stylesheet      extFile            on        0 referenced as external files
 HTML                    J/script          extFile            on        0 referenced as external files
 HTML                    c/class           attribute          on        0 assigned as attributes
+JSX                     c/class           chainElt           off       0 (EXPERIMENTAL)used as an element in a name chain like a.b.c
+JSX                     f/function        foreigndecl        on        1 declared in foreign languages
+JSX                     v/variable        chainElt           off       0 (EXPERIMENTAL)used as an element in a name chain like a.b.c
 Java                    p/package         imported           on        0 imported package
 JavaScript              c/class           chainElt           off       0 (EXPERIMENTAL)used as an element in a name chain like a.b.c
 JavaScript              f/function        foreigndecl        on        1 declared in foreign languages
@@ -220,6 +223,9 @@ Go                      p/package         imported           on        0 importe
 HTML                    C/stylesheet      extFile            on        0 referenced as external files
 HTML                    J/script          extFile            on        0 referenced as external files
 HTML                    c/class           attribute          on        0 assigned as attributes
+JSX                     c/class           chainElt           off       0 (EXPERIMENTAL)used as an element in a name chain like a.b.c
+JSX                     f/function        foreigndecl        on        1 declared in foreign languages
+JSX                     v/variable        chainElt           off       0 (EXPERIMENTAL)used as an element in a name chain like a.b.c
 Java                    p/package         imported           on        0 imported package
 JavaScript              c/class           chainElt           off       0 (EXPERIMENTAL)used as an element in a name chain like a.b.c
 JavaScript              f/function        foreigndecl        on        1 declared in foreign languages

--- a/Units/parser-javascript.r/simple-jsx-no-guest.d/expected.tags
+++ b/Units/parser-javascript.r/simple-jsx-no-guest.d/expected.tags
@@ -1,8 +1,8 @@
-foo	input.jsx	/^function foo() {$/;"	f	language:JavaScript	roles:def
-Comp1	input-0.jsx	/^const Comp1 = () => {$/;"	f	language:JavaScript	roles:def
-x	input-0.jsx	/^    const x = (arg) => console.log(arg)$/;"	f	language:JavaScript	function:Comp1	roles:def
-Comp2	input-0.jsx	/^const Comp2 = (props) => {$/;"	f	language:JavaScript	roles:def
-Comp3	input-0.jsx	/^const Comp3 = (str) => {$/;"	f	language:JavaScript	roles:def
-Comp4	input-0.jsx	/^const Comp4 = (str) => {$/;"	f	language:JavaScript	roles:def
-Comp5	input-0.jsx	/^const Comp5 = (str) => {$/;"	f	language:JavaScript	roles:def
-z0	input-0.jsx	/^var z0$/;"	v	language:JavaScript	roles:def
+foo	input.jsx	/^function foo() {$/;"	f	language:JSX	roles:def
+Comp1	input-0.jsx	/^const Comp1 = () => {$/;"	f	language:JSX	roles:def
+x	input-0.jsx	/^    const x = (arg) => console.log(arg)$/;"	f	language:JSX	function:Comp1	roles:def
+Comp2	input-0.jsx	/^const Comp2 = (props) => {$/;"	f	language:JSX	roles:def
+Comp3	input-0.jsx	/^const Comp3 = (str) => {$/;"	f	language:JSX	roles:def
+Comp4	input-0.jsx	/^const Comp4 = (str) => {$/;"	f	language:JSX	roles:def
+Comp5	input-0.jsx	/^const Comp5 = (str) => {$/;"	f	language:JSX	roles:def
+z0	input-0.jsx	/^var z0$/;"	v	language:JSX	roles:def

--- a/Units/parser-javascript.r/simple-jsx.d/expected.tags
+++ b/Units/parser-javascript.r/simple-jsx.d/expected.tags
@@ -1,13 +1,13 @@
-foo	input.jsx	/^function foo() {$/;"	f	language:JavaScript	roles:def
-Comp1	input-0.jsx	/^const Comp1 = () => {$/;"	f	language:JavaScript	roles:def
-x	input-0.jsx	/^    const x = (arg) => console.log(arg)$/;"	f	language:JavaScript	function:Comp1	roles:def
-Comp2	input-0.jsx	/^const Comp2 = (props) => {$/;"	f	language:JavaScript	roles:def
-Comp3	input-0.jsx	/^const Comp3 = (str) => {$/;"	f	language:JavaScript	roles:def
+foo	input.jsx	/^function foo() {$/;"	f	language:JSX	roles:def
+Comp1	input-0.jsx	/^const Comp1 = () => {$/;"	f	language:JSX	roles:def
+x	input-0.jsx	/^    const x = (arg) => console.log(arg)$/;"	f	language:JSX	function:Comp1	roles:def
+Comp2	input-0.jsx	/^const Comp2 = (props) => {$/;"	f	language:JSX	roles:def
+Comp3	input-0.jsx	/^const Comp3 = (str) => {$/;"	f	language:JSX	roles:def
 hello	input-0.jsx	/^	       <h1>hello<\/h1>$/;"	h	language:HTML	roles:def
 bye	input-0.jsx	/^	       <h1>bye<\/h1>$/;"	h	language:HTML	roles:def
-Comp4	input-0.jsx	/^const Comp4 = (str) => {$/;"	f	language:JavaScript	roles:def
+Comp4	input-0.jsx	/^const Comp4 = (str) => {$/;"	f	language:JSX	roles:def
 bonjour	input-0.jsx	/^	       <h1>bonjour<\/h1>$/;"	h	language:HTML	roles:def
 frag ment	input-0.jsx	/^	       {<h2>frag{subtitle}ment<\/h2>}$/;"	i	language:HTML	roles:def
 au revoir	input-0.jsx	/^	       <h1>au revoir<\/h1>$/;"	h	language:HTML	roles:def
-Comp5	input-0.jsx	/^const Comp5 = (str) => {$/;"	f	language:JavaScript	roles:def
-z0	input-0.jsx	/^var z0$/;"	v	language:JavaScript	roles:def
+Comp5	input-0.jsx	/^const Comp5 = (str) => {$/;"	f	language:JSX	roles:def
+z0	input-0.jsx	/^var z0$/;"	v	language:JSX	roles:def

--- a/main/parsers_p.h
+++ b/main/parsers_p.h
@@ -122,6 +122,7 @@
 	JavaScriptParser, \
 	JNIParser, \
 	JsonParser, \
+	JsxParser, \
 	JuliaParser, \
 	KconfigParser, \
 	LdScriptParser, \


### PR DESCRIPTION
JSX doesn't support XML comments, and their presence can prevent further parsing of JS code embedded in HTML, which is more relaxed about them.

Fix this by separating the JSX from the regular JavaScript parser, as JSX is a JavaScript extension that is not meant to be standardized to JavaScript anyway.

Fixes #4373.