### PR TITLE
Forth: fix for indentation

### DIFF
--- a/Units/parser-forth.r/simple-forth.d/expected.tags
+++ b/Units/parser-forth.r/simple-forth.d/expected.tags
@@ -1,9 +1,13 @@
 DUMMY1	input.fth	/^10 constant DUMMY1$/;"	c
 DUMMY2	input.fth	/^12 CONSTANT DUMMY2$/;"	c
+DUMMY_INDENTED	input.fth	/^  13 CONSTANT DUMMY_INDENTED$/;"	c
 dummy3	input.fth	/^variable dummy3$/;"	v
 dummy4	input.fth	/^variable dummy4$/;"	v
 dummy5	input.fth	/^VARIABLE dummy5$/;"	v
+dummy_indented2	input.fth	/^  VARIABLE dummy_indented2$/;"	v
+IN_ONE_LINE	input.fth	/^7 constant SEVERAL variable _DEFINITIONS : IN_ONE_LINE 7 emit ;$/;"	w
 fizz?	input.fth	/^: fizz?  \\ a simple comment $/;"	w
 buzz?	input.fth	/^: buzz?  $/;"	w
+baz_indented	input.fth	/^  : baz_indented ( - )$/;"	w
 fizz-buzz?	input.fth	/^: fizz-buzz?  $/;"	w
 do-fizz-buzz	input.fth	/^: do-fizz-buzz  $/;"	w

--- a/Units/parser-forth.r/simple-forth.d/expected.tags
+++ b/Units/parser-forth.r/simple-forth.d/expected.tags
@@ -7,3 +7,7 @@ fizz?	input.fth	/^: fizz?  \\ a simple comment $/;"	w
 buzz?	input.fth	/^: buzz?  $/;"	w
 fizz-buzz?	input.fth	/^: fizz-buzz?  $/;"	w
 do-fizz-buzz	input.fth	/^: do-fizz-buzz  $/;"	w
+DUMMY_INDENTED	input.fth	/^  13 CONSTANT DUMMY_INDENTED$/;"	c
+IN_ONE_LINE	input.fth	/^7 constant SEVERAL variable _DEFINITIONS : IN_ONE_LINE 7 emit ;$/;"	w
+baz_indented	input.fth	/^  : baz_indented ( - )$/;"	w
+dummy_indented2	input.fth	/^  VARIABLE dummy_indented2$/;"	v

--- a/Units/parser-forth.r/simple-forth.d/expected.tags
+++ b/Units/parser-forth.r/simple-forth.d/expected.tags
@@ -7,7 +7,3 @@ fizz?	input.fth	/^: fizz?  \\ a simple comment $/;"	w
 buzz?	input.fth	/^: buzz?  $/;"	w
 fizz-buzz?	input.fth	/^: fizz-buzz?  $/;"	w
 do-fizz-buzz	input.fth	/^: do-fizz-buzz  $/;"	w
-DUMMY_INDENTED	input.fth	/^  13 CONSTANT DUMMY_INDENTED$/;"	c
-IN_ONE_LINE	input.fth	/^7 constant SEVERAL variable _DEFINITIONS : IN_ONE_LINE 7 emit ;$/;"	w
-baz_indented	input.fth	/^  : baz_indented ( - )$/;"	w
-dummy_indented2	input.fth	/^  VARIABLE dummy_indented2$/;"	v

--- a/Units/parser-forth.r/simple-forth.d/input.fth
+++ b/Units/parser-forth.r/simple-forth.d/input.fth
@@ -5,18 +5,27 @@
 
 10 constant DUMMY1
 12 CONSTANT DUMMY2
-
+  13 CONSTANT DUMMY_INDENTED
+  
 variable dummy3
 variable dummy4
 VARIABLE dummy5
-
+  VARIABLE dummy_indented2
 11 dummy3 !
 13 dummy4 !
+42 dummy_indented2 !
+
+7 constant SEVERAL variable _DEFINITIONS : IN_ONE_LINE 7 emit ;
 
 : fizz?  \ a simple comment 
 3 mod 0 = dup if ." Fizz" then ;
 : buzz?  
 5 mod 0 = dup if ." Buzz" then ;
+  : baz_indented ( - )
+    10 0 do 
+      i . cr
+    loop ;
+\ colon : in comment
 
 : fizz-buzz?  
 dup fizz? swap buzz? or invert ;
@@ -26,6 +35,8 @@ dup fizz? swap buzz? or invert ;
 
 do-fizz-buzz
 cr
+baz_indented
+SEVERAL _DEFINITIONS ! IN_ONE_LINE
 
 quit
 \ bye

--- a/optlib/forth.c
+++ b/optlib/forth.c
@@ -46,11 +46,11 @@ extern parserDefinition* ForthParser (void)
 	static tagRegexTable ForthTagRegexTable [] = {
 		{"^[[:space:]]*\\\\.*", "",
 		"", "{exclusive}", NULL, false},
-		{"^:[[:space:]]+([^[:space:]]+)", "\\1",
+		{":[[:space:]]+([^[:space:]]+)", "\\1",
 		"w", "{exclusive}", NULL, false},
-		{"^variable[[:space:]]+([^[:space:]]+)", "\\1",
+		{"variable[[:space:]]+([^[:space:]]+)", "\\1",
 		"v", "{exclusive}{icase}", NULL, false},
-		{"^[[:alnum:]]+[[:space:]]+constant[[:space:]]+([^[:space:]]+)", "\\1",
+		{"[[:alnum:]]+[[:space:]]+constant[[:space:]]+([^[:space:]]+)", "\\1",
 		"c", "{exclusive}{icase}", NULL, false},
 	};
 

--- a/optlib/forth.ctags
+++ b/optlib/forth.ctags
@@ -22,6 +22,6 @@
 --kinddef-Forth=c,constant,constants
 
 --regex-Forth=/^[[:space:]]*\\.*//{exclusive}
---regex-Forth=/^:[[:space:]]+([^[:space:]]+)/\1/w/{exclusive}
---regex-Forth=/^variable[[:space:]]+([^[:space:]]+)/\1/v/{exclusive}{icase}
---regex-Forth=/^[[:alnum:]]+[[:space:]]+constant[[:space:]]+([^[:space:]]+)/\1/c/{exclusive}{icase}
+--regex-Forth=/:[[:space:]]+([^[:space:]]+)/\1/w/{exclusive}
+--regex-Forth=/variable[[:space:]]+([^[:space:]]+)/\1/v/{exclusive}{icase}
+--regex-Forth=/[[:alnum:]]+[[:space:]]+constant[[:space:]]+([^[:space:]]+)/\1/c/{exclusive}{icase}


### PR DESCRIPTION
Forth's ctags only work if they are placed at the beginning of a line without indentation.  Regexps contained the ^ character, making indentation impossible.

https://github.com/geany/geany/issues/4551