### PR TITLE
parsers/c-based: add nesting depth limit to prevent stack overflow

### DIFF
--- a/parsers/c-based.c
+++ b/parsers/c-based.c
@@ -51,6 +51,8 @@
 
 enum { NumTokens = 3 };
 
+#define MAX_NEST_LEVEL 1024
+
 typedef enum eException {
 	ExceptionNone, ExceptionEOF, ExceptionFormattingError,
 	ExceptionBraceFormattingError
@@ -3005,7 +3007,17 @@ static void createTags (const unsigned int nestLevel,
 		{
 			int corkIndex = tagCheck (st);
 			if (isType (token, TOKEN_BRACE_OPEN))
-				nest (st, nestLevel + 1);
+			{
+				if (nestLevel < MAX_NEST_LEVEL)
+					nest (st, nestLevel + 1);
+				else
+				{
+					verbose ("%s: nesting level too deep (%u) at line %lu, skipping\n",
+						 getInputFileName (), nestLevel, getInputLineNumber ());
+					skipToMatch ("{}");
+					setToken (st, TOKEN_BRACE_CLOSE);
+				}
+			}
 			checkStatementEnd (st, corkIndex);
 		}
 	}


### PR DESCRIPTION
## Summary
- Added a nesting depth limit (`MAX_NEST_LEVEL = 1024`) to the C-based parser to prevent stack overflow when processing deeply nested braces
- When the limit is exceeded, the parser skips to the matching brace (`skipToMatch("{}")`) instead of recursing
- This prevents SIGSEGV crashes on crafted or extremely nested source files (e.g. Java files with thousands of nested blocks)

## Changes
| File | Change |
|------|--------|
| `parsers/c-based.c` | Added `#define MAX_NEST_LEVEL 1024`; added depth check in `createTags()` before recursive `nest()` call |

## Root Cause
The `createTags()` → `nest()` → `createTags()` recursive call chain has no depth bound. When processing a file with deeply nested braces (e.g. 54000 levels), this causes uncontrolled stack growth leading to SIGSEGV.

## Test Plan
- Build ctags and run against the PoC file (`poc-java-stack-overflow-54000.java`) attached to the issue — should no longer crash
- Existing test suite should pass unchanged (1024 levels is well above any reasonable real-world nesting depth)
- Tested with `gcc -std=c99 -fsyntax-only` — no compilation errors

Fixes universal-ctags/ctags#4439
