### PR TITLE
Fortran: add end fields to generated tags

### DIFF
--- a/Units/parser-fortran.r/end-field.d/args.ctags
+++ b/Units/parser-fortran.r/end-field.d/args.ctags
@@ -1,0 +1,3 @@
+--fields=ne
+--sort=no
+--kinds-Fortran=+P

--- a/Units/parser-fortran.r/end-field.d/expected.tags
+++ b/Units/parser-fortran.r/end-field.d/expected.tags
@@ -1,0 +1,15 @@
+mod1	input.f90	/^module mod1$/;"	line:1	end:26
+iface1	input.f90	/^  interface iface1$/;"	line:2	end:5
+proto1	input.f90	/^    subroutine proto1(/;"	line:3	end:4
+type1	input.f90	/^  type :: type1$/;"	line:7	end:9
+x	input.f90	/^    integer :: x$/;"	line:8
+struct1	input.f90	/^  structure \/struct1\//;"	line:11	end:13
+y	input.f90	/^    integer :: y$/;"	line:12
+enum1	input.f90	/^  enum :: enum1$/;"	line:15	end:16
+sub1	input.f90	/^  subroutine sub1(/;"	line:20	end:21
+func1	input.f90	/^  function func1(/;"	line:23	end:25
+submod1	input.f90	/^submodule (mod1) submod1$/;"	line:28	end:32
+sub2	input.f90	/^  module subroutine sub2(/;"	line:30	end:31
+block1	input.f90	/^block data block1$/;"	line:34	end:36
+z	input.f90	/^  integer :: z$/;"	line:35
+prog1	input.f90	/^program prog1$/;"	line:38	end:39

--- a/Units/parser-fortran.r/end-field.d/input.f90
+++ b/Units/parser-fortran.r/end-field.d/input.f90
@@ -1,0 +1,39 @@
+module mod1
+  interface iface1
+    subroutine proto1()
+    end subroutine proto1
+  end interface iface1
+
+  type :: type1
+    integer :: x
+  end type type1
+
+  structure /struct1/
+    integer :: y
+  end structure
+
+  enum :: enum1
+  end enum
+
+contains
+
+  subroutine sub1()
+  end subroutine sub1
+
+  function func1() result(x)
+    integer :: x
+  end function func1
+end module mod1
+
+submodule (mod1) submod1
+contains
+  module subroutine sub2()
+  end subroutine sub2
+end submodule submod1
+
+block data block1
+  integer :: z
+end block data block1
+
+program prog1
+end

--- a/Units/parser-fypp.r/run-guest.d/expected.tags
+++ b/Units/parser-fypp.r/run-guest.d/expected.tags
@@ -1,13 +1,13 @@
-+	input.fy	/^  interface operator(+)/;"	i	line:31	module:test_interface
-__anonca2bcf340105	input.fy	/^  interface ! anonymous interface$/;"	i	line:39	module:test_interface
-add	input.fy	/^    type(atype) function add(/;"	P	line:33	module:test_interface
-atype	input.fy	/^  type atype$/;"	t	line:28	module:test_interface
++	input.fy	/^  interface operator(+)/;"	i	line:31	module:test_interface	end:37
+__anonca2bcf340105	input.fy	/^  interface ! anonymous interface$/;"	i	line:39	module:test_interface	end:44
+add	input.fy	/^    type(atype) function add(/;"	P	line:33	module:test_interface	end:36
+atype	input.fy	/^  type atype$/;"	t	line:28	module:test_interface	end:29
 debug_code	input.fy	/^#:def debug_code(code)$/;"	m	line:4	end:8
-get	input.fy	/^  interface get$/;"	i	line:47	module:test_interface
-get_1d	input.fy	/^  subroutine get_1d(/;"	s	line:55	module:test_interface
-get_2d	input.fy	/^  subroutine get_2d(/;"	s	line:62	module:test_interface
-helloworld	input.fy	/^program helloworld$/;"	p	line:17
+get	input.fy	/^  interface get$/;"	i	line:47	module:test_interface	end:52
+get_1d	input.fy	/^  subroutine get_1d(/;"	s	line:55	module:test_interface	end:57
+get_2d	input.fy	/^  subroutine get_2d(/;"	s	line:62	module:test_interface	end:64
+helloworld	input.fy	/^program helloworld$/;"	p	line:17	end:19
 repeat_code	input.fy	/^#:def repeat_code(code, repeat)$/;"	m	line:23	end:27
-suba	input.fy	/^    subroutine suba(/;"	P	line:40	interface:__anonca2bcf340105
-subb	input.fy	/^    subroutine subb(/;"	P	line:42	interface:__anonca2bcf340105
-test_interface	input.fy	/^module test_interface$/;"	m	line:21
+suba	input.fy	/^    subroutine suba(/;"	P	line:40	interface:__anonca2bcf340105	end:41
+subb	input.fy	/^    subroutine subb(/;"	P	line:42	interface:__anonca2bcf340105	end:43
+test_interface	input.fy	/^module test_interface$/;"	m	line:21	end:65

--- a/docs/news/HEAD.rst
+++ b/docs/news/HEAD.rst
@@ -115,6 +115,10 @@ HTML:
 
     * Extract ``h4``, ``h5``, and ``h6`` contents.
 
+Fortran:
+
+    * Fill ``end`` field.
+
 New parsers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The following parsers have been added:

--- a/parsers/fortran.c
+++ b/parsers/fortran.c
@@ -221,6 +221,7 @@ typedef struct sTokenInfo {
 	unsigned long lineNumber;
 	MIOPos filePosition;
 	bool anonymous;
+	int corkIndex;
 } tokenInfo;
 
 /*
@@ -421,10 +422,13 @@ static void ancestorPush (tokenInfo *const token)
 	Ancestors.count++;
 }
 
-static void ancestorPop (void)
+/* Set the end line when nonzero. */
+static void ancestorPop (unsigned long endLine)
 {
 	Assert (Ancestors.count > 0);
 	--Ancestors.count;
+	if (endLine > 0)
+		setTagEndLineToCorkEntry (Ancestors.list [Ancestors.count].corkIndex, endLine);
 	vStringDelete (Ancestors.list [Ancestors.count].string);
 	vStringDelete (Ancestors.list [Ancestors.count].signature);
 
@@ -436,6 +440,7 @@ static void ancestorPop (void)
 	Ancestors.list [Ancestors.count].lineNumber = 0L;
 	Ancestors.list [Ancestors.count].implementation = IMP_DEFAULT;
 	Ancestors.list [Ancestors.count].isMethod   = false;
+	Ancestors.list [Ancestors.count].corkIndex  = CORK_NIL;
 }
 
 static const tokenInfo* ancestorScope (void)
@@ -463,7 +468,7 @@ static const tokenInfo* ancestorTop (void)
 static void ancestorClear (void)
 {
 	while (Ancestors.count > 0)
-		ancestorPop ();
+		ancestorPop (0);
 	if (Ancestors.list != NULL)
 		eFree (Ancestors.list);
 	Ancestors.list = NULL;
@@ -502,6 +507,7 @@ static tokenInfo *newToken (void)
 	token->lineNumber   = getInputLineNumber ();
 	token->filePosition = getInputFilePosition ();
 	token->anonymous    = false;
+	token->corkIndex    = CORK_NIL;
 
 	return token;
 }
@@ -652,7 +658,7 @@ static void makeFortranTag (tokenInfo *const token, tagType tag)
 			 token->tag == TAG_SUBROUTINE ||
 			 token->tag == TAG_PROTOTYPE))
 			e.extensionFields.signature = vStringValue (token->signature);
-		makeTagEntry (&e);
+		token->corkIndex = makeTagEntry (&e);
 		if (isXtagEnabled (FortranXtagTable[X_LINK_NAME].xtype)
 			&& hasLinkName(&e))
 			makeFortranLinkNameTag(&e);
@@ -1089,6 +1095,7 @@ static void readToken (tokenInfo *const token)
 	token->parentType = NULL;
 	token->isMethod = false;
 	token->signature = NULL;
+	token->corkIndex = CORK_NIL;
 
 getNextChar:
 	c = getChar ();
@@ -1877,10 +1884,11 @@ static void parseStructureStmt (tokenInfo *const token)
 	while (! isKeyword (token, KEYWORD_end) &&
 		   ! isType (token, TOKEN_EOF))
 		parseFieldDefinition (token);
+	unsigned long endLine = token->lineNumber;
 	readSubToken (token);
 	/* secondary token should be KEYWORD_structure token */
 	skipToNextStatement (token);
-	ancestorPop ();
+	ancestorPop (endLine);
 	deleteToken (name);
 }
 
@@ -2048,10 +2056,11 @@ static void parseDerivedTypeDef (tokenInfo *const token)
 		else
 			skipToNextStatement (token);
 	}
+	unsigned long endLine = token->lineNumber;
 	readSubToken (token);
 	/* secondary token should be KEYWORD_type token */
 	skipToToken (token, TOKEN_STATEMENT_END);
-	ancestorPop ();
+	ancestorPop (endLine);
 }
 
 /*  interface-block
@@ -2121,10 +2130,11 @@ static void parseInterfaceBlock (tokenInfo *const token)
 				break;
 		}
 	}
+	unsigned long endLine = token->lineNumber;
 	readSubToken (token);
 	/* secondary token should be KEYWORD_interface token */
 	skipToNextStatement (token);
-	ancestorPop ();
+	ancestorPop (endLine);
 	deleteToken (name);
 }
 
@@ -2172,10 +2182,11 @@ static void parseEnumBlock (tokenInfo *const token)
 		else
 			skipToNextStatement (token);
 	}
+	unsigned long endLine = token->lineNumber;
 	readSubToken (token);
 	/* secondary token should be KEYWORD_enum token */
 	skipToNextStatement (token);
-	ancestorPop ();
+	ancestorPop (endLine);
 	deleteToken (name);
 }
 
@@ -2364,10 +2375,11 @@ static void parseBlockData (tokenInfo *const token)
 	while (! isKeyword (token, KEYWORD_end) &&
 		   ! isType (token, TOKEN_EOF))
 		skipToNextStatement (token);
+	unsigned long endLine = token->lineNumber;
 	readSubToken (token);
 	/* secondary token should be KEYWORD_NONE or KEYWORD_block token */
 	skipToNextStatement (token);
-	ancestorPop ();
+	ancestorPop (endLine);
 }
 
 /*  internal-subprogram-part is
@@ -2508,10 +2520,11 @@ static void parseModule (tokenInfo *const token, bool isSubmodule)
 	while (! isKeyword (token, KEYWORD_end) &&
 		   ! isType (token, TOKEN_EOF))
 		skipToNextStatement (token);
+	unsigned long endLine = token->lineNumber;
 	readSubToken (token);
 	/* secondary token should be KEYWORD_NONE or KEYWORD_module token */
 	skipToNextStatement (token);
-	ancestorPop ();
+	ancestorPop (endLine);
 
 	if (parentIdentifier)
 		vStringDelete (parentIdentifier);
@@ -2625,12 +2638,13 @@ static void parseSubprogramFull (tokenInfo *const token, const tagType tag)
 	if (isKeyword (token, KEYWORD_contains))
 		parseInternalSubprogramPart (token);
 	/* should be at KEYWORD_end token */
+	unsigned long endLine = token->lineNumber;
 	readSubToken (token);
 	/* secondary token should be one of KEYWORD_NONE, KEYWORD_program,
 	 * KEYWORD_function, KEYWORD_function
 	 */
 	skipToNextStatement (token);
-	ancestorPop ();
+	ancestorPop (endLine);
 }
 
 static tagType subprogramTagType (tokenInfo *const token)
@@ -2785,6 +2799,7 @@ extern parserDefinition* FortranParser (void)
 	def->keywordCount = ARRAY_SIZE (FortranKeywordTable);
 	def->xtagTable  = FortranXtagTable;
 	def->xtagCount  = ARRAY_SIZE(FortranXtagTable);
+	def->useCork    = CORK_QUEUE;
 
 	def->versionCurrent = 1;
 	def->versionAge = 1;


### PR DESCRIPTION
This adds end field support to tags generated by the Fortran parser and adds the `parser-fortran.r/end-field.d` test case.

The parser records the line containing the corresponding END statement for: modules, submodules, programs, functions, subroutines, interfaces, prototypes, derived types, structures, enumerations, and block data. 
