### PR TITLE
JavaScript: fix bug in line termination logic (semicolon not required)

### DIFF
--- a/Units/parser-javascript.r/github-issue-4421.d/expected.tags
+++ b/Units/parser-javascript.r/github-issue-4421.d/expected.tags
@@ -1,3 +1,6 @@
 Bar	input.js	/^function Bar() {}$/;"	c
 Foo	input.js	/^function Foo() {$/;"	c
 foo	input.js	/^Foo.prototype.foo = function() {}$/;"	m	class:Foo
+Baz	input.js	/^function Baz() {$/;"	c
+constructor	input.js	/^	Bar.prototype.constructor = call(this)$/;"	m	class:Bar
+baz	input.js	/^Baz.prototype.baz = function() {}/;"	m	class:Baz

--- a/Units/parser-javascript.r/github-issue-4421.d/input.js
+++ b/Units/parser-javascript.r/github-issue-4421.d/input.js
@@ -6,3 +6,10 @@ function Foo() {
 }
 
 Foo.prototype.foo = function() {}
+
+function Baz() {
+	Bar.prototype.constructor = call(this)
+	this.baz = null
+}
+
+Baz.prototype.baz = function() {}

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -2816,12 +2816,11 @@ static bool parsePrototype (tokenInfo *const name, tokenInfo *const token, state
 			vStringDelete (signature);
 
 			if ( isType (method_body_token, TOKEN_OPEN_CURLY))
-			{
 				parseBlock (method_body_token, index);
-				state->isTerminated = true;
-			}
-			else
-				state->isTerminated = isType (method_body_token, TOKEN_SEMICOLON);
+			else if ( isType (method_body_token, TOKEN_CLOSE_CURLY))
+				ungetcToInputFile ('}');
+
+			state->isTerminated = true;
 
 			deleteToken (method_body_token);
 			TRACE_LEAVE_TEXT("done: single");


### PR DESCRIPTION
JavaScript: ignore calls to prototype function; fix bug in line termination logic (semicolon not required)

Fixes #4421