### PR TITLE
buildsys: docs: restore clean target

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,12 +7,16 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
 BUILDDIR      = _build
+EXTDIR        = _ext
 
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help clean Makefile
+
+clean:
+	rm -rf $(BUILDDIR) $(EXTDIR)/__pycache__
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
docs clean target was removed in #4465

We expect that clean target will remove `_build/` `_ext/__pycache__` directories. `sphinx-build -M clean` command won't do this.

If users don't want to generate docs, it will fail while executing `make clean` if `sphinx-build` is not installed.

It is unreasonable to force users to install `Sphinx`, as they may have only executed `make clean`.