### PR TITLE
GitHub Actions: drop netbsd 9.2 in cross-compile-for--netbsd-on-ubuntu.yml

### DIFF
--- a/.github/workflows/cross-compile-for--netbsd-on-ubuntu.yml
+++ b/.github/workflows/cross-compile-for--netbsd-on-ubuntu.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        netbsd-release-version: ['10.1', '10.0', '9.4', '9.3', '9.2']
+        netbsd-release-version: ['10.1', '10.0', '9.4', '9.3']
         # https://ftp.netbsd.org/pub/NetBSD/
 
     runs-on: ubuntu-latest
@@ -36,14 +36,7 @@ jobs:
           for item in base comp
           do
             FILENAME="$item.tar.xz"
-
-            if [ "${{ matrix.netbsd-release-version }}" = '9.2' ] ; then
-              SERVER_URL='https://archive.netbsd.org/pub/NetBSD-archive'
-            else
-              SERVER_URL='https://ftp.netbsd.org/pub/NetBSD'
-            fi
-
-            curl -LO "$SERVER_URL/NetBSD-${{ matrix.netbsd-release-version }}/amd64/binary/sets/$FILENAME"
+            curl -LO "https://ftp.netbsd.org/pub/NetBSD/NetBSD-${{ matrix.netbsd-release-version }}/amd64/binary/sets/$FILENAME"
             tar vxf "$FILENAME" -C amd64-unknown-netbsd-sysroot
           done
 


### PR DESCRIPTION


https://archive.netbsd.org/pub/NetBSD-archive/NetBSD-9.2/amd64/binary/sets/base.tar.xz https://archive.netbsd.org/pub/NetBSD-archive/NetBSD-9.2/amd64/binary/sets/comp.tar.xz

It seems that these two resources can not be downloaded via curl directly.

NetBSD 9.2 has reached its end of life (EOL) since March 28, 2024.