### PR TITLE
main,cosmetic: silence two -Wmaybe-uninitialized warnings

### DIFF
--- a/parsers/python.c
+++ b/parsers/python.c
@@ -1261,7 +1261,7 @@ static bool parseImport (tokenInfo *const token)
 	if (token->keyword == KEYWORD_import)
 	{
 		bool parenthesized = false;
-		int moduleIndex;
+		int moduleIndex = CORK_NIL;
 
 		if (fromModule)
 		{

--- a/parsers/ruby.c
+++ b/parsers/ruby.c
@@ -220,7 +220,7 @@ static bool canMatchKeywordWithAssignFull (const unsigned char** s, const unsign
 										   const char* literal, vString *assignee)
 {
 	const unsigned char* original_pos = *s;
-	size_t original_len;
+	size_t original_len = 0;
 	if (assignee)
 		original_len = vStringLength  (assignee);
 


### PR DESCRIPTION
GCC 11 warns about `moduleIndex' in parseImport() and `original_len' in canMatchKeywordWithAssignFull().  Both are guarded by the same condition that initializes them (`fromModule' and `assignee'), so the warnings are false positives; initialize them anyway to keep the build warning-free.