### PR TITLE
main: add ctagsBacktrace as a debug helper

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -206,6 +206,12 @@ libctags_a_CFLAGS  += $(LIBYAML_CFLAGS)
 libctags_a_CFLAGS  += $(SECCOMP_CFLAGS)
 libctags_a_CFLAGS  += $(PCRE2_CFLAGS)
 
+if ENABLE_DEBUGGING
+if HAVE_BACKTRACE
+libctags_a_CFLAGS  += -g
+endif
+endif
+
 nodist_libctags_a_SOURCES = $(REPOINFO_HEADS) $(PEG_SRCS) $(PEG_HEADS)
 BUILT_SOURCES = $(REPOINFO_HEADS)
 CLEANFILES += $(REPOINFO_HEADS) $(PEG_SRCS) $(PEG_HEADS)
@@ -292,6 +298,14 @@ ctags_LDADD += $(LIBYAML_LIBS)
 ctags_LDADD += $(SECCOMP_LIBS)
 ctags_LDADD += $(ICONV_LIBS)
 ctags_LDADD += $(PCRE2_LIBS)
+
+ctags_LDFLAGS =
+if ENABLE_DEBUGGING
+if HAVE_BACKTRACE
+ctags_LDFLAGS += -rdynamic
+endif
+endif
+
 dist_ctags_SOURCES = $(CMDLINE_HEADS) $(CMDLINE_SRCS)
 
 if HOST_MINGW

--- a/configure.ac
+++ b/configure.ac
@@ -535,6 +535,25 @@ AC_TYPE_OFF_T
 
 AC_CHECK_HEADERS([stdbool.h])
 
+# Check if struct stat contains st_ino.
+# MinGW has st_ino, but it doesn't work.
+if test yes != "$host_mingw"; then
+	AC_MSG_CHECKING(if struct stat contains st_ino)
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+		#include <sys/stat.h>
+		#include <stdlib.h>
+		], [
+		struct stat st;
+		stat(".", &st);
+		if (st.st_ino > 0)
+			exit(0);
+	])],[have_st_ino=yes],[have_st_ino=no])
+	AC_MSG_RESULT($have_st_ino)
+	if test yes = "$have_st_ino"; then
+		AC_DEFINE(HAVE_STAT_ST_INO)
+	fi
+fi
+
 # Checks for compiler characteristics
 # -----------------------------------
 
@@ -554,26 +573,6 @@ int main(int argc, char **argv) {return ({ int x = 1; x + argc;});}
 AC_MSG_RESULT($have_statement_expression_ext)
 if test yes = "$have_statement_expression_ext"; then
 	AC_DEFINE(HAVE_STATEMENT_EXPRESSION_EXT)
-fi
-
-
-# Check if struct stat contains st_ino.
-# MinGW has st_ino, but it doesn't work.
-if test yes != "$host_mingw"; then
-	AC_MSG_CHECKING(if struct stat contains st_ino)
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
-		#include <sys/stat.h>
-		#include <stdlib.h>
-		], [
-		struct stat st;
-		stat(".", &st);
-		if (st.st_ino > 0)
-			exit(0);
-	])],[have_st_ino=yes],[have_st_ino=no])
-	AC_MSG_RESULT($have_st_ino)
-	if test yes = "$have_st_ino"; then
-		AC_DEFINE(HAVE_STAT_ST_INO)
-	fi
 fi
 
 PRETTY_ARG_VAR([EXTRA_CPPFLAGS], [extra (Objective) C/C++ preprocessor flags],

--- a/configure.ac
+++ b/configure.ac
@@ -500,6 +500,21 @@ if test "$enable_external_sort" != yes ; then
 	AC_MSG_NOTICE(using internal sort algorithm as fallback)
 fi
 
+# Check for host type
+case "$host" in
+  i?86-*-mingw* | x86_64-*-mingw*)
+	host_mingw=yes
+	# See https://github.com/universal-ctags/ctags/pull/3069
+	gl_cv_have_weak=no
+	AC_DEFINE(MSDOS_STYLE_PATH)
+	AC_DEFINE(MANUAL_GLOBBING)
+	AC_DEFINE(HAVE__FINDFIRST)
+	;;
+  *-cygwin | *-msys)
+	gl_cv_have_weak=no
+	;;
+esac
+AM_CONDITIONAL([HOST_MINGW], [test "x${host_mingw}" = "xyes"])
 
 # Checks for header files
 # -----------------------
@@ -531,22 +546,6 @@ AC_C_TYPEOF
 if test "${enable_static}" = "yes"; then
 	LDFLAGS="$LDFLAGS -static"
 fi
-
-# Check for host type
-case "$host" in
-  i?86-*-mingw* | x86_64-*-mingw*)
-	host_mingw=yes
-	# See https://github.com/universal-ctags/ctags/pull/3069
-	gl_cv_have_weak=no
-	AC_DEFINE(MSDOS_STYLE_PATH)
-	AC_DEFINE(MANUAL_GLOBBING)
-	AC_DEFINE(HAVE__FINDFIRST)
-	;;
-  *-cygwin | *-msys)
-	gl_cv_have_weak=no
-	;;
-esac
-AM_CONDITIONAL([HOST_MINGW], [test "x${host_mingw}" = "xyes"])
 
 AC_MSG_CHECKING(if compiler supports statement expressions)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[

--- a/configure.ac
+++ b/configure.ac
@@ -522,6 +522,9 @@ AM_CONDITIONAL([HOST_MINGW], [test "x${host_mingw}" = "xyes"])
 AC_CHECK_HEADERS([direct.h dirent.h fcntl.h io.h stat.h types.h unistd.h])
 AC_CHECK_HEADERS([sys/dir.h sys/stat.h sys/types.h sys/wait.h])
 
+dnl for backtrace().
+AC_CHECK_HEADERS([execinfo.h],have_execinfo_h=yes)
+
 # Checks for header file macros
 # -----------------------------
 
@@ -631,6 +634,9 @@ AS_VAR_IF([use_lto], [yes], [
 		AC_MSG_ERROR([though --enable-lto is specified, the fto feature is not available nor usable.])
 	])
 ])
+
+CC_CHECK_LDFLAGS([-rdynamic], have_cc_rdynamic=yes)
+
 
 # Checks for function availability
 # -----------------------------------
@@ -873,6 +879,11 @@ if test "${enable_static}" = "yes"; then
 		fi
 	fi
 fi
+
+AC_CHECK_FUNCS(backtrace, have_backtrace=yes)
+AC_CHECK_FUNCS(backtrace_symbols_fd, have_backtrace_symbols_fd=yes)
+AM_CONDITIONAL(HAVE_BACKTRACE,
+	[test "x${have_cc_rdynamic}${have_execinfo_h}${have_backtrace}${have_backtrace_symbols_fd}" = "xyesyesyesyes"])
 
 
 # Checks for missing prototypes

--- a/main/debug.c
+++ b/main/debug.c
@@ -25,6 +25,10 @@
 #include "read.h"
 #include "read_p.h"
 
+#ifdef HAVE_EXECINFO_H
+#include <execinfo.h>
+#endif
+
 /*
 *   FUNCTION DEFINITIONS
 */
@@ -215,6 +219,22 @@ extern void circularRefCheckClear (struct circularRefChecker *c)
 {
 	hashTableClear (c->visitTable);
 	c->counter = 0;
+}
+
+extern void ctagsBacktrace (void)
+{
+#if defined(HAVE_EXECINFO_H) && \
+	defined(HAVE_BACKTRACE) && defined(HAVE_BACKTRACE_SYMBOLS_FD)
+	void *trace[128];
+	int fd = fileno(stderr);
+	int n = backtrace(trace, sizeof(trace) / sizeof(trace[0]));
+
+	fputs("------------------------------------------------------------------------\n",
+		  stderr);
+	backtrace_symbols_fd(trace, n, fd);
+	fputs("------------------------------------------------------------------------\n",
+		  stderr);
+#endif
 }
 
 #endif

--- a/main/debug.h
+++ b/main/debug.h
@@ -100,6 +100,8 @@ extern int circularRefCheckerCheck (struct circularRefChecker *c, void *ptr);
 extern int circularRefCheckerGetCurrent (struct circularRefChecker *c);
 extern void circularRefCheckClear (struct circularRefChecker *c);
 
+extern void ctagsBacktrace (void);
+
 #else
 #define DEBUG_INIT() do { } while(0)
 #endif	/* DEBUG */


### PR DESCRIPTION
The function works only if you pass --enable-debugging to ./configure and CFLAGS='-g -O0' to make.