### PR TITLE
Preserve constness of variables passed to libc

### DIFF
--- a/dsl/optscript.c
+++ b/dsl/optscript.c
@@ -3409,7 +3409,7 @@ op__strpbrk (OptVM *vm, EsObject *name)
 	vString *acceptv = es_pointer_get (acceptobj);
 
 	const char *str = vStringValue (strv);
-	char *p = strpbrk (str, vStringValue (acceptv));
+	const char *p = strpbrk (str, vStringValue (acceptv));
 	if (p)
 	{
 		int d = p - str;

--- a/main/flags.c
+++ b/main/flags.c
@@ -40,7 +40,7 @@ extern const char *flagsEval (const char* flags_original, flagDefinition* defs, 
 		}
 		else if (flags [i] == LONG_FLAGS_OPEN)
 		{
-			const char* aflag = flags + i + 1;
+			char* aflag = flags + i + 1;
 			char* needle_close_paren = strchr(aflag, LONG_FLAGS_CLOSE);
 			const char* param;
 			char* needle_equal;

--- a/main/lregex.c
+++ b/main/lregex.c
@@ -855,6 +855,8 @@ static void pre_ptrn_flag_guest_long (const char* const s, const char* const v, 
 	enum regexParserType type = flagData->type;
 	struct guestSpec *guest = flagData->guest;
 	struct boundarySpec *current;
+	char *vdup;
+	char *tmp;
 
 	if (!v)
 	{
@@ -862,34 +864,36 @@ static void pre_ptrn_flag_guest_long (const char* const s, const char* const v, 
 		return;
 	}
 
-	char *tmp = strchr (v, ',');
+	vdup = eStrdup (v);
+	tmp = strchr (vdup, ',');
+
 	if (tmp == NULL)
 	{
 		error (WARNING, "no terminator found for parser name: %s", s);
-		return;
+		goto cleanup;
 	}
 
-	if ((tmp - v) == 0)
+	if ((tmp - vdup) == 0)
 	{
 		if (type == REG_PARSER_MULTI_LINE)
 		{
 			error (WARNING,
-				   "using placeholder for guest name field is not allowed in multiline regex spec: %s", v);
+				   "using placeholder for guest name field is not allowed in multiline regex spec: %s", vdup);
 			goto err;
 		}
 
 		guest->lang.type = GUEST_LANG_PLACEHOLDER;
 	}
-	else if (*v == '\\' || *v == '*')
+	else if (*vdup == '\\' || *vdup == '*')
 	{
-		const char *n_tmp = v + 1;
+		char *n_tmp = vdup + 1;
 		const char *n = n_tmp;
 		for (; isdigit ((unsigned char) *n_tmp); n_tmp++);
 		char c = *n_tmp;
-		*(char *)n_tmp = '\0';
+		*n_tmp = '\0';
 		if (!strToInt (n, 10, &(guest->lang.spec.patternGroup)))
 		{
-			error (WARNING, "wrong guest name specification: %s", v);
+			error (WARNING, "wrong guest name specification: %s", vdup);
 			goto err;
 		}
 		else if (guest->lang.spec.patternGroup >= BACK_REFERENCE_COUNT)
@@ -899,23 +903,23 @@ static void pre_ptrn_flag_guest_long (const char* const s, const char* const v, 
 			goto err;
 		}
 
-		*(char *)n_tmp = c;
+		*n_tmp = c;
 		if (*n_tmp != ',')
 		{
-			error (WARNING, "wrong guest specification (garbage at the end of end guest spec): %s", v);
+			error (WARNING, "wrong guest specification (garbage at the end of end guest spec): %s", vdup);
 			goto err;
 		}
 
-		guest->lang.type = (*v == '\\')
+		guest->lang.type = (*vdup == '\\')
 			? GUEST_LANG_PTN_GROUP_FOR_LANGNAME
 			: GUEST_LANG_PTN_GROUP_FOR_FILEMAP;
 	}
 	else
 	{
-		guest->lang.spec.lang = getNamedLanguageOrAlias (v, (tmp - v));
+		guest->lang.spec.lang = getNamedLanguageOrAlias (vdup, (tmp - vdup));
 		if (guest->lang.spec.lang == LANG_IGNORE)
 		{
-			error (WARNING, "no parser found for the guest spec: %s", v);
+			error (WARNING, "no parser found for the guest spec: %s", vdup);
 			goto err;
 		}
 		guest->lang.type = GUEST_LANG_STATIC_LANGNAME;
@@ -924,7 +928,7 @@ static void pre_ptrn_flag_guest_long (const char* const s, const char* const v, 
 	tmp++;
 	if (*tmp == '\0')
 	{
-		error (WARNING, "no area spec found in the guest spec: %s", v);
+		error (WARNING, "no area spec found in the guest spec: %s", vdup);
 		goto err;
 	}
 
@@ -938,7 +942,7 @@ static void pre_ptrn_flag_guest_long (const char* const s, const char* const v, 
 			if (type == REG_PARSER_MULTI_LINE)
 				error (WARNING,
 					   "using placeholder for %s field is not allowed in multiline regex spec: %s",
-					   current_field_str, v);
+					   current_field_str, vdup);
 
 			current->placeholder = true;
 		}
@@ -952,14 +956,14 @@ static void pre_ptrn_flag_guest_long (const char* const s, const char* const v, 
 			if (!strToInt (n, 10, &(current->patternGroup)))
 			{
 				error (WARNING, "wrong guest area specification (patternGroup of %s, number expected): %s:%s",
-					   current_field_str, v, n);
+					   current_field_str, vdup, n);
 				goto err;
 			}
 			*tmp = c;
 			if (*tmp == '\0')
 			{
 				error (WARNING, "wrong guest area specification (patternGroup of %s, nether start nor end given): %s",
-					   current_field_str, v);
+					   current_field_str, vdup);
 				goto err;
 			}
 			else if (strncmp (tmp, "start", 5) == 0)
@@ -975,7 +979,7 @@ static void pre_ptrn_flag_guest_long (const char* const s, const char* const v, 
 			else
 			{
 				error (WARNING, "wrong guest area specification (%s): %s",
-					   current_field_str, v);
+					   current_field_str, vdup);
 				goto err;
 			}
 		}
@@ -985,20 +989,22 @@ static void pre_ptrn_flag_guest_long (const char* const s, const char* const v, 
 			if (*tmp != ',')
 			{
 				error (WARNING,
-					   "wrong guest area specification (separator between start and end boundaries): %s", v);
+					   "wrong guest area specification (separator between start and end boundaries): %s", vdup);
 				goto err;
 			}
 			tmp++;
 		}
 		else if (i == 1 && (*tmp != '\0'))
 		{
-			error (WARNING, "wrong guest area specification (garbage at the end of end boundary spec): %s", v);
+			error (WARNING, "wrong guest area specification (garbage at the end of end boundary spec): %s", vdup);
 			goto err;
 		}
 	}
-	return;
+	goto cleanup;
  err:
 	guest->lang.type = GUEST_LANG_UNKNOWN;
+ cleanup:
+	eFree (vdup);
 }
 
 static flagDefinition multilinePtrnFlagDef[] = {
@@ -1121,7 +1127,7 @@ static void common_flag_field_long (const char* const s, const char* const v, vo
 	fieldType ftype;
 	char *fname;
 	const char* template;
-	char *tmp;
+	const char *tmp;
 
 	if (!v)
 	{
@@ -1316,7 +1322,7 @@ static void pre_ptrn_flag_mtable_long (const char* const s, const char* const v,
 	if (taking_table)
 	{
 		int t;
-		char *continuation = NULL;
+		const char *continuation = NULL;
 
 
 		if (!v || (!*v))

--- a/main/options.c
+++ b/main/options.c
@@ -804,7 +804,7 @@ extern langType getLanguageComponentInOptionFull (const char *const option,
 	size_t prefix_len;
 	langType language;
 	const char *lang;
-	char *sep = NULL;
+	const char *sep = NULL;
 	size_t lang_len = 0;
 
 	Assert (prefix && prefix[0]);
@@ -1076,7 +1076,7 @@ static void addExtensionList (
 		stringList *const slist, const char *const elist, const bool clear)
 {
 	char *const extensionList = eStrdup (elist);
-	const char *extension = NULL;
+	char *extension = NULL;
 	bool first = true;
 
 	if (clear)

--- a/main/parse.c
+++ b/main/parse.c
@@ -2543,7 +2543,7 @@ extern void processLanguageDefineOption (
 		const char *const option, const char *const parameter)
 {
 	char *name;
-	char *flags;
+	const char *flags;
 	parserDefinition*  def;
 
 	flags = strchr (parameter, LONG_FLAGS_OPEN);
@@ -3395,7 +3395,7 @@ static void processLangKindRoleDefinition (
 		else if (*p == '{')
 		{
 			p++;
-			char *q = strchr (p, '}');
+			const char *q = strchr (p, '}');
 			if (!q)
 
 				error (FATAL, "no '}' representing the end of role name in --%s option: %s",

--- a/main/routines.c
+++ b/main/routines.c
@@ -547,9 +547,9 @@ static bool isPathSeparator (const int c)
 static char *strSeparator (const char *s)
 {
 #if defined (MSDOS_STYLE_PATH)
-	return strpbrk (s, PathDelimiters);
+	return (char*) strpbrk (s, PathDelimiters);
 #else
-	return strchr (s, PATH_SEPARATOR);
+	return (char*) strchr (s, PATH_SEPARATOR);
 #endif
 }
 
@@ -565,7 +565,7 @@ static char *strRSeparator (const char *s)
 	}
 	return (char*) last;
 #else
-	return strrchr (s, PATH_SEPARATOR);
+	return (char*) strrchr (s, PATH_SEPARATOR);
 #endif
 }
 

--- a/main/writer-ctags.c
+++ b/main/writer-ctags.c
@@ -434,7 +434,7 @@ static int writeCtagsPtagEntry (tagWriter *writer,
 	}
 	else if (fileName)
 	{
-		char *c = NULL;
+		const char *c = NULL;
 		if ((c = strchr (fileName, '\t')) || (c = strchr (fileName, '\n')))
 		{
 			vStringDelete (vfileName);

--- a/parsers/jscript.c
+++ b/parsers/jscript.c
@@ -2643,7 +2643,7 @@ static vString *trimGarbageInSignature (vString *sig)
 {
 	/* Drop "=>" at the end. */
 	const char *sigstr = vStringValue (sig);
-	char *last = strrchr (sigstr, ')');
+	const char *last = strrchr (sigstr, ')');
 	Assert (last);
 	vStringTruncate (sig, last - sigstr + 1);
 	return sig;

--- a/parsers/pascal.c
+++ b/parsers/pascal.c
@@ -116,7 +116,7 @@ static void parseArglist (const char *buf, vString *arglist, vString *vartype)
 	/* parse return type if requested by passing a non-NULL vartype argument */
 	if (NULL != vartype)
 	{
-		char *var, *var_start;
+		const char *var, *var_start;
 
 		if (NULL != (var = strchr (end, ':')))
 		{

--- a/parsers/python-entry-points.c
+++ b/parsers/python-entry-points.c
@@ -93,11 +93,13 @@ static void newDataCallback (iniconfSubparser *iniconf,
 	if (!value)
 		return;
 
-	char *sep = strrchr (value, ':');
+	char *vdup = eStrdup (value);
+	char *sep = strrchr (vdup, ':');
+
 	if (sep)
 		*sep = '\0';
 
-	initForeignRefTagEntry (&e, value, Lang_python,
+	initForeignRefTagEntry (&e, vdup, Lang_python,
 							PYTHON_MODULE_KIND, PYTHON_MODULE_ENTRY_POINT);
 	int mod = makeTagEntry (&e);
 
@@ -109,8 +111,7 @@ static void newDataCallback (iniconfSubparser *iniconf,
 		makeTagEntry (&e);
 	}
 
-	if (sep)
-		*sep = ':';
+	eFree (vdup);
 }
 
 static void findPythonEntryPointsTags (void)


### PR DESCRIPTION
Historically, some libc functions like strchr have dropped the "const" type qualifier. There are also functions within ctags which, like libc, drop const (see strSeparator in main/routines.c).

Dropping qualifiers allows these functions to generically accept arguments with different qualifications and return a value with no qualification. The caller is expected to carefully manage qualification and cast when necessary.

C11 and C23 address this shortcoming by allowing for _Generic definitions which can be used to preserve qualifiers. glibc 2.43 began adopting generics in a backwards-compatible way, allowing gcc to emit warnings when some libc function calls cause type qualification to be lost (see commit cd748a63ab ("Implement C23 const-preserving standard library macros") in glibc).

Where compiling against glibc >= 2.43 causes warnings to be emitted, fix the loss of constness.

TODO: Use _Generic to make strSeparator and others preserve constness