### PR TITLE
configure.ac: use AC_PROG_AR

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -267,7 +267,8 @@ gl_EARLY
 
 AC_ARG_VAR(RANLIB,[ranlib command or path])
 AC_PROG_RANLIB
-PRETTY_ARG_VAR([AR], [ar command or path], [ar])
+AC_ARG_VAR(AR,[ar command or path])
+AM_PROG_AR
 AC_C_BIGENDIAN
 
 if test "$cross_compiling" = "yes"; then


### PR DESCRIPTION
This way AR is properly queried for including when cross-compiling
where a more graceful fallback than "ar" is needed.
