### PR TITLE
Forth: there should be new line or white space before :

### DIFF
--- a/Units/parser-forth.r/simple-forth.d/expected.tags
+++ b/Units/parser-forth.r/simple-forth.d/expected.tags
@@ -13,3 +13,4 @@ buzz?	input.fth	/^: buzz?  $/;"	w
 baz_indented	input.fth	/^  : baz_indented ( - )$/;"	w
 fizz-buzz?	input.fth	/^: fizz-buzz?  $/;"	w
 do-fizz-buzz	input.fth	/^: do-fizz-buzz  $/;"	w
+anon-tst	input.fth	/^: anon-tst [: cr ." hello" cr ;] execute ;$/;"	w

--- a/Units/parser-forth.r/simple-forth.d/input.fth
+++ b/Units/parser-forth.r/simple-forth.d/input.fth
@@ -33,6 +33,8 @@ dup fizz? swap buzz? or invert ;
 : do-fizz-buzz  
 25 1 do cr i fizz-buzz? if i . then loop ;
 
+: anon-tst [: cr ." hello" cr ;] execute ;
+
 do-fizz-buzz
 cr
 baz_indented

--- a/optlib/forth.c
+++ b/optlib/forth.c
@@ -46,7 +46,7 @@ extern parserDefinition* ForthParser (void)
 	static tagRegexTable ForthTagRegexTable [] = {
 		{"^[[:space:]]*\\\\.*", "",
 		"", "{exclusive}", NULL, false},
-		{":[[:space:]]+([^[:space:]]+)", "\\1",
+		{"(^|[[:space:]]+):[[:space:]]+([^[:space:]]+)", "\\2",
 		"w", NULL, NULL, false},
 		{"variable[[:space:]]+([^[:space:]]+)", "\\1",
 		"v", "{icase}", NULL, false},

--- a/optlib/forth.ctags
+++ b/optlib/forth.ctags
@@ -22,6 +22,6 @@
 --kinddef-Forth=c,constant,constants
 
 --regex-Forth=/^[[:space:]]*\\.*//{exclusive}
---regex-Forth=/:[[:space:]]+([^[:space:]]+)/\1/w/
+--regex-Forth=/(^|[[:space:]]+):[[:space:]]+([^[:space:]]+)/\2/w/
 --regex-Forth=/variable[[:space:]]+([^[:space:]]+)/\1/v/{icase}
 --regex-Forth=/[[:alnum:]]+[[:space:]]+constant[[:space:]]+([^[:space:]]+)/\1/c/{icase}


### PR DESCRIPTION
Some forth language words may end with colons, for example, "[:". Only words after ":" with white spaces on both sides should be tagged. This patch adds a check for white spaces or the start of the line before ":".