### PR TITLE
main: fix the va_list handling of the asprintf() fallback

### DIFF
--- a/main/options.c
+++ b/main/options.c
@@ -687,8 +687,13 @@ int asprintf(char **strp, const char *fmt, ...)
 #endif
 
 	va_end(args_copy);
+	va_end(args);
 
 	Assert(length >= 0);
+	if (length < 0) {
+		*strp = NULL;
+		return -1;
+	}
 	size = length + 1;
 
 	*strp = malloc(size);


### PR DESCRIPTION
The replacement asprintf() built on hosts without HAVE_ASPRINTF starts `args' twice without an intervening va_end(), which C99 7.15.1p1 forbids; on the malloc() failure path `args' is never ended at all.

The negative return of vsnprintf()/_vscprintf() is only caught by Assert(), which expands to nothing in a non-debugging build.  `size' would then be 0, malloc(0) may return a non-NULL zero-length buffer and the caller reads an unterminated string out of bounds.

End `args' before restarting it, and bail out on a negative length instead of relying on the assertion.

Found by cppcheck (va_end_missing, va_list_usedBeforeStarted).