### PR TITLE
TOML,Cargo: Suppress redundant warnings when disabled

### DIFF
--- a/main/parse.c
+++ b/main/parse.c
@@ -1961,13 +1961,13 @@ extern void enableLanguage (const langType language, const bool state)
 	static bool warned_cargo;
 
 	/* See #4096 */
-	if (!warned_toml && strcmp (LanguageTable [language].def->name, "TOML") == 0)
+	if (state && !warned_toml && strcmp (LanguageTable [language].def->name, "TOML") == 0)
 	{
 		warned_toml = true;
 		error (WARNING, "The current implementation of the TOML parser is broken.");
 	}
 
-	if (!warned_cargo && strcmp (LanguageTable [language].def->name, "Cargo") == 0)
+	if (state && !warned_cargo && strcmp (LanguageTable [language].def->name, "Cargo") == 0)
 	{
 		warned_cargo = true;
 		error (WARNING, "Enabling Cargo subparser may enable TOML parser.");


### PR DESCRIPTION
Ref #4248 , to solve the issue #4096 , the TOML and Cargo parser has been disabled temporarily. If we try to use these parsers, we will get warnings :

```
ctags: Warning: Enabling Cargo subparser may enable TOML parser.
ctags: Warning: The current implementation of the TOML parser is broken.
```

**Now the issue is that the Warning above was output even though we did not enable the parsers.** When we pass `languages` parameters by replace mode like `--languages=c`, neither the Cargo nor the TOML parser is active, we still receive the Warnings mentioned above.
