### PR TITLE
main: don't take the address of a member of a NULL pointer in foreach…

### DIFF
--- a/main/entry.c
+++ b/main/entry.c
@@ -1405,7 +1405,10 @@ extern bool foreachEntriesInScope (int corkIndex,
 			verbose ("symtbl[< ] %s->%p\n", name, &entry->slot);
 			if (!func (entry->corkIndex, &entry->slot, data))
 				return false;
-			if (cursor == &rep->symnode)
+			/* REP is filled only when NAME is given.  Don't take the
+			 * address of a member of a NULL pointer; that is undefined
+			 * behavior. */
+			if (rep && cursor == &rep->symnode)
 				revisited_rep = true;
 		}
 		else if (name)


### PR DESCRIPTION
Fix #4497.

foreachEntriesInScope() fills `rep' only when NAME is given.  With a NULL NAME the iteration loop still evaluates `&rep->symnode', a member access on a NULL pointer (C11 6.5.3.2).  UBSan reports it as

    main/entry.c:1408:24: runtime error: member access within null
    pointer of type 'tagEntryInfoX'

`revisited_rep' is only consulted when NAME is non-NULL, so simply guard the comparison with `rep'.

Reproducer (from #4497):

    $ printf 'var obj = {x: 1};\nvar y = obj.x;\n' > valid.js
    $ ctags --sort=no -o - valid.js

`make units' (1622 tests) is passed, and the reproducer is clean under -fsanitize=address,undefined.